### PR TITLE
LocalStore uses a SparseArray to track target ids, not a set

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruDelegate.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.firestore.local;
 
+import android.util.SparseArray;
+
 import com.google.firebase.firestore.util.Consumer;
 import java.util.Set;
 
@@ -37,7 +39,7 @@ interface LruDelegate {
    *
    * @return the number of targets removed.
    */
-  int removeTargets(long upperBound, Set<Integer> activeTargetIds);
+  int removeTargets(long upperBound, SparseArray<?> activeTargetIds);
 
   /**
    * Removes all unreferenced documents from the cache that have a sequence number less than or

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruGarbageCollector.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruGarbageCollector.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.firestore.local;
 
+import android.util.SparseArray;
+
 import com.google.firebase.firestore.core.ListenSequence;
 import java.util.Comparator;
 import java.util.PriorityQueue;
@@ -80,7 +82,7 @@ class LruGarbageCollector {
    * Removes targets with a sequence number equal to or less than the given upper bound, and removes
    * document associations with those targets.
    */
-  int removeTargets(long upperBound, Set<Integer> activeTargetIds) {
+  int removeTargets(long upperBound, SparseArray<?> activeTargetIds) {
     return delegate.removeTargets(upperBound, activeTargetIds);
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.firestore.local;
 
+import android.util.SparseArray;
+
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import com.google.firebase.firestore.core.ListenSequence;
@@ -94,7 +96,7 @@ class MemoryLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   }
 
   @Override
-  public int removeTargets(long upperBound, Set<Integer> activeTargetIds) {
+  public int removeTargets(long upperBound, SparseArray<?> activeTargetIds) {
     return persistence.getQueryCache().removeQueries(upperBound, activeTargetIds);
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryQueryCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryQueryCache.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.firestore.local;
 
+import android.util.SparseArray;
+
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.model.DocumentKey;
@@ -22,7 +24,6 @@ import com.google.firebase.firestore.util.Consumer;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -115,13 +116,13 @@ final class MemoryQueryCache implements QueryCache {
    *
    * @return the number of targets removed
    */
-  int removeQueries(long upperBound, Set<Integer> activeTargetIds) {
+  int removeQueries(long upperBound, SparseArray<?> activeTargetIds) {
     int removed = 0;
     for (Iterator<Map.Entry<Query, QueryData>> it = queries.entrySet().iterator(); it.hasNext(); ) {
       Map.Entry<Query, QueryData> entry = it.next();
       int targetId = entry.getValue().getTargetId();
       long sequenceNumber = entry.getValue().getSequenceNumber();
-      if (sequenceNumber <= upperBound && !activeTargetIds.contains(targetId)) {
+      if (sequenceNumber <= upperBound && activeTargetIds.get(targetId) == null) {
         it.remove();
         removeMatchingKeysForTargetId(targetId);
         removed++;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.firestore.local;
 
+import android.util.SparseArray;
+
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import com.google.firebase.firestore.core.ListenSequence;
@@ -103,7 +105,7 @@ class SQLiteLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   }
 
   @Override
-  public int removeTargets(long upperBound, Set<Integer> activeTargetIds) {
+  public int removeTargets(long upperBound, SparseArray<?> activeTargetIds) {
     return persistence.getQueryCache().removeQueries(upperBound, activeTargetIds);
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteQueryCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteQueryCache.java
@@ -18,6 +18,8 @@ import static com.google.firebase.firestore.util.Assert.fail;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import android.database.sqlite.SQLiteStatement;
+import android.util.SparseArray;
+
 import com.google.firebase.Timestamp;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.Query;
@@ -186,7 +188,7 @@ final class SQLiteQueryCache implements QueryCache {
    * present in `activeTargetIds`. Document associations for the removed targets are also removed.
    * Returns the number of targets removed.
    */
-  int removeQueries(long upperBound, Set<Integer> activeTargetIds) {
+  int removeQueries(long upperBound, SparseArray<?> activeTargetIds) {
     int[] count = new int[1];
     // SQLite has a max sql statement size, so there is technically a possibility that including a
     // an IN clause in this query to filter `activeTargetIds` could overflow. Rather than deal with
@@ -196,7 +198,7 @@ final class SQLiteQueryCache implements QueryCache {
         .forEach(
             row -> {
               int targetId = row.getInt(0);
-              if (!activeTargetIds.contains(targetId)) {
+              if (activeTargetIds.get(targetId) == null) {
                 removeTarget(targetId);
                 count[0]++;
               }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.firestore.local;
 
+import android.util.SparseArray;
+
 import static com.google.firebase.firestore.testutil.TestUtil.doc;
 import static com.google.firebase.firestore.testutil.TestUtil.keySet;
 import static com.google.firebase.firestore.testutil.TestUtil.query;
@@ -162,7 +164,7 @@ public abstract class LruGarbageCollectorTestCase {
     queryCache.removeMatchingKeys(keySet(key), targetId);
   }
 
-  private int removeTargets(long upperBound, Set<Integer> activeTargetIds) {
+  private int removeTargets(long upperBound, SparseArray<?> activeTargetIds) {
     return persistence.runTransaction(
         "Remove queries", () -> garbageCollector.removeTargets(upperBound, activeTargetIds));
   }
@@ -283,7 +285,7 @@ public abstract class LruGarbageCollectorTestCase {
 
   @Test
   public void testRemoveQueriesUpThroughSequenceNumber() {
-    Map<Integer, QueryData> activeTargetIds = new HashMap<>();
+    SparseArray<QueryData> activeTargetIds = new SparseArray<>();
     for (int i = 0; i < 100; i++) {
       QueryData queryData = addNextQuery();
       // Mark odd queries as live so we can test filtering out live queries.
@@ -295,7 +297,7 @@ public abstract class LruGarbageCollectorTestCase {
     // GC up through 20th query, which is 20%.
     // Expect to have GC'd 10 targets, since every other target is live
     long upperBound = 20 + initialSequenceNumber;
-    int removed = removeTargets(upperBound, activeTargetIds.keySet());
+    int removed = removeTargets(upperBound, activeTargetIds);
     assertEquals(10, removed);
     // Make sure we removed the even targets with targetID <= 20.
     persistence.runTransaction(
@@ -567,8 +569,8 @@ public abstract class LruGarbageCollectorTestCase {
         });
 
     // Finally, do the garbage collection, up to but not including the removal of middleTarget
-    Set<Integer> activeTargetIds = new HashSet<>();
-    activeTargetIds.add(oldestTarget.getTargetId());
+    SparseArray<QueryData> activeTargetIds = new SparseArray<>();
+    activeTargetIds.put(oldestTarget.getTargetId(), oldestTarget);
     int targetsRemoved = garbageCollector.removeTargets(upperBound, activeTargetIds);
     // Expect to remove newest target
     assertEquals(1, targetsRemoved);


### PR DESCRIPTION
No functional changes, just switches `Set` -> `SparseArray` for LRU stuff since `LocalStore` already uses a `SparseArray` to track active targets.