### PR TITLE
Add runtime support for Set-components

### DIFF
--- a/firebase-common/src/main/java/com/google/firebase/components/AbstractComponentContainer.java
+++ b/firebase-common/src/main/java/com/google/firebase/components/AbstractComponentContainer.java
@@ -15,6 +15,7 @@
 package com.google.firebase.components;
 
 import com.google.firebase.inject.Provider;
+import java.util.Set;
 
 abstract class AbstractComponentContainer implements ComponentContainer {
   @Override
@@ -24,5 +25,10 @@ abstract class AbstractComponentContainer implements ComponentContainer {
       return null;
     }
     return provider.get();
+  }
+
+  @Override
+  public <T> Set<T> setOf(Class<T> anInterface) {
+    return setOfProvider(anInterface).get();
   }
 }

--- a/firebase-common/src/main/java/com/google/firebase/components/ComponentContainer.java
+++ b/firebase-common/src/main/java/com/google/firebase/components/ComponentContainer.java
@@ -16,6 +16,7 @@ package com.google.firebase.components;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
 import com.google.firebase.inject.Provider;
+import java.util.Set;
 
 /** Provides a means to retrieve instances of requested classes/interfaces. */
 @KeepForSdk
@@ -25,4 +26,10 @@ public interface ComponentContainer {
 
   @KeepForSdk
   <T> Provider<T> getProvider(Class<T> anInterface);
+
+  @KeepForSdk
+  <T> Set<T> setOf(Class<T> anInterface);
+
+  @KeepForSdk
+  <T> Provider<Set<T>> setOfProvider(Class<T> anInterface);
 }

