### PR TITLE
Add RestrictTo annotations to Firestore

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -8,6 +8,9 @@
 - [changed] Prepared the persistence layer to support collection group queries.
   While this feature is not yet available, all schema changes are included
   in this release.
+- [changed] Added `@RestrictTo` annotations to discourage the use of APIs that
+  are not public. This affects internal APIs that were previously obfuscated
+  and are not mentioned in our documentation.
 
 # 18.0.1
 - [fixed] Fixed an issue where Firestore would crash if handling write batches

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Blob.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Blob.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
 import com.google.firebase.annotations.PublicApi;
 import com.google.firebase.firestore.util.Util;
 import com.google.protobuf.ByteString;
@@ -38,8 +39,8 @@ public class Blob implements Comparable<Blob> {
    * @param bytes The bytes to use for this Blob instance.
    * @return The new Blob instance
    */
-  @Keep
   @NonNull
+  @PublicApi
   public static Blob fromBytes(@NonNull byte[] bytes) {
     checkNotNull(bytes, "Provided bytes array must not be null.");
     return new Blob(ByteString.copyFrom(bytes));
@@ -47,14 +48,15 @@ public class Blob implements Comparable<Blob> {
 
   /** @hide */
   @NonNull
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public static Blob fromByteString(@NonNull ByteString bytes) {
     checkNotNull(bytes, "Provided ByteString must not be null.");
     return new Blob(bytes);
   }
 
   /** @return The bytes of this blob as a new byte[] array. */
-  @Keep
   @NonNull
+  @PublicApi
   public byte[] toBytes() {
     return bytes.toByteArray();
   }
@@ -67,6 +69,7 @@ public class Blob implements Comparable<Blob> {
 
   /** @hide */
   @NonNull
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public ByteString toByteString() {
     return bytes;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Blob.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Blob.java
@@ -16,7 +16,6 @@ package com.google.firebase.firestore;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RestrictTo;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -21,6 +21,7 @@ import static java.util.Collections.singletonList;
 
 import android.app.Activity;
 import android.support.annotation.NonNull;
+import android.support.annotation.RestrictTo;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
@@ -71,6 +72,7 @@ public class DocumentReference {
   }
 
   /** @hide */
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public static DocumentReference forPath(ResourcePath path, FirebaseFirestore firestore) {
     if (path.length() % 2 != 0) {
       throw new IllegalArgumentException(

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -298,6 +298,7 @@ public class DocumentSnapshot {
    * @return The value at the given field or null.
    */
   @Nullable
+  @PublicApi
   public <T> T get(@NonNull String field, @NonNull Class<T> valueType) {
     return get(FieldPath.fromDotSeparatedPath(field), valueType, ServerTimestampBehavior.DEFAULT);
   }
@@ -313,6 +314,7 @@ public class DocumentSnapshot {
    * @return The value at the given field or null.
    */
   @Nullable
+  @PublicApi
   public <T> T get(
       @NonNull String field,
       @NonNull Class<T> valueType,
@@ -329,6 +331,7 @@ public class DocumentSnapshot {
    * @return The value at the given field or null.
    */
   @Nullable
+  @PublicApi
   public <T> T get(@NonNull FieldPath fieldPath, @NonNull Class<T> valueType) {
     return get(fieldPath, valueType, ServerTimestampBehavior.DEFAULT);
   }
@@ -344,6 +347,7 @@ public class DocumentSnapshot {
    * @return The value at the given field or null.
    */
   @Nullable
+  @PublicApi
   public <T> T get(
       @NonNull FieldPath fieldPath,
       @NonNull Class<T> valueType,

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreRegistrar.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreRegistrar.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore;
 
 import android.content.Context;
 import android.support.annotation.Keep;
+import android.support.annotation.RestrictTo;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.internal.InternalAuthProvider;
 import com.google.firebase.components.Component;
@@ -31,6 +32,7 @@ import java.util.List;
  * @hide
  */
 @Keep
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class FirestoreRegistrar implements ComponentRegistrar {
   @Override
   @Keep

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -19,7 +19,6 @@ import static com.google.firebase.firestore.util.Assert.fail;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import android.app.Activity;
-import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -65,8 +65,7 @@ public class Query {
   final FirebaseFirestore firestore;
 
   /** An enum for the direction of a sort. */
-  // TODO: Remove this annotation once our proguard issues are sorted out.
-  @Keep
+  @PublicApi
   public enum Direction {
     ASCENDING,
     DESCENDING

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/SetOptions.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/SetOptions.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
 import com.google.firebase.annotations.PublicApi;
 import com.google.firebase.firestore.model.mutation.FieldMask;
 import java.util.HashSet;
@@ -46,12 +47,14 @@ public final class SetOptions {
   }
 
   /** @hide */
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public boolean isMerge() {
     return merge;
   }
 
   /** @hide */
   @Nullable
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public FieldMask getFieldMask() {
     return fieldMask;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -17,6 +17,7 @@ package com.google.firebase.firestore;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import android.support.annotation.RestrictTo;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.FieldValue.ArrayRemoveFieldValue;
 import com.google.firebase.firestore.FieldValue.ArrayUnionFieldValue;
@@ -63,6 +64,7 @@ import javax.annotation.Nullable;
  *
  * @hide
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public final class UserDataConverter {
 
   private final DatabaseId databaseId;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/auth/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/auth/package-info.java
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 /** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 package com.google.firebase.firestore.auth;
+
+import android.support.annotation.RestrictTo;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/package-info.java
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 /** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 package com.google.firebase.firestore.core;
+
+import android.support.annotation.RestrictTo;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/package-info.java
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 /** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 package com.google.firebase.firestore.local;
+
+import android.support.annotation.RestrictTo;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/package-info.java
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 /** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 package com.google.firebase.firestore.model.mutation;
+
+import android.support.annotation.RestrictTo;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/package-info.java
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 /** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 package com.google.firebase.firestore.model;
+
+import android.support.annotation.RestrictTo;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/value/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/value/package-info.java
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 /** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 package com.google.firebase.firestore.model.value;
+
+import android.support.annotation.RestrictTo;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/package-info.java
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 /** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 package com.google.firebase.firestore.remote;
+
+import android.support.annotation.RestrictTo;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/package-info.java
@@ -13,4 +13,7 @@
 // limitations under the License.
 
 /** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 package com.google.firebase.firestore.util;
+
+import android.support.annotation.RestrictTo;


### PR DESCRIPTION
Same as #266 and #270 but for Firestore.

I fixed a couple of places where we were missing the `@PublicApi` annotation. See cr/151329304 (internal) for reference.

Addresses #264