### PR TITLE
Allow passing POJOs as field values throughout API.

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -2,6 +2,9 @@
 - [feature] Custom objects (POJOs) can now be passed as a field value in
   update(), within `Map<>` objects passed to set(), in array transform
   operations, and in query filters.
+- [feature] DocumentSnapshot.get() now supports retrieving fields as
+  custom objects (POJOs) by passing a Class<T> instance, e.g.
+  `snapshot.get("field", CustomType.class)`.
 
 # 17.1.2
 - [changed] Changed the internal handling for locally updated documents that

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [feature] Custom objects (POJOs) can now be passed as a field value in
+  update(), within `Map<>` objects passed to set(), in array transform
+  operations, and in query filters.
 
 # 17.1.2
 - [changed] Changed the internal handling for locally updated documents that
@@ -8,9 +11,6 @@
 - [changed] Eliminated superfluous update events for locally cached documents
   that are known to lag behind the server version. Instead, we buffer these
   events until the client has caught up with the server.
-- [feature] Custom objects (POJOs) can now be passed as a field value in
-  update(), within `Map<>` objects passed to set(), in array transform
-  operations, and in query filters.
 
 # 17.1.1
 - [fixed] Fixed an issue where the first `get()` call made after being offline

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -6,6 +6,9 @@
 - [changed] Eliminated superfluous update events for locally cached documents
   that are known to lag behind the server version. Instead, we buffer these
   events until the client has caught up with the server.
+- [feature] Custom objects (POJOs) can now be passed as a field value in
+  update(), within `Map<>` objects passed to set(), in array transform
+  operations, and in query filters.
 
 # 17.1.1
 - [fixed] Fixed an issue where the first `get()` call made after being offline

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
@@ -15,13 +15,18 @@
 package com.google.firebase.firestore;
 
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testCollection;
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testDocument;
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.waitFor;
 import static com.google.firebase.firestore.testutil.TestUtil.expectError;
+import static com.google.firebase.firestore.testutil.TestUtil.map;
 import static junit.framework.Assert.assertEquals;
 
 import android.support.test.runner.AndroidJUnit4;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
+import java.util.ArrayList;
 import java.util.Date;
 import org.junit.After;
 import org.junit.Test;
@@ -175,7 +180,7 @@ public class POJOTest {
   }
 
   @Test
