### PR TITLE
Add gradle task for generating JaCoCo coverage report for unit tests.

### DIFF
--- a/root-project.gradle
+++ b/root-project.gradle
@@ -97,10 +97,10 @@ configure(subprojects) {
     }
     apply plugin: 'jacoco'
     jacoco {
-        toolVersion = '0.8.2'
+        toolVersion = '0.8.3'
     }
     task(['type': JacocoReport, 'dependsOn': 'check', 'group': 'Coverage',
-          'description': 'Generates JaCoCo unit test coverage reports.'], 'coverage') {
+          'description': 'Generates JaCoCo unit test coverage reports.'], 'checkCoverage') {
         def excludes = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**Manifest*.*']
         classDirectories = files([
             fileTree(dir: "$buildDir/intermediates/javac/debug", excludes: excludes)

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -95,6 +95,27 @@ configure(subprojects) {
         exclude 'src/testUtil/java/com/google/firebase/firestore/testutil/ThrowingRunnable.java'
         exclude '**/package-info.java'
     }
+    apply plugin: 'jacoco'
+    jacoco {
+        toolVersion = '0.8.2'
+    }
+    task(['type': JacocoReport, 'dependsOn': 'check', 'group': 'Coverage',
+          'description': 'Generates JaCoCo unit test coverage reports.'], 'coverage') {
+        def excludes = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**Manifest*.*']
+        classDirectories = files([
+            fileTree(dir: "$buildDir/intermediates/javac/debug", excludes: excludes)
+        ])
+        sourceDirectories = files(['src/main/java'])
+        executionData = fileTree(dir: "$buildDir", includes: ['jacoco/*.exec'])
+        reports {
+            html.enabled true
+            xml.enabled true
+            csv.enabled true
+        }
+    }
+    tasks.withType(Test) {
+        jacoco.includeNoLocationClasses true
+    }
 
     tasks.withType(JavaCompile) {
         options.errorprone.excludedPaths = '.*/build/generated/.*'


### PR DESCRIPTION
This commit will add a gradle task to run the instrumented unit test and generate a jacoco coverage report.

The command for the gradle task is `./gradlew :<firebase-project>:coverage` for specific sdk or `./gradlew coverage` for all sdks.

Generated html report and xml report reside in `build/reports/jacoco/coverage` under each sdk directory.