### PR TITLE
Downgrade google truth library to 0.40.

### DIFF
--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -61,12 +61,12 @@ dependencies {
     testImplementation 'com.android.support.test:runner:1.0.2'
     testImplementation 'org.robolectric:robolectric:4.0-alpha-3'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'com.google.truth:truth:0.42'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:2.21.0'
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.google.truth:truth:0.42'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'org.mockito:mockito-core:2.21.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.16.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.16.0'

--- a/firebase-database/firebase-database.gradle
+++ b/firebase-database/firebase-database.gradle
@@ -83,7 +83,7 @@ dependencies {
     androidTestImplementation "com.android.support:support-annotations:$supportAnnotationsVersion"
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.google.truth:truth:0.42'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-core:2.9.6'
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
     androidTestImplementation 'junit:junit:4.12'
@@ -99,7 +99,7 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.9.6'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
     testImplementation 'net.java.quickcheck:quickcheck:0.6'
-    testImplementation 'com.google.truth:truth:0.42'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'com.android.support.test:rules:1.0.2'
 
 }

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -111,12 +111,12 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.21.0'
     testImplementation 'org.robolectric:robolectric:4.0-alpha-3'
-    testImplementation 'com.google.truth:truth:0.42'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
     testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
 
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.google.truth:truth:0.42'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
     androidTestImplementation "com.android.support:support-annotations:$supportAnnotationsVersion"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/firebase-functions/firebase-functions.gradle
+++ b/firebase-functions/firebase-functions.gradle
@@ -60,10 +60,9 @@ dependencies {
     annotationProcessor 'com.google.auto.value:auto-value:1.6'
 
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.google.truth:truth:0.42'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'org.mockito:mockito-core:2.21.0'
-    androidTestImplementation 'com.google.truth:truth:0.42'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.16.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.16.0'
 

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -75,7 +75,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:3.8"
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.18.3"
-    testImplementation "com.google.truth:truth:0.39"
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
 
     androidTestImplementation "org.mockito:mockito-core:2.18.3"
     androidTestImplementation "com.google.dexmaker:dexmaker:1.2"

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -83,7 +83,7 @@ dependencies {
     androidTestImplementation "com.android.support:support-annotations:$supportAnnotationsVersion"
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.google.truth:truth:0.42'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'junit:junit:4.12'
 
     testImplementation 'junit:junit:4.12'

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -43,6 +43,7 @@ ext {
     supportAnnotationsVersion = '28.0.0'
     errorproneVersion = '2.3.2'
     errorproneJavacVersion = '9+181-r4173-1'
+    googleTruthVersion = '0.40'
 }
 
 apply plugin: com.google.firebase.gradle.plugins.publish.PublishingPlugin


### PR DESCRIPTION
This avoids the dependency on Guava 25.1 which causes tests run through
Android Studio to fail. Fixes #108.