### PR TITLE
Unify android sdk version configuration.

### DIFF
--- a/fiamui-app/fiamui-app.gradle
+++ b/fiamui-app/fiamui-app.gradle
@@ -15,12 +15,12 @@
 apply plugin: "com.android.application"
 
 android {
-  compileSdkVersion 27
+  compileSdkVersion project.targetSdkVersion
 
   defaultConfig {
     applicationId "com.example.firebase.fiamui"
     minSdkVersion 16
-    targetSdkVersion 27
+    targetSdkVersion project.targetSdkVersion
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -14,17 +14,15 @@
 
 apply plugin: 'com.android.library'
 
-def androidVersion = 28
-
 android {
     adbOptions {
         timeOutInMs 60 * 1000
     }
 
-    compileSdkVersion androidVersion
+    compileSdkVersion project.targetSdkVersion
     defaultConfig {
-      minSdkVersion 14
-      targetSdkVersion androidVersion
+      minSdkVersion project.minSdkVersion
+      targetSdkVersion project.targetSdkVersion
       versionName version
       multiDexEnabled true
       testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/firebase-database/firebase-database.gradle
+++ b/firebase-database/firebase-database.gradle
@@ -14,9 +14,6 @@
 
 apply plugin: 'com.android.library'
 
-def androidVersion = 28
-
-
 tasks.withType(org.gradle.api.tasks.testing.Test) {
     testLogging {
         exceptionFormat = 'full'
@@ -32,10 +29,10 @@ android {
         timeOutInMs 60 * 1000
     }
 
-    compileSdkVersion androidVersion
+    compileSdkVersion project.targetSdkVersion
     defaultConfig {
-        targetSdkVersion androidVersion
-        minSdkVersion 14
+        targetSdkVersion project.targetSdkVersion
+        minSdkVersion project.minSdkVersion
         versionName version
         multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -15,8 +15,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.google.protobuf'
 
-def androidVersion = 28
-
 protobuf {
     // Configure the protoc executable
     protoc {
@@ -53,10 +51,10 @@ android {
         timeOutInMs 60 * 1000
     }
 
-    compileSdkVersion androidVersion
+    compileSdkVersion project.targetSdkVersion
     defaultConfig {
-        targetSdkVersion androidVersion
-        minSdkVersion 14
+        targetSdkVersion project.targetSdkVersion
+        minSdkVersion project.minSdkVersion
         versionName version
         multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/firebase-functions/firebase-functions.gradle
+++ b/firebase-functions/firebase-functions.gradle
@@ -14,17 +14,15 @@
 
 apply plugin: 'com.android.library'
 
-def androidVersion = 28
-
 android {
     adbOptions {
         timeOutInMs 60 * 1000
     }
 
-    compileSdkVersion androidVersion
+    compileSdkVersion project.targetSdkVersion
     defaultConfig {
-        targetSdkVersion androidVersion
-        minSdkVersion 14
+        targetSdkVersion project.targetSdkVersion
+        minSdkVersion project.minSdkVersion
         versionName version
         multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -15,11 +15,10 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 28
-
+    compileSdkVersion project.targetSdkVersion
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion project.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -14,8 +14,6 @@
 
 apply plugin: 'com.android.library'
 
-def androidVersion = 28
-
 
 tasks.withType(org.gradle.api.tasks.testing.Test) {
     testLogging {
@@ -32,10 +30,10 @@ android {
         timeOutInMs 60 * 1000
     }
 
-    compileSdkVersion androidVersion
+    compileSdkVersion project.targetSdkVersion
     defaultConfig {
-        targetSdkVersion androidVersion
-        minSdkVersion 14
+        targetSdkVersion project.targetSdkVersion
+        minSdkVersion project.minSdkVersion
         multiDexEnabled true
         versionName version
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/protolite-well-known-types/protolite-well-known-types.gradle
+++ b/protolite-well-known-types/protolite-well-known-types.gradle
@@ -40,11 +40,10 @@ protobuf {
     }
 }
 android {
-    compileSdkVersion 28
-
+    compileSdkVersion project.targetSdkVersion
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion project.targetSdkVersion
+        minSdkVersion project.minSdkVersion
         versionCode 1
         versionName '1.0'
     }

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -37,6 +37,8 @@ buildscript {
     }
 }
 
+apply from: 'sdkProperties.gradle'
+
 ext {
     playServicesVersion = '16.0.1'
     supportAnnotationsVersion = '28.0.0'

--- a/sdkProperties.gradle
+++ b/sdkProperties.gradle
@@ -12,18 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-apply plugin: 'com.android.library'
-
-android {
-    compileSdkVersion project.targetSdkVersion
-    defaultConfig {
-        minSdkVersion 9
-    }
-}
-
-dependencies {
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'net.java:quickcheck:0.6'
-    testAnnotationProcessor 'net.java:quickcheck-src-generator:0.6'
-    testAnnotationProcessor 'net.java.quickcheck:quickcheck-src-generator:0.6'
+ext {
+    targetSdkVersion = 28
+    minSdkVersion = 14
 }

--- a/test-apps/build.gradle
+++ b/test-apps/build.gradle
@@ -31,6 +31,8 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.20.0'
 }
 
+apply from: '../sdkProperties.gradle'
+
 allprojects {
     ext.testBuildType = project.getProperties().get("testBuildType", "debug")
 

--- a/test-apps/database-test-app/build.gradle
+++ b/test-apps/database-test-app/build.gradle
@@ -18,12 +18,12 @@ apply plugin: 'com.android.application'
 
 android {
     testBuildType = project.testBuildType
-    compileSdkVersion 28
+    compileSdkVersion project.targetSdkVersion
 
     defaultConfig {
         applicationId "com.google.firebase.testapps.database"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion project.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/test-apps/firestore-test-app/build.gradle
+++ b/test-apps/firestore-test-app/build.gradle
@@ -18,12 +18,12 @@ apply plugin: 'com.android.application'
 
 android {
     testBuildType = project.testBuildType
-    compileSdkVersion 28
+    compileSdkVersion project.targetSdkVersion
 
     defaultConfig {
         applicationId "com.google.firebase.testapps.firestore"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion project.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/test-apps/functions-test-app/build.gradle
+++ b/test-apps/functions-test-app/build.gradle
@@ -18,12 +18,12 @@ apply plugin: 'com.android.application'
 
 android {
     testBuildType = project.testBuildType
-    compileSdkVersion 28
+    compileSdkVersion project.targetSdkVersion
 
     defaultConfig {
         applicationId "com.google.firebase.testapps.functions"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion project.targetSdkVersion
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'

--- a/test-apps/storage-test-app/build.gradle
+++ b/test-apps/storage-test-app/build.gradle
@@ -18,12 +18,12 @@ apply plugin: 'com.android.application'
 
 android {
     testBuildType = project.testBuildType
-    compileSdkVersion 28
+    compileSdkVersion project.targetSdkVersion
 
     defaultConfig {
         applicationId "com.google.firebase.testapps.storage"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion project.targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/tools/apksize/default.gradle
+++ b/tools/apksize/default.gradle
@@ -25,13 +25,13 @@ android {
         abortOnError false
         checkReleaseBuilds false
     }
-    compileSdkVersion 26
+    compileSdkVersion project.targetSdkVersion
 
     defaultConfig {
         applicationId 'com.google.apksize'
-        minSdkVersion 26
-	multiDexEnabled true
-        targetSdkVersion 26
+        minSdkVersion project.targetSdkVersion
+	    multiDexEnabled true
+        targetSdkVersion project.targetSdkVersion
         versionCode 1
         versionName '1.0'
     }


### PR DESCRIPTION
2 benefits:
* We build all sdks with the same build toolchain
* CI is faster as we don't have to download platforms v26 and v27