### PR TITLE
Revert "Add maven proxy configuration. (#20)"

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,11 +17,6 @@ plugins {
 }
 
 repositories {
-    if (System.getenv().containsKey("FIREBASE_CI")) {
-        maven {
-            url "http://maven-proxy/"
-        }
-    }
     maven {
         url 'https://maven.google.com/'
     }

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -18,11 +18,6 @@ import groovy.io.FileType
 buildscript {
 
     repositories {
-        if (System.getenv().containsKey("FIREBASE_CI")) {
-            maven {
-                url "http://maven-proxy/"
-            }
-        }
         google()
         jcenter()
         mavenCentral()
@@ -52,11 +47,6 @@ apply plugin: com.google.firebase.gradle.plugins.publish.PublishingPlugin
 
 configure(subprojects) {
     repositories {
-        if (System.getenv().containsKey("FIREBASE_CI")) {
-            maven {
-                url "http://maven-proxy/"
-            }
-        }
         google()
         jcenter()
         mavenLocal()

--- a/test-apps/build.gradle
+++ b/test-apps/build.gradle
@@ -16,11 +16,6 @@
 
 buildscript {
     repositories {
-        if (System.getenv().containsKey("FIREBASE_CI")) {
-            maven {
-                url "http://maven-proxy/"
-            }
-        }
         jcenter()
         mavenLocal()
         google()
@@ -49,11 +44,6 @@ allprojects {
     }
 
     repositories {
-        if (System.getenv().containsKey("FIREBASE_CI")) {
-            maven {
-                url "http://maven-proxy/"
-            }
-        }
         //mavenLocal() can be overridden via GRADLE_OPTS="-Dmaven.repo.local=<path>"
         mavenLocal()
         jcenter()


### PR DESCRIPTION
This reverts commit a4357b884f9e526fb5252cb372236bb7d1df73f7.

https://github.com/firebase/firebase-android-sdk/pull/50 is currently failing on maven artifact downloads. It is unclear whether the proxy is causing the issue. This seems like a good way to test if it is.