### PR TITLE
Make schema migrations idempotent

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -17,10 +17,13 @@ package com.google.firebase.firestore.local;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import android.content.ContentValues;
+import android.database.Cursor;
 import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Migrates schemas from version 0 (empty) to whatever the current version is.
@@ -111,29 +114,31 @@ class SQLiteSchema {
   }
 
   private void createMutationQueue() {
-    // A table naming all the mutation queues in the system.
-    db.execSQL(
-        "CREATE TABLE mutation_queues ("
-            + "uid TEXT PRIMARY KEY, "
-            + "last_acknowledged_batch_id INTEGER, "
-            + "last_stream_token BLOB)");
+    if (!tableExists("mutation_queues")) {
+      // A table naming all the mutation queues in the system.
+      db.execSQL(
+          "CREATE TABLE mutation_queues ("
+              + "uid TEXT PRIMARY KEY, "
+              + "last_acknowledged_batch_id INTEGER, "
+              + "last_stream_token BLOB)");
 
-    // All the mutation batches in the system, partitioned by user.
-    db.execSQL(
-        "CREATE TABLE mutations ("
-            + "uid TEXT, "
-            + "batch_id INTEGER, "
-            + "mutations BLOB, "
-            + "PRIMARY KEY (uid, batch_id))");
+      // All the mutation batches in the system, partitioned by user.
+      db.execSQL(
+          "CREATE TABLE mutations ("
+              + "uid TEXT, "
+              + "batch_id INTEGER, "
+              + "mutations BLOB, "
+              + "PRIMARY KEY (uid, batch_id))");
 
-    // A manually maintained index of all the mutation batches that affect a given document key.
-    // the rows in this table are references based on the contents of mutations.mutations.
-    db.execSQL(
-        "CREATE TABLE document_mutations ("
-            + "uid TEXT, "
-            + "path TEXT, "
-            + "batch_id INTEGER, "
-            + "PRIMARY KEY (uid, path, batch_id))");
+      // A manually maintained index of all the mutation batches that affect a given document key.
+      // the rows in this table are references based on the contents of mutations.mutations.
+      db.execSQL(
+          "CREATE TABLE document_mutations ("
+              + "uid TEXT, "
+              + "path TEXT, "
+              + "batch_id INTEGER, "
+              + "PRIMARY KEY (uid, path, batch_id))");
+    }
   }
 
   private void removeAcknowledgedMutations() {
@@ -169,63 +174,77 @@ class SQLiteSchema {
   }
 
   private void createQueryCache() {
-    // A cache of targets and associated metadata
-    db.execSQL(
-        "CREATE TABLE targets ("
-            + "target_id INTEGER PRIMARY KEY, "
-            + "canonical_id TEXT, "
-            + "snapshot_version_seconds INTEGER, "
-            + "snapshot_version_nanos INTEGER, "
-            + "resume_token BLOB, "
-            + "last_listen_sequence_number INTEGER,"
-            + "target_proto BLOB)");
+    if (!tableExists("targets")) {
+      // A cache of targets and associated metadata
+      db.execSQL(
+          "CREATE TABLE targets ("
+              + "target_id INTEGER PRIMARY KEY, "
+              + "canonical_id TEXT, "
+              + "snapshot_version_seconds INTEGER, "
+              + "snapshot_version_nanos INTEGER, "
+              + "resume_token BLOB, "
+              + "last_listen_sequence_number INTEGER,"
+              + "target_proto BLOB)");
 
-    db.execSQL("CREATE INDEX query_targets ON targets (canonical_id, target_id)");
+      db.execSQL("CREATE INDEX query_targets ON targets (canonical_id, target_id)");
 
-    // Global state tracked across all queries, tracked separately
-    db.execSQL(
-        "CREATE TABLE target_globals ("
-            + "highest_target_id INTEGER, "
-            + "highest_listen_sequence_number INTEGER, "
-            + "last_remote_snapshot_version_seconds INTEGER, "
-            + "last_remote_snapshot_version_nanos INTEGER)");
+      // Global state tracked across all queries, tracked separately
+      db.execSQL(
+          "CREATE TABLE target_globals ("
+              + "highest_target_id INTEGER, "
+              + "highest_listen_sequence_number INTEGER, "
+              + "last_remote_snapshot_version_seconds INTEGER, "
+              + "last_remote_snapshot_version_nanos INTEGER)");
 
-    // A Mapping table between targets and document paths
-    db.execSQL(
-        "CREATE TABLE target_documents ("
-            + "target_id INTEGER, "
-            + "path TEXT, "
-            + "PRIMARY KEY (target_id, path))");
+      // A Mapping table between targets and document paths
+      db.execSQL(
+          "CREATE TABLE target_documents ("
+              + "target_id INTEGER, "
+              + "path TEXT, "
+              + "PRIMARY KEY (target_id, path))");
 
-    // The document_targets reverse mapping table is just an index on target_documents.
-    db.execSQL("CREATE INDEX document_targets ON target_documents (path, target_id)");
+      // The document_targets reverse mapping table is just an index on target_documents.
+      db.execSQL("CREATE INDEX document_targets ON target_documents (path, target_id)");
+    }
   }
 
   private void dropQueryCache() {
-    db.execSQL("DROP TABLE targets");
-    db.execSQL("DROP TABLE target_globals");
-    db.execSQL("DROP TABLE target_documents");
+    // This might be overkill, but if any future migration drops these, it's possible we could try
+    // dropping tables that don't exist.
+    if (tableExists("targets")) {
+      db.execSQL("DROP TABLE targets");
+    }
+    if (tableExists("target_globals")) {
+      db.execSQL("DROP TABLE target_globals");
+    }
+    if (tableExists("target_documents")) {
+      db.execSQL("DROP TABLE target_documents");
+    }
   }
 
   private void createRemoteDocumentCache() {
-    // A cache of documents obtained from the server.
-    db.execSQL("CREATE TABLE remote_documents (path TEXT PRIMARY KEY, contents BLOB)");
+    if (!tableExists("remote_documents")) {
+      // A cache of documents obtained from the server.
+      db.execSQL("CREATE TABLE remote_documents (path TEXT PRIMARY KEY, contents BLOB)");
+    }
   }
 
   private void createLocalDocumentsCollectionIndex() {
-    // A per-user, per-collection index for cached documents indexed by a single field's name and
-    // value.
-    db.execSQL(
-        "CREATE TABLE collection_index ("
-            + "uid TEXT, "
-            + "collection_path TEXT, "
-            + "field_path TEXT, "
-            + "field_value_type INTEGER, " // determines type of field_value fields.
-            + "field_value_1, " // first component
-            + "field_value_2, " // second component; required for timestamps, GeoPoints
-            + "document_id TEXT, "
-            + "PRIMARY KEY (uid, collection_path, field_path, field_value_type, field_value_1, "
-            + "field_value_2, document_id))");
+    if (!tableExists("collection_index")) {
+      // A per-user, per-collection index for cached documents indexed by a single field's name and
+      // value.
+      db.execSQL(
+          "CREATE TABLE collection_index ("
+              + "uid TEXT, "
+              + "collection_path TEXT, "
+              + "field_path TEXT, "
+              + "field_value_type INTEGER, " // determines type of field_value fields.
+              + "field_value_1, " // first component
+              + "field_value_2, " // second component; required for timestamps, GeoPoints
+              + "document_id TEXT, "
+              + "PRIMARY KEY (uid, collection_path, field_path, field_value_type, field_value_1, "
+              + "field_value_2, document_id))");
+    }
   }
 
   // Note that this runs before we add the target count column, so we don't populate it yet.
@@ -241,15 +260,20 @@ class SQLiteSchema {
   }
 
   private void addTargetCount() {
+    if (!tableContainsColumn("target_globals", "target_count")) {
+      db.execSQL("ALTER TABLE target_globals ADD COLUMN target_count INTEGER");
+    }
+    // Even if the column already existed, rerun the data migration to make sure it's correct.
     long count = DatabaseUtils.queryNumEntries(db, "targets");
-    db.execSQL("ALTER TABLE target_globals ADD COLUMN target_count INTEGER");
     ContentValues cv = new ContentValues();
     cv.put("target_count", count);
     db.update("target_globals", cv, null, null);
   }
 
   private void addSequenceNumber() {
-    db.execSQL("ALTER TABLE target_documents ADD COLUMN sequence_number INTEGER");
+    if (!tableContainsColumn("target_documents", "sequence_number")) {
+      db.execSQL("ALTER TABLE target_documents ADD COLUMN sequence_number INTEGER");
+    }
   }
 
   /**
@@ -280,5 +304,35 @@ class SQLiteSchema {
           tagDocument.bindLong(2, sequenceNumber);
           hardAssert(tagDocument.executeInsert() != -1, "Failed to insert a sentinel row");
         });
+  }
+
+  private boolean tableContainsColumn(String table, String column) {
+    List<String> columns = getTableColumns(table);
+    return columns.indexOf(column) != -1;
+  }
+
+  private List<String> getTableColumns(String table) {
+    // NOTE: SQLitePersistence.Query helper binding doesn't work with PRAGMA queries. So, just use
+    // `rawQuery`.
+    Cursor c = null;
+    List<String> columns = new ArrayList<>();
+    try {
+      c = db.rawQuery("PRAGMA table_info(" + table + ")", null);
+      int nameIndex = c.getColumnIndex("name");
+      while (c.moveToNext()) {
+        columns.add(c.getString(nameIndex));
+      }
+    } finally {
+      if (c != null) {
+        c.close();
+      }
+    }
+    return columns;
+  }
+
+  private boolean tableExists(String table) {
+    return !new SQLitePersistence.Query(db, "SELECT 1=1 FROM sqlite_master WHERE tbl_name = ?")
+        .binding(table)
+        .isEmpty();
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -24,9 +24,7 @@ import android.database.sqlite.SQLiteStatement;
 import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
-
 import com.google.common.base.Preconditions;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -134,10 +132,10 @@ class SQLiteSchema {
   }
 
   /**
-   * Used to assert that a set of tables either all exist or not. The supplied function is
-   * run if none of the tables exist. Use this method to create a set of tables at once.
+   * Used to assert that a set of tables either all exist or not. The supplied function is run if
+   * none of the tables exist. Use this method to create a set of tables at once.
    *
-   * If some but not all of the tables exist, an exception will be thrown.
+   * <p>If some but not all of the tables exist, an exception will be thrown.
    */
   private void ifTablesDontExist(String[] tables, Runnable fn) {
     boolean tablesFound = false;
@@ -165,31 +163,34 @@ class SQLiteSchema {
   }
 
   private void createV1MutationQueue() {
-    ifTablesDontExist(new String[] {"mutation_queues", "mutations", "document_mutations"}, () -> {
-      // A table naming all the mutation queues in the system.
-      db.execSQL(
-          "CREATE TABLE mutation_queues ("
-              + "uid TEXT PRIMARY KEY, "
-              + "last_acknowledged_batch_id INTEGER, "
-              + "last_stream_token BLOB)");
+    ifTablesDontExist(
+        new String[] {"mutation_queues", "mutations", "document_mutations"},
+        () -> {
+          // A table naming all the mutation queues in the system.
+          db.execSQL(
+              "CREATE TABLE mutation_queues ("
+                  + "uid TEXT PRIMARY KEY, "
+                  + "last_acknowledged_batch_id INTEGER, "
+                  + "last_stream_token BLOB)");
 
-      // All the mutation batches in the system, partitioned by user.
-      db.execSQL(
-          "CREATE TABLE mutations ("
-              + "uid TEXT, "
-              + "batch_id INTEGER, "
-              + "mutations BLOB, "
-              + "PRIMARY KEY (uid, batch_id))");
+          // All the mutation batches in the system, partitioned by user.
+          db.execSQL(
+              "CREATE TABLE mutations ("
+                  + "uid TEXT, "
+                  + "batch_id INTEGER, "
+                  + "mutations BLOB, "
+                  + "PRIMARY KEY (uid, batch_id))");
 
-      // A manually maintained index of all the mutation batches that affect a given document key.
-      // the rows in this table are references based on the contents of mutations.mutations.
-      db.execSQL(
-          "CREATE TABLE document_mutations ("
-              + "uid TEXT, "
-              + "path TEXT, "
-              + "batch_id INTEGER, "
-              + "PRIMARY KEY (uid, path, batch_id))");
-    });
+          // A manually maintained index of all the mutation batches that affect a given document
+          // key.
+          // the rows in this table are references based on the contents of mutations.mutations.
+          db.execSQL(
+              "CREATE TABLE document_mutations ("
+                  + "uid TEXT, "
+                  + "path TEXT, "
+                  + "batch_id INTEGER, "
+                  + "PRIMARY KEY (uid, path, batch_id))");
+        });
   }
 
   private void removeAcknowledgedMutations() {
@@ -225,38 +226,40 @@ class SQLiteSchema {
   }
 
   private void createV1QueryCache() {
-    ifTablesDontExist(new String[] {"targets", "target_globals", "target_documents"}, () -> {
-      // A cache of targets and associated metadata
-      db.execSQL(
-          "CREATE TABLE targets ("
-              + "target_id INTEGER PRIMARY KEY, "
-              + "canonical_id TEXT, "
-              + "snapshot_version_seconds INTEGER, "
-              + "snapshot_version_nanos INTEGER, "
-              + "resume_token BLOB, "
-              + "last_listen_sequence_number INTEGER,"
-              + "target_proto BLOB)");
+    ifTablesDontExist(
+        new String[] {"targets", "target_globals", "target_documents"},
+        () -> {
+          // A cache of targets and associated metadata
+          db.execSQL(
+              "CREATE TABLE targets ("
+                  + "target_id INTEGER PRIMARY KEY, "
+                  + "canonical_id TEXT, "
+                  + "snapshot_version_seconds INTEGER, "
+                  + "snapshot_version_nanos INTEGER, "
+                  + "resume_token BLOB, "
+                  + "last_listen_sequence_number INTEGER,"
+                  + "target_proto BLOB)");
 
-      db.execSQL("CREATE INDEX query_targets ON targets (canonical_id, target_id)");
+          db.execSQL("CREATE INDEX query_targets ON targets (canonical_id, target_id)");
 
-      // Global state tracked across all queries, tracked separately
-      db.execSQL(
-          "CREATE TABLE target_globals ("
-              + "highest_target_id INTEGER, "
-              + "highest_listen_sequence_number INTEGER, "
-              + "last_remote_snapshot_version_seconds INTEGER, "
-              + "last_remote_snapshot_version_nanos INTEGER)");
+          // Global state tracked across all queries, tracked separately
+          db.execSQL(
+              "CREATE TABLE target_globals ("
+                  + "highest_target_id INTEGER, "
+                  + "highest_listen_sequence_number INTEGER, "
+                  + "last_remote_snapshot_version_seconds INTEGER, "
+                  + "last_remote_snapshot_version_nanos INTEGER)");
 
-      // A Mapping table between targets and document paths
-      db.execSQL(
-          "CREATE TABLE target_documents ("
-              + "target_id INTEGER, "
-              + "path TEXT, "
-              + "PRIMARY KEY (target_id, path))");
+          // A Mapping table between targets and document paths
+          db.execSQL(
+              "CREATE TABLE target_documents ("
+                  + "target_id INTEGER, "
+                  + "path TEXT, "
+                  + "PRIMARY KEY (target_id, path))");
 
-      // The document_targets reverse mapping table is just an index on target_documents.
-      db.execSQL("CREATE INDEX document_targets ON target_documents (path, target_id)");
-    });
+          // The document_targets reverse mapping table is just an index on target_documents.
+          db.execSQL("CREATE INDEX document_targets ON target_documents (path, target_id)");
+        });
   }
 
   private void dropV1QueryCache() {
@@ -274,29 +277,34 @@ class SQLiteSchema {
   }
 
   private void createV1RemoteDocumentCache() {
-    ifTablesDontExist(new String[] {"remote_documents"}, () -> {
-      // A cache of documents obtained from the server.
-      db.execSQL("CREATE TABLE remote_documents (path TEXT PRIMARY KEY, contents BLOB)");
-    });
+    ifTablesDontExist(
+        new String[] {"remote_documents"},
+        () -> {
+          // A cache of documents obtained from the server.
+          db.execSQL("CREATE TABLE remote_documents (path TEXT PRIMARY KEY, contents BLOB)");
+        });
   }
 
   // TODO(indexing): Put the schema version in this method name.
   private void createLocalDocumentsCollectionIndex() {
-    ifTablesDontExist(new String[] {"collection_index"}, () -> {
-      // A per-user, per-collection index for cached documents indexed by a single field's name and
-      // value.
-      db.execSQL(
-          "CREATE TABLE collection_index ("
-              + "uid TEXT, "
-              + "collection_path TEXT, "
-              + "field_path TEXT, "
-              + "field_value_type INTEGER, " // determines type of field_value fields.
-              + "field_value_1, " // first component
-              + "field_value_2, " // second component; required for timestamps, GeoPoints
-              + "document_id TEXT, "
-              + "PRIMARY KEY (uid, collection_path, field_path, field_value_type, field_value_1, "
-              + "field_value_2, document_id))");
-    });
+    ifTablesDontExist(
+        new String[] {"collection_index"},
+        () -> {
+          // A per-user, per-collection index for cached documents indexed by a single field's name
+          // and
+          // value.
+          db.execSQL(
+              "CREATE TABLE collection_index ("
+                  + "uid TEXT, "
+                  + "collection_path TEXT, "
+                  + "field_path TEXT, "
+                  + "field_value_type INTEGER, " // determines type of field_value fields.
+                  + "field_value_1, " // first component
+                  + "field_value_2, " // second component; required for timestamps, GeoPoints
+                  + "document_id TEXT, "
+                  + "PRIMARY KEY (uid, collection_path, field_path, field_value_type, field_value_1, "
+                  + "field_value_2, document_id))");
+        });
   }
 
   // Note that this runs before we add the target count column, so we don't populate it yet.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -291,8 +291,7 @@ class SQLiteSchema {
         new String[] {"collection_index"},
         () -> {
           // A per-user, per-collection index for cached documents indexed by a single field's name
-          // and
-          // value.
+          // and value.
           db.execSQL(
               "CREATE TABLE collection_index ("
                   + "uid TEXT, "

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -311,7 +311,7 @@ class SQLiteSchema {
     return columns.indexOf(column) != -1;
   }
 
-  private List<String> getTableColumns(String table) {
+  List<String> getTableColumns(String table) {
     // NOTE: SQLitePersistence.Query helper binding doesn't work with PRAGMA queries. So, just use
     // `rawQuery`.
     Cursor c = null;

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -66,6 +66,15 @@ public class SQLiteSchemaTest {
   }
 
   @Test
+  public void canRerunMigrations() {
+    schema.runMigrations();
+    // Run the whole thing again
+    schema.runMigrations();
+    // Run just a piece. Adds a column, make sure it doesn't throw
+    schema.runMigrations(4, 6);
+  }
+
+  @Test
   public void createsMutationsTable() {
     schema.runMigrations();
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -110,8 +110,11 @@ public class SQLiteSchemaTest {
 
   @Test
   public void migrationsDontDeleteTablesOrColumns() {
-    // We would like to enforce that migrations don't remove tables or columns, as that will cause
-    // trouble for SDK version downgrades.
+    // In order to support users downgrading the SDK we need to make sure that every prior-released
+    // version of the SDK can gracefully handle running against an upgraded schema. We can't
+    // guarantee this in the general case, but this test at least ensures that no schema upgrade
+    // deletes an existing table or column, which would be very likely to break old versions of the
+    // SDK relying on that table or column.
     Map<String, Set<String>> tables = new HashMap<>();
     for (int toVersion = 1; toVersion <= SQLiteSchema.VERSION; toVersion++) {
       schema.runMigrations(toVersion - 1, toVersion);


### PR DESCRIPTION
Adds guards for schema migrations so that they are safe to run multiple times.