### PR TITLE
Fix automatic data collection(b/120600091).

### DIFF
--- a/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
@@ -104,7 +104,7 @@ public class FirebaseApp {
 
   public static final String DEFAULT_APP_NAME = "[DEFAULT]";
 
-  @VisibleForTesting static final String FIREBASE_APP_PREFS = "com.google.firebase.common.prefs";
+  private static final String FIREBASE_APP_PREFS = "com.google.firebase.common.prefs:";
 
   @VisibleForTesting
   static final String DATA_COLLECTION_DEFAULT_ENABLED = "firebase_data_collection_default_enabled";
@@ -525,7 +525,7 @@ public class FirebaseApp {
     idTokenListenersCountChangedListener = new DefaultIdTokenListenersCountChangedListener();
 
     sharedPreferences =
-        applicationContext.getSharedPreferences(FIREBASE_APP_PREFS, Context.MODE_PRIVATE);
+        applicationContext.getSharedPreferences(getSharedPrefsName(name), Context.MODE_PRIVATE);
     dataCollectionDefaultEnabled = new AtomicBoolean(readAutoDataCollectionEnabled());
 
     List<ComponentRegistrar> registrars =
@@ -538,6 +538,11 @@ public class FirebaseApp {
             Component.of(this, FirebaseApp.class),
             Component.of(options, FirebaseOptions.class));
     publisher = componentRuntime.get(Publisher.class);
+  }
+
+  @VisibleForTesting
+  static String getSharedPrefsName(String appName) {
+    return FIREBASE_APP_PREFS + appName;
   }
 
   private boolean readAutoDataCollectionEnabled() {

--- a/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
@@ -540,8 +540,7 @@ public class FirebaseApp {
     publisher = componentRuntime.get(Publisher.class);
   }
 
-  @VisibleForTesting
-  static String getSharedPrefsName(String appName) {
+  private static String getSharedPrefsName(String appName) {
     return FIREBASE_APP_PREFS + appName;
   }
 

--- a/firebase-common/src/test/java/com/google/firebase/DataCollectionDefaultDisabledTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/DataCollectionDefaultDisabledTest.java
@@ -15,21 +15,19 @@
 package com.google.firebase;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.DataCollectionTestUtil.getSharedPreferences;
+import static com.google.firebase.DataCollectionTestUtil.setSharedPreferencesTo;
+import static com.google.firebase.DataCollectionTestUtil.withApp;
 
-import android.content.Context;
 import android.content.SharedPreferences;
-import java.util.function.Consumer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = "NoAutoDataCollectionAndroidManifest.xml")
 public class DataCollectionDefaultDisabledTest {
-
-  private static final String APP_NAME = "someApp";
 
   @Test
   public void isDataCollectionDefaultEnabled_whenMetadataFalse_shouldReturnFalse() {
@@ -77,30 +75,5 @@ public class DataCollectionDefaultDisabledTest {
           app.setDataCollectionDefaultEnabled(false);
           assertThat(changeListener.changes).containsExactly(true, false).inOrder();
         });
-  }
-
-  private static void withApp(Consumer<FirebaseApp> callable) {
-    FirebaseApp app =
-        FirebaseApp.initializeApp(
-            RuntimeEnvironment.application.getApplicationContext(),
-            new FirebaseOptions.Builder().setApplicationId("appId").build(),
-            APP_NAME);
-    try {
-      callable.accept(app);
-    } finally {
-      app.delete();
-    }
-  }
-
-  private static SharedPreferences getSharedPreferences() {
-    return RuntimeEnvironment.application.getSharedPreferences(
-        FirebaseApp.getSharedPrefsName(APP_NAME), Context.MODE_PRIVATE);
-  }
-
-  private static void setSharedPreferencesTo(boolean enabled) {
-    getSharedPreferences()
-        .edit()
-        .putBoolean(FirebaseApp.DATA_COLLECTION_DEFAULT_ENABLED, enabled)
-        .commit();
   }
 }

--- a/firebase-common/src/test/java/com/google/firebase/DataCollectionDefaultDisabledTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/DataCollectionDefaultDisabledTest.java
@@ -29,6 +29,8 @@ import org.robolectric.annotation.Config;
 @Config(manifest = "NoAutoDataCollectionAndroidManifest.xml")
 public class DataCollectionDefaultDisabledTest {
 
+  private static final String APP_NAME = "someApp";
+
   @Test
   public void isDataCollectionDefaultEnabled_whenMetadataFalse_shouldReturnFalse() {
     withApp(app -> assertThat(app.isDataCollectionDefaultEnabled()).isFalse());
@@ -82,7 +84,7 @@ public class DataCollectionDefaultDisabledTest {
         FirebaseApp.initializeApp(
             RuntimeEnvironment.application.getApplicationContext(),
             new FirebaseOptions.Builder().setApplicationId("appId").build(),
-            "someApp");
+            APP_NAME);
     try {
       callable.accept(app);
     } finally {
@@ -92,7 +94,7 @@ public class DataCollectionDefaultDisabledTest {
 
   private static SharedPreferences getSharedPreferences() {
     return RuntimeEnvironment.application.getSharedPreferences(
-        FirebaseApp.FIREBASE_APP_PREFS, Context.MODE_PRIVATE);
+        FirebaseApp.getSharedPrefsName(APP_NAME), Context.MODE_PRIVATE);
   }
 
   private static void setSharedPreferencesTo(boolean enabled) {

--- a/firebase-common/src/test/java/com/google/firebase/DataCollectionDefaultEnabledTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/DataCollectionDefaultEnabledTest.java
@@ -15,18 +15,17 @@
 package com.google.firebase;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.DataCollectionTestUtil.getSharedPreferences;
+import static com.google.firebase.DataCollectionTestUtil.setSharedPreferencesTo;
+import static com.google.firebase.DataCollectionTestUtil.withApp;
 
-import android.content.Context;
 import android.content.SharedPreferences;
-import java.util.function.Consumer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 @RunWith(RobolectricTestRunner.class)
 public class DataCollectionDefaultEnabledTest {
-  private static final String APP_NAME = "someApp";
 
   @Test
   public void isDataCollectionDefaultEnabled_shouldDefaultToTrue() {
@@ -79,34 +78,5 @@ public class DataCollectionDefaultEnabledTest {
                 assertThat(app2.isDataCollectionDefaultEnabled()).isTrue();
               });
         });
-  }
-
-  private static void withApp(Consumer<FirebaseApp> callable) {
-    withApp(APP_NAME, callable);
-  }
-
-  private static void withApp(String name, Consumer<FirebaseApp> callable) {
-    FirebaseApp app =
-        FirebaseApp.initializeApp(
-            RuntimeEnvironment.application.getApplicationContext(),
-            new FirebaseOptions.Builder().setApplicationId("appId").build(),
-            name);
-    try {
-      callable.accept(app);
-    } finally {
-      app.delete();
-    }
-  }
-
-  private static SharedPreferences getSharedPreferences() {
-    return RuntimeEnvironment.application.getSharedPreferences(
-        FirebaseApp.getSharedPrefsName(APP_NAME), Context.MODE_PRIVATE);
-  }
-
-  private static void setSharedPreferencesTo(boolean enabled) {
-    getSharedPreferences()
-        .edit()
-        .putBoolean(FirebaseApp.DATA_COLLECTION_DEFAULT_ENABLED, enabled)
-        .commit();
   }
 }

--- a/firebase-common/src/test/java/com/google/firebase/DataCollectionTestUtil.java
+++ b/firebase-common/src/test/java/com/google/firebase/DataCollectionTestUtil.java
@@ -1,0 +1,57 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import java.util.function.Consumer;
+import org.robolectric.RuntimeEnvironment;
+
+public final class DataCollectionTestUtil {
+  static final String APP_NAME = "someApp";
+
+  static final String FIREBASE_APP_PREFS = "com.google.firebase.common.prefs:";
+
+  private DataCollectionTestUtil() {}
+
+  static void withApp(Consumer<FirebaseApp> callable) {
+    withApp(APP_NAME, callable);
+  }
+
+  static void withApp(String name, Consumer<FirebaseApp> callable) {
+    FirebaseApp app =
+        FirebaseApp.initializeApp(
+            RuntimeEnvironment.application.getApplicationContext(),
+            new FirebaseOptions.Builder().setApplicationId("appId").build(),
+            name);
+    try {
+      callable.accept(app);
+    } finally {
+      app.delete();
+    }
+  }
+
+  static SharedPreferences getSharedPreferences() {
+    return RuntimeEnvironment.application.getSharedPreferences(
+        FIREBASE_APP_PREFS + APP_NAME, Context.MODE_PRIVATE);
+  }
+
+  static void setSharedPreferencesTo(boolean enabled) {
+    getSharedPreferences()
+        .edit()
+        .putBoolean(FirebaseApp.DATA_COLLECTION_DEFAULT_ENABLED, enabled)
+        .commit();
+  }
+}


### PR DESCRIPTION
Makes setting persistense scoped per FirebaseApp instance instead of
being scoped globally.