### PR TITLE
Don't leak orphaned docs when deleting

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
@@ -152,7 +152,7 @@ class MemoryLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
 
   /**
    * @return true if there is anything that would keep the given document alive or if the document's
-   * sequence number is greater than the provided upper bound.
+   *     sequence number is greater than the provided upper bound.
    */
   private boolean isPinned(DocumentKey key, long upperBound) {
     if (mutationQueuesContainsKey(key)) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -83,17 +83,7 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
     return result;
   }
 
-  /** Remove any documents that the delegate reports as not pinned at the given upper bound. */
-  int removeOrphanedDocuments(MemoryLruReferenceDelegate delegate, long upperBound) {
-    int count = 0;
-    ImmutableSortedMap<DocumentKey, MaybeDocument> updated = docs;
-    for (Map.Entry<DocumentKey, MaybeDocument> entry : docs) {
-      if (!delegate.isPinned(entry.getKey(), upperBound)) {
-        updated = updated.remove(entry.getKey());
-        count++;
-      }
-    }
-    docs = updated;
-    return count;
+  ImmutableSortedMap<DocumentKey, MaybeDocument> getDocuments() {
+    return docs;
   }
 }


### PR DESCRIPTION
Previously, we weren't deleting our tracking of orphaned documents when we deleted the doc itself. I moved the deletion into the reference delegate, which is probably a better home anyways, and delete from the orphaned doc map at the same time so we no longer leak.

Caught while porting to web.