### PR TITLE
Experimental namespacing

### DIFF
--- a/firebase-common/gradle.properties
+++ b/firebase-common/gradle.properties
@@ -1,2 +1,3 @@
 version=16.0.4
 latestReleasedVersion=16.0.3
+android.namespacedRClass=true

--- a/firebase-database-collection/gradle.properties
+++ b/firebase-database-collection/gradle.properties
@@ -1,2 +1,3 @@
 version=16.0.1
 latestReleasedVersion=16.0.0
+android.namespacedRClass=true

--- a/firebase-firestore/gradle.properties
+++ b/firebase-firestore/gradle.properties
@@ -1,2 +1,3 @@
 version=17.1.2
 latestReleasedVersion=17.1.1
+android.namespacedRClass=true

--- a/firebase-functions/gradle.properties
+++ b/firebase-functions/gradle.properties
@@ -1,2 +1,3 @@
 version=16.1.2
 latestReleasedVersion=16.1.1
+android.namespacedRClass=true

--- a/firebase-storage/gradle.properties
+++ b/firebase-storage/gradle.properties
@@ -14,3 +14,4 @@
 
 version=16.0.4
 latestReleasedVersion=16.0.3
+android.namespacedRClass=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.namespacedRClass=true

--- a/protolite-well-known-types/gradle.properties
+++ b/protolite-well-known-types/gradle.properties
@@ -1,2 +1,3 @@
 version=16.1.0
 latestReleasedVersion=16.0.0
+android.namespacedRClass=true

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -27,7 +27,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha06'
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
         classpath 'org.jsoup:jsoup:1.11.2'


### PR DESCRIPTION
This is supposed to fix https://github.com/firebase/firebase-android-sdk/issues/59. But, I see that the R.txt files in the published aar still contain transitive resources.

Steps to repro
```
./gradlew clean :firebase-firestore:publishToMavenLocal
jar xf ~/.m2/repository/com/google/firebase/firebase-firestore/17.1.2-SNAPSHOT/firebase-firestore-17.1.2-SNAPSHOT.aar
vi R.txt
```

I was hoping to get an extra pair of eyes.