### PR TITLE
Reduce visibility of non-public portions of our api.

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -71,7 +71,7 @@ public class DocumentReference {
   }
 
   /** @hide */
-  public static DocumentReference forPath(ResourcePath path, FirebaseFirestore firestore) {
+  static DocumentReference forPath(ResourcePath path, FirebaseFirestore firestore) {
     if (path.length() % 2 != 0) {
       throw new IllegalArgumentException(
           "Invalid document reference. Document references must have an even number "

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/SetOptions.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/SetOptions.java
@@ -46,7 +46,7 @@ public final class SetOptions {
   }
 
   /** @hide */
-  public boolean isMerge() {
+  boolean isMerge() {
     return merge;
   }
 


### PR DESCRIPTION
Since we no longer proguard our sdk, some internal methods can now
appear in IDE autocompletion lists. This PR reduces the visibility of
these methods so that this no longer occurs.