### PR TITLE
Add dependency on empty version of listenablefuture.

### DIFF
--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -99,6 +99,8 @@ dependencies {
     implementation "com.google.android.gms:play-services-tasks:$playServicesVersion"
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
 
+    implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
+
     implementation 'com.squareup.okhttp:okhttp:2.7.2'
     implementation ('com.google.firebase:firebase-auth-interop:16.0.1') {
         exclude group: "com.google.firebase", module: "firebase-common"


### PR DESCRIPTION
This avoids the classpath conflict when both guava and listenablefuture
libraries are present.

See https://groups.google.com/forum/#!topic/guava-announce/Km82fZG68Sw
for context.