### PR TITLE
Revert "Better POJO Support for Document Fields"

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,10 +1,4 @@
 # Unreleased
-- [feature] Custom objects (POJOs) can now be passed as a field value in
-  update(), within `Map<>` objects passed to set(), in array transform
-  operations, and in query filters.
-- [feature] DocumentSnapshot.get() now supports retrieving fields as
-  custom objects (POJOs) by passing a Class<T> instance, e.g.
-  `snapshot.get("field", CustomType.class)`.
 
 # 17.1.2
 - [changed] Changed how the SDK handles locally-updated documents while syncing

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
@@ -15,18 +15,13 @@
 package com.google.firebase.firestore;
 
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testCollection;
-import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testDocument;
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.waitFor;
 import static com.google.firebase.firestore.testutil.TestUtil.expectError;
-import static com.google.firebase.firestore.testutil.TestUtil.map;
 import static junit.framework.Assert.assertEquals;
 
 import android.support.test.runner.AndroidJUnit4;
-import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
-import java.util.ArrayList;
 import java.util.Date;
 import org.junit.After;
 import org.junit.Test;
@@ -180,7 +175,7 @@ public class POJOTest {
   }
 
   @Test
-  public void testSetMerge() {
+  public void testUpdate() {
     CollectionReference collection = testCollection();
     POJO data = new POJO(1.0, "a", collection.document());
     DocumentReference reference = waitFor(collection.add(data));
@@ -193,55 +188,6 @@ public class POJOTest {
     POJO expected = new POJO(2.0, "a", data.getDocumentReference());
     doc = waitFor(reference.get());
     assertEquals(expected, doc.toObject(POJO.class));
-  }
-
-  // General smoke test that makes sure APIs accept POJOs.
-  @Test
-  public void testAPIsAcceptPOJOsForFields() {
-    DocumentReference ref = testDocument();
-    ArrayList<Task<?>> tasks = new ArrayList<>();
-
-    // as Map<> entries in a set() call.
-    POJO data = new POJO(1.0, "a", ref);
-    tasks.add(ref.set(map("a", data, "b", map("c", data))));
-
-    // as Map<> entries in an update() call.
-    tasks.add(ref.update(map("a", data)));
-
-    // as field values in an update() call.
-    tasks.add(ref.update("c", data));
-
-    // as values in arrayUnion() / arrayRemove().
-    tasks.add(ref.update("c", FieldValue.arrayUnion(data)));
-    tasks.add(ref.update("c", FieldValue.arrayRemove(data)));
-
-    // as Query parameters.
-    data.setBlob(null); // blobs are broken, see b/117680212
-    tasks.add(testCollection().whereEqualTo("field", data).get());
-
-    waitFor(Tasks.whenAll(tasks));
-  }
-
-  @Test
-  public void testDocumentSnapshotGetWithPOJOs() {
-    DocumentReference ref = testDocument();
-
-    // Go offline so that we can verify server timestamp behavior overload.
-    ref.getFirestore().disableNetwork();
-
-    POJO pojo = new POJO(1.0, "a", ref);
-    ref.set(map("field", pojo));
-
-    DocumentSnapshot snap = waitFor(ref.get());
-
-    assertEquals(pojo, snap.get("field", POJO.class));
-    assertEquals(pojo, snap.get(FieldPath.of("field"), POJO.class));
-    assertEquals(
-        pojo, snap.get("field", POJO.class, DocumentSnapshot.ServerTimestampBehavior.DEFAULT));
-    assertEquals(
-        pojo,
-        snap.get(
-            FieldPath.of("field"), POJO.class, DocumentSnapshot.ServerTimestampBehavior.DEFAULT));
   }
 
   @Test

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
@@ -249,28 +249,6 @@ public class ServerTimestampTest {
   }
 
   @Test
-  public void testServerTimestampBehaviorOverloadsOfDocumentSnapshotGet() {
-    writeInitialData();
-    waitFor(docRef.update(updateData));
-    DocumentSnapshot snap = accumulator.awaitLocalEvent();
-
-    // Default behavior should return null timestamp (via any overload).
-    assertNull(snap.get("when"));
-    assertNull(snap.get(FieldPath.of("when")));
-    assertNull(snap.get("when", Timestamp.class));
-    assertNull(snap.get(FieldPath.of("when"), Timestamp.class));
-
-    // Estimate should return a Timestamp object (via any overload).
-    assertThat(snap.get("when", ServerTimestampBehavior.ESTIMATE)).isInstanceOf(Timestamp.class);
-    assertThat(snap.get(FieldPath.of("when"), ServerTimestampBehavior.ESTIMATE))
-        .isInstanceOf(Timestamp.class);
-    assertThat(snap.get("when", Timestamp.class, ServerTimestampBehavior.ESTIMATE))
-        .isInstanceOf(Timestamp.class);
-    assertThat(snap.get(FieldPath.of("when"), Timestamp.class, ServerTimestampBehavior.ESTIMATE))
-        .isInstanceOf(Timestamp.class);
-  }
-
-  @Test
   public void testServerTimestampsWorkViaTransactionSet() {
     waitFor(
         docRef

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
@@ -23,6 +23,7 @@ import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.util.Executors;
 import com.google.firebase.firestore.util.Util;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -116,13 +117,12 @@ public class CollectionReference extends Query {
    * Adds a new document to this collection with the specified data, assigning it a document ID
    * automatically.
    *
-   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param data A Map containing the data for the new document.
    * @return A Task that will be resolved with the DocumentReference of the newly created document.
    */
   @NonNull
   @PublicApi
-  public Task<DocumentReference> add(@NonNull Object data) {
+  public Task<DocumentReference> add(@NonNull Map<String, Object> data) {
     checkNotNull(data, "Provided data must not be null.");
     final DocumentReference ref = document();
     return ref.set(data)
@@ -133,5 +133,18 @@ public class CollectionReference extends Query {
               task.getResult();
               return ref;
             });
+  }
+
+  /**
+   * Adds a new document to this collection with the specified POJO as contents, assigning it a
+   * document ID automatically.
+   *
+   * @param pojo The POJO that will be used to populate the contents of the document
+   * @return A Task that will be resolved with the DocumentReference of the newly created document.
+   */
+  @NonNull
+  @PublicApi
+  public Task<DocumentReference> add(@NonNull Object pojo) {
+    return add(firestore.getDataConverter().convertPOJO(pojo));
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -143,13 +143,12 @@ public class DocumentReference {
    * Overwrites the document referred to by this DocumentReference. If the document does not yet
    * exist, it will be created. If a document already exists, it will be overwritten.
    *
-   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param data A map of the fields and values for the document.
    * @return A Task that will be resolved when the write finishes.
    */
   @NonNull
   @PublicApi
-  public Task<Void> set(@NonNull Object data) {
+  public Task<Void> set(@NonNull Map<String, Object> data) {
     return set(data, SetOptions.OVERWRITE);
   }
 
@@ -158,14 +157,13 @@ public class DocumentReference {
    * exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged into
    * an existing document.
    *
-   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param data A map of the fields and values for the document.
    * @param options An object to configure the set behavior.
    * @return A Task that will be resolved when the write finishes.
    */
   @NonNull
   @PublicApi
-  public Task<Void> set(@NonNull Object data, @NonNull SetOptions options) {
+  public Task<Void> set(@NonNull Map<String, Object> data, @NonNull SetOptions options) {
     checkNotNull(data, "Provided data must not be null.");
     checkNotNull(options, "Provided options must not be null.");
     ParsedSetData parsed =
@@ -176,6 +174,34 @@ public class DocumentReference {
         .getClient()
         .write(parsed.toMutationList(key, Precondition.NONE))
         .continueWith(Executors.DIRECT_EXECUTOR, voidErrorTransformer());
+  }
+
+  /**
+   * Overwrites the document referred to by this DocumentReference. If the document does not yet
+   * exist, it will be created. If a document already exists, it will be overwritten.
+   *
+   * @param pojo The POJO that will be used to populate the document contents
+   * @return A Task that will be resolved when the write finishes.
+   */
+  @NonNull
+  @PublicApi
+  public Task<Void> set(@NonNull Object pojo) {
+    return set(firestore.getDataConverter().convertPOJO(pojo), SetOptions.OVERWRITE);
+  }
+
+  /**
+   * Writes to the document referred to by this DocumentReference. If the document does not yet
+   * exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged into
+   * an existing document.
+   *
+   * @param pojo The POJO that will be used to populate the document contents
+   * @param options An object to configure the set behavior.
+   * @return A Task that will be resolved when the write finishes.
+   */
+  @NonNull
+  @PublicApi
+  public Task<Void> set(@NonNull Object pojo, @NonNull SetOptions options) {
+    return set(firestore.getDataConverter().convertPOJO(pojo), options);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -290,69 +290,6 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
-   * exist.
-   *
-   * @param field The path to the field
-   * @param valueType The Java class to convert the field value to.
-   * @return The value at the given field or null.
-   */
-  @Nullable
-  public <T> T get(@NonNull String field, @NonNull Class<T> valueType) {
-    return get(FieldPath.fromDotSeparatedPath(field), valueType, ServerTimestampBehavior.DEFAULT);
-  }
-
-  /**
-   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
-   * exist.
-   *
-   * @param field The path to the field
-   * @param valueType The Java class to convert the field value to.
-   * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
-   *     been set to their final value.
-   * @return The value at the given field or null.
-   */
-  @Nullable
-  public <T> T get(
-      @NonNull String field,
-      @NonNull Class<T> valueType,
-      @NonNull ServerTimestampBehavior serverTimestampBehavior) {
-    return get(FieldPath.fromDotSeparatedPath(field), valueType, serverTimestampBehavior);
-  }
-
-  /**
-   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
-   * exist.
-   *
-   * @param fieldPath The path to the field
-   * @param valueType The Java class to convert the field value to.
-   * @return The value at the given field or null.
-   */
-  @Nullable
-  public <T> T get(@NonNull FieldPath fieldPath, @NonNull Class<T> valueType) {
-    return get(fieldPath, valueType, ServerTimestampBehavior.DEFAULT);
-  }
-
-  /**
-   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
-   * exist.
-   *
-   * @param fieldPath The path to the field
-   * @param valueType The Java class to convert the field value to.
-   * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
-   *     been set to their final value.
-   * @return The value at the given field or null.
-   */
-  @Nullable
-  public <T> T get(
-      @NonNull FieldPath fieldPath,
-      @NonNull Class<T> valueType,
-      @NonNull ServerTimestampBehavior serverTimestampBehavior) {
-    Object data = get(fieldPath, serverTimestampBehavior);
-    return data == null ? null : CustomClassMapper.convertToCustomClass(data, valueType);
-  }
-
-  /**
    * Returns the value of the field as a boolean. If the value is not a boolean this will throw a
    * runtime exception.
    *

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
@@ -60,13 +60,13 @@ public class Transaction {
    * yet exist, it will be created. If a document already exists, it will be overwritten.
    *
    * @param documentRef The DocumentReference to overwrite.
-   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param data A map of the fields and values for the document.
    * @return This Transaction instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
-  public Transaction set(@NonNull DocumentReference documentRef, @NonNull Object data) {
+  public Transaction set(
+      @NonNull DocumentReference documentRef, @NonNull Map<String, Object> data) {
     return set(documentRef, data, SetOptions.OVERWRITE);
   }
 
@@ -76,15 +76,16 @@ public class Transaction {
    * into an existing document.
    *
    * @param documentRef The DocumentReference to overwrite.
-   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param data A map of the fields and values for the document.
    * @param options An object to configure the set behavior.
    * @return This Transaction instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
   public Transaction set(
-      @NonNull DocumentReference documentRef, @NonNull Object data, @NonNull SetOptions options) {
+      @NonNull DocumentReference documentRef,
+      @NonNull Map<String, Object> data,
+      @NonNull SetOptions options) {
     firestore.validateReference(documentRef);
     checkNotNull(data, "Provided data must not be null.");
     checkNotNull(options, "Provided options must not be null.");
@@ -94,6 +95,37 @@ public class Transaction {
             : firestore.getDataConverter().parseSetData(data);
     transaction.set(documentRef.getKey(), parsed);
     return this;
+  }
+
+  /**
+   * Overwrites the document referred to by the provided DocumentReference. If the document does not
+   * yet exist, it will be created. If a document already exists, it will be overwritten.
+   *
+   * @param documentRef The DocumentReference to overwrite.
+   * @param pojo The POJO that will be used to populate the document contents
+   * @return This Transaction instance. Used for chaining method calls.
+   */
+  @NonNull
+  @PublicApi
+  public Transaction set(@NonNull DocumentReference documentRef, @NonNull Object pojo) {
+    return set(documentRef, firestore.getDataConverter().convertPOJO(pojo), SetOptions.OVERWRITE);
+  }
+
+  /**
+   * Writes to the document referred to by the provided DocumentReference. If the document does not
+   * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
+   * into an existing document.
+   *
+   * @param documentRef The DocumentReference to overwrite.
+   * @param pojo The POJO that will be used to populate the document contents
+   * @param options An object to configure the set behavior.
+   * @return This Transaction instance. Used for chaining method calls.
+   */
+  @NonNull
+  @PublicApi
+  public Transaction set(
+      @NonNull DocumentReference documentRef, @NonNull Object pojo, @NonNull SetOptions options) {
+    return set(documentRef, firestore.getDataConverter().convertPOJO(pojo), options);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -70,16 +70,17 @@ public final class UserDataConverter {
   }
 
   /** Parse document data from a non-merge set() call. */
-  public ParsedSetData parseSetData(Object input) {
+  public ParsedSetData parseSetData(Map<String, Object> input) {
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.Set);
-    ObjectValue updateData = convertAndParseDocumentData(input, accumulator.rootContext());
-    return accumulator.toSetData(updateData);
+    FieldValue updateData = parseData(input, accumulator.rootContext());
+
+    return accumulator.toSetData((ObjectValue) updateData);
   }
 
   /** Parse document data from a set() call with SetOptions.merge() set. */
-  public ParsedSetData parseMergeData(Object input, @Nullable FieldMask fieldMask) {
+  public ParsedSetData parseMergeData(Map<String, Object> input, @Nullable FieldMask fieldMask) {
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.MergeSet);
-    ObjectValue updateData = convertAndParseDocumentData(input, accumulator.rootContext());
+    ObjectValue updateData = (ObjectValue) parseData(input, accumulator.rootContext());
 
     if (fieldMask != null) {
       // Verify that all elements specified in the field mask are part of the parsed context.
@@ -93,6 +94,7 @@ public final class UserDataConverter {
       }
 
       return accumulator.toMergeData(updateData, fieldMask);
+
     } else {
       return accumulator.toMergeData(updateData);
     }
@@ -116,9 +118,7 @@ public final class UserDataConverter {
         // Add it to the field mask, but don't add anything to updateData.
         context.addToFieldMask(fieldPath);
       } else {
-        @Nullable
-        FieldValue parsedValue =
-            convertAndParseFieldData(fieldValue, context.childContext(fieldPath));
+        @Nullable FieldValue parsedValue = parseData(fieldValue, context.childContext(fieldPath));
         if (parsedValue != null) {
           context.addToFieldMask(fieldPath);
           updateData = updateData.set(fieldPath, parsedValue);
@@ -168,8 +168,7 @@ public final class UserDataConverter {
         // Add it to the field mask, but don't add anything to updateData.
         context.addToFieldMask(parsedField);
       } else {
-        FieldValue parsedValue =
-            convertAndParseFieldData(fieldValue, context.childContext(parsedField));
+        FieldValue parsedValue = parseData(fieldValue, context.childContext(parsedField));
         if (parsedValue != null) {
           context.addToFieldMask(parsedField);
           updateData = updateData.set(parsedField, parsedValue);
@@ -184,7 +183,7 @@ public final class UserDataConverter {
   public FieldValue parseQueryValue(Object input) {
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.Argument);
 
-    @Nullable FieldValue parsed = convertAndParseFieldData(input, accumulator.rootContext());
+    @Nullable FieldValue parsed = parseData(input, accumulator.rootContext());
     hardAssert(parsed != null, "Parsed data should not be null.");
     hardAssert(
         accumulator.getFieldTransforms().isEmpty(),
@@ -192,38 +191,32 @@ public final class UserDataConverter {
     return parsed;
   }
 
-  /** Converts a POJO to native types and then parses it into model types. */
-  private FieldValue convertAndParseFieldData(Object input, ParseContext context) {
-    Object converted = CustomClassMapper.convertToPlainJavaTypes(input);
-    return parseData(converted, context);
-  }
-
   /**
-   * Converts a POJO to native types and then parses it into model types. It expects the input to
-   * conform to document data (i.e. it must parse into an ObjectValue model type) and will throw an
-   * appropriate error otherwise.
+   * Converts a POJO into a Map, throwing appropriate errors if it wasn't actually a proper POJO.
    */
-  private ObjectValue convertAndParseDocumentData(Object input, ParseContext context) {
-    String badDocReason =
+  public Map<String, Object> convertPOJO(Object pojo) {
+    checkNotNull(pojo, "Provided data must not be null.");
+    String reason =
         "Invalid data. Data must be a Map<String, Object> or a suitable POJO object, but it was ";
 
     // Check Array before calling CustomClassMapper since it'll give you a confusing message
-    // to use List instead, which also won't work in a set().
-    if (input.getClass().isArray()) {
-      throw new IllegalArgumentException(badDocReason + "an array");
+    // to use List instead, which also won't work.
+    if (pojo.getClass().isArray()) {
+      throw new IllegalArgumentException(reason + "an array");
     }
 
-    Object converted = CustomClassMapper.convertToPlainJavaTypes(input);
-    FieldValue value = parseData(converted, context);
-
-    if (!(value instanceof ObjectValue)) {
-      throw new IllegalArgumentException(badDocReason + "of type: " + Util.typeName(input));
+    Object converted = CustomClassMapper.convertToPlainJavaTypes(pojo);
+    if (!(converted instanceof Map)) {
+      throw new IllegalArgumentException(reason + "of type: " + Util.typeName(pojo));
     }
-    return (ObjectValue) value;
+
+    @SuppressWarnings("unchecked") // CustomClassMapper promises to map keys to Strings.
+    Map<String, Object> map = (Map<String, Object>) converted;
+    return map;
   }
 
   /**
-   * Recursive helper for parsing user data.
+   * Internal helper for parsing user data.
    *
    * @param input Data to be parsed.
    * @param context A context object representing the current path being parsed, the source of the
@@ -423,7 +416,7 @@ public final class UserDataConverter {
       // being unioned or removed are not considered writes since they cannot
       // contain any FieldValue sentinels, etc.
       ParseContext context = accumulator.rootContext();
-      result.add(convertAndParseFieldData(element, context.childContext(i)));
+      result.add(parseData(element, context.childContext(i)));
     }
     return result;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
@@ -59,13 +59,12 @@ public class WriteBatch {
    * yet exist, it will be created. If a document already exists, it will be overwritten.
    *
    * @param documentRef The DocumentReference to overwrite.
-   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param data A map of the fields and values for the document.
    * @return This WriteBatch instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
-  public WriteBatch set(@NonNull DocumentReference documentRef, @NonNull Object data) {
+  public WriteBatch set(@NonNull DocumentReference documentRef, @NonNull Map<String, Object> data) {
     return set(documentRef, data, SetOptions.OVERWRITE);
   }
 
@@ -75,18 +74,18 @@ public class WriteBatch {
    * into an existing document.
    *
    * @param documentRef The DocumentReference to overwrite.
-   * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
-   *     document contents).
+   * @param data A map of the fields and values for the document.
    * @param options An object to configure the set behavior.
    * @return This WriteBatch instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
   public WriteBatch set(
-      @NonNull DocumentReference documentRef, @NonNull Object data, @NonNull SetOptions options) {
+      @NonNull DocumentReference documentRef,
+      @NonNull Map<String, Object> data,
+      @NonNull SetOptions options) {
     firestore.validateReference(documentRef);
     checkNotNull(data, "Provided data must not be null.");
-    checkNotNull(options, "Provided options must not be null.");
     verifyNotCommitted();
     ParsedSetData parsed =
         options.isMerge()
@@ -94,6 +93,37 @@ public class WriteBatch {
             : firestore.getDataConverter().parseSetData(data);
     mutations.addAll(parsed.toMutationList(documentRef.getKey(), Precondition.NONE));
     return this;
+  }
+
+  /**
+   * Overwrites the document referred to by the provided DocumentReference. If the document does not
+   * yet exist, it will be created. If a document already exists, it will be overwritten.
+   *
+   * @param documentRef The DocumentReference to overwrite.
+   * @param pojo The POJO that will be used to populate the document contents.
+   * @return This WriteBatch instance. Used for chaining method calls.
+   */
+  @NonNull
+  @PublicApi
+  public WriteBatch set(@NonNull DocumentReference documentRef, @NonNull Object pojo) {
+    return set(documentRef, firestore.getDataConverter().convertPOJO(pojo), SetOptions.OVERWRITE);
+  }
+
+  /**
+   * Writes to the document referred to by the provided DocumentReference. If the document does not
+   * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
+   * into an existing document.
+   *
+   * @param documentRef The DocumentReference to overwrite.
+   * @param pojo The POJO that will be used to populate the document contents.
+   * @param options An object to configure the set behavior.
+   * @return This WriteBatch instance. Used for chaining method calls.
+   */
+  @NonNull
+  @PublicApi
+  public WriteBatch set(
+      @NonNull DocumentReference documentRef, @NonNull Object pojo, @NonNull SetOptions options) {
+    return set(documentRef, firestore.getDataConverter().convertPOJO(pojo), options);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
@@ -161,8 +161,7 @@ public class CustomClassMapper {
         || o instanceof Timestamp
         || o instanceof GeoPoint
         || o instanceof Blob
-        || o instanceof DocumentReference
-        || o instanceof FieldValue) {
+        || o instanceof DocumentReference) {
       return o;
     } else {
       Class<T> clazz = (Class<T>) o.getClass();
@@ -509,12 +508,12 @@ public class CustomClassMapper {
     }
   }
 
-  private static IllegalArgumentException serializeError(ErrorPath path, String reason) {
+  private static RuntimeException serializeError(ErrorPath path, String reason) {
     reason = "Could not serialize object. " + reason;
     if (path.getLength() > 0) {
       reason = reason + " (found in field '" + path.toString() + "')";
     }
-    return new IllegalArgumentException(reason);
+    return new RuntimeException(reason);
   }
 
   private static RuntimeException deserializeError(ErrorPath path, String reason) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
@@ -411,7 +411,7 @@ public class FieldValueTest {
       wrap(array);
       fail("wrap should have failed");
     } catch (IllegalArgumentException e) {
-      assertNotEquals(-1, e.getMessage().indexOf("use Lists instead"));
+      assertNotEquals(-1, e.getMessage().indexOf("use a List instead"));
     }
   }
 


### PR DESCRIPTION
This reverts commit ddda9268537e096b978803df46d31b4541137d9a.

This makes master shippable again while we wait for API change approvals.