### PR TITLE
Upgrade gRPC to 1.16.1 for compatibility with CallCredentials2

### DIFF
--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -25,7 +25,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.12.0'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.16.1'
         }
         javalite {
             // The codegen for lite comes as a separate artifact
@@ -94,9 +94,9 @@ dependencies {
     //To provide @Generated annotations
     compileOnly 'javax.annotation:jsr250-api:1.0'
 
-    implementation 'io.grpc:grpc-stub:1.12.0'
-    implementation 'io.grpc:grpc-protobuf-lite:1.12.0'
-    implementation 'io.grpc:grpc-okhttp:1.12.0'
+    implementation 'io.grpc:grpc-stub:1.16.1'
+    implementation 'io.grpc:grpc-protobuf-lite:1.16.1'
+    implementation 'io.grpc:grpc-okhttp:1.16.1'
     implementation "com.google.android.gms:play-services-basement:$playServicesVersion"
     implementation "com.google.android.gms:play-services-tasks:$playServicesVersion"
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/FirestoreCallCredentials.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/FirestoreCallCredentials.java
@@ -18,15 +18,13 @@ import com.google.firebase.FirebaseApiNotAvailableException;
 import com.google.firebase.firestore.auth.CredentialsProvider;
 import com.google.firebase.firestore.util.Logger;
 import com.google.firebase.internal.api.FirebaseNoSignedInUserException;
-import io.grpc.Attributes;
-import io.grpc.CallCredentials;
+import io.grpc.CallCredentials2;
 import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.concurrent.Executor;
 
 /** CallCredentials that applies any authorization headers. */
-public final class FirestoreCallCredentials implements CallCredentials {
+public final class FirestoreCallCredentials extends CallCredentials2 {
 
   private static final String LOG_TAG = "FirestoreCallCredentials";
 
@@ -45,10 +43,7 @@ public final class FirestoreCallCredentials implements CallCredentials {
 
   @Override
   public void applyRequestMetadata(
-      MethodDescriptor<?, ?> methodDescriptor,
-      Attributes attributes,
-      Executor executor,
-      final MetadataApplier metadataApplier) {
+      RequestInfo requestInfo, Executor executor, final MetadataApplier metadataApplier) {
     credentialsProvider
         .getToken()
         .addOnSuccessListener(


### PR DESCRIPTION
This mirrors cl/218434754, and prepares us for the finalization of the
CallCredentials API in a subsequent gRPC release.

(CallCredentials has previously been marked experimental and this is an
effort on the part of the gRPC team to finalize that API.)