### PR TITLE
Enable proguard of proto library, various fixes.

### DIFF
--- a/transport/transport-backend-cct/gradle.properties
+++ b/transport/transport-backend-cct/gradle.properties
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 version=16.0.0
+firebaseSkipPreguard=false

--- a/transport/transport-backend-cct/preguard.txt
+++ b/transport/transport-backend-cct/preguard.txt
@@ -1,0 +1,4 @@
+-keep class com.google.android.datatransport.cct.GoogleTransportBackend {
+  public *;
+}
+

--- a/transport/transport-backend-cct/src/main/AndroidManifest.xml
+++ b/transport/transport-backend-cct/src/main/AndroidManifest.xml
@@ -16,4 +16,6 @@
     package="com.google.android.datatransport.backend.cct">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
   <!--<uses-sdk android:minSdkVersion="14"/>-->
+
+  <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/BackendRegistry.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/BackendRegistry.java
@@ -16,12 +16,16 @@ package com.google.android.datatransport.runtime;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /** Container for registered {@link TransportBackend}s. */
 @Singleton
 public class BackendRegistry {
   private final Map<String, TransportBackend> backends = new HashMap<>();
+
+  @Inject
+  public BackendRegistry() {}
 
   void register(String name, TransportBackend backend) {
     synchronized (backends) {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportFactoryImpl.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportFactoryImpl.java
@@ -22,7 +22,7 @@ public final class TransportFactoryImpl implements TransportFactory {
   private String backendName;
   private final TransportInternal transportInternal;
 
-  public TransportFactoryImpl(String backendName, TransportInternal transportInternal) {
+  TransportFactoryImpl(String backendName, TransportInternal transportInternal) {
     this.backendName = backendName;
     this.transportInternal = transportInternal;
   }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntime.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntime.java
@@ -87,6 +87,11 @@ public class TransportRuntime implements TransportInternal {
     backendRegistry.register(name, backend);
   }
 
+  /** Returns a {@link TransportFactory} for a given {@code backendName}. */
+  public TransportFactory newFactory(String backendName) {
+    return new TransportFactoryImpl(backendName, this);
+  }
+
   @Override
   public void send(SendRequest request) {
     scheduler.schedule(request.getBackendName(), convert(request));

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntimeModule.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntimeModule.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 @Module
-public class TransportRuntimeModule {
+class TransportRuntimeModule {
   @Provides
   Executor executor() {
     return Executors.newSingleThreadExecutor();
@@ -43,11 +43,6 @@ public class TransportRuntimeModule {
   @Uptime
   Clock uptimeClock() {
     return new UptimeClock();
-  }
-
-  @Provides
-  BackendRegistry backendRegistry() {
-    return new BackendRegistry();
   }
 
   @Provides

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
@@ -84,7 +84,7 @@ public class TransportRuntimeTest {
                         .toBuilder()
                         .addMetadata(TEST_KEY, TEST_VALUE)
                         .build());
-    TransportFactory factory = new TransportFactoryImpl(mockBackendName, runtime);
+    TransportFactory factory = runtime.newFactory(mockBackendName);
     Transport<String> transport =
         factory.getTransport(testTransport, String.class, String::getBytes);
     Event<String> stringEvent = Event.ofTelemetry("TelemetryData");

--- a/transport/transport.gradle
+++ b/transport/transport.gradle
@@ -1,0 +1,19 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+configure(subprojects) {
+    group = 'com.google.android.datatransport'
+}
+


### PR DESCRIPTION
* Enable proguarding of CCT backend. This reduces the size of the library to
  53KB from 100KB.
* Properly declare INTERNET permission.
* Rename maven groupId to com.google.android.datatransport.
* Fix invalid `@Singleton` use.
* Runtime is not responsible for creating TransportFactory's.