### PR TITLE
Retrying firestore integration tests

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsServerApplicationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsServerApplicationTest.java
@@ -24,7 +24,9 @@ import static junit.framework.Assert.assertEquals;
 
 import android.support.test.runner.AndroidJUnit4;
 import com.google.firebase.firestore.FirebaseFirestoreException.Code;
+import java.util.Random;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,6 +38,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(AndroidJUnit4.class)
 public class ArrayTransformsServerApplicationTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
+
   // A document reference to read and write to.
   DocumentReference docRef;
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsTest.java
@@ -27,6 +27,7 @@ import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,6 +38,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(AndroidJUnit4.class)
 public class ArrayTransformsTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
+
   // A document reference to read and write to.
   private DocumentReference docRef;
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CursorTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CursorTest.java
@@ -34,11 +34,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class CursorTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FieldsTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FieldsTest.java
@@ -37,11 +37,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class FieldsTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -47,12 +47,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 // TODO: Add the skipped tests from typescript.
 @RunWith(AndroidJUnit4.class)
 public class FirestoreTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ListenerRegistrationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ListenerRegistrationTest.java
@@ -24,11 +24,13 @@ import android.support.test.runner.AndroidJUnit4;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.concurrent.Semaphore;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class ListenerRegistrationTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
@@ -24,11 +24,13 @@ import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Date;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class POJOTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   public static class POJO {
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -37,11 +37,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class QueryTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/RetryRule.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/RetryRule.java
@@ -1,0 +1,48 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RetryRule implements TestRule {
+  private int retryCount;
+
+  public RetryRule(int retryCount) {
+    this.retryCount = retryCount;
+  }
+
+  public Statement apply(final Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        Throwable caughtThrowable = null;
+
+        for (int i = 0; i < retryCount; i++) {
+          System.out.println("Trying...." +  i);
+          try {
+            base.evaluate();
+            return;
+          } catch (Throwable t) {
+            caughtThrowable = t;
+          }
+        }
+
+        throw caughtThrowable;
+      }
+    };
+  }
+}

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
@@ -37,11 +37,13 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class ServerTimestampTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   // Data written in tests via set.
   private static final Map<String, Object> setData =

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SmokeTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SmokeTest.java
@@ -32,11 +32,13 @@ import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class SmokeTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SourceTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SourceTest.java
@@ -34,11 +34,13 @@ import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public final class SourceTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -34,11 +34,13 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class TransactionTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TypeTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TypeTest.java
@@ -31,11 +31,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class TypeTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -40,12 +40,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 // NOTE: The SDK has exhaustive nullability checks, but we don't exhaustively test them. :-)
 @RunWith(AndroidJUnit4.class)
 public class ValidationTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
@@ -34,11 +34,13 @@ import com.google.firebase.firestore.testutil.EventAccumulator;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Arrays;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class WriteBatchTest {
+  @Rule public RetryRule retryRule = new RetryRule(3);
 
   @After
   public void tearDown() {


### PR DESCRIPTION
In #7  @bjornick pointed out that retrying the integration tests might helps alleviate this issue. I think we should try this and see if the issue surfaces over the next couples of weeks 🤞.

If we find other projects that have similar flakes fixable by retrying, it might make sense to create a shared Gradle module with the `RetryRule` that projects can depend on in their `testImplementation` Gradle configs.
