### PR TITLE
RTDB: Don't NPE when a header is missing

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
@@ -29,6 +29,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -410,12 +411,13 @@ public class WebSocket {
       handshake.verifyServerStatusLine(handshakeLines.get(0));
       handshakeLines.remove(0);
 
-      HashMap<String, String> headers = new HashMap<String, String>();
+      HashMap<String, String> lowercaseHeaders = new HashMap<String, String>();
       for (String line : handshakeLines) {
         String[] keyValue = line.split(": ", 2);
-        headers.put(keyValue[0], keyValue[1]);
+        lowercaseHeaders.put(
+            keyValue[0].toLowerCase(Locale.US), keyValue[1].toLowerCase(Locale.US));
       }
-      handshake.verifyServerHandshakeHeaders(headers);
+      handshake.verifyServerHandshakeHeaders(lowercaseHeaders);
 
       writer.setOutput(output);
       receiver.setInput(input);

--- a/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocketHandshake.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocketHandshake.java
@@ -19,7 +19,6 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
 
 class WebSocketHandshake {
@@ -107,11 +106,11 @@ class WebSocketHandshake {
     }
   }
 
-  public void verifyServerHandshakeHeaders(HashMap<String, String> headers) {
-    if (!headers.get("Upgrade").toLowerCase(Locale.US).equals("websocket")) {
+  public void verifyServerHandshakeHeaders(HashMap<String, String> lowercaseHeaders) {
+    if (!"websocket".equals(lowercaseHeaders.get("upgrade"))) {
       throw new WebSocketException(
           "connection failed: missing header field in server handshake: Upgrade");
-    } else if (!headers.get("Connection").toLowerCase(Locale.US).equals("upgrade")) {
+    } else if (!"upgrade".equals(lowercaseHeaders.get("connection"))) {
       throw new WebSocketException(
           "connection failed: missing header field in server handshake: Connection");
     }


### PR DESCRIPTION
We should
a) make sure our HTTP header logic is case insensitive
b) not NPE when a header is missing

This addresses https://buganizer.corp.google.com/issues/118593067