### PR TITLE
Firebase Storage Component Registration

### DIFF
--- a/firebase-storage/CHANGELOG.md
+++ b/firebase-storage/CHANGELOG.md
@@ -2,3 +2,5 @@
 - [changed] Added `@RestrictTo` annotations to discourage the use of APIs that
   are not public. This affects internal APIs that were previously obfuscated
   and are not mentioned in our documentation.
+- [internal] Updated the SDK initialization process and removed usages of
+  deprecated methods.

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -69,6 +69,9 @@ dependencies {
 
     implementation "com.google.android.gms:play-services-base:$playServicesVersion"
     implementation "com.google.android.gms:play-services-tasks:$playServicesVersion"
+    implementation('com.google.firebase:firebase-auth-interop:16.0.1') {
+        exclude group: "com.google.firebase", module: "firebase-common"
+    }
 
     androidTestImplementation "com.android.support:support-annotations:$supportAnnotationsVersion"
     androidTestImplementation 'com.android.support.test:rules:1.0.2'

--- a/firebase-storage/src/main/java/com/google/firebase/storage/DeleteStorageTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/DeleteStorageTask.java
@@ -42,10 +42,13 @@ import com.google.firebase.storage.network.NetworkRequest;
     Preconditions.checkNotNull(pendingResult);
     this.mStorageRef = storageRef;
     this.mPendingResult = pendingResult;
+
+    FirebaseStorage storage = mStorageRef.getStorage();
     mSender =
         new ExponentialBackoffSender(
-            mStorageRef.getStorage().getApp(),
-            mStorageRef.getStorage().getMaxOperationRetryTimeMillis());
+            storage.getApp().getApplicationContext(),
+            storage.getAuthProvider(),
+            storage.getMaxDownloadRetryTimeMillis());
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
@@ -49,10 +49,13 @@ public class FileDownloadTask extends StorageTask<FileDownloadTask.TaskSnapshot>
   /*package*/ FileDownloadTask(@NonNull StorageReference storageRef, @NonNull Uri destinationFile) {
     mStorageRef = storageRef;
     mDestinationFile = destinationFile;
+
+    FirebaseStorage storage = mStorageRef.getStorage();
     mSender =
         new ExponentialBackoffSender(
-            mStorageRef.getStorage().getApp(),
-            mStorageRef.getStorage().getMaxDownloadRetryTimeMillis());
+            storage.getApp().getApplicationContext(),
+            storage.getAuthProvider(),
+            storage.getMaxDownloadRetryTimeMillis());
   }
 
   /** @return the number of bytes downloaded so far into the file. */

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
@@ -14,8 +14,6 @@
 
 package com.google.firebase.storage;
 
-import static com.google.android.gms.common.internal.Preconditions.checkNotNull;
-
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -27,6 +25,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.annotations.PublicApi;
 import com.google.firebase.auth.internal.InternalAuthProvider;
+import com.google.firebase.inject.Provider;
 import com.google.firebase.storage.internal.Util;
 import java.io.UnsupportedEncodingException;
 
