### PR TITLE
Remove local references from reference delegate

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -558,8 +558,10 @@ public final class LocalStore {
             queryCache.updateQueryData(queryData);
           }
 
-          // We remove both locally edited documents and documents that are associated via the query
-          // cache.
+          // References for documents sent via Watch are automatically removed when we delete a
+          // query's target data from the reference delegate. Since this does not remove references
+          // for locally mutated documents, we have to remove the target associations for these
+          // documents manually.
           ImmutableSortedSet<DocumentKey> removedReferences =
               localViewReferences.removeReferencesForId(queryData.getTargetId());
           for (DocumentKey key : removedReferences) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/ReferenceSet.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/ReferenceSet.java
@@ -77,19 +77,27 @@ public class ReferenceSet {
     }
   }
 
-  /** Clears all references with a given ID. Calls removeReference() for each key removed. */
-  public void removeReferencesForId(int targetId) {
+  /**
+   * Clears all references with a given ID. Calls removeReference() for each key removed.
+   *
+   * @return The keys of the documents that were removed.
+   */
+  public ImmutableSortedSet<DocumentKey> removeReferencesForId(int targetId) {
     DocumentKey emptyKey = DocumentKey.empty();
     DocumentReference startRef = new DocumentReference(emptyKey, targetId);
     Iterator<DocumentReference> it = referencesByTarget.iteratorFrom(startRef);
+    ImmutableSortedSet<DocumentKey> keys = DocumentKey.emptyKeySet();
     while (it.hasNext()) {
       DocumentReference ref = it.next();
       if (ref.getId() == targetId) {
+        keys = keys.insert(ref.getKey());
         removeReference(ref);
       } else {
         break;
       }
     }
+
+    return keys;
   }
 
   /** Clears all references for all IDs. */

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -240,6 +240,31 @@ public abstract class LocalStoreTestCase {
   }
 
   @Test
+  public void testHandlesSetMutationThenAckThenRelease() {
+    Query query = Query.atPath(ResourcePath.fromSegments(asList("foo")));
+    allocateQuery(query);
+
+    writeMutation(setMutation("foo/bar", map("foo", "bar")));
+    assertChanged(doc("foo/bar", 0, map("foo", "bar"), true));
+    assertContains(doc("foo/bar", 0, map("foo", "bar"), true));
+
+    acknowledgeMutation(1);
+    notifyLocalViewChanges(viewChanges(2, asList("foo/bar"), emptyList()));
+
+    assertChanged();
+    assertContains(doc("foo/bar", 0, map("foo", "bar"), true));
+
+    releaseQuery(query);
+
+    // It has been acknowledged, and should no longer be retained as there is no target and mutation
+    if (garbageCollectorIsEager()) {
+      assertNotContains("foo/bar");
+    } else {
+      assertContains(doc("foo/bar", 0, map("foo", "bar"), false));
+    }
+  }
+
+  @Test
   public void testHandlesAckThenRejectThenRemoteEvent() {
     // Start a query that requires acks to be held.
     Query query = Query.atPath(ResourcePath.fromSegments(asList("foo")));


### PR DESCRIPTION
Fixes issue with GC that prevented local document removal for documents that had pending mutations.

Also renames applyBatchResult to applyWriteToRemoteDocuments to match Web.