### PR TITLE
Add shutdown logic...

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.firestore.remote;
 
-import android.support.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.auth.CredentialsProvider;
@@ -26,7 +25,6 @@ import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.model.mutation.MutationResult;
 import com.google.firebase.firestore.util.AsyncQueue;
 import com.google.firebase.firestore.util.FirestoreChannel;
-import com.google.firebase.firestore.util.Supplier;
 import com.google.firestore.v1beta1.BatchGetDocumentsRequest;
 import com.google.firestore.v1beta1.BatchGetDocumentsResponse;
 import com.google.firestore.v1beta1.CommitRequest;
@@ -79,7 +77,8 @@ public class Datastore {
     this.workerQueue = workerQueue;
     this.serializer = new RemoteSerializer(databaseInfo.getDatabaseId());
 
-    ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forTarget(databaseInfo.getHost());
+    ManagedChannelBuilder<?> channelBuilder =
+        ManagedChannelBuilder.forTarget(databaseInfo.getHost());
     if (!databaseInfo.isSslEnabled()) {
       // Note that the boolean flag does *NOT* indicate whether or not plaintext should be used
       channelBuilder.usePlaintext();
@@ -92,6 +91,14 @@ public class Datastore {
     channel =
         new FirestoreChannel(
             workerQueue, credentialsProvider, channelBuilder.build(), databaseInfo.getDatabaseId());
+  }
+
+  /**
+   * Shuts down the Datastore, closing the grpc channel and otherwise cleaning up. This is not
+   * reversible and renders the Datastore unusable.
+   */
+  void shutdown() {
+    channel.shutdown();
   }
 
   AsyncQueue getWorkerQueue() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
@@ -73,36 +73,16 @@ public class Datastore {
 
   private final FirestoreChannel channel;
 
-  private static Supplier<ManagedChannelBuilder<?>> overrideChannelBuilderSupplier;
-
-  /**
-   * Helper function to globally override the channel that RPCs use. Useful for testing when you
-   * want to bypass SSL certificate checking.
-   *
-   * @param channelBuilderSupplier The supplier for a channel builder that is used to create gRPC
-   *     channels.
-   */
-  @VisibleForTesting
-  public static void overrideChannelBuilder(
-      Supplier<ManagedChannelBuilder<?>> channelBuilderSupplier) {
-    Datastore.overrideChannelBuilderSupplier = channelBuilderSupplier;
-  }
-
   public Datastore(
       DatabaseInfo databaseInfo, AsyncQueue workerQueue, CredentialsProvider credentialsProvider) {
     this.databaseInfo = databaseInfo;
     this.workerQueue = workerQueue;
     this.serializer = new RemoteSerializer(databaseInfo.getDatabaseId());
 
-    ManagedChannelBuilder<?> channelBuilder;
-    if (overrideChannelBuilderSupplier != null) {
-      channelBuilder = overrideChannelBuilderSupplier.get();
-    } else {
-      channelBuilder = ManagedChannelBuilder.forTarget(databaseInfo.getHost());
-      if (!databaseInfo.isSslEnabled()) {
-        // Note that the boolean flag does *NOT* indicate whether or not plaintext should be used
-        channelBuilder.usePlaintext();
-      }
+    ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder.forTarget(databaseInfo.getHost());
+    if (!databaseInfo.isSslEnabled()) {
+      // Note that the boolean flag does *NOT* indicate whether or not plaintext should be used
+      channelBuilder.usePlaintext();
     }
 
     // This ensures all callbacks are issued on the worker queue. If this call is removed,

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
@@ -258,10 +258,10 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
    */
   public void shutdown() {
     Logger.debug(LOG_TAG, "Shutting down");
-    // For now, all shutdown logic is handled by disableNetworkInternal(). We might expand on this
-    // in the future.
     networkEnabled = false;
     this.disableNetworkInternal();
+    datastore.shutdown();
+
     // Set the OnlineState to UNKNOWN (rather than OFFLINE) to avoid potentially triggering
     // spurious listener events with cached data, etc.
     onlineStateTracker.updateState(OnlineState.UNKNOWN);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -453,7 +453,7 @@ public class AsyncQueue {
     executor.shutdown();
     return Tasks.call(
         () -> {
-          if (!executor.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+          if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
             Logger.debug(
                 AsyncQueue.class.getSimpleName(),
                 "Unable to gracefully shutdown the executor. Will attempt an immediate shutdown.");
@@ -461,7 +461,7 @@ public class AsyncQueue {
 
             // shutdownNow() uses Thread.interrupt() to cancel running tasks. There's no guarantee
             // that these will stop immediately (or ever.)
-            if (!executor.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+            if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
               // Something bad has happened. We could assert, but this is just resource cleanup for
               // a resource that is likely only released at the end of the execution. So instead,
               // we'll just log the error.


### PR DESCRIPTION
... to the Datastore, AsyncQueue, FirestoreChannel. Without this, we get
a potential resource leak when Firestore shuts down. Currently, it only
shuts down in tests, so this doesn't impact production, however, with
the (soon-to-come) AndroidManagedChannel change, the integration tests
will fail, as the Android OS itself tracks resources associated with
AndroidManagedChannel and will terminate if they're not properly cleaned
up.