### PR TITLE
Use orphaned docs as part of GC calculation

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
@@ -25,8 +25,8 @@ import com.google.firebase.annotations.PublicApi;
 @PublicApi
 public final class FirebaseFirestoreSettings {
   /**
-   * Constant to use with {@link
-   * FirebaseFirestoreSettings.Builder#setCacheSizeBytes(long)} to disable garbage collection.
+   * Constant to use with {@link FirebaseFirestoreSettings.Builder#setCacheSizeBytes(long)} to
+   * disable garbage collection.
    */
   @PublicApi public static final long CACHE_SIZE_UNLIMITED = -1;
 
@@ -140,8 +140,8 @@ public final class FirebaseFirestoreSettings {
      * guarantee that the cache will stay below that size, only that if the cache exceeds the given
      * size, cleanup will be attempted.
      *
-     * <p>The default value is 100 MB. The threshold must be set to at least 1 MB, and can be set
-     * to {@link FirebaseFirestoreSettings#CACHE_SIZE_UNLIMITED} to disable garbage collection.
+     * <p>The default value is 100 MB. The threshold must be set to at least 1 MB, and can be set to
+     * {@link FirebaseFirestoreSettings#CACHE_SIZE_UNLIMITED} to disable garbage collection.
      *
      * @return A settings object on which the cache size is configured as specified by the given
      *     {@code value}.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruDelegate.java
@@ -26,7 +26,7 @@ public interface LruDelegate {
   /** Enumerates all the targets in the QueryCache. */
   void forEachTarget(Consumer<QueryData> consumer);
 
-  long getTargetCount();
+  long getSequenceNumberCount();
 
   /** Enumerates sequence numbers for documents not associated with a target. */
   void forEachOrphanedDocumentSequenceNumber(Consumer<Long> consumer);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruGarbageCollector.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruGarbageCollector.java
@@ -109,7 +109,7 @@ public class LruGarbageCollector {
 
   /** Given a percentile of target to collect, returns the number of targets to collect. */
   int calculateQueryCount(int percentile) {
-    long targetCount = delegate.getTargetCount();
+    long targetCount = delegate.getSequenceNumberCount();
     return (int) ((percentile / 100.0f) * targetCount);
   }
 
@@ -216,15 +216,13 @@ public class LruGarbageCollector {
     int numDocumentsRemoved = removeOrphanedDocuments(upperBound);
     long removedDocumentsTs = System.currentTimeMillis();
 
-    // TODO(gsoltis): post-compaction?
-
     if (Logger.isDebugEnabled()) {
       String desc = "LRU Garbage Collection:\n";
       desc += "\tCounted targets in " + (countedTargetsTs - startTs) + "ms\n";
       desc +=
           String.format(
               Locale.ROOT,
-              "\tDetermined least recently used %d sequence numbers in %dms",
+              "\tDetermined least recently used %d sequence numbers in %dms\n",
               sequenceNumbers,
               (foundUpperBoundTs - countedTargetsTs));
       desc +=

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
@@ -85,9 +85,10 @@ class MemoryLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   public long getSequenceNumberCount() {
     long targetCount = persistence.getQueryCache().getTargetCount();
     long orphanedCount[] = new long[1];
-    forEachOrphanedDocumentSequenceNumber(sequenceNumber -> {
-      orphanedCount[0]++;
-    });
+    forEachOrphanedDocumentSequenceNumber(
+        sequenceNumber -> {
+          orphanedCount[0]++;
+        });
     return targetCount + orphanedCount[0];
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
@@ -82,8 +82,13 @@ class MemoryLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   }
 
   @Override
-  public long getTargetCount() {
-    return persistence.getQueryCache().getTargetCount();
+  public long getSequenceNumberCount() {
+    long targetCount = persistence.getQueryCache().getTargetCount();
+    long orphanedCount[] = new long[1];
+    forEachOrphanedDocumentSequenceNumber(sequenceNumber -> {
+      orphanedCount[0]++;
+    });
+    return targetCount + orphanedCount[0];
   }
 
   @Override

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
@@ -70,8 +70,12 @@ class SQLiteLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   }
 
   @Override
-  public long getTargetCount() {
-    return persistence.getQueryCache().getTargetCount();
+  public long getSequenceNumberCount() {
+    long targetCount = persistence.getQueryCache().getTargetCount();
+    long orphanedDocumentCount = persistence.query(
+            "SELECT COUNT(*) FROM (SELECT sequence_number FROM target_documents GROUP BY path HAVING COUNT(*) = 1 AND target_id = 0)"
+    ).firstValue(row -> row.getLong(0));
+    return targetCount + orphanedDocumentCount;
   }
 
   @Override

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
@@ -72,9 +72,11 @@ class SQLiteLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   @Override
   public long getSequenceNumberCount() {
     long targetCount = persistence.getQueryCache().getTargetCount();
-    long orphanedDocumentCount = persistence.query(
-            "SELECT COUNT(*) FROM (SELECT sequence_number FROM target_documents GROUP BY path HAVING COUNT(*) = 1 AND target_id = 0)"
-    ).firstValue(row -> row.getLong(0));
+    long orphanedDocumentCount =
+        persistence
+            .query(
+                "SELECT COUNT(*) FROM (SELECT sequence_number FROM target_documents GROUP BY path HAVING COUNT(*) = 1 AND target_id = 0)")
+            .firstValue(row -> row.getLong(0));
     return targetCount + orphanedDocumentCount;
   }
 


### PR DESCRIPTION
We had originally decided to only look at targets when assessing how much to run GC. However, based on running a write-heavy workload test, we need to include documents that ended up cached without being part of a target.

This is a port of a portion of https://github.com/firebase/firebase-ios-sdk/pull/1961

Note that merge base is into the LRU branch, not master.

Integration tests pass :)