### PR TITLE
Forbid queries endAt an uncommitted server timestamp.

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.firestore;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.firestore.testutil.Assert.assertThrows;
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testAlternateFirestore;
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testCollection;
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testCollectionWithDocs;
@@ -30,6 +32,7 @@ import static org.junit.Assert.fail;
 
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.firestore.Transaction.Function;
@@ -430,6 +433,56 @@ public class ValidationTest {
     expectError(() -> query.startAfter(snapshot), reason);
     expectError(() -> query.endBefore(snapshot), reason);
     expectError(() -> query.endAt(snapshot), reason);
+  }
+
+  @Test
+  public void queriesCannotBeSortedByAnUncommittedServerTimestamp() {
+    CollectionReference collection = testCollection();
+
+    // Ensure the server timestamp stays uncommitted for the first half of the test
+    waitFor(collection.firestore.getClient().disableNetwork());
+
+    TaskCompletionSource<Void> offlineCallbackDone = new TaskCompletionSource<>();
+    TaskCompletionSource<Void> onlineCallbackDone = new TaskCompletionSource<>();
+
+    collection.addSnapshotListener(
+        (snapshot, error) -> {
+          assertNotNull(snapshot);
+
+          // Skip the initial empty snapshot.
+          if (snapshot.isEmpty()) return;
+
+          assertThat(snapshot.getDocuments()).hasSize(1);
+          DocumentSnapshot docSnap = snapshot.getDocuments().get(0);
+
+          if (snapshot.getMetadata().hasPendingWrites()) {
+            // Offline snapshot. Since the server timestamp is uncommitted, we shouldn't be able to
+            // query by it.
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    collection
+                        .orderBy("timestamp")
+                        .endAt(docSnap)
+                        .addSnapshotListener((snapshot2, error2) -> {}));
+            offlineCallbackDone.setResult(null);
+          } else {
+            // Online snapshot. Since the server timestamp is committed, we should be able to query
+            // by it.
+            collection
+                .orderBy("timestamp")
+                .endAt(docSnap)
+                .addSnapshotListener((snapshot2, error2) -> {});
+            onlineCallbackDone.setResult(null);
+          }
+        });
+
+    DocumentReference document = collection.document();
+    document.set(map("timestamp", FieldValue.serverTimestamp()));
+    waitFor(offlineCallbackDone.getTask());
+
+    waitFor(collection.firestore.getClient().enableNetwork());
+    waitFor(onlineCallbackDone.getTask());
   }
 
   @Test

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -39,6 +39,7 @@ import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.model.value.FieldValue;
 import com.google.firebase.firestore.model.value.ReferenceValue;
+import com.google.firebase.firestore.model.value.ServerTimestampValue;
 import com.google.firebase.firestore.util.ExecutorEventListener;
 import com.google.firebase.firestore.util.Executors;
 import com.google.firebase.firestore.util.ListenerRegistrationImpl;
@@ -582,7 +583,8 @@ public class Query {
    * <p>Note that the Bound will always include the key of the document and so only the provided
    * document will compare equal to the returned position.
    *
-   * <p>Will throw if the document does not contain all fields of the order by of the query.
+   * <p>Will throw if the document does not contain all fields of the order by of the query or if
+   * any of the fields in the order by are an uncommitted server timestamp.
    */
   private Bound boundFromDocumentSnapshot(
       String methodName, DocumentSnapshot snapshot, boolean before) {
@@ -606,7 +608,14 @@ public class Query {
         components.add(ReferenceValue.valueOf(firestore.getDatabaseId(), document.getKey()));
       } else {
         FieldValue value = document.getField(orderBy.getField());
-        if (value != null) {
+        if (value instanceof ServerTimestampValue) {
+          throw new IllegalArgumentException(
+              "Invalid query. You are trying to start or end a query using a document for which "
+                  + "the field '"
+                  + orderBy.getField()
+                  + "' is an uncommitted server timestamp. (Since the value of this field is "
+                  + "unknown, you cannot start/end a query with it.)");
+        } else if (value != null) {
           components.add(value);
         } else {
           throw new IllegalArgumentException(


### PR DESCRIPTION
Without this, it still fails, but:
a) not until serializing the query, and
b) the error is an internal error, and
c) the error message is quite cryptic and has nothing to do with the problem.