### PR TITLE
Handle large write batches

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [fixed] Fixed an issue where Firestore would crash if handling write batches
+  larger than 2 MB in size (#208).
 
 # 18.0.0
 - [changed] The `timestampsInSnapshotsEnabled` setting is now enabled by

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
@@ -279,5 +279,7 @@ public class WriteBatchTest {
     }
 
     waitFor(batch.commit());
+    DocumentSnapshot snap = waitFor(doc.get());
+    assertEquals(values, snap.getData());
   }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
@@ -259,6 +259,12 @@ public class WriteBatchTest {
 
   @Test
   public void testCanWriteVeryLargeBatches() {
+    // On Android, SQLite Cursors are limited reading no more than 2 MB per row (despite being able
+    // to write very large values). This test verifies that the SQLiteMutationQueue properly works
+    // around this limitation.
+
+    // Create a map containing nearly 1 MB of data. Note that if you use 1024 below this will create
+    // a document larger than 1 MB, which will be rejected by the backend as too large.
     String a = Character.toString('a');
     StringBuilder buf = new StringBuilder(1000);
     for (int i = 0; i < 1000; i++) {
@@ -273,6 +279,9 @@ public class WriteBatchTest {
     DocumentReference doc = testDocument();
     WriteBatch batch = doc.getFirestore().batch();
 
+    // Write a batch containing 3 copies of the data, creating a ~3 MB batch. Writing to the same
+    // document in a batch is allowed and so long as the net size of the document is under 1 MB the
+    // batch is allowed.
     batch.set(doc, values);
     for (int i = 0; i < 2; i++) {
       batch.update(doc, values);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
@@ -434,6 +434,9 @@ final class SQLiteMutationQueue implements MutationQueue {
 
       BlobAccumulator accumulator = new BlobAccumulator(bytes);
       while (accumulator.more) {
+        // As we read in chunks the start of the next chunk should be the total accumulated length
+        // plus 1 (since SUBSTR() counts from 1). The second argument is not adjusted because it's
+        // the length of the chunk, not the end index.
         int start = accumulator.numChunks() * BLOB_MAX_INLINE_LENGTH + 1;
 
         db.query("SELECT SUBSTR(mutations, ?, ?) FROM mutations WHERE uid = ? AND batch_id = ?")

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteMutationQueue.java
@@ -223,9 +223,10 @@ final class SQLiteMutationQueue implements MutationQueue {
     int nextBatchId = batchId + 1;
 
     SQLiteStatement query =
-        db.prepare("SELECT mutations FROM mutations "
-            + "WHERE uid = ? AND batch_id >= ? "
-            + "ORDER BY batch_id ASC LIMIT 1");
+        db.prepare(
+            "SELECT mutations FROM mutations "
+                + "WHERE uid = ? AND batch_id >= ? "
+                + "ORDER BY batch_id ASC LIMIT 1");
     query.bindString(1, uid);
     query.bindLong(2, nextBatchId);
 
@@ -242,7 +243,7 @@ final class SQLiteMutationQueue implements MutationQueue {
     }
 
     try (ParcelFileDescriptor.AutoCloseInputStream stream =
-             new ParcelFileDescriptor.AutoCloseInputStream(blobFile)) {
+        new ParcelFileDescriptor.AutoCloseInputStream(blobFile)) {
       return serializer.decodeMutationBatch(
           com.google.firebase.firestore.proto.WriteBatch.parseFrom(stream));
     } catch (InvalidProtocolBufferException e) {
@@ -440,7 +441,7 @@ final class SQLiteMutationQueue implements MutationQueue {
    * too large, executes another query to load the blob directly.
    *
    * @param batchId The batch ID of the row containing the bytes, for fallback lookup if the value
-   *                is too large.
+   *     is too large.
    * @param bytes The bytes represented
    */
   private MutationBatch decodeInlineMutationBatch(int batchId, byte[] bytes) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/MutationQueueTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/MutationQueueTestCase.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.firebase.Timestamp;
@@ -326,7 +325,6 @@ public abstract class MutationQueueTestCase {
   @Test
   public void testRemoveMutationBatches() {
     List<MutationBatch> batches = createBatches(10);
-    MutationBatch last = batches.get(batches.size() - 1);
 
     removeMutationBatches(batches.remove(0));
     assertEquals(9, batchCount());


### PR DESCRIPTION
This addresses #208.

While this works, I'm not yet sure this approach performs well enough to merge as-is. For example, we could make the two methods I changed to use direct load to use the inline method that others use.

I've sent this out to get feedback on this before I invest time in benchmarking.