### PR TITLE
Adjust sqlite size calculation to account for WAL

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [fixed] Fixed calculation of SQLite database size on Android 9 (P) devices.
+  Previous method could be off by a few MBs on these devices, potentially
+  delaying garbage collection.
 
 # 18.0.1
 - [fixed] Fixed an issue where Firestore would crash if handling write batches

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] Fixed calculation of SQLite database size on Android 9 (P) devices.
+- [fixed] Fixed calculation of SQLite database size on Android 9 Pie devices.
   Previous method could be off by a few MBs on these devices, potentially
   delaying garbage collection.
 

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -83,6 +83,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -34,7 +34,6 @@ import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.util.Consumer;
 import com.google.firebase.firestore.util.Logger;
 import com.google.firebase.firestore.util.Supplier;
-import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -77,7 +76,6 @@ public final class SQLitePersistence extends Persistence {
   private final OpenHelper opener;
   private final LocalSerializer serializer;
   private SQLiteDatabase db;
-  private File databasePath;
   private boolean started;
   private final SQLiteQueryCache queryCache;
   private final SQLiteRemoteDocumentCache remoteDocumentCache;
@@ -106,7 +104,6 @@ public final class SQLitePersistence extends Persistence {
       LruGarbageCollector.Params params) {
     String databaseName = databaseName(persistenceKey, databaseId);
     this.opener = new OpenHelper(context, databaseName);
-    this.databasePath = context.getDatabasePath(databaseName);
     this.serializer = serializer;
     this.queryCache = new SQLiteQueryCache(this, this.serializer);
     this.remoteDocumentCache = new SQLiteRemoteDocumentCache(this, this.serializer);
@@ -199,7 +196,40 @@ public final class SQLitePersistence extends Persistence {
   }
 
   long getByteSize() {
-    return databasePath.length();
+    return getPageCount() * getPageSize();
+  }
+
+  /**
+   * Gets the page size of the database. Typically 4096.
+   *
+   * @see https://www.sqlite.org/pragma.html#pragma_page_size
+   */
+  private long getPageSize() {
+    return pragma("page_size");
+  }
+
+  /**
+   * Gets the number of pages in the database file. Multiplying this with the page size yields the
+   * approximate size of the database on disk (including the WAL, if relevant).
+   *
+   * @see https://www.sqlite.org/pragma.html#pragma_page_count.
+   */
+  private long getPageCount() {
+    return pragma("page_count");
+  }
+
+  /**
+   * @param pragmaName Must be a valid 'pragma-name' and must refer to a long value.
+   * @see https://www.sqlite.org/pragma.html
+   */
+  private long pragma(String pragmaName) {
+    Cursor cursor = db.rawQuery("PRAGMA " + pragmaName, null);
+    try {
+      cursor.moveToFirst();
+      return cursor.getLong(/*column=*/ 0);
+    } finally {
+      cursor.close();
+    }
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -205,13 +205,7 @@ public final class SQLitePersistence extends Persistence {
    * @see https://www.sqlite.org/pragma.html#pragma_page_size
    */
   private long getPageSize() {
-    Cursor cursor = db.rawQuery("PRAGMA page_size", null);
-    try {
-      cursor.moveToFirst();
-      return cursor.getLong(/*column=*/ 0);
-    } finally {
-      cursor.close();
-    }
+    return query("PRAGMA page_size").firstValue(row -> row.getLong(/*column=*/ 0));
   }
 
   /**
@@ -221,13 +215,7 @@ public final class SQLitePersistence extends Persistence {
    * @see https://www.sqlite.org/pragma.html#pragma_page_count.
    */
   private long getPageCount() {
-    Cursor cursor = db.rawQuery("PRAGMA page_count", null);
-    try {
-      cursor.moveToFirst();
-      return cursor.getLong(/*column=*/ 0);
-    } finally {
-      cursor.close();
-    }
+    return query("PRAGMA page_count").firstValue(row -> row.getLong(/*column=*/ 0));
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -205,7 +205,13 @@ public final class SQLitePersistence extends Persistence {
    * @see https://www.sqlite.org/pragma.html#pragma_page_size
    */
   private long getPageSize() {
-    return pragma("page_size");
+    Cursor cursor = db.rawQuery("PRAGMA page_size", null);
+    try {
+      cursor.moveToFirst();
+      return cursor.getLong(/*column=*/ 0);
+    } finally {
+      cursor.close();
+    }
   }
 
   /**
@@ -215,15 +221,7 @@ public final class SQLitePersistence extends Persistence {
    * @see https://www.sqlite.org/pragma.html#pragma_page_count.
    */
   private long getPageCount() {
-    return pragma("page_count");
-  }
-
-  /**
-   * @param pragmaName Must be a valid 'pragma-name' and must refer to a long value.
-   * @see https://www.sqlite.org/pragma.html
-   */
-  private long pragma(String pragmaName) {
-    Cursor cursor = db.rawQuery("PRAGMA " + pragmaName, null);
+    Cursor cursor = db.rawQuery("PRAGMA page_count", null);
     try {
       cursor.moveToFirst();
       return cursor.getLong(/*column=*/ 0);


### PR DESCRIPTION
SQLite supports two methods of commiting; a rollback journal and a
write-ahead-log (WAL). By default, a rollback journal is used. However,
on Android 9 (P), the default changed slightly to a WAL-compatible mode:
https://source.android.com/devices/tech/perf/compatibility-wal. This
mode causes a WAL to be written to disk.

Our prior method of calculating the database size did not take the WAL
into account. In practice, this isn't too awful, as the contents of the
WAL would eventually be written back into the main database file, but in
the meantime, our calculation could be off by upwards of a few MB. This
commit changes the size calulation to ask sqlite rather than looking at
the size of the file on disk.