### PR TITLE
Fix handling of sqlite transactions

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore.local;
 
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import android.database.sqlite.SQLiteTransactionListener;
 import android.util.SparseArray;
 import com.google.firebase.firestore.core.ListenSequence;
 import com.google.firebase.firestore.model.DocumentKey;
@@ -23,7 +24,8 @@ import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.util.Consumer;
 
 /** Provides LRU functionality for SQLite persistence. */
-class SQLiteLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
+class SQLiteLruReferenceDelegate
+    implements ReferenceDelegate, LruDelegate, SQLiteTransactionListener {
   private final SQLitePersistence persistence;
   private ListenSequence listenSequence;
   private long currentSequenceNumber;
@@ -39,6 +41,19 @@ class SQLiteLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   void start(long highestSequenceNumber) {
     listenSequence = new ListenSequence(highestSequenceNumber);
   }
+
+  @Override
+  public void onBegin() {
+    onTransactionStarted();
+  }
+
+  @Override
+  public void onCommit() {
+    onTransactionCommitted();
+  }
+
+  @Override
+  public void onRollback() {}
 
   @Override
   public void onTransactionStarted() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteLruReferenceDelegate.java
@@ -16,7 +16,6 @@ package com.google.firebase.firestore.local;
 
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
-import android.database.sqlite.SQLiteTransactionListener;
 import android.util.SparseArray;
 import com.google.firebase.firestore.core.ListenSequence;
 import com.google.firebase.firestore.model.DocumentKey;
@@ -24,8 +23,7 @@ import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.util.Consumer;
 
 /** Provides LRU functionality for SQLite persistence. */
-class SQLiteLruReferenceDelegate
-    implements ReferenceDelegate, LruDelegate, SQLiteTransactionListener {
+class SQLiteLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   private final SQLitePersistence persistence;
   private ListenSequence listenSequence;
   private long currentSequenceNumber;
@@ -41,19 +39,6 @@ class SQLiteLruReferenceDelegate
   void start(long highestSequenceNumber) {
     listenSequence = new ListenSequence(highestSequenceNumber);
   }
-
-  @Override
-  public void onBegin() {
-    onTransactionStarted();
-  }
-
-  @Override
-  public void onCommit() {
-    onTransactionCommitted();
-  }
-
-  @Override
-  public void onRollback() {}
 
   @Override
   public void onTransactionStarted() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -144,8 +144,7 @@ public final class SQLitePersistence extends Persistence {
   @Override
   void runTransaction(String action, Runnable operation) {
     Logger.debug(TAG, "Starting transaction: %s", action);
-    referenceDelegate.onTransactionStarted();
-    db.beginTransaction();
+    db.beginTransactionWithListener(referenceDelegate);
     try {
       operation.run();
 
@@ -154,15 +153,13 @@ public final class SQLitePersistence extends Persistence {
     } finally {
       db.endTransaction();
     }
-    referenceDelegate.onTransactionCommitted();
   }
 
   @Override
   <T> T runTransaction(String action, Supplier<T> operation) {
     Logger.debug(TAG, "Starting transaction: %s", action);
     T value = null;
-    referenceDelegate.onTransactionStarted();
-    db.beginTransaction();
+    db.beginTransactionWithListener(referenceDelegate);
     try {
       value = operation.get();
 
@@ -171,7 +168,6 @@ public final class SQLitePersistence extends Persistence {
     } finally {
       db.endTransaction();
     }
-    referenceDelegate.onTransactionCommitted();
     return value;
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -26,6 +26,7 @@ import android.database.sqlite.SQLiteDatabaseLockedException;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.database.sqlite.SQLiteProgram;
 import android.database.sqlite.SQLiteStatement;
+import android.database.sqlite.SQLiteTransactionListener;
 import android.support.annotation.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.firebase.firestore.auth.User;
@@ -144,7 +145,21 @@ public final class SQLitePersistence extends Persistence {
   @Override
   void runTransaction(String action, Runnable operation) {
     Logger.debug(TAG, "Starting transaction: %s", action);
-    db.beginTransactionWithListener(referenceDelegate);
+    db.beginTransactionWithListener(
+        new SQLiteTransactionListener() {
+          @Override
+          public void onBegin() {
+            referenceDelegate.onTransactionStarted();
+          }
+
+          @Override
+          public void onCommit() {
+            referenceDelegate.onTransactionCommitted();
+          }
+
+          @Override
+          public void onRollback() {}
+        });
     try {
       operation.run();
 
@@ -159,7 +174,21 @@ public final class SQLitePersistence extends Persistence {
   <T> T runTransaction(String action, Supplier<T> operation) {
     Logger.debug(TAG, "Starting transaction: %s", action);
     T value = null;
-    db.beginTransactionWithListener(referenceDelegate);
+    db.beginTransactionWithListener(
+        new SQLiteTransactionListener() {
+          @Override
+          public void onBegin() {
+            referenceDelegate.onTransactionStarted();
+          }
+
+          @Override
+          public void onCommit() {
+            referenceDelegate.onTransactionCommitted();
+          }
+
+          @Override
+          public void onRollback() {}
+        });
     try {
       value = operation.get();
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -143,35 +143,36 @@ public final class SQLitePersistence extends Persistence {
 
   @Override
   void runTransaction(String action, Runnable operation) {
+    Logger.debug(TAG, "Starting transaction: %s", action);
+    referenceDelegate.onTransactionStarted();
+    db.beginTransaction();
     try {
-      Logger.debug(TAG, "Starting transaction: %s", action);
-      referenceDelegate.onTransactionStarted();
-      db.beginTransaction();
       operation.run();
 
       // Note that an exception in operation.run() will prevent this code from running.
       db.setTransactionSuccessful();
     } finally {
       db.endTransaction();
-      referenceDelegate.onTransactionCommitted();
     }
+    referenceDelegate.onTransactionCommitted();
   }
 
   @Override
   <T> T runTransaction(String action, Supplier<T> operation) {
+    Logger.debug(TAG, "Starting transaction: %s", action);
+    T value = null;
+    referenceDelegate.onTransactionStarted();
+    db.beginTransaction();
     try {
-      Logger.debug(TAG, "Starting transaction: %s", action);
-      referenceDelegate.onTransactionStarted();
-      db.beginTransaction();
-      T value = operation.get();
+      value = operation.get();
 
       // Note that an exception in operation.run() will prevent this code from running.
       db.setTransactionSuccessful();
-      return value;
     } finally {
       db.endTransaction();
-      referenceDelegate.onTransactionCommitted();
     }
+    referenceDelegate.onTransactionCommitted();
+    return value;
   }
 
   /**


### PR DESCRIPTION
* Move as much work as possible out of the sqlite txn.

  In particular, don't do anything that could throw in the finally block, as this will mask any exception thrown within the transaction itself.

* Use sqlite transaction listeners (rather than doing so manually)

  Using sqlite's version allows us to not worry about getting the transaction semantics correct in the face of exceptions.