### PR TITLE
Fix errorprone annotation processor classpath

### DIFF
--- a/tools/errorprone/errorprone.gradle
+++ b/tools/errorprone/errorprone.gradle
@@ -18,6 +18,7 @@ apply plugin: 'java-library'
 dependencies {
     implementation 'com.google.errorprone:error_prone_check_api:2.3.2'
     implementation 'com.google.auto.service:auto-service:1.0-rc4'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.errorprone:error_prone_test_helpers:2.3.1'


### PR DESCRIPTION
The issue results in a missing `META-INF/services/com.google.errorprone.bugpatterns.BugChecker` file in the resulting binary which prevents the errorprone plugin from discovering the custom checks.