### PR TITLE
Allow initial call to .getReference() from any thread

### DIFF
--- a/firebase-database/src/androidTest/java/com/google/firebase/database/TestHelpers.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/TestHelpers.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import android.os.Looper;
 import android.support.test.InstrumentationRegistry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -489,7 +488,6 @@ public class TestHelpers {
 
   public static void ensureAppInitialized() {
     if (!appInitialized) {
-      Looper.prepare();
       appInitialized = true;
       android.content.Context context = InstrumentationRegistry.getTargetContext();
       FirebaseApp.initializeApp(
@@ -504,7 +502,6 @@ public class TestHelpers {
 
   public static void ensureConstantsInitialized() {
     if (!appInitialized) {
-      Looper.prepare();
       appInitialized = true;
       android.content.Context context = InstrumentationRegistry.getTargetContext();
       FirebaseApp.initializeApp(

--- a/firebase-database/src/main/java/com/google/firebase/database/android/AndroidEventTarget.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/android/AndroidEventTarget.java
@@ -15,13 +15,14 @@
 package com.google.firebase.database.android;
 
 import android.os.Handler;
+import android.os.Looper;
 import com.google.firebase.database.core.EventTarget;
 
 public class AndroidEventTarget implements EventTarget {
   private final Handler handler;
 
   public AndroidEventTarget() {
-    this.handler = new Handler();
+    this.handler = new Handler(Looper.getMainLooper());
   }
 
   @Override


### PR DESCRIPTION
This allows me to run the following in a test app without crashes:
```
  new Thread(new Runnable() {
            @Override
            public void run() {
                try {
                    final DatabaseReference reference = FirebaseDatabase.getInstance().getReference();
                    reference.child("foo/test").setValue("done");
                    } catch (Throwable t) {
                    System.out.println(t);
                    }
            }
        }).start();
```