### PR TITLE
Disable verbose stdout logging for storage and rtdb.

### DIFF
--- a/firebase-database/firebase-database.gradle
+++ b/firebase-database/firebase-database.gradle
@@ -14,16 +14,6 @@
 
 apply plugin: 'com.android.library'
 
-tasks.withType(org.gradle.api.tasks.testing.Test) {
-    testLogging {
-        exceptionFormat = 'full'
-        showStandardStreams = true
-        showCauses = true
-        showExceptions =true
-        showStackTraces = true
-    }
-}
-
 android {
     adbOptions {
         timeOutInMs 60 * 1000

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -14,17 +14,6 @@
 
 apply plugin: 'com.android.library'
 
-
-tasks.withType(org.gradle.api.tasks.testing.Test) {
-    testLogging {
-        exceptionFormat = 'full'
-        showStandardStreams = true
-        showCauses = true
-        showExceptions =true
-        showStackTraces = true
-    }
-}
-
 android {
     adbOptions {
         timeOutInMs 60 * 1000


### PR DESCRIPTION
Test results are available in the artifacts directory, so stdout logging
is no longer necessary.