### PR TITLE
Include a trailing /documents on root resource paths

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
@@ -174,17 +174,15 @@ public final class RemoteSerializer {
   }
 
   private String encodeQueryPath(ResourcePath path) {
-    if (path.length() == 0) {
-      // If the path is empty, the backend requires we leave off the /documents at the end.
-      return databaseName;
-    }
     return encodeResourceName(databaseId, path);
   }
 
   private ResourcePath decodeQueryPath(String name) {
     ResourcePath resource = decodeResourceName(name);
     if (resource.length() == 4) {
-      // Path missing the trailing documents path segment, indicating an empty path.
+      // In v1beta1 queries for collections at the root did not have a trailing "/documents". In v1
+      // all resource paths contain "/documents". Preserve the ability to read the v1beta1 form for
+      // compatibility with queries persisted in the local query cache.
       return ResourcePath.EMPTY;
     } else {
       return extractLocalPathFromResourceName(resource);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/RemoteSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/RemoteSerializerTest.java
@@ -498,7 +498,7 @@ public final class RemoteSerializerTest {
             .addOrderBy(defaultKeyOrder());
     QueryTarget.Builder queryBuilder =
         QueryTarget.newBuilder()
-            .setParent("projects/p/databases/d")
+            .setParent("projects/p/databases/d/documents")
             .setStructuredQuery(structuredQueryBuilder);
     Target expected =
         Target.newBuilder()
@@ -558,7 +558,7 @@ public final class RemoteSerializerTest {
             .addOrderBy(defaultKeyOrder());
     QueryTarget.Builder queryBuilder =
         QueryTarget.newBuilder()
-            .setParent("projects/p/databases/d")
+            .setParent("projects/p/databases/d/documents")
             .setStructuredQuery(structuredQueryBuilder);
     Target expected =
         Target.newBuilder()
@@ -664,7 +664,7 @@ public final class RemoteSerializerTest {
             .addOrderBy(defaultKeyOrder());
     QueryTarget.Builder queryBuilder =
         QueryTarget.newBuilder()
-            .setParent("projects/p/databases/d")
+            .setParent("projects/p/databases/d/documents")
             .setStructuredQuery(structuredQueryBuilder);
     Target expected =
         Target.newBuilder()
@@ -692,7 +692,7 @@ public final class RemoteSerializerTest {
             .addOrderBy(defaultKeyOrder());
     QueryTarget.Builder queryBuilder =
         QueryTarget.newBuilder()
-            .setParent("projects/p/databases/d")
+            .setParent("projects/p/databases/d/documents")
             .setStructuredQuery(structuredQueryBuilder);
     Target expected =
         Target.newBuilder()
@@ -751,7 +751,7 @@ public final class RemoteSerializerTest {
             .setLimit(Int32Value.newBuilder().setValue(26));
     QueryTarget.Builder queryBuilder =
         QueryTarget.newBuilder()
-            .setParent("projects/p/databases/d")
+            .setParent("projects/p/databases/d/documents")
             .setStructuredQuery(structuredQueryBuilder);
     Target expected =
         Target.newBuilder()
@@ -791,7 +791,7 @@ public final class RemoteSerializerTest {
 
     QueryTarget.Builder queryBuilder =
         QueryTarget.newBuilder()
-            .setParent("projects/p/databases/d")
+            .setParent("projects/p/databases/d/documents")
             .setStructuredQuery(structuredQueryBuilder);
     Target expected =
         Target.newBuilder()
@@ -819,7 +819,7 @@ public final class RemoteSerializerTest {
 
     QueryTarget.Builder queryBuilder =
         QueryTarget.newBuilder()
-            .setParent("projects/p/databases/d")
+            .setParent("projects/p/databases/d/documents")
             .setStructuredQuery(structuredQueryBuilder);
     Target expected =
         Target.newBuilder()


### PR DESCRIPTION
This is required for v1 and accepted in v1beta1.

Port of firebase/firebase-js-sdk@4cec9b1.