### PR TITLE
Port structural changes from Multi-Tab

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/QuerySnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/QuerySnapshot.java
@@ -117,6 +117,11 @@ public class QuerySnapshot implements Iterable<QueryDocumentSnapshot> {
   @NonNull
   @PublicApi
   public List<DocumentChange> getDocumentChanges(MetadataChanges metadataChanges) {
+    if (MetadataChanges.INCLUDE.equals(metadataChanges) && snapshot.excludesMetadataChanges()) {
+      throw new IllegalArgumentException(
+          "To include metadata changes with your document changes, you must also pass MetadataChanges.INCLUDE to addSnapshotListener().");
+    }
+
     if (cachedChanges == null || cachedChangesMetadataState != metadataChanges) {
       cachedChanges =
           Collections.unmodifiableList(

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -248,7 +248,6 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
   @Override
   public void handleOnlineStateChange(OnlineState onlineState) {
     syncEngine.handleOnlineStateChange(onlineState);
-    eventManager.handleOnlineStateChange(onlineState);
   }
 
   @Override

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
@@ -80,7 +80,8 @@ public class QueryListener {
               documentChanges,
               newSnapshot.isFromCache(),
               newSnapshot.getMutatedKeys(),
-              newSnapshot.didSyncStateChange());
+              newSnapshot.didSyncStateChange(),
+              /* excludesMetadataChanges= */ true);
     }
 
     if (!raisedInitialEvent) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
@@ -157,7 +157,8 @@ public class QueryListener {
             snapshot.getQuery(),
             snapshot.getDocuments(),
             snapshot.getMutatedKeys(),
-            snapshot.isFromCache());
+            snapshot.isFromCache(),
+            snapshot.excludesMetadataChanges());
     raisedInitialEvent = true;
     listener.onEvent(snapshot, null);
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
@@ -19,8 +19,6 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.core.DocumentViewChange.Type;
-import com.google.firebase.firestore.model.Document;
-import com.google.firebase.firestore.model.DocumentSet;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -154,23 +152,12 @@ public class QueryListener {
   private void raiseInitialEvent(ViewSnapshot snapshot) {
     hardAssert(!raisedInitialEvent, "Trying to raise initial event for second time");
     snapshot =
-        new ViewSnapshot(
+        ViewSnapshot.fromInitialDocuments(
             snapshot.getQuery(),
             snapshot.getDocuments(),
-            DocumentSet.emptySet(snapshot.getQuery().comparator()),
-            QueryListener.getInitialViewChanges(snapshot),
-            snapshot.isFromCache(),
             snapshot.getMutatedKeys(),
-            /*didSyncStateChange=*/ true);
+            snapshot.isFromCache());
     raisedInitialEvent = true;
     listener.onEvent(snapshot, null);
-  }
-
-  private static List<DocumentViewChange> getInitialViewChanges(ViewSnapshot snapshot) {
-    List<DocumentViewChange> res = new ArrayList<>();
-    for (Document doc : snapshot.getDocuments()) {
-      res.add(DocumentViewChange.create(Type.ADDED, doc));
-    }
-    return res;
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TargetIdGenerator.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TargetIdGenerator.java
@@ -61,9 +61,7 @@ public class TargetIdGenerator {
   private int nextId;
   private int generatorId;
 
-  /**
-   * Instantiates a new TargetIdGenerator, using the seed as the first target ID to return.
-   */
+  /** Instantiates a new TargetIdGenerator, using the seed as the first target ID to return. */
   TargetIdGenerator(int generatorId, int seed) {
     hardAssert(
         (generatorId & RESERVED_BITS) == generatorId,

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
@@ -310,7 +310,8 @@ public class View {
               viewChanges,
               fromCache,
               docChanges.mutatedKeys,
-              syncStatedChanged);
+              syncStatedChanged,
+              /* excludesMetadataChanges= */ false);
     }
     return new ViewChange(snapshot, limboDocumentChanges);
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 /** A view snapshot is an immutable capture of the results of a query and the changes to them. */
 public class ViewSnapshot {
+
   /** The possibly states a document can be in w.r.t syncing from local storage to the backend. */
   public enum SyncState {
     NONE,
@@ -37,6 +38,7 @@ public class ViewSnapshot {
   private final boolean isFromCache;
   private final ImmutableSortedSet<DocumentKey> mutatedKeys;
   private final boolean didSyncStateChange;
+  private boolean excludesMetadataChanges;
 
   public ViewSnapshot(
       Query query,
@@ -45,7 +47,8 @@ public class ViewSnapshot {
       List<DocumentViewChange> changes,
       boolean isFromCache,
       ImmutableSortedSet<DocumentKey> mutatedKeys,
-      boolean didSyncStateChange) {
+      boolean didSyncStateChange,
+      boolean excludesMetadataChanges) {
     this.query = query;
     this.documents = documents;
     this.oldDocuments = oldDocuments;
@@ -53,6 +56,7 @@ public class ViewSnapshot {
     this.isFromCache = isFromCache;
     this.mutatedKeys = mutatedKeys;
     this.didSyncStateChange = didSyncStateChange;
+    this.excludesMetadataChanges = excludesMetadataChanges;
   }
 
   /** Returns a view snapshot as if all documents in the snapshot were added. */
@@ -72,7 +76,8 @@ public class ViewSnapshot {
         viewChanges,
         fromCache,
         mutatedKeys,
-        true);
+        /* didSyncStateChange= */ true,
+        /* excludesMetadataChanges= */ false);
   }
 
   public Query getQuery() {
@@ -107,6 +112,10 @@ public class ViewSnapshot {
     return didSyncStateChange;
   }
 
+  public boolean excludesMetadataChanges() {
+    return excludesMetadataChanges;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -122,6 +131,9 @@ public class ViewSnapshot {
       return false;
     }
     if (didSyncStateChange != that.didSyncStateChange) {
+      return false;
+    }
+    if (excludesMetadataChanges != that.excludesMetadataChanges) {
       return false;
     }
     if (!query.equals(that.query)) {
@@ -148,6 +160,7 @@ public class ViewSnapshot {
     result = 31 * result + mutatedKeys.hashCode();
     result = 31 * result + (isFromCache ? 1 : 0);
     result = 31 * result + (didSyncStateChange ? 1 : 0);
+    result = 31 * result + (excludesMetadataChanges ? 1 : 0);
     return result;
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
@@ -64,7 +64,8 @@ public class ViewSnapshot {
       Query query,
       DocumentSet documents,
       ImmutableSortedSet<DocumentKey> mutatedKeys,
-      boolean fromCache) {
+      boolean fromCache,
+      boolean excludesMetadataChanges) {
     List<DocumentViewChange> viewChanges = new ArrayList<>();
     for (Document doc : documents) {
       viewChanges.add(DocumentViewChange.create(DocumentViewChange.Type.ADDED, doc));
@@ -77,7 +78,7 @@ public class ViewSnapshot {
         fromCache,
         mutatedKeys,
         /* didSyncStateChange= */ true,
-        /* excludesMetadataChanges= */ false);
+        excludesMetadataChanges);
   }
 
   public Query getQuery() {
@@ -180,6 +181,8 @@ public class ViewSnapshot {
         + mutatedKeys.size()
         + ", didSyncStateChange="
         + didSyncStateChange
+        + ", excludesMetadataChanges="
+        + excludesMetadataChanges
         + ")";
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
@@ -15,8 +15,10 @@
 package com.google.firebase.firestore.core;
 
 import com.google.firebase.database.collection.ImmutableSortedSet;
+import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.DocumentSet;
+import java.util.ArrayList;
 import java.util.List;
 
 /** A view snapshot is an immutable capture of the results of a query and the changes to them. */
@@ -51,6 +53,26 @@ public class ViewSnapshot {
     this.isFromCache = isFromCache;
     this.mutatedKeys = mutatedKeys;
     this.didSyncStateChange = didSyncStateChange;
+  }
+
+  /** Returns a view snapshot as if all documents in the snapshot were added. */
+  public static ViewSnapshot fromInitialDocuments(
+      Query query,
+      DocumentSet documents,
+      ImmutableSortedSet<DocumentKey> mutatedKeys,
+      boolean fromCache) {
+    List<DocumentViewChange> viewChanges = new ArrayList<>();
+    for (Document doc : documents) {
+      viewChanges.add(DocumentViewChange.create(DocumentViewChange.Type.ADDED, doc));
+    }
+    return new ViewSnapshot(
+        query,
+        documents,
+        DocumentSet.emptySet(query.comparator()),
+        viewChanges,
+        fromCache,
+        mutatedKeys,
+        true);
   }
 
   public Query getQuery() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -124,7 +124,7 @@ public final class LocalStore {
         persistence.isStarted(), "LocalStore was passed an unstarted persistence implementation");
     this.persistence = persistence;
     queryCache = persistence.getQueryCache();
-    targetIdGenerator = TargetIdGenerator.getLocalStoreIdGenerator(queryCache.getHighestTargetId());
+    targetIdGenerator = TargetIdGenerator.forQueryCache(queryCache.getHighestTargetId());
     mutationQueue = persistence.getMutationQueue(initialUser);
     remoteDocuments = persistence.getRemoteDocumentCache();
     localDocuments = new LocalDocumentsView(remoteDocuments, mutationQueue);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryMutationQueue.java
@@ -107,11 +107,6 @@ final class MemoryMutationQueue implements MutationQueue {
   }
 
   @Override
-  public int getNextBatchId() {
-    return nextBatchId;
-  }
-
-  @Override
   public void acknowledgeBatch(MutationBatch batch, ByteString streamToken) {
     int batchId = batch.getBatchId();
     hardAssert(

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
@@ -38,15 +38,6 @@ interface MutationQueue {
   /** Returns true if this queue contains no mutation batches. */
   boolean isEmpty();
 
-  /**
-   * Returns the next batch ID that will be assigned to a new mutation batch.
-   *
-   * <p>Callers generally don't care about this value except to test that the mutation queue is
-   * properly maintaining the invariant that getHighestAcknowledgedBatchId is less than
-   * getNextBatchId.
-   */
-  int getNextBatchId();
-
   /** Acknowledges the given batch. */
   void acknowledgeBatch(MutationBatch batch, ByteString streamToken);
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
@@ -160,11 +160,6 @@ final class SQLiteMutationQueue implements MutationQueue {
   }
 
   @Override
-  public int getNextBatchId() {
-    return nextBatchId;
-  }
-
-  @Override
   public void acknowledgeBatch(MutationBatch batch, ByteString streamToken) {
     int batchId = batch.getBatchId();
     hardAssert(

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/QuerySnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/QuerySnapshotTest.java
@@ -124,7 +124,8 @@ public class QuerySnapshotTest {
             documentChanges,
             /*isFromCache=*/ false,
             /*mutatedKeys=*/ keySet(),
-            /*didSyncStateChange=*/ true);
+            /*didSyncStateChange=*/ true,
+            /* excludesMetadataChanges= */ false);
 
     QuerySnapshot snapshot =
         new QuerySnapshot(new Query(fooQuery, firestore), viewSnapshot, firestore);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/TestUtil.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/TestUtil.java
@@ -133,7 +133,8 @@ public class TestUtil {
             documentChanges,
             isFromCache,
             mutatedKeys,
-            true);
+            true,
+            /* excludesMetadataChanges= */ false);
     return new QuerySnapshot(query(path), viewSnapshot, FIRESTORE);
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryListenerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryListenerTest.java
@@ -107,7 +107,8 @@ public class QueryListenerTest {
             asList(change1, change4),
             snap2.isFromCache(),
             snap2.getMutatedKeys(),
-            /* didSyncStateChange= */ true);
+            /* didSyncStateChange= */ true,
+            /* excludesMetadataChanges= */ false);
     assertEquals(asList(snap2Prime), otherAccum);
   }
 
@@ -254,7 +255,8 @@ public class QueryListenerTest {
             asList(),
             snap4.isFromCache(),
             snap4.getMutatedKeys(),
-            snap4.didSyncStateChange());
+            snap4.didSyncStateChange(),
+            snap4.excludesMetadataChanges());
     assertEquals(asList(snap1, snap3, expectedSnapshot4), fullAccum);
   }
 
@@ -288,7 +290,8 @@ public class QueryListenerTest {
             asList(change3),
             snap2.isFromCache(),
             snap2.getMutatedKeys(),
-            snap2.didSyncStateChange());
+            snap2.didSyncStateChange(),
+            snap2.excludesMetadataChanges());
     assertEquals(asList(snap1, expectedSnapshot2), filteredAccum);
   }
 
@@ -327,7 +330,8 @@ public class QueryListenerTest {
             asList(change1, change2),
             /* isFromCache= */ false,
             snap3.getMutatedKeys(),
-            /* didSyncStateChange= */ true);
+            /* didSyncStateChange= */ true,
+            /* excludesMetadataChanges= */ false);
     assertEquals(asList(expectedSnapshot), events);
   }
 
@@ -364,7 +368,8 @@ public class QueryListenerTest {
             asList(change1),
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
-            /* didSyncStateChange= */ true);
+            /* didSyncStateChange= */ true,
+            /* excludesMetadataChanges= */ false);
     ViewSnapshot expectedSnapshot2 =
         new ViewSnapshot(
             snap2.getQuery(),
@@ -373,7 +378,8 @@ public class QueryListenerTest {
             asList(change2),
             /* isFromCache= */ true,
             snap2.getMutatedKeys(),
-            /* didSyncStateChange= */ false);
+            /* didSyncStateChange= */ false,
+            /* excludesMetadataChanges= */ false);
     assertEquals(asList(expectedSnapshot1, expectedSnapshot2), events);
   }
 
@@ -399,7 +405,8 @@ public class QueryListenerTest {
             asList(),
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
-            /* didSyncStateChange= */ true);
+            /* didSyncStateChange= */ true,
+            /* excludesMetadataChanges= */ false);
     assertEquals(asList(expectedSnapshot), events);
   }
 
@@ -424,7 +431,8 @@ public class QueryListenerTest {
             asList(),
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
-            /* didSyncStateChange= */ true);
+            /* didSyncStateChange= */ true,
+            /* excludesMetadataChanges= */ false);
     assertEquals(asList(expectedSnapshot), events);
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetIdGeneratorTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetIdGeneratorTest.java
@@ -28,54 +28,32 @@ public class TargetIdGeneratorTest {
 
   @Test
   public void testConstructor() {
-    assertEquals(2, TargetIdGenerator.getLocalStoreIdGenerator(0).nextId());
-    assertEquals(1, TargetIdGenerator.getSyncEngineGenerator(0).nextId());
-  }
-
-  @Test
-  public void testSkipPast() {
-    TargetIdGenerator gen = new TargetIdGenerator(1, -1);
-    assertEquals(1, gen.nextId());
-
-    gen = new TargetIdGenerator(1, 2);
-    assertEquals(3, gen.nextId());
-
-    gen = new TargetIdGenerator(1, 4);
-    assertEquals(5, gen.nextId());
-
-    for (int i = 4; i < 12; i++) {
-      TargetIdGenerator gen0 = new TargetIdGenerator(0, i);
-      TargetIdGenerator gen1 = new TargetIdGenerator(1, i);
-      assertEquals(i + 2 & ~1, gen0.nextId());
-      assertEquals(i + 1 | 1, gen1.nextId());
-    }
-
-    gen = new TargetIdGenerator(1, 12);
-    assertEquals(13, gen.nextId());
-
-    gen = new TargetIdGenerator(0, 22);
-    assertEquals(24, gen.nextId());
+    assertEquals(2, TargetIdGenerator.forQueryCache(0).nextId());
+    assertEquals(1, TargetIdGenerator.forSyncEngine().nextId());
   }
 
   @Test
   public void testIncrement() {
     TargetIdGenerator gen = new TargetIdGenerator(0, 0);
+    assertEquals(0, gen.nextId());
     assertEquals(2, gen.nextId());
     assertEquals(4, gen.nextId());
     assertEquals(6, gen.nextId());
 
     gen = new TargetIdGenerator(0, 46);
+    assertEquals(46, gen.nextId());
     assertEquals(48, gen.nextId());
     assertEquals(50, gen.nextId());
     assertEquals(52, gen.nextId());
     assertEquals(54, gen.nextId());
 
-    gen = new TargetIdGenerator(1, 0);
+    gen = new TargetIdGenerator(1, 1);
     assertEquals(1, gen.nextId());
     assertEquals(3, gen.nextId());
     assertEquals(5, gen.nextId());
 
-    gen = new TargetIdGenerator(1, 46);
+    gen = new TargetIdGenerator(1, 45);
+    assertEquals(45, gen.nextId());
     assertEquals(47, gen.nextId());
     assertEquals(49, gen.nextId());
     assertEquals(51, gen.nextId());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewSnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewSnapshotTest.java
@@ -48,9 +48,18 @@ public class ViewSnapshotTest {
     boolean fromCache = true;
     boolean hasPendingWrites = true;
     boolean syncStateChanges = true;
+    boolean excludesMetadataChanges = true;
 
     ViewSnapshot snapshot =
-        new ViewSnapshot(query, docs, oldDocs, changes, fromCache, mutatedKeys, syncStateChanges);
+        new ViewSnapshot(
+            query,
+            docs,
+            oldDocs,
+            changes,
+            fromCache,
+            mutatedKeys,
+            syncStateChanges,
+            excludesMetadataChanges);
 
     assertEquals(query, snapshot.getQuery());
     assertEquals(docs, snapshot.getDocuments());
@@ -60,5 +69,6 @@ public class ViewSnapshotTest {
     assertEquals(mutatedKeys, snapshot.getMutatedKeys());
     assertEquals(hasPendingWrites, snapshot.hasPendingWrites());
     assertEquals(syncStateChanges, snapshot.didSyncStateChange());
+    assertEquals(excludesMetadataChanges, snapshot.excludesMetadataChanges());
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -275,7 +275,6 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
   @Override
   public void handleOnlineStateChange(OnlineState onlineState) {
     syncEngine.handleOnlineStateChange(onlineState);
-    eventManager.handleOnlineStateChange(onlineState);
   }
 
   private List<Pair<Mutation, Task<Void>>> getCurrentOutstandingWrites() {


### PR DESCRIPTION
This PR contains a port of the structural changes from the Multi-Tab PR (https://github.com/firebase/firebase-js-sdk/pull/1000)

It's might be worth discussing just getting rid of the TargetIdGenerator at this point...