-  public void testUpdate() {
+  public void testSetMerge() {
     CollectionReference collection = testCollection();
     POJO data = new POJO(1.0, "a", collection.document());
     DocumentReference reference = waitFor(collection.add(data));
@@ -188,6 +193,33 @@ public class POJOTest {
     POJO expected = new POJO(2.0, "a", data.getDocumentReference());
     doc = waitFor(reference.get());
     assertEquals(expected, doc.toObject(POJO.class));
+  }
+
+  // General smoke test that makes sure APIs accept POJOs.
+  @Test
+  public void testAPIsAcceptPOJOsForFields() {
+    DocumentReference ref = testDocument();
+    ArrayList<Task<?>> tasks = new ArrayList<>();
+
+    // as Map<> entries in a set() call.
+    POJO data = new POJO(1.0, "a", ref);
+    tasks.add(ref.set(map("a", data, "b", map("c", data))));
+
+    // as Map<> entries in an update() call.
+    tasks.add(ref.update(map("a", data)));
+
+    // as field values in an update() call.
+    tasks.add(ref.update("c", data));
+
+    // as values in arrayUnion() / arrayRemove().
+    tasks.add(ref.update("c", FieldValue.arrayUnion(data)));
+    tasks.add(ref.update("c", FieldValue.arrayRemove(data)));
+
+    // as Query parameters.
+    data.setBlob(null); // blobs are broken, see b/117680212
+    tasks.add(testCollection().whereEqualTo("field", data).get());
+
+    waitFor(Tasks.whenAll(tasks));
   }
 
   @Test

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
@@ -223,6 +223,28 @@ public class POJOTest {
   }
 
   @Test
+  public void testDocumentSnapshotGetWithPOJOs() {
+    DocumentReference ref = testDocument();
+
+    // Go offline so that we can verify server timestamp behavior overload.
+    ref.getFirestore().disableNetwork();
+
+    POJO pojo = new POJO(1.0, "a", ref);
+    ref.set(map("field", pojo));
+
+    DocumentSnapshot snap = waitFor(ref.get());
+
+    assertEquals(pojo, snap.get("field", POJO.class));
+    assertEquals(pojo, snap.get(FieldPath.of("field"), POJO.class));
+    assertEquals(
+        pojo, snap.get("field", POJO.class, DocumentSnapshot.ServerTimestampBehavior.DEFAULT));
+    assertEquals(
+        pojo,
+        snap.get(
+            FieldPath.of("field"), POJO.class, DocumentSnapshot.ServerTimestampBehavior.DEFAULT));
+  }
+
+  @Test
   public void setFieldMaskMustHaveCorrespondingValue() {
     CollectionReference collection = testCollection();
     DocumentReference reference = collection.document();

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
@@ -249,6 +249,28 @@ public class ServerTimestampTest {
   }
 
   @Test
+  public void testServerTimestampBehaviorOverloadsOfDocumentSnapshotGet() {
+    writeInitialData();
+    waitFor(docRef.update(updateData));
+    DocumentSnapshot snap = accumulator.awaitLocalEvent();
+
+    // Default behavior should return null timestamp (via any overload).
+    assertNull(snap.get("when"));
+    assertNull(snap.get(FieldPath.of("when")));
+    assertNull(snap.get("when", Timestamp.class));
+    assertNull(snap.get(FieldPath.of("when"), Timestamp.class));
+
+    // Estimate should return a Timestamp object (via any overload).
+    assertThat(snap.get("when", ServerTimestampBehavior.ESTIMATE)).isInstanceOf(Timestamp.class);
+    assertThat(snap.get(FieldPath.of("when"), ServerTimestampBehavior.ESTIMATE))
+        .isInstanceOf(Timestamp.class);
+    assertThat(snap.get("when", Timestamp.class, ServerTimestampBehavior.ESTIMATE))
+        .isInstanceOf(Timestamp.class);
+    assertThat(snap.get(FieldPath.of("when"), Timestamp.class, ServerTimestampBehavior.ESTIMATE))
+        .isInstanceOf(Timestamp.class);
+  }
+
+  @Test
   public void testServerTimestampsWorkViaTransactionSet() {
     waitFor(
         docRef

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -376,7 +376,8 @@ public class ValidationTest {
   @Test
   public void arrayTransformsRejectInvalidElements() {
     DocumentReference doc = testDocument();
-    String reason = "No properties to serialize found on class com.google.firebase.firestore.ValidationTest";
+    String reason =
+        "No properties to serialize found on class com.google.firebase.firestore.ValidationTest";
     // TODO: If we get more permissive with POJOs, perhaps we should make this work.
     expectError(() -> doc.set(map("x", FieldValue.arrayUnion(1, this))), reason);
     expectError(() -> doc.set(map("x", FieldValue.arrayRemove(1, this))), reason);

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -558,15 +558,8 @@ public class ValidationTest {
     DocumentReference ref = testDocument();
 
     if (includeSets) {
-      if (data instanceof Map) {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> setMap = (Map<String, Object>) data;
-        expectError(() -> ref.set(setMap), reason);
-        expectError(() -> ref.getFirestore().batch().set(ref, setMap), reason);
-      } else {
-        expectError(() -> ref.set(data), reason);
-        expectError(() -> ref.getFirestore().batch().set(ref, data), reason);
-      }
+      expectError(() -> ref.set(data), reason);
+      expectError(() -> ref.getFirestore().batch().set(ref, data), reason);
     }
 
     if (includeUpdates) {
@@ -593,13 +586,7 @@ public class ValidationTest {
                 (Function<Void>)
                     transaction -> {
                       if (includeSets) {
-                        if (data instanceof Map) {
-                          @SuppressWarnings("unchecked")
-                          Map<String, Object> setMap = (Map<String, Object>) data;
-                          expectError(() -> transaction.set(ref, setMap), reason);
-                        } else {
-                          expectError(() -> transaction.set(ref, data), reason);
-                        }
+                        expectError(() -> transaction.set(ref, data), reason);
                       }
                       if (includeUpdates) {
                         assertTrue("update() only support Maps.", data instanceof Map);

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -257,22 +257,16 @@ public class ValidationTest {
 
   @Test
   public void setsMustNotContainFieldValueDelete() {
-    // PORTING NOTE: We avoid using expectSetError(), since it hits the POJO overload which
-    // can't handle FieldValue.delete().
-    DocumentReference ref = testDocument();
-    expectError(
-        () -> ref.set(map("foo", FieldValue.delete())),
+    expectSetError(
+        map("foo", FieldValue.delete()),
         "Invalid data. FieldValue.delete() can only be used with update() and set() with "
             + "SetOptions.merge() (found in field foo)");
   }
 
   @Test
   public void updatesMustNotContainNestedFieldValueDeletes() {
-    // PORTING NOTE: We avoid using expectSetError(), since it hits the POJO overload which
-    // can't handle FieldValue.delete().
-    DocumentReference ref = testDocument();
-    expectError(
-        () -> ref.update(map("foo", map("bar", FieldValue.delete()))),
+    expectUpdateError(
+        map("foo", map("bar", FieldValue.delete())),
         "Invalid data. FieldValue.delete() can only appear at the top level of your update data "
             + "(found in field foo.bar)");
   }
@@ -378,7 +372,6 @@ public class ValidationTest {
     DocumentReference doc = testDocument();
     String reason =
         "No properties to serialize found on class com.google.firebase.firestore.ValidationTest";
-    // TODO: If we get more permissive with POJOs, perhaps we should make this work.
     expectError(() -> doc.set(map("x", FieldValue.arrayUnion(1, this))), reason);
     expectError(() -> doc.set(map("x", FieldValue.arrayRemove(1, this))), reason);
   }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -376,7 +376,7 @@ public class ValidationTest {
   @Test
   public void arrayTransformsRejectInvalidElements() {
     DocumentReference doc = testDocument();
-    String reason = "Invalid data. Unsupported type: com.google.firebase.firestore.ValidationTest";
+    String reason = "No properties to serialize found on class com.google.firebase.firestore.ValidationTest";
     // TODO: If we get more permissive with POJOs, perhaps we should make this work.
     expectError(() -> doc.set(map("x", FieldValue.arrayUnion(1, this))), reason);
     expectError(() -> doc.set(map("x", FieldValue.arrayRemove(1, this))), reason);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
@@ -23,7 +23,6 @@ import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.util.Executors;
 import com.google.firebase.firestore.util.Util;
-import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -117,12 +116,13 @@ public class CollectionReference extends Query {
    * Adds a new document to this collection with the specified data, assigning it a document ID
    * automatically.
    *
-   * @param data A Map containing the data for the new document.
+   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
+   *     document contents).
    * @return A Task that will be resolved with the DocumentReference of the newly created document.
    */
   @NonNull
   @PublicApi
-  public Task<DocumentReference> add(@NonNull Map<String, Object> data) {
+  public Task<DocumentReference> add(@NonNull Object data) {
     checkNotNull(data, "Provided data must not be null.");
     final DocumentReference ref = document();
     return ref.set(data)
@@ -133,18 +133,5 @@ public class CollectionReference extends Query {
               task.getResult();
               return ref;
             });
-  }
-
-  /**
-   * Adds a new document to this collection with the specified POJO as contents, assigning it a
-   * document ID automatically.
-   *
-   * @param pojo The POJO that will be used to populate the contents of the document
-   * @return A Task that will be resolved with the DocumentReference of the newly created document.
-   */
-  @NonNull
-  @PublicApi
-  public Task<DocumentReference> add(@NonNull Object pojo) {
-    return add(firestore.getDataConverter().convertPOJO(pojo));
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -143,12 +143,13 @@ public class DocumentReference {
    * Overwrites the document referred to by this DocumentReference. If the document does not yet
    * exist, it will be created. If a document already exists, it will be overwritten.
    *
-   * @param data A map of the fields and values for the document.
+   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
+   *     document contents).
    * @return A Task that will be resolved when the write finishes.
    */
   @NonNull
   @PublicApi
-  public Task<Void> set(@NonNull Map<String, Object> data) {
+  public Task<Void> set(@NonNull Object data) {
     return set(data, SetOptions.OVERWRITE);
   }
 
@@ -157,13 +158,14 @@ public class DocumentReference {
    * exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged into
    * an existing document.
    *
-   * @param data A map of the fields and values for the document.
+   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
+   *     document contents).
    * @param options An object to configure the set behavior.
    * @return A Task that will be resolved when the write finishes.
    */
   @NonNull
   @PublicApi
-  public Task<Void> set(@NonNull Map<String, Object> data, @NonNull SetOptions options) {
+  public Task<Void> set(@NonNull Object data, @NonNull SetOptions options) {
     checkNotNull(data, "Provided data must not be null.");
     checkNotNull(options, "Provided options must not be null.");
     ParsedSetData parsed =
@@ -174,34 +176,6 @@ public class DocumentReference {
         .getClient()
         .write(parsed.toMutationList(key, Precondition.NONE))
         .continueWith(Executors.DIRECT_EXECUTOR, voidErrorTransformer());
-  }
-
-  /**
-   * Overwrites the document referred to by this DocumentReference. If the document does not yet
-   * exist, it will be created. If a document already exists, it will be overwritten.
-   *
-   * @param pojo The POJO that will be used to populate the document contents
-   * @return A Task that will be resolved when the write finishes.
-   */
-  @NonNull
-  @PublicApi
-  public Task<Void> set(@NonNull Object pojo) {
-    return set(firestore.getDataConverter().convertPOJO(pojo), SetOptions.OVERWRITE);
-  }
-
-  /**
-   * Writes to the document referred to by this DocumentReference. If the document does not yet
-   * exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged into
-   * an existing document.
-   *
-   * @param pojo The POJO that will be used to populate the document contents
-   * @param options An object to configure the set behavior.
-   * @return A Task that will be resolved when the write finishes.
-   */
-  @NonNull
-  @PublicApi
-  public Task<Void> set(@NonNull Object pojo, @NonNull SetOptions options) {
-    return set(firestore.getDataConverter().convertPOJO(pojo), options);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -290,6 +290,69 @@ public class DocumentSnapshot {
   }
 
   /**
+   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
+   * exist.
+   *
+   * @param field The path to the field
+   * @param valueType The Java class to convert the field value to.
+   * @return The value at the given field or null.
+   */
+  @Nullable
+  public <T> T get(@NonNull String field, @NonNull Class<T> valueType) {
+    return get(FieldPath.fromDotSeparatedPath(field), valueType, ServerTimestampBehavior.DEFAULT);
+  }
+
+  /**
+   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
+   * exist.
+   *
+   * @param field The path to the field
+   * @param valueType The Java class to convert the field value to.
+   * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
+   *     been set to their final value.
+   * @return The value at the given field or null.
+   */
+  @Nullable
+  public <T> T get(
+      @NonNull String field,
+      @NonNull Class<T> valueType,
+      @NonNull ServerTimestampBehavior serverTimestampBehavior) {
+    return get(FieldPath.fromDotSeparatedPath(field), valueType, serverTimestampBehavior);
+  }
+
+  /**
+   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
+   * exist.
+   *
+   * @param fieldPath The path to the field
+   * @param valueType The Java class to convert the field value to.
+   * @return The value at the given field or null.
+   */
+  @Nullable
+  public <T> T get(@NonNull FieldPath fieldPath, @NonNull Class<T> valueType) {
+    return get(fieldPath, valueType, ServerTimestampBehavior.DEFAULT);
+  }
+
+  /**
+   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
+   * exist.
+   *
+   * @param fieldPath The path to the field
+   * @param valueType The Java class to convert the field value to.
+   * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
+   *     been set to their final value.
+   * @return The value at the given field or null.
+   */
+  @Nullable
+  public <T> T get(
+      @NonNull FieldPath fieldPath,
+      @NonNull Class<T> valueType,
+      @NonNull ServerTimestampBehavior serverTimestampBehavior) {
+    Object data = get(fieldPath, serverTimestampBehavior);
+    return data == null ? null : CustomClassMapper.convertToCustomClass(data, valueType);
+  }
+
+  /**
    * Returns the value of the field as a boolean. If the value is not a boolean this will throw a
    * runtime exception.
    *

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
@@ -60,13 +60,13 @@ public class Transaction {
    * yet exist, it will be created. If a document already exists, it will be overwritten.
    *
    * @param documentRef The DocumentReference to overwrite.
-   * @param data A map of the fields and values for the document.
+   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
+   *     document contents).
    * @return This Transaction instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
-  public Transaction set(
-      @NonNull DocumentReference documentRef, @NonNull Map<String, Object> data) {
+  public Transaction set(@NonNull DocumentReference documentRef, @NonNull Object data) {
     return set(documentRef, data, SetOptions.OVERWRITE);
   }
 
@@ -76,16 +76,15 @@ public class Transaction {
    * into an existing document.
    *
    * @param documentRef The DocumentReference to overwrite.
-   * @param data A map of the fields and values for the document.
+   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
+   *     document contents).
    * @param options An object to configure the set behavior.
    * @return This Transaction instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
   public Transaction set(
-      @NonNull DocumentReference documentRef,
-      @NonNull Map<String, Object> data,
-      @NonNull SetOptions options) {
+      @NonNull DocumentReference documentRef, @NonNull Object data, @NonNull SetOptions options) {
     firestore.validateReference(documentRef);
     checkNotNull(data, "Provided data must not be null.");
     checkNotNull(options, "Provided options must not be null.");
@@ -95,37 +94,6 @@ public class Transaction {
             : firestore.getDataConverter().parseSetData(data);
     transaction.set(documentRef.getKey(), parsed);
     return this;
-  }
-
-  /**
-   * Overwrites the document referred to by the provided DocumentReference. If the document does not
-   * yet exist, it will be created. If a document already exists, it will be overwritten.
-   *
-   * @param documentRef The DocumentReference to overwrite.
-   * @param pojo The POJO that will be used to populate the document contents
-   * @return This Transaction instance. Used for chaining method calls.
-   */
-  @NonNull
-  @PublicApi
-  public Transaction set(@NonNull DocumentReference documentRef, @NonNull Object pojo) {
-    return set(documentRef, firestore.getDataConverter().convertPOJO(pojo), SetOptions.OVERWRITE);
-  }
-
-  /**
-   * Writes to the document referred to by the provided DocumentReference. If the document does not
-   * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
-   * into an existing document.
-   *
-   * @param documentRef The DocumentReference to overwrite.
-   * @param pojo The POJO that will be used to populate the document contents
-   * @param options An object to configure the set behavior.
-   * @return This Transaction instance. Used for chaining method calls.
-   */
-  @NonNull
-  @PublicApi
-  public Transaction set(
-      @NonNull DocumentReference documentRef, @NonNull Object pojo, @NonNull SetOptions options) {
-    return set(documentRef, firestore.getDataConverter().convertPOJO(pojo), options);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
@@ -59,12 +59,13 @@ public class WriteBatch {
    * yet exist, it will be created. If a document already exists, it will be overwritten.
    *
    * @param documentRef The DocumentReference to overwrite.
-   * @param data A map of the fields and values for the document.
+   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
+   *     document contents).
    * @return This WriteBatch instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
-  public WriteBatch set(@NonNull DocumentReference documentRef, @NonNull Map<String, Object> data) {
+  public WriteBatch set(@NonNull DocumentReference documentRef, @NonNull Object data) {
     return set(documentRef, data, SetOptions.OVERWRITE);
   }
 
@@ -74,18 +75,18 @@ public class WriteBatch {
    * into an existing document.
    *
    * @param documentRef The DocumentReference to overwrite.
-   * @param data A map of the fields and values for the document.
+   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
+   *     document contents).
    * @param options An object to configure the set behavior.
    * @return This WriteBatch instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
   public WriteBatch set(
-      @NonNull DocumentReference documentRef,
-      @NonNull Map<String, Object> data,
-      @NonNull SetOptions options) {
+      @NonNull DocumentReference documentRef, @NonNull Object data, @NonNull SetOptions options) {
     firestore.validateReference(documentRef);
     checkNotNull(data, "Provided data must not be null.");
+    checkNotNull(options, "Provided options must not be null.");
     verifyNotCommitted();
     ParsedSetData parsed =
         options.isMerge()
@@ -93,37 +94,6 @@ public class WriteBatch {
             : firestore.getDataConverter().parseSetData(data);
     mutations.addAll(parsed.toMutationList(documentRef.getKey(), Precondition.NONE));
     return this;
-  }
-
-  /**
-   * Overwrites the document referred to by the provided DocumentReference. If the document does not
-   * yet exist, it will be created. If a document already exists, it will be overwritten.
-   *
-   * @param documentRef The DocumentReference to overwrite.
-   * @param pojo The POJO that will be used to populate the document contents.
-   * @return This WriteBatch instance. Used for chaining method calls.
-   */
-  @NonNull
-  @PublicApi
-  public WriteBatch set(@NonNull DocumentReference documentRef, @NonNull Object pojo) {
-    return set(documentRef, firestore.getDataConverter().convertPOJO(pojo), SetOptions.OVERWRITE);
-  }
-
-  /**
-   * Writes to the document referred to by the provided DocumentReference. If the document does not
-   * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
-   * into an existing document.
-   *
-   * @param documentRef The DocumentReference to overwrite.
-   * @param pojo The POJO that will be used to populate the document contents.
-   * @param options An object to configure the set behavior.
-   * @return This WriteBatch instance. Used for chaining method calls.
-   */
-  @NonNull
-  @PublicApi
-  public WriteBatch set(
-      @NonNull DocumentReference documentRef, @NonNull Object pojo, @NonNull SetOptions options) {
-    return set(documentRef, firestore.getDataConverter().convertPOJO(pojo), options);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
@@ -161,7 +161,8 @@ public class CustomClassMapper {
         || o instanceof Timestamp
         || o instanceof GeoPoint
         || o instanceof Blob
-        || o instanceof DocumentReference) {
+        || o instanceof DocumentReference
+        || o instanceof FieldValue) {
       return o;
     } else {
       Class<T> clazz = (Class<T>) o.getClass();
@@ -508,12 +509,12 @@ public class CustomClassMapper {
     }
   }
 
-  private static RuntimeException serializeError(ErrorPath path, String reason) {
+  private static IllegalArgumentException serializeError(ErrorPath path, String reason) {
     reason = "Could not serialize object. " + reason;
     if (path.getLength() > 0) {
       reason = reason + " (found in field '" + path.toString() + "')";
     }
-    return new RuntimeException(reason);
+    return new IllegalArgumentException(reason);
   }
 
   private static RuntimeException deserializeError(ErrorPath path, String reason) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
@@ -411,7 +411,7 @@ public class FieldValueTest {
       wrap(array);
       fail("wrap should have failed");
     } catch (IllegalArgumentException e) {
-      assertNotEquals(-1, e.getMessage().indexOf("use a List instead"));
+      assertNotEquals(-1, e.getMessage().indexOf("use Lists instead"));
     }
   }
 


### PR DESCRIPTION
All of our parsing code now accepts POJOs meaning you can pass them:
* As values in a Map<> passed to set().
* As values to a update() call.
* As elements in an array transform operation.
* As values in query field filters.

Also removed set(Map<>) overloads since they are now redundant with set(Object).