--- a/firebase-common/src/main/java/com/google/firebase/components/ComponentRuntime.java
+++ b/firebase-common/src/main/java/com/google/firebase/components/ComponentRuntime.java
@@ -21,8 +21,10 @@ import com.google.firebase.inject.Provider;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 
 /**
@@ -32,8 +34,10 @@ import java.util.concurrent.Executor;
  * Component}s via {@link #get(Class)} method.
  */
 public class ComponentRuntime extends AbstractComponentContainer {
-  private final List<Component<?>> components;
+  private static final Provider<Set<Object>> EMPTY_PROVIDER = Collections::emptySet;
+  private final Map<Component<?>, Lazy<?>> components = new HashMap<>();
   private final Map<Class<?>, Lazy<?>> lazyInstanceMap = new HashMap<>();
+  private final Map<Class<?>, Lazy<Set<?>>> lazySetMap = new HashMap<>();
   private final EventBus eventBus;
 
   /**
@@ -54,12 +58,49 @@ public class ComponentRuntime extends AbstractComponentContainer {
     Collections.addAll(componentsToAdd, additionalComponents);
 
     CycleDetector.detect(componentsToAdd);
-    components = Collections.unmodifiableList(componentsToAdd);
 
-    for (Component<?> component : components) {
+    for (Component<?> component : componentsToAdd) {
       register(component);
     }
     validateDependencies();
+
+    processSetComponents();
+  }
+
+  /** Populates lazySetMap to make set components available for consumption via set dependencies. */
+  private void processSetComponents() {
+    Map<Class<?>, Set<Lazy<?>>> setIndex = new HashMap<>();
+    for (Map.Entry<Component<?>, Lazy<?>> entry : components.entrySet()) {
+      Component<?> component = entry.getKey();
+
+      // only process set components.
+      if (component.isValue()) {
+        continue;
+      }
+
+      Lazy<?> lazy = entry.getValue();
+
+      for (Class<?> anInterface : component.getProvidedInterfaces()) {
+        if (!setIndex.containsKey(anInterface)) {
+          setIndex.put(anInterface, new HashSet<>());
+        }
+        setIndex.get(anInterface).add(lazy);
+      }
+    }
+
+    for (Map.Entry<Class<?>, Set<Lazy<?>>> entry : setIndex.entrySet()) {
+      Set<Lazy<?>> lazies = entry.getValue();
+      lazySetMap.put(
+          entry.getKey(),
+          new Lazy<>(
+              () -> {
+                Set<Object> set = new HashSet<>();
+                for (Lazy<?> lazy : lazies) {
+                  set.add(lazy.get());
+                }
+                return Collections.unmodifiableSet(set);
+              }));
+    }
   }
 
   @Override
@@ -67,6 +108,16 @@ public class ComponentRuntime extends AbstractComponentContainer {
   public <T> Provider<T> getProvider(Class<T> anInterface) {
     Preconditions.checkNotNull(anInterface, "Null interface requested.");
     return (Provider<T>) lazyInstanceMap.get(anInterface);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> Provider<Set<T>> setOfProvider(Class<T> anInterface) {
+    Lazy<Set<?>> lazy = lazySetMap.get(anInterface);
+    if (lazy != null) {
+      return (Provider<Set<T>>) (Provider<?>) lazy;
+    }
+    return (Provider<Set<T>>) (Provider<?>) EMPTY_PROVIDER;
   }
 
   /**
@@ -77,10 +128,12 @@ public class ComponentRuntime extends AbstractComponentContainer {
    * <p>Note: the method is idempotent.
    */
   public void initializeEagerComponents(boolean isDefaultApp) {
-    for (Component<?> component : components) {
+    for (Map.Entry<Component<?>, Lazy<?>> entry : components.entrySet()) {
+      Component<?> component = entry.getKey();
+      Lazy<?> lazy = entry.getValue();
+
       if (component.isAlwaysEager() || (component.isEagerInDefaultApp() && isDefaultApp)) {
-        // at least one interface is guarenteed to be provided by a component.
-        get(component.getProvidedInterfaces().iterator().next());
+        lazy.get();
       }
     }
 
@@ -89,15 +142,20 @@ public class ComponentRuntime extends AbstractComponentContainer {
 
   private <T> void register(Component<T> component) {
     Lazy<T> lazy =
-        new Lazy<>(component.getFactory(), new RestrictedComponentContainer(component, this));
+        new Lazy<>(
+            () -> component.getFactory().create(new RestrictedComponentContainer(component, this)));
 
+    components.put(component, lazy);
+    if (!component.isValue()) {
+      return;
+    }
     for (Class<? super T> anInterface : component.getProvidedInterfaces()) {
       lazyInstanceMap.put(anInterface, lazy);
     }
   }
 
   private void validateDependencies() {
-    for (Component<?> component : components) {
+    for (Component<?> component : components.keySet()) {
       for (Dependency dependency : component.getDependencies()) {
         if (dependency.isRequired() && !lazyInstanceMap.containsKey(dependency.getInterface())) {
           throw new MissingDependencyException(

--- a/firebase-common/src/main/java/com/google/firebase/components/ComponentRuntime.java
+++ b/firebase-common/src/main/java/com/google/firebase/components/ComponentRuntime.java
@@ -53,7 +53,8 @@ public class ComponentRuntime extends AbstractComponentContainer {
     }
     Collections.addAll(componentsToAdd, additionalComponents);
 
-    components = Collections.unmodifiableList(ComponentSorter.sorted(componentsToAdd));
+    CycleDetector.detect(componentsToAdd);
+    components = Collections.unmodifiableList(componentsToAdd);
 
     for (Component<?> component : components) {
       register(component);

--- a/firebase-common/src/main/java/com/google/firebase/components/Lazy.java
+++ b/firebase-common/src/main/java/com/google/firebase/components/Lazy.java
@@ -38,9 +38,8 @@ class Lazy<T> implements Provider<T> {
     this.instance = instance;
   }
 
-  /** Creates a lazy backed by a {@link ComponentFactory} and {@link ComponentContainer}. */
-  Lazy(ComponentFactory<T> factory, ComponentContainer container) {
-    provider = () -> factory.create(container);
+  Lazy(Provider<T> provider) {
+    this.provider = provider;
   }
 
   /** Returns the initialized value. */
@@ -59,7 +58,10 @@ class Lazy<T> implements Provider<T> {
         }
       }
     }
-    return (T) result;
+
+    @SuppressWarnings("unchecked")
+    T tResult = (T) result;
+    return tResult;
   }
 
   @VisibleForTesting

--- a/firebase-common/src/main/java/com/google/firebase/components/RestrictedComponentContainer.java
+++ b/firebase-common/src/main/java/com/google/firebase/components/RestrictedComponentContainer.java
@@ -64,6 +64,11 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
     delegateContainer = container;
   }
 
+  /**
+   * Returns an instance of the requested class if it is allowed.
+   *
+   * @throws IllegalArgumentException otherwise.
+   */
   @Override
   public <T> T get(Class<T> anInterface) {
     if (!allowedDirectInterfaces.contains(anInterface)) {
@@ -85,6 +90,11 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
     return publisher;
   }
 
+  /**
+   * Returns an instance of the provider for the requested class if it is allowed.
+   *
+   * @throws IllegalArgumentException otherwise.
+   */
   @Override
   public <T> Provider<T> getProvider(Class<T> anInterface) {
     if (!allowedProviderInterfaces.contains(anInterface)) {
@@ -95,6 +105,11 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
     return delegateContainer.getProvider(anInterface);
   }
 
+  /**
+   * Returns an instance of the provider for the set of requested classes if it is allowed.
+   *
+   * @throws IllegalArgumentException otherwise.
+   */
   @Override
   public <T> Provider<Set<T>> setOfProvider(Class<T> anInterface) {
     if (!allowedSetProviderInterfaces.contains(anInterface)) {
@@ -105,6 +120,11 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
     return delegateContainer.setOfProvider(anInterface);
   }
 
+  /**
+   * Returns a set of requested classes if it is allowed.
+   *
+   * @throws IllegalArgumentException otherwise.
+   */
   @Override
   public <T> Set<T> setOf(Class<T> anInterface) {
     if (!allowedSetDirectInterfaces.contains(anInterface)) {

--- a/firebase-common/src/test/java/com/google/firebase/components/ComponentRuntimeTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/components/ComponentRuntimeTest.java
@@ -233,4 +233,37 @@ public final class ComponentRuntimeTest {
     assertThat(child).isSameAs(parent);
     assertThat(child.get()).isSameAs(parent.get());
   }
+
+  @Test
+  public void container_shouldExposeAllRegisteredSetValues() {
+    ComponentRuntime runtime =
+        new ComponentRuntime(
+            EXECUTOR,
+            Collections.emptyList(),
+            Component.intoSet(1, Integer.class),
+            Component.intoSet(2, Integer.class));
+
+    assertThat(runtime.setOf(Integer.class)).containsExactly(1, 2);
+  }
+
+  @Test
+  public void setComponents_shouldParticipateInCycleDetection() {
+    try {
+      new ComponentRuntime(
+          EXECUTOR,
+          Collections.emptyList(),
+          Component.builder(ComponentOne.class)
+              .add(Dependency.setOf(Integer.class))
+              .factory(c -> null)
+              .build(),
+          Component.intoSet(1, Integer.class),
+          Component.intoSetBuilder(Integer.class)
+              .add(Dependency.required(ComponentOne.class))
+              .factory(c -> 2)
+              .build());
+      fail("Expected exception not thrown.");
+    } catch (DependencyCycleException ex) {
+      // success.
+    }
+  }
 }

--- a/firebase-common/src/test/java/com/google/firebase/components/LazyTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/components/LazyTest.java
@@ -14,12 +14,13 @@
 
 package com.google.firebase.components;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.firebase.inject.Provider;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -30,12 +31,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public final class LazyTest {

--- a/firebase-common/src/test/java/com/google/firebase/components/LazyTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/components/LazyTest.java
@@ -14,14 +14,12 @@
 
 package com.google.firebase.components;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.google.firebase.inject.Provider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -32,16 +30,18 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
 public final class LazyTest {
-  private static final ComponentContainer CONTAINER = new EmptyContainer();
 
   @SuppressWarnings("unchecked")
-  private final ComponentFactory<Object> mockFactory = mock(ComponentFactory.class);
+  private final Provider<Object> mockProvider = mock(Provider.class);
 
   @Test
   public void get_whenLazyIsInitializedWithValue_shouldReturnTheValue() {
@@ -54,13 +54,13 @@ public final class LazyTest {
   @Test
   public void get_shouldDelegateToFactory() {
     Object instance = new Object();
-    Lazy<Object> lazy = new Lazy<>(mockFactory, CONTAINER);
+    Lazy<Object> lazy = new Lazy<>(mockProvider);
 
-    when(mockFactory.create(any())).thenReturn(instance);
+    when(mockProvider.get()).thenReturn(instance);
 
     assertThat(lazy.get()).isSameAs(instance);
 
-    verify(mockFactory, times(1)).create(CONTAINER);
+    verify(mockProvider, times(1)).get();
   }
 
   @Test
@@ -70,8 +70,8 @@ public final class LazyTest {
 
     ExecutorService executor = Executors.newFixedThreadPool(numThreads);
 
-    LatchedFactory factory = new LatchedFactory(latch);
-    Lazy<Object> lazy = new Lazy<>(factory, CONTAINER);
+    LatchedProvider provider = new LatchedProvider(latch);
+    Lazy<Object> lazy = new Lazy<>(provider);
 
     List<Callable<Object>> tasks = new ArrayList<>(numThreads);
     for (int i = 0; i < numThreads; i++) {
@@ -83,7 +83,7 @@ public final class LazyTest {
     }
     List<Future<Object>> futures = executor.invokeAll(tasks);
 
-    assertThat(factory.instantiationCount.get()).isEqualTo(1);
+    assertThat(provider.instantiationCount.get()).isEqualTo(1);
 
     Set<Object> createdInstances = new HashSet<>();
     for (Future<Object> future : futures) {
@@ -92,23 +92,16 @@ public final class LazyTest {
     assertThat(createdInstances).hasSize(1);
   }
 
-  private static class EmptyContainer extends AbstractComponentContainer {
-    @Override
-    public <T> Provider<T> getProvider(Class<T> anInterface) {
-      return null;
-    }
-  }
-
-  private static class LatchedFactory implements ComponentFactory<Object> {
+  private static class LatchedProvider implements Provider<Object> {
     private final CountDownLatch latch;
     final AtomicInteger instantiationCount = new AtomicInteger();
 
-    LatchedFactory(CountDownLatch latch) {
+    LatchedProvider(CountDownLatch latch) {
       this.latch = latch;
     }
 
     @Override
-    public Object create(ComponentContainer container) {
+    public Object get() {
       // wait for all threads to start and get as close to calling Lazy#get() as possible.
       uninterruptablyAwait(latch);
       instantiationCount.incrementAndGet();


### PR DESCRIPTION
The gist of the change is that it introduces support for Set-multibindings that enables components to declare a dependency on a Set<T> as well as to create components that contribute values to a Set<T>.