@@ -48,7 +47,7 @@ public class FirebaseStorage {
   private static final String STORAGE_BUCKET_WITH_PATH_EXCEPTION =
       "The storage Uri cannot contain a path element.";
   @NonNull private final FirebaseApp mApp;
-  @Nullable private final InternalAuthProvider mAuthProvider;
+  @Nullable private final Provider<InternalAuthProvider> mAuthProvider;
   @Nullable private final String mBucketName;
   private long sMaxUploadRetry = 10 * DateUtils.MINUTE_IN_MILLIS; //  10 * 60 * 1000
   private long sMaxDownloadRetry = 10 * DateUtils.MINUTE_IN_MILLIS; //  10 * 60 * 1000
@@ -57,7 +56,7 @@ public class FirebaseStorage {
   FirebaseStorage(
       @Nullable String bucketName,
       @NonNull FirebaseApp app,
-      @Nullable InternalAuthProvider authProvider) {
+      @Nullable Provider<InternalAuthProvider> authProvider) {
     mBucketName = bucketName;
     mApp = app;
     mAuthProvider = authProvider;
@@ -70,9 +69,9 @@ public class FirebaseStorage {
       throw new IllegalArgumentException(STORAGE_BUCKET_WITH_PATH_EXCEPTION);
     }
 
-    checkNotNull(app, "Provided FirebaseApp must not be null.");
+    Preconditions.checkNotNull(app, "Provided FirebaseApp must not be null.");
     FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
-    checkNotNull(component, "Firebase Storage component is not present.");
+    Preconditions.checkNotNull(component, "Firebase Storage component is not present.");
     return component.get(bucketName);
   }
 
@@ -304,7 +303,7 @@ public class FirebaseStorage {
   @NonNull
   private StorageReference getReference(@NonNull Uri uri) {
     // ensure that the authority represents the correct bucket.
-    checkNotNull(uri, "uri must not be null");
+    Preconditions.checkNotNull(uri, "uri must not be null");
     String bucketName = getBucketName();
     Preconditions.checkArgument(
         TextUtils.isEmpty(bucketName) || uri.getAuthority().equalsIgnoreCase(bucketName),
@@ -322,6 +321,6 @@ public class FirebaseStorage {
 
   @Nullable
   InternalAuthProvider getAuthProvider() {
-    return mAuthProvider;
+    return mAuthProvider != null ? mAuthProvider.get() : null;
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
@@ -26,6 +26,7 @@ import com.google.android.gms.common.internal.Preconditions;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.annotations.PublicApi;
+import com.google.firebase.auth.internal.InternalAuthProvider;
 import com.google.firebase.storage.internal.Util;
 import java.io.UnsupportedEncodingException;
 
@@ -47,19 +48,19 @@ public class FirebaseStorage {
   private static final String STORAGE_BUCKET_WITH_PATH_EXCEPTION =
       "The storage Uri cannot contain a path element.";
   @NonNull private final FirebaseApp mApp;
+  @Nullable private final InternalAuthProvider mAuthProvider;
   @Nullable private final String mBucketName;
   private long sMaxUploadRetry = 10 * DateUtils.MINUTE_IN_MILLIS; //  10 * 60 * 1000
   private long sMaxDownloadRetry = 10 * DateUtils.MINUTE_IN_MILLIS; //  10 * 60 * 1000
   private long sMaxQueryRetry = 2 * DateUtils.MINUTE_IN_MILLIS; //  2 * 60 * 1000
 
-  private FirebaseStorage(@Nullable String bucketName, @NonNull FirebaseApp app) {
+  FirebaseStorage(
+      @Nullable String bucketName,
+      @NonNull FirebaseApp app,
+      @Nullable InternalAuthProvider authProvider) {
     mBucketName = bucketName;
     mApp = app;
-  }
-
-  @NonNull
-  static FirebaseStorage newInstance(@Nullable String bucketName, @NonNull FirebaseApp app) {
-    return new FirebaseStorage(bucketName, app);
+    mAuthProvider = authProvider;
   }
 
   private static FirebaseStorage getInstanceImpl(@NonNull FirebaseApp app, @Nullable Uri url) {
@@ -71,7 +72,7 @@ public class FirebaseStorage {
 
     checkNotNull(app, "Provided FirebaseApp must not be null.");
     FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
-    checkNotNull(component, "Firestore component is not present.");
+    checkNotNull(component, "Firebase Storage component is not present.");
     return component.get(bucketName);
   }
 
@@ -317,5 +318,10 @@ public class FirebaseStorage {
   @PublicApi
   public FirebaseApp getApp() {
     return mApp;
+  }
+
+  @Nullable
+  InternalAuthProvider getAuthProvider() {
+    return mAuthProvider;
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorageComponent.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorageComponent.java
@@ -34,7 +34,7 @@ class FirebaseStorageComponent {
     this.authProvider = authProvider;
   }
 
-  /** Provides instances of Firebase Storage for given database names. */
+  /** Provides instances of Firebase Storage for given bucket names. */
   @NonNull
   synchronized FirebaseStorage get(@Nullable String bucketName) {
     FirebaseStorage storage = instances.get(bucketName);

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorageComponent.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorageComponent.java
@@ -18,31 +18,33 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.internal.InternalAuthProvider;
 import java.util.HashMap;
 import java.util.Map;
 
 class FirebaseStorageComponent {
-  /** A static map from storage buckets to FirebaseStorage instances. */
-  private static final Map<String, FirebaseStorage> instances = new HashMap<>();
+  /** A map from storage buckets to Firebase Storage instances. */
+  private final Map<String, FirebaseStorage> instances = new HashMap<>();
 
   private final FirebaseApp app;
+  @Nullable private final InternalAuthProvider authProvider;
 
-  FirebaseStorageComponent(@NonNull FirebaseApp app) {
+  FirebaseStorageComponent(@NonNull FirebaseApp app, @Nullable InternalAuthProvider authProvider) {
     this.app = app;
+    this.authProvider = authProvider;
   }
 
-  /** Provides instances of Firestore for given database names. */
+  /** Provides instances of Firebase Storage for given database names. */
   @NonNull
   synchronized FirebaseStorage get(@Nullable String bucketName) {
     FirebaseStorage storage = instances.get(bucketName);
     if (storage == null) {
-      storage = FirebaseStorage.newInstance(bucketName, app);
+      storage = new FirebaseStorage(bucketName, app, authProvider);
       instances.put(bucketName, storage);
     }
     return storage;
   }
 
-  /** @hide */
   @VisibleForTesting
   synchronized void clearInstancesForTesting() {
     instances.clear();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorageComponent.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorageComponent.java
@@ -19,6 +19,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.internal.InternalAuthProvider;
+import com.google.firebase.inject.Provider;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,9 +28,10 @@ class FirebaseStorageComponent {
   private final Map<String, FirebaseStorage> instances = new HashMap<>();
 
   private final FirebaseApp app;
-  @Nullable private final InternalAuthProvider authProvider;
+  @Nullable private final Provider<InternalAuthProvider> authProvider;
 
-  FirebaseStorageComponent(@NonNull FirebaseApp app, @Nullable InternalAuthProvider authProvider) {
+  FirebaseStorageComponent(
+      @NonNull FirebaseApp app, @Nullable Provider<InternalAuthProvider> authProvider) {
     this.app = app;
     this.authProvider = authProvider;
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorageComponent.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorageComponent.java
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.storage;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+import com.google.firebase.FirebaseApp;
+import java.util.HashMap;
+import java.util.Map;
+
+class FirebaseStorageComponent {
+  /** A static map from storage buckets to FirebaseStorage instances. */
+  private static final Map<String, FirebaseStorage> instances = new HashMap<>();
+
+  private final FirebaseApp app;
+
+  FirebaseStorageComponent(@NonNull FirebaseApp app) {
+    this.app = app;
+  }
+
+  /** Provides instances of Firestore for given database names. */
+  @NonNull
+  synchronized FirebaseStorage get(@Nullable String bucketName) {
+    FirebaseStorage storage = instances.get(bucketName);
+    if (storage == null) {
+      storage = FirebaseStorage.newInstance(bucketName, app);
+      instances.put(bucketName, storage);
+    }
+    return storage;
+  }
+
+  /** @hide */
+  @VisibleForTesting
+  synchronized void clearInstancesForTesting() {
+    instances.clear();
+  }
+}

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
@@ -44,10 +44,13 @@ class GetDownloadUrlTask implements Runnable {
 
     this.storageRef = storageRef;
     this.pendingResult = pendingResult;
+
+    FirebaseStorage storage = this.storageRef.getStorage();
     sender =
         new ExponentialBackoffSender(
-            this.storageRef.getApp(),
-            this.storageRef.getStorage().getMaxOperationRetryTimeMillis());
+            storage.getApp().getApplicationContext(),
+            storage.getAuthProvider(),
+            storage.getMaxOperationRetryTimeMillis());
   }
 
   private Uri extractDownloadUrl(JSONObject response) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
@@ -42,9 +42,13 @@ class GetMetadataTask implements Runnable {
 
     this.mStorageRef = storageRef;
     this.mPendingResult = pendingResult;
+
+    FirebaseStorage storage = mStorageRef.getStorage();
     mSender =
         new ExponentialBackoffSender(
-            mStorageRef.getApp(), mStorageRef.getStorage().getMaxOperationRetryTimeMillis());
+            storage.getApp().getApplicationContext(),
+            storage.getAuthProvider(),
+            storage.getMaxDownloadRetryTimeMillis());
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageRegistrar.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageRegistrar.java
@@ -30,7 +30,6 @@ import java.util.List;
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class StorageRegistrar implements ComponentRegistrar {
   @Override
-  @Keep
   public List<Component<?>> getComponents() {
     return Arrays.asList(
         Component.builder(FirebaseStorageComponent.class)

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageRegistrar.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageRegistrar.java
@@ -16,10 +16,12 @@ package com.google.firebase.storage;
 
 import android.support.annotation.Keep;
 import android.support.annotation.RestrictTo;
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
+import com.google.firebase.components.Dependency;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 /** @hide */
@@ -27,8 +29,13 @@ import java.util.List;
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class StorageRegistrar implements ComponentRegistrar {
   @Override
+  @Keep
   public List<Component<?>> getComponents() {
-    return Collections.singletonList(
+    return Arrays.asList(
+        Component.builder(FirebaseStorageComponent.class)
+            .add(Dependency.required(FirebaseApp.class))
+            .factory(c -> new FirebaseStorageComponent(c.get(FirebaseApp.class)))
+            .build(),
         LibraryVersionComponent.create("fire-gcs", BuildConfig.VERSION_NAME));
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageRegistrar.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageRegistrar.java
@@ -35,11 +35,11 @@ public class StorageRegistrar implements ComponentRegistrar {
     return Arrays.asList(
         Component.builder(FirebaseStorageComponent.class)
             .add(Dependency.required(FirebaseApp.class))
-            .add(Dependency.optional(InternalAuthProvider.class))
+            .add(Dependency.optionalProvider(InternalAuthProvider.class))
             .factory(
                 c ->
                     new FirebaseStorageComponent(
-                        c.get(FirebaseApp.class), c.get(InternalAuthProvider.class)))
+                        c.get(FirebaseApp.class), c.getProvider(InternalAuthProvider.class)))
             .build(),
         LibraryVersionComponent.create("fire-gcs", BuildConfig.VERSION_NAME));
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageRegistrar.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageRegistrar.java
@@ -17,6 +17,7 @@ package com.google.firebase.storage;
 import android.support.annotation.Keep;
 import android.support.annotation.RestrictTo;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.internal.InternalAuthProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.components.Dependency;
@@ -34,7 +35,11 @@ public class StorageRegistrar implements ComponentRegistrar {
     return Arrays.asList(
         Component.builder(FirebaseStorageComponent.class)
             .add(Dependency.required(FirebaseApp.class))
-            .factory(c -> new FirebaseStorageComponent(c.get(FirebaseApp.class)))
+            .add(Dependency.optional(InternalAuthProvider.class))
+            .factory(
+                c ->
+                    new FirebaseStorageComponent(
+                        c.get(FirebaseApp.class), c.get(InternalAuthProvider.class)))
             .build(),
         LibraryVersionComponent.create("fire-gcs", BuildConfig.VERSION_NAME));
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
@@ -53,9 +53,13 @@ public class StreamDownloadTask extends StorageTask<StreamDownloadTask.TaskSnaps
 
   /*package*/ StreamDownloadTask(@NonNull StorageReference storageRef) {
     mStorageRef = storageRef;
+
+    FirebaseStorage storage = mStorageRef.getStorage();
     mSender =
         new ExponentialBackoffSender(
-            mStorageRef.getApp(), mStorageRef.getStorage().getMaxDownloadRetryTimeMillis());
+            storage.getApp().getApplicationContext(),
+            storage.getAuthProvider(),
+            storage.getMaxDownloadRetryTimeMillis());
   }
 
   /**

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
@@ -39,9 +39,13 @@ class UpdateMetadataTask implements Runnable {
     this.mStorageRef = storageRef;
     this.mPendingResult = pendingResult;
     mNewMetadata = newMetadata;
+
+    FirebaseStorage storage = mStorageRef.getStorage();
     mSender =
         new ExponentialBackoffSender(
-            mStorageRef.getApp(), mStorageRef.getStorage().getMaxOperationRetryTimeMillis());
+            storage.getApp().getApplicationContext(),
+            storage.getAuthProvider(),
+            storage.getMaxOperationRetryTimeMillis());
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.firebase.annotations.PublicApi;
+import com.google.firebase.auth.internal.InternalAuthProvider;
 import com.google.firebase.storage.internal.AdaptiveStreamBuffer;
 import com.google.firebase.storage.internal.ExponentialBackoffSender;
 import com.google.firebase.storage.internal.Util;
@@ -61,6 +62,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
   private final AdaptiveStreamBuffer mStreamBuffer;
   // Active, current mutable state.
   private final AtomicLong mBytesUploaded = new AtomicLong(0);
+  @Nullable final InternalAuthProvider mAuthProvider;
   private int mCurrentChunkSize = PREFERRED_CHUNK_SIZE;
   private ExponentialBackoffSender mSender;
   private boolean mIsStreamOwned;
@@ -74,29 +76,42 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
   UploadTask(StorageReference targetRef, StorageMetadata metadata, byte[] bytes) {
     Preconditions.checkNotNull(targetRef);
     Preconditions.checkNotNull(bytes);
+
+    FirebaseStorage storage = targetRef.getStorage();
+
     this.mTotalByteCount = bytes.length;
     this.mStorageRef = targetRef;
     this.mMetadata = metadata;
+    this.mAuthProvider = storage.getAuthProvider();
     this.mUri = null;
     this.mStreamBuffer =
         new AdaptiveStreamBuffer(new ByteArrayInputStream(bytes), PREFERRED_CHUNK_SIZE);
     this.mIsStreamOwned = true;
+
     mSender =
         new ExponentialBackoffSender(
-            mStorageRef.getApp(), mStorageRef.getStorage().getMaxUploadRetryTimeMillis());
+            storage.getApp().getApplicationContext(),
+            storage.getAuthProvider(),
+            storage.getMaxDownloadRetryTimeMillis());
   }
 
   UploadTask(
       StorageReference targetRef, StorageMetadata metadata, Uri file, Uri existingUploadUri) {
     Preconditions.checkNotNull(targetRef);
     Preconditions.checkNotNull(file);
+
+    FirebaseStorage storage = targetRef.getStorage();
+
     this.mStorageRef = targetRef;
     this.mMetadata = metadata;
+    this.mAuthProvider = storage.getAuthProvider();
     this.mUri = file;
     InputStream inputStream = null;
     mSender =
         new ExponentialBackoffSender(
-            mStorageRef.getApp(), mStorageRef.getStorage().getMaxUploadRetryTimeMillis());
+            mStorageRef.getApp().getApplicationContext(),
+            mAuthProvider,
+            storage.getMaxUploadRetryTimeMillis());
     long size = -1;
     try {
       ContentResolver resolver =
@@ -144,15 +159,20 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
     Preconditions.checkNotNull(targetRef);
     Preconditions.checkNotNull(stream);
 
+    FirebaseStorage storage = targetRef.getStorage();
+
     this.mTotalByteCount = -1;
     this.mStorageRef = targetRef;
     this.mMetadata = metadata;
+    this.mAuthProvider = storage.getAuthProvider();
     this.mStreamBuffer = new AdaptiveStreamBuffer(stream, PREFERRED_CHUNK_SIZE);
     this.mIsStreamOwned = false;
     this.mUri = null;
     mSender =
         new ExponentialBackoffSender(
-            mStorageRef.getApp(), mStorageRef.getStorage().getMaxUploadRetryTimeMillis());
+            mStorageRef.getApp().getApplicationContext(),
+            mAuthProvider,
+            mStorageRef.getStorage().getMaxUploadRetryTimeMillis());
   }
 
   /** @return the target of the upload. */
@@ -448,8 +468,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
 
   private boolean send(NetworkRequest request) {
     request.performRequest(
-        Util.getCurrentAuthToken(mStorageRef.getApp()),
-        mStorageRef.getApp().getApplicationContext());
+        Util.getCurrentAuthToken(mAuthProvider), mStorageRef.getApp().getApplicationContext());
     return processResultValid(request);
   }
 
@@ -485,7 +504,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
                 @Override
                 public void run() {
                   finalCancelRequest.performRequest(
-                      Util.getCurrentAuthToken(mStorageRef.getApp()),
+                      Util.getCurrentAuthToken(mAuthProvider),
                       mStorageRef.getApp().getApplicationContext());
                 }
               });

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -62,7 +62,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
   private final AdaptiveStreamBuffer mStreamBuffer;
   // Active, current mutable state.
   private final AtomicLong mBytesUploaded = new AtomicLong(0);
-  @Nullable final InternalAuthProvider mAuthProvider;
+  @Nullable private final InternalAuthProvider mAuthProvider;
   private int mCurrentChunkSize = PREFERRED_CHUNK_SIZE;
   private ExponentialBackoffSender mSender;
   private boolean mIsStreamOwned;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/ExponentialBackoffSender.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/ExponentialBackoffSender.java
@@ -16,6 +16,7 @@ package com.google.firebase.storage.internal;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.common.util.Clock;
@@ -39,12 +40,12 @@ public class ExponentialBackoffSender {
   /*package*/ static Sleeper sleeper = new SleeperImpl();
   /*package*/ static Clock clock = DefaultClock.getInstance();
   private final Context context;
-  private final InternalAuthProvider authProvider;
+  @Nullable private final InternalAuthProvider authProvider;
   private long retryTime;
   private volatile boolean canceled;
 
   public ExponentialBackoffSender(
-      Context context, InternalAuthProvider authProvider, long retryTime) {
+      Context context, @Nullable InternalAuthProvider authProvider, long retryTime) {
     this.context = context;
     this.authProvider = authProvider;
     this.retryTime = retryTime;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/ExponentialBackoffSender.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/ExponentialBackoffSender.java
@@ -14,12 +14,13 @@
 
 package com.google.firebase.storage.internal;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.common.util.Clock;
 import com.google.android.gms.common.util.DefaultClock;
-import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.internal.InternalAuthProvider;
 import com.google.firebase.storage.network.NetworkRequest;
 import java.util.Random;
 
@@ -34,15 +35,18 @@ public class ExponentialBackoffSender {
   public static final int RND_MAX = 250;
   private static final int NETWORK_STATUS_POLL_INTERVAL = 1000;
   private static final int MAXIMUM_WAIT_TIME_MILLI = 30000;
+  private static final Random random = new Random();
   /*package*/ static Sleeper sleeper = new SleeperImpl();
   /*package*/ static Clock clock = DefaultClock.getInstance();
-  private static Random random = new Random();
-  private FirebaseApp app;
+  private final Context context;
+  private final InternalAuthProvider authProvider;
   private long retryTime;
   private volatile boolean canceled;
 
-  public ExponentialBackoffSender(FirebaseApp app, long retryTime) {
-    this.app = app;
+  public ExponentialBackoffSender(
+      Context context, InternalAuthProvider authProvider, long retryTime) {
+    this.context = context;
+    this.authProvider = authProvider;
     this.retryTime = retryTime;
   }
 
@@ -62,9 +66,9 @@ public class ExponentialBackoffSender {
     Preconditions.checkNotNull(request);
     long deadLine = clock.elapsedRealtime() + retryTime;
     if (closeRequest) {
-      request.performRequest(Util.getCurrentAuthToken(app), app.getApplicationContext());
+      request.performRequest(Util.getCurrentAuthToken(authProvider), context);
     } else {
-      request.performRequestStart(Util.getCurrentAuthToken(app));
+      request.performRequestStart(Util.getCurrentAuthToken(authProvider));
     }
 
     int currentSleepTime = NETWORK_STATUS_POLL_INTERVAL;
@@ -95,9 +99,9 @@ public class ExponentialBackoffSender {
       }
       request.reset();
       if (closeRequest) {
-        request.performRequest(Util.getCurrentAuthToken(app), app.getApplicationContext());
+        request.performRequest(Util.getCurrentAuthToken(authProvider), context);
       } else {
-        request.performRequestStart(Util.getCurrentAuthToken(app));
+        request.performRequestStart(Util.getCurrentAuthToken(authProvider));
       }
     }
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
@@ -26,6 +26,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.GetTokenResult;
+import com.google.firebase.auth.internal.InternalAuthProvider;
 import com.google.firebase.storage.network.NetworkRequest;
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
@@ -144,12 +145,17 @@ public class Util {
   }
 
   @Nullable
-  public static String getCurrentAuthToken(FirebaseApp app) {
-    Task<GetTokenResult> pendingResult = app.getToken(false);
-    GetTokenResult result;
+  public static String getCurrentAuthToken(@Nullable InternalAuthProvider authProvider) {
     try {
-      result = Tasks.await(pendingResult, MAXIMUM_TOKEN_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
-      String token = result.getToken();
+      String token = null;
+
+      if (authProvider != null) {
+        Task<GetTokenResult> pendingResult = authProvider.getAccessToken(false);
+        GetTokenResult result =
+            Tasks.await(pendingResult, MAXIMUM_TOKEN_WAIT_TIME_MS, TimeUnit.MILLISECONDS);
+        token = result.getToken();
+      }
+
       if (!TextUtils.isEmpty(token)) {
         return token;
       } else {

--- a/firebase-storage/src/test/java/com/google/firebase/storage/DeleteTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/DeleteTest.java
@@ -16,6 +16,8 @@ package com.google.firebase.storage;
 
 import android.os.Build;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.storage.internal.MockClockHelper;
 import com.google.firebase.storage.internal.RobolectricThreadFix;
 import com.google.firebase.storage.network.MockConnectionFactory;
 import com.google.firebase.storage.network.NetworkLayerMock;
@@ -38,15 +40,19 @@ public class DeleteTest {
 
   @Rule public FirebaseAppRule firebaseAppRule = new FirebaseAppRule();
 
+  FirebaseApp app;
+
   @Before
   public void setUp() throws Exception {
     RobolectricThreadFix.install();
-    TestUtil.setup();
+    MockClockHelper.install();
+    app = TestUtil.createApp();
   }
 
   @After
   public void tearDown() {
-    TestUtil.unInit();
+    FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
+    component.clearInstancesForTesting();
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/firebase-storage/src/test/java/com/google/firebase/storage/DownloadTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/DownloadTest.java
@@ -22,7 +22,9 @@ import static org.junit.Assert.fail;
 import android.net.Uri;
 import android.os.Build;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.storage.TestDownloadHelper.StreamDownloadResponse;
+import com.google.firebase.storage.internal.MockClockHelper;
 import com.google.firebase.storage.internal.RobolectricThreadFix;
 import com.google.firebase.storage.network.MockConnectionFactory;
 import com.google.firebase.storage.network.NetworkLayerMock;
@@ -53,15 +55,19 @@ public class DownloadTest {
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
+  private FirebaseApp app;
+
   @Before
   public void setUp() throws Exception {
     RobolectricThreadFix.install();
-    TestUtil.setup();
+    MockClockHelper.install();
+    app = TestUtil.createApp();
   }
 
   @After
   public void tearDown() {
-    TestUtil.unInit();
+    FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
+    component.clearInstancesForTesting();
   }
 
   @Test

--- a/firebase-storage/src/test/java/com/google/firebase/storage/MetadataTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/MetadataTest.java
@@ -16,6 +16,8 @@ package com.google.firebase.storage;
 
 import android.os.Build;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.storage.internal.MockClockHelper;
 import com.google.firebase.storage.internal.RobolectricThreadFix;
 import com.google.firebase.storage.network.MockConnectionFactory;
 import com.google.firebase.storage.network.NetworkLayerMock;
@@ -38,15 +40,19 @@ public class MetadataTest {
   @Rule public RetryRule retryRule = new RetryRule(3);
   @Rule public FirebaseAppRule firebaseAppRule = new FirebaseAppRule();
 
+  private FirebaseApp app;
+
   @Before
   public void setUp() throws Exception {
     RobolectricThreadFix.install();
-    TestUtil.setup();
+    MockClockHelper.install();
+    app = TestUtil.createApp();
   }
 
   @After
   public void tearDown() {
-    TestUtil.unInit();
+    FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
+    component.clearInstancesForTesting();
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/firebase-storage/src/test/java/com/google/firebase/storage/PathingTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/PathingTest.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
@@ -43,22 +42,25 @@ public class PathingTest {
   @Rule public RetryRule retryRule = new RetryRule(3);
   @Rule public FirebaseAppRule firebaseAppRule = new FirebaseAppRule();
 
+  FirebaseApp app;
+
   @Before
   public void setUp() throws Exception {
     RobolectricThreadFix.install();
-    FirebaseApp.initializeApp(
-        RuntimeEnvironment.application.getApplicationContext(),
-        new FirebaseOptions.Builder()
-            .setApiKey("AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM")
-            .setApplicationId("fooey")
-            .build());
     MockClockHelper.install();
-    MockitoAnnotations.initMocks(this);
+    app =
+        FirebaseApp.initializeApp(
+            RuntimeEnvironment.application.getApplicationContext(),
+            new FirebaseOptions.Builder()
+                .setApiKey("AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM")
+                .setApplicationId("fooey")
+                .build());
   }
 
   @After
   public void tearDown() {
-    TestUtil.unInit();
+    FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
+    component.clearInstancesForTesting();
   }
 
   @Test

--- a/firebase-storage/src/test/java/com/google/firebase/storage/StorageReferenceTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/StorageReferenceTest.java
@@ -20,6 +20,7 @@ import android.os.Build;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.storage.internal.MockClockHelper;
 import com.google.firebase.storage.internal.RobolectricThreadFix;
 import com.google.firebase.storage.network.MockConnectionFactory;
 import com.google.firebase.storage.network.NetworkLayerMock;
@@ -43,15 +44,19 @@ public class StorageReferenceTest {
   @Rule public RetryRule retryRule = new RetryRule(3);
   @Rule public FirebaseAppRule firebaseAppRule = new FirebaseAppRule();
 
+  private FirebaseApp app;
+
   @Before
   public void setUp() throws Exception {
     RobolectricThreadFix.install();
-    TestUtil.setup();
+    MockClockHelper.install();
+    app = TestUtil.createApp();
   }
 
   @After
   public void tearDown() {
-    TestUtil.unInit();
+    FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
+    component.clearInstancesForTesting();
   }
 
   @Test

--- a/firebase-storage/src/test/java/com/google/firebase/storage/TestUtil.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/TestUtil.java
@@ -17,7 +17,6 @@ package com.google.firebase.storage;
 import android.support.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import com.google.firebase.storage.internal.MockClockHelper;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,24 +27,19 @@ import org.robolectric.RuntimeEnvironment;
 
 /** Test helpers. */
 public class TestUtil {
-  static void setup() throws Exception {
-    FirebaseApp.initializeApp(
+
+  static FirebaseApp createApp() {
+    return FirebaseApp.initializeApp(
         RuntimeEnvironment.application.getApplicationContext(),
         new FirebaseOptions.Builder()
             .setApiKey("AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM")
             .setApplicationId("fooey")
             .setStorageBucket("project-5516366556574091405.appspot.com")
             .build());
-    // point to staging.
+    // Point to staging:
     // NetworkRequest.sNetworkRequestUrl = "https://staging-firebasestorage.sandbox.googleapis"
     // + ".com/v0";
     // NetworkRequest.sUploadUrl = "https://staging-firebasestorage.sandbox.googleapis.com/v0/b/";
-
-    MockClockHelper.install();
-  }
-
-  static void unInit() {
-    FirebaseStorage.clearInstancesForTest();
   }
 
   static void verifyTaskStateChanges(

--- a/firebase-storage/src/test/java/com/google/firebase/storage/UploadTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/UploadTest.java
@@ -28,6 +28,7 @@ import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.RuntimeExecutionException;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.storage.UploadTask.TaskSnapshot;
 import com.google.firebase.storage.internal.MockClockHelper;
 import com.google.firebase.storage.internal.RobolectricThreadFix;
@@ -71,15 +72,19 @@ public class UploadTest {
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
+  private FirebaseApp app;
+
   @Before
   public void setUp() throws Exception {
     RobolectricThreadFix.install();
-    TestUtil.setup();
+    MockClockHelper.install();
+    app = TestUtil.createApp();
   }
 
   @After
   public void tearDown() {
-    TestUtil.unInit();
+    FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
+    component.clearInstancesForTesting();
   }
 
   @Test

--- a/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
+++ b/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
@@ -21,6 +21,7 @@ import static com.google.errorprone.matchers.Matchers.enclosingMethod;
 import static com.google.errorprone.matchers.Matchers.hasAnnotation;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 import static com.google.errorprone.matchers.Matchers.isStatic;
+import static com.google.errorprone.matchers.Matchers.methodHasVisibility;
 import static com.google.errorprone.matchers.Matchers.methodInvocation;
 import static com.google.errorprone.matchers.Matchers.methodIsNamed;
 import static com.google.errorprone.matchers.Matchers.methodReturns;
@@ -34,6 +35,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.AbstractTypeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.MethodVisibility;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
@@ -85,11 +87,34 @@ public class ComponentsAppGetCheck extends BugChecker
                   isSupertypeOf(
                       state -> ASTHelpers.getType(state.findEnclosing(ClassTree.class))))));
 
+  /**
+   * This matches methods of the forms:
+   *
+   * <pre>{@code
+   * class Foo {
+   *     private static Foo getInstanceImpl(/* any number of parameters * /);
+   * }
+   *
+   * class Foo extends/implements Bar {
+   *     private static Bar getInstanceImpl(/* any number of parameters * /);
+   * }
+   * }</pre>
+   */
+  private static final Matcher<ExpressionTree> WITHIN_GET_INSTANCE_IMPL =
+      enclosingMethod(
+          allOf(
+              isStatic(),
+              methodHasVisibility(MethodVisibility.Visibility.PRIVATE),
+              methodIsNamed("getInstanceImpl"),
+              methodReturns(
+                  isSupertypeOf(
+                      state -> ASTHelpers.getType(state.findEnclosing(ClassTree.class))))));
+
   private static final Matcher<ExpressionTree> WITHIN_JUNIT_TEST =
       enclosingClass(hasAnnotation("org.junit.runner.RunWith"));
 
   private static final Matcher<ExpressionTree> ALLOWED_USAGES =
-      anyOf(WITHIN_GET_INSTANCE, WITHIN_JUNIT_TEST);
+      anyOf(WITHIN_GET_INSTANCE, WITHIN_GET_INSTANCE_IMPL, WITHIN_JUNIT_TEST);
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {


### PR DESCRIPTION
This definitely falls under the umbrella "I don't know what I am doing". But here we go...

This follows the pattern in Firestore to register the component for Firebase Storage. It changes FirebaseStorage to only ever work with a single app, but keeps the option to get different instances for different storage buckets.

I also added `getInstanceImpl` as a valid name for the FirebaseApp.get() call, as I didn't want to add yet another `getInstance()` overload (which would result in an ambiguous null cast).

So what does everyone think? :)