### PR TITLE
Add INTERNET and ACCESS_NETWORK_STATE to database permissions.

### DIFF
--- a/firebase-database/src/main/AndroidManifest.xml
+++ b/firebase-database/src/main/AndroidManifest.xml
@@ -16,4 +16,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.firebase.database">
     <uses-sdk android:minSdkVersion="14"/>
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
I'm not sure what changed so that now this is necessary, but I assume this change will resolve https://github.com/firebase/firebase-android-sdk/issues/18.  That said I haven't explicitly validated this as I'm not sure how.

cc/ @samtstern 