### PR TITLE
Add okhttp3 settings to Functions proguard.

### DIFF
--- a/firebase-functions/proguard.txt
+++ b/firebase-functions/proguard.txt
@@ -1,1 +1,17 @@
 -dontwarn okio.**
+
+# These rules come from:
+# https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
+
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+-dontwarn org.codehaus.mojo.animal_sniffer.*
+
+# OkHttp platform used only on JVM and when Conscrypt dependency is available.
+-dontwarn okhttp3.internal.platform.ConscryptPlatform
+

--- a/test-apps/functions-test-app/proguard-rules.pro
+++ b/test-apps/functions-test-app/proguard-rules.pro
@@ -3,18 +3,3 @@
 -keep class android.support.test.espresso.IdlingResource { *; }
 -keep class android.support.test.espresso.IdlingRegistry { *; }
 
-# These rules come from:
-# https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
-
-# JSR 305 annotations are for embedding nullability information.
--dontwarn javax.annotation.**
-
-# A resource is loaded with a relative path so the package of this class must be preserved.
--keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
-
-# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
--dontwarn org.codehaus.mojo.animal_sniffer.*
-
-# OkHttp platform used only on JVM and when Conscrypt dependency is available.
--dontwarn okhttp3.internal.platform.ConscryptPlatform
-

--- a/test-apps/functions-test-app/proguard-rules.pro
+++ b/test-apps/functions-test-app/proguard-rules.pro
@@ -2,3 +2,19 @@
 
 -keep class android.support.test.espresso.IdlingResource { *; }
 -keep class android.support.test.espresso.IdlingRegistry { *; }
+
+# These rules come from:
+# https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
+
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+-dontwarn org.codehaus.mojo.animal_sniffer.*
+
+# OkHttp platform used only on JVM and when Conscrypt dependency is available.
+-dontwarn okhttp3.internal.platform.ConscryptPlatform
+


### PR DESCRIPTION
I'm not sure if this is the best way to implement this. But this was needed to make the warnings go away for the test app so that it would pass smoke tests.