### PR TITLE
Add grpc keepalive timeout

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Datastore represents a proxy for the remote server, hiding details of the RPC layer. It:
@@ -109,6 +110,10 @@ public class Datastore {
         channelBuilder.usePlaintext();
       }
     }
+
+    // Ensure gRPC recovers from a dead connection. (Not typically necessary, as the OS will usually
+    // notify gRPC when a connection dies. But not always. This acts as a failsafe.)
+    channelBuilder.keepAliveTime(30, TimeUnit.SECONDS);
 
     // This ensures all callbacks are issued on the worker queue. If this call is removed,
     // all calls need to be audited to make sure they are executed on the right thread.


### PR DESCRIPTION
To work around dead connections where the OS doesn't actually close the
socket. This allows us to not have to wait for a tcp timeout to occur.