### PR TITLE
Adjust a few READMEs to eliminate some redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://firebase.google.com.
 ## Table of contents
 
 1. [Getting Started](#getting-started)
+1. [Building](#building)
 1. [Testing](#testing)
    1. [Unit Testing](#unit-testing)
    1. [Integration Testing](#integration-testing)
@@ -38,6 +39,14 @@ https://firebase.google.com.
 * Clone the repo (`git clone git@github.com:firebase/firebase-android-sdk.git`)
 * Import the firebase-android-sdk gradle project into Android Studio using the
   **Import project(Gradle, Eclipse ADT, etc.** option.
+
+## Building
+
+Building the Firebase SDKs can be performed by invoking the following on the
+command line:
+```bash
+./gradlew :<firebase-project>:assemble`
+```
 
 ## Testing
 
@@ -86,6 +95,11 @@ If you don't have a suitable testing project already:
   * Give the app any package name you like.
   * Download the resulting `google-services.json` file and put it in the root of
     your checkout.
+
+For now, you have to disable security rule enforcement for the Realtime
+Database, Cloud Firestore, and Cloud Storage in your test project (if running
+the integration tests for any of those). Re-enable your security rules after
+your test run.
 
 #### Running Integration Tests
 
@@ -203,6 +217,9 @@ projects may be published as follows.
 ./gradlew -PprojectsToPublish=":firebase-firestore,:firebase-functions" \
     publishProjectsToMavenLocal
 ```
+
+To generate the Maven dependency tree under `build/` instead, you can use
+`firebasePublish` instead of `publishProjectsToMavenLocal`
 
 ### Code Formatting
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ https://firebase.google.com.
 ## Table of contents
 
 1. [Getting Started](#getting-started)
-1. [Building](#building)
 1. [Testing](#testing)
    1. [Unit Testing](#unit-testing)
    1. [Integration Testing](#integration-testing)
@@ -39,14 +38,6 @@ https://firebase.google.com.
 * Clone the repo (`git clone git@github.com:firebase/firebase-android-sdk.git`)
 * Import the firebase-android-sdk gradle project into Android Studio using the
   **Import project(Gradle, Eclipse ADT, etc.** option.
-
-## Building
-
-Building the Firebase SDKs can be performed by invoking the following on the
-command line:
-```bash
-./gradlew :<firebase-project>:assemble`
-```
 
 ## Testing
 
@@ -218,8 +209,8 @@ projects may be published as follows.
     publishProjectsToMavenLocal
 ```
 
-To generate the Maven dependency tree under `build/` instead, you can use
-`firebasePublish` instead of `publishProjectsToMavenLocal`
+To generate the Maven dependency tree under `build/` instead, you can replace
+`publishProjectsToMavenLocal` in the above command with `firebasePublish`.
 
 ### Code Formatting
 

--- a/firebase-database/README.md
+++ b/firebase-database/README.md
@@ -7,35 +7,6 @@ in realtime to every connected client. When you build cross-platform apps with o
 and JavaScript SDKs, all of your clients share one Realtime Database instance and automatically
 receive updates with the newest data.
 
-All Gradle commands should be run from the source root (which is one level up from this folder).
-
-Building
-========
-You can build the SDK by invoking `./gradlew :firebase-database:assemble`.
-
-If you want to test changes locally, you may also run
-`./gradlew -PprojectsToPublish="firebase-database" firebasePublish`. This generates the Maven 
-dependency tree (under `build/`) that you can use during app development.
-
-Testing
-=======
-
-To run the unit tests:
-
-- Invoke `./gradlew :firebase-database:check`.
-
-To run the integration tests:
-
-- Make sure that you have configured a `google-service.json` from your Firebase test project in the
-  source root.
-- For now, you have to disable security rule enforcement for the Realtime Databse in your test
-  project.
-- Start an Android Emulator.
-- Invoke `./gradlew :firebase-database:connectedCheck`.
-- Re-enable your security rules after your test run.
-
-
-Formatting
-==========
-Format your source files via `./gradlew :firebase-database:googleJavaFormat`
-
+All Gradle commands should be run from the source root (which is one level up
+from this folder). See the README.md in the source root for instructions on
+publishing/testing the Realtime Database.

--- a/firebase-firestore/README.md
+++ b/firebase-firestore/README.md
@@ -1,1 +1,15 @@
-Prior to submitting please run `./gradlew :firebase-firestore:googleJavaFormat` to format your code.
+# firebase-firestore
+
+This is the Cloud Firestore component of the Firebase Android SDK.
+
+Cloud Firestore is a flexible, scalable database for mobile, web, and server
+development from Firebase and Google Cloud Platform. Like Firebase Realtime
+Database, it keeps your data in sync across client apps through realtime
+listeners and offers offline support for mobile and web so you can build
+responsive apps that work regardless of network latency or Internet
+connectivity. Cloud Firestore also offers seamless integration with other
+Firebase and Google Cloud Platform products, including Cloud Functions.
+
+All Gradle commands should be run from the source root (which is one level up
+from this folder). See the README.md in the source root for instructions on
+publishing/testing Cloud Firestore.

--- a/firebase-storage/README.md
+++ b/firebase-storage/README.md
@@ -8,36 +8,6 @@ downloads for your Firebase apps, regardless of network quality. You can use our
 images, audio, video, or other user-generated content. On the server, you can use Google Cloud
 Storage, to access the same files.
 
-All Gradle commands should be run from the source root (which is one level up from this folder).
-
-Building
-========
-You can build the SDK by invoking `./gradlew :firebase-storage:assemble`.
-
-If you want to test changes locally, you may also run
-`./gradlew -PprojectsToPublish="firebase-storage" firebasePublish`. This generates the Maven 
-dependency tree (under `build/`) that you can use during app development.
-
-Testing
-=======
-
-To run the unit tests:
-
-- Invoke `./gradlew :firebase-storage:check`.
-
-To run the integration tests:
-
-- Make sure that you have configured a `google-service.json` from your Firebase test project in the
-  source root. 
-- Enable Firebase Storage in your project. Firebase Storage can be implicitly enabled by visiting
-  the Storage tab in the [Firebase Console](https://console.firebase.google.com/).
-- For now, you have to disable security rule enforcement for Cloud Storage in your test project.
-- Start an Android Emulator.
-- Invoke `./gradlew :firebase-storage:connectedCheck`.
-- Re-enable your security rules after your test run.
-
-
-Formatting
-==========
-Format your source files via `./gradlew :firebase-storage:googleJavaFormat`
-
+All Gradle commands should be run from the source root (which is one level up
+from this folder). See the README.md in the source root for instructions on
+publishing/testing Firebase Storage.


### PR DESCRIPTION
Build/publish/test commands are common across the projects, so we can
just refer to them in the top level README rather than repeating them in
the sub-READMEs.