### PR TITLE
Audit code to ensure printf style templates are compile time constants.

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -636,7 +636,7 @@ public class FirestoreTest {
                   assertFalse(doc2.getMetadata().hasPendingWrites());
                   break;
                 default:
-                  fail("unexpected call to onSnapshot:" + snapshot);
+                  fail("unexpected call to onSnapshot: %s", snapshot);
               }
             });
     waitFor(emptyLatch);
@@ -682,7 +682,7 @@ public class FirestoreTest {
                   assertFalse(document3.getMetadata().hasPendingWrites());
                   break;
                 default:
-                  fail("unexpected event " + snapshot);
+                  fail("unexpected event %s", snapshot);
               }
             });
     waitFor(initialLatch);
@@ -717,7 +717,7 @@ public class FirestoreTest {
                   assertEquals(0, snapshot.size());
                   break;
                 default:
-                  fail("unexpected event " + snapshot);
+                  fail("unexpected event %s", snapshot);
               }
             });
     waitFor(initialLatch);
@@ -747,7 +747,7 @@ public class FirestoreTest {
                   assertEquals(map("b", 1.0), snapshot.getData());
                   break;
                 default:
-                  fail("unexpected event " + snapshot);
+                  fail("unexpected event %s", snapshot);
               }
             });
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -306,7 +306,7 @@ public class ValidationTest {
                             try {
                               transaction.get(badRef);
                             } catch (FirebaseFirestoreException e) {
-                              fail("transaction.get() triggered wrong exception: " + e);
+                              fail("transaction.get() triggered wrong exception: %s", e);
                             }
                           },
                           reason);

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/EventAccumulator.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/EventAccumulator.java
@@ -39,7 +39,7 @@ public class EventAccumulator<T> {
   public EventListener<T> listener() {
     return (value, error) -> {
       synchronized (EventAccumulator.this) {
-        hardAssert(error == null, "Unexpected error: " + error);
+        hardAssert(error == null, "Unexpected error: %s", error);
         Log.i("EventAccumulator", "Received new event: " + value);
         events.add(value);
         checkFulfilled();

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -160,7 +160,7 @@ public class IntegrationTestUtil {
     try {
       asyncQueue = new AsyncQueue();
     } catch (Exception e) {
-      fail("Failed to initialize AsyncQueue:" + e);
+      fail(e, "Failed to initialize AsyncQueue");
     }
 
     FirebaseFirestore firestore =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -505,15 +505,14 @@ public class DocumentSnapshot {
         // TODO: Somehow support foreign references.
         Logger.warn(
             "DocumentSnapshot",
-            String.format(
-                "Document %s contains a document reference within a different database "
-                    + "(%s/%s) which is not supported. It will be treated as a reference in "
-                    + "the current database (%s/%s) instead.",
-                key.getPath(),
-                refDatabase.getProjectId(),
-                refDatabase.getDatabaseId(),
-                database.getProjectId(),
-                database.getDatabaseId()));
+            "Document %s contains a document reference within a different database "
+                + "(%s/%s) which is not supported. It will be treated as a reference in "
+                + "the current database (%s/%s) instead.",
+            key.getPath(),
+            refDatabase.getProjectId(),
+            refDatabase.getDatabaseId(),
+            database.getProjectId(),
+            database.getDatabaseId());
       }
       return new DocumentReference(key, firestore);
     } else {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/RelationFilter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/RelationFilter.java
@@ -94,7 +94,7 @@ public class RelationFilter extends Filter {
       case GREATER_THAN_OR_EQUAL:
         return comp >= 0;
       default:
-        throw Assert.fail("Unknown operator: ", operator);
+        throw Assert.fail("Unknown operator: %s", operator);
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -376,7 +376,7 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
       handleRemoteEvent(event);
     } else {
       QueryView queryView = queryViewsByTarget.get(targetId);
-      hardAssert(queryView != null, "Unknown target: " + targetId);
+      hardAssert(queryView != null, "Unknown target: %s", targetId);
       localStore.releaseQuery(queryView.getQuery());
       removeAndCleanup(queryView);
       callback.onError(queryView.getQuery(), error);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -143,7 +143,7 @@ final class LocalDocumentsView {
         } else if (mutatedDoc instanceof Document) {
           results = results.insert(key, (Document) mutatedDoc);
         } else {
-          throw fail("Unknown document type: " + mutatedDoc);
+          throw fail("Unknown document type: %s", mutatedDoc);
         }
       }
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
@@ -68,7 +68,7 @@ public final class LocalSerializer {
         return decodeNoDocument(proto.getNoDocument());
 
       default:
-        throw fail("Unknown MaybeDocument " + proto);
+        throw fail("Unknown MaybeDocument %s", proto);
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/MutationBatchResult.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/MutationBatchResult.java
@@ -55,10 +55,9 @@ public final class MutationBatchResult {
       ByteString streamToken) {
     Assert.hardAssert(
         batch.getMutations().size() == mutationResults.size(),
-        "Mutations sent "
-            + batch.getMutations().size()
-            + " must equal results received "
-            + mutationResults.size());
+        "Mutations sent %d must equal results received %d",
+        batch.getMutations().size(),
+        mutationResults.size());
     ImmutableSortedMap<DocumentKey, SnapshotVersion> docVersions =
         DocumentCollections.emptyVersionMap();
     List<Mutation> mutations = batch.getMutations();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/TransformMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/TransformMutation.java
@@ -126,7 +126,7 @@ public final class TransformMutation extends Mutation {
    * method is guaranteed to be safe.
    */
   private Document requireDocument(@Nullable MaybeDocument maybeDoc) {
-    hardAssert(maybeDoc instanceof Document, "Unknown MaybeDocument type " + maybeDoc);
+    hardAssert(maybeDoc instanceof Document, "Unknown MaybeDocument type %s", maybeDoc);
     Document doc = (Document) maybeDoc;
     hardAssert(doc.getKey().equals(getKey()), "Can only transform a document with the same key");
     return doc;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/OnlineStateTracker.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/OnlineStateTracker.java
@@ -187,10 +187,10 @@ class OnlineStateTracker {
             reason);
 
     if (shouldWarnClientIsOffline) {
-      Logger.warn(LOG_TAG, message);
+      Logger.warn(LOG_TAG, "%s", message);
       shouldWarnClientIsOffline = false;
     } else {
-      Logger.debug(LOG_TAG, message);
+      Logger.debug(LOG_TAG, "%s", message);
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
@@ -287,7 +287,7 @@ public final class RemoteSerializer {
       DocumentKey key = (DocumentKey) encodedValue;
       builder.setReferenceValue(encodeResourceName(id, key.getPath()));
     } else {
-      throw fail("Can't serialize " + value);
+      throw fail("Can't serialize %s", value);
     }
 
     return builder.build();
@@ -330,7 +330,7 @@ public final class RemoteSerializer {
       case MAP_VALUE:
         return decodeMapValue(proto.getMapValue());
       default:
-        throw fail("Unknown value " + proto);
+        throw fail("Unknown value %s", proto);
     }
   }
 
@@ -446,7 +446,7 @@ public final class RemoteSerializer {
     } else if (mutation instanceof DeleteMutation) {
       builder.setDelete(encodeKey(mutation.getKey()));
     } else {
-      throw fail("unknown mutation type ", mutation.getClass());
+      throw fail("unknown mutation type %s", mutation.getClass());
     }
 
     if (!mutation.getPrecondition().isNone()) {
@@ -579,7 +579,8 @@ public final class RemoteSerializer {
         hardAssert(
             fieldTransform.getSetToServerValue()
                 == DocumentTransform.FieldTransform.ServerValue.REQUEST_TIME,
-            "Unknown transform setToServerValue: " + fieldTransform.getSetToServerValue());
+            "Unknown transform setToServerValue: %s",
+            fieldTransform.getSetToServerValue());
         return new FieldTransform(
             FieldPath.fromServerFormat(fieldTransform.getFieldPath()),
             ServerTimestampOperation.getInstance());
@@ -857,7 +858,7 @@ public final class RemoteSerializer {
     } else if (filter instanceof NullFilter) {
       proto.setOp(UnaryFilter.Operator.IS_NULL);
     } else {
-      throw fail("Unrecognized filter: " + filter.getCanonicalId());
+      throw fail("Unrecognized filter: %s", filter.getCanonicalId());
     }
     return StructuredQuery.Filter.newBuilder().setUnaryFilter(proto).build();
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/TargetState.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/TargetState.java
@@ -106,7 +106,7 @@ final class TargetState {
           removedDocuments = removedDocuments.insert(key);
           break;
         default:
-          throw fail("Encountered invalid change type: " + changeType);
+          throw fail("Encountered invalid change type: %s", changeType);
       }
     }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/WatchChangeAggregator.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/WatchChangeAggregator.java
@@ -148,7 +148,7 @@ public class WatchChangeAggregator {
           }
           break;
         default:
-          throw fail("Unknown target watch change state: " + targetChange.getChangeType());
+          throw fail("Unknown target watch change state: %s", targetChange.getChangeType());
       }
     }
   }
@@ -187,7 +187,7 @@ public class WatchChangeAggregator {
           removeDocumentFromTarget(targetId, key, new NoDocument(key, SnapshotVersion.NONE));
         } else {
           hardAssert(
-              expectedCount == 1, "Single document existence filter with count: " + expectedCount);
+              expectedCount == 1, "Single document existence filter with count: %d", expectedCount);
         }
       } else {
         long currentSize = getCurrentDocumentCountForTarget(targetId);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
@@ -718,7 +718,7 @@ public class CustomClassMapper {
           if (throwOnUnknownProperties) {
             throw new RuntimeException(message);
           } else if (warnOnUnknownProperties) {
-            Logger.warn(CustomClassMapper.class.getSimpleName(), message);
+            Logger.warn(CustomClassMapper.class.getSimpleName(), "%s", message);
           }
         }
       }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -344,7 +344,7 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
       }
       return query;
     } else {
-      throw Assert.fail("Invalid query: " + querySpec);
+      throw Assert.fail("Invalid query: %s", querySpec);
     }
   }
 
@@ -761,7 +761,7 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
       throw Assert.fail(
           "'applyClientState' is not supported on Android and should only be used in multi-client tests");
     } else {
-      throw Assert.fail("Unknown step: " + step);
+      throw Assert.fail("Unknown step: %s", step);
     }
   }
 


### PR DESCRIPTION
When the format string is not, it could be imfluenced by error messages
or user input, and could possibly include illegal format specifiers
(such as %p). While not as dangerous as in C/C++, this can cause
exceptions to be thrown, which is especially bad, since the reason we're
printf'ing is typically because we're in the middle of error handling.

As part of this, I've audited usages of:
- f.f.util.Assert.hardAssert
- f.f.util.Assert.fail
- f.f.util.Logger.warn
- f.f.util.Logger.debug
- java.lang.String.format