### PR TITLE
Swap smoke test deps

### DIFF
--- a/test-apps/build.gradle
+++ b/test-apps/build.gradle
@@ -46,8 +46,8 @@ allprojects {
     repositories {
         //mavenLocal() can be overridden via GRADLE_OPTS="-Dmaven.repo.local=<path>"
         mavenLocal()
-        jcenter()
         google()
+        jcenter()
         maven { url 'https://maven.fabric.io/public' }
     }
 


### PR DESCRIPTION
This swaps the order of the repositories in the test-apps Gradle file. Specifically, jCenter() is swapped with google().

jCenter seems to be incompletely mirroring some Android artifacts. They host the pom files but not the actual jar or aar files. This confuses Gradle, leading to build errors. Placing google() first causes Gradle to check Google's repository first, which should always contain Android artifacts. As long as Google doesn't host only pom files for other dependencies, this shouldn't cause any issues.