### PR TITLE
Database: Rename test helpers

### DIFF
--- a/firebase-database/src/androidTest/java/com/google/firebase/database/DataTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/DataTest.java
@@ -53,18 +53,18 @@ public class DataTest {
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
 
   @Test
   public void basicInstantiation() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     assertTrue(ref != null);
   }
 
   @Test
   public void writeData() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     // just make sure it doesn't throw
     ref.setValue(42);
     assertTrue(true);
@@ -74,7 +74,7 @@ public class DataTest {
   public void readAndWrite()
       throws DatabaseException, ExecutionException, InterruptedException, TimeoutException,
           TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ReadFuture future = ReadFuture.untilNonNull(ref);
 
     ref.setValue(42);
@@ -90,7 +90,7 @@ public class DataTest {
     innerExpected.put("bar", 5L);
     expected.put("foo", innerExpected);
 
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture future = ReadFuture.untilNonNull(ref);
 
@@ -104,7 +104,7 @@ public class DataTest {
   @Test
   public void writeDataAndWaitForServerConfirmation()
       throws DatabaseException, TimeoutException, InterruptedException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ref.setValue(42);
 
     ReadFuture future = new ReadFuture(ref);
@@ -117,7 +117,7 @@ public class DataTest {
   public void writeAValueReconnectRead()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -136,7 +136,7 @@ public class DataTest {
   public void writeABunchOfDataReconnectRead()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -167,7 +167,7 @@ public class DataTest {
   @Test
   public void writeLeafNodeOverwriteParentNodeWaitForEvents()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     EventHelper helper =
         new EventHelper()
@@ -189,7 +189,7 @@ public class DataTest {
   @Test
   public void writeLeafNodeOverwriteAtParentMultipleTimesWaitForExpectedEvents()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final AtomicInteger bbCount = new AtomicInteger(0);
     ValueEventListener listener =
@@ -233,7 +233,7 @@ public class DataTest {
   @Test
   public void writeParentNodeOverwriteAtLeafNodeWaitForEvents()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     EventHelper helper =
         new EventHelper()
@@ -256,7 +256,7 @@ public class DataTest {
   public void writeLeafNodeRemoveParentWaitForEvents()
       throws DatabaseException, InterruptedException, TimeoutException, TestFailure,
           ExecutionException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -307,8 +307,8 @@ public class DataTest {
     readHelper.cleanup();
 
     // Make sure we actually have null there now
-    assertNull(TestHelpers.getSnap(reader).getValue());
-    assertNull(TestHelpers.getSnap(writer).getValue());
+    assertNull(IntegrationTestHelpers.getSnap(reader).getValue());
+    assertNull(IntegrationTestHelpers.getSnap(writer).getValue());
 
     ReadFuture readFuture = ReadFuture.untilNonNull(reader);
 
@@ -332,7 +332,7 @@ public class DataTest {
   public void writeLeafNodeRemoveLeafNodeWaitForEvents()
       throws DatabaseException, InterruptedException, TimeoutException, TestFailure,
           ExecutionException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -382,16 +382,16 @@ public class DataTest {
     writeHelper.cleanup();
     readHelper.cleanup();
 
-    DataSnapshot readerSnap = TestHelpers.getSnap(reader);
+    DataSnapshot readerSnap = IntegrationTestHelpers.getSnap(reader);
     assertNull(readerSnap.getValue());
 
-    DataSnapshot writerSnap = TestHelpers.getSnap(writer);
+    DataSnapshot writerSnap = IntegrationTestHelpers.getSnap(writer);
     assertNull(writerSnap.getValue());
 
-    readerSnap = TestHelpers.getSnap(reader.child("a/aa"));
+    readerSnap = IntegrationTestHelpers.getSnap(reader.child("a/aa"));
     assertNull(readerSnap.getValue());
 
-    writerSnap = TestHelpers.getSnap(writer.child("a/aa"));
+    writerSnap = IntegrationTestHelpers.getSnap(writer.child("a/aa"));
     assertNull(writerSnap.getValue());
 
     ReadFuture readFuture = ReadFuture.untilNonNull(reader);
@@ -414,7 +414,7 @@ public class DataTest {
   @Test
   public void writeMultipleLeafNodesRemoveOneLeafNodeWaitForEvents()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -470,8 +470,8 @@ public class DataTest {
     assertTrue(writeHelper.waitForEvents());
     assertTrue(readHelper.waitForEvents());
 
-    DataSnapshot readerSnap = TestHelpers.getSnap(reader);
-    DataSnapshot writerSnap = TestHelpers.getSnap(writer);
+    DataSnapshot readerSnap = IntegrationTestHelpers.getSnap(reader);
+    DataSnapshot writerSnap = IntegrationTestHelpers.getSnap(writer);
     Map<String, Object> expected =
         new MapBuilder().put("a", new MapBuilder().put("bb", 24L).build()).build();
     DeepEquals.assertEquals(expected, readerSnap.getValue());
@@ -483,7 +483,7 @@ public class DataTest {
 
   @Test
   public void verifyCantNameNodesStartingWithAPeriod() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     try {
       ref.child(".foo");
       fail("Should fail");
@@ -504,14 +504,14 @@ public class DataTest {
 
   @Test
   public void numericKeysGetTurnedIntoArrays() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ref.child("0").setValue("alpha");
     ref.child("1").setValue("bravo");
     ref.child("2").setValue("charlie");
     ref.child("3").setValue("delta");
     ref.child("4").setValue("echo");
 
-    DataSnapshot snap = TestHelpers.getSnap(ref);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref);
     List<Object> expected = new ArrayList<Object>();
     expected.addAll(Arrays.asList((Object) "alpha", "bravo", "charlie", "delta", "echo"));
     DeepEquals.assertEquals(expected, snap.getValue());
@@ -520,7 +520,7 @@ public class DataTest {
   @Test
   public void canWriteFullJSONObjectsWithSetAndGetThemBack()
       throws DatabaseException, TimeoutException, InterruptedException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> expected =
         new MapBuilder()
@@ -560,7 +560,7 @@ public class DataTest {
   public void removeCallbackIsHit()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     WriteFuture writeFuture = new WriteFuture(ref, 42);
     writeFuture.timedGet();
@@ -593,7 +593,7 @@ public class DataTest {
   @Test
   public void removeCallbackIsHitForNodesThatAreAlreadyRemoved()
       throws DatabaseException, InterruptedException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore callbackHit = new Semaphore(0);
     ref.removeValue(
@@ -620,7 +620,7 @@ public class DataTest {
   @Test
   public void usingNumbersAsKeysDoesntCreateHugeSparseArrays()
       throws DatabaseException, TimeoutException, InterruptedException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ref.child("3024").setValue(5);
     ReadFuture future = new ReadFuture(ref);
 
@@ -632,7 +632,7 @@ public class DataTest {
   public void onceWithCallbackHitsServerToGetData()
       throws DatabaseException, InterruptedException, ExecutionException, TimeoutException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(3);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(3);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
     DatabaseReference reader2 = refs.get(2);
@@ -652,7 +652,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     new WriteFuture(writer, 42).timedGet();
 
     reader2.addListenerForSingleValueEvent(
@@ -669,7 +669,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   // NOTE: skipping forEach abort test. Not relevant, we return an iterable that can be stopped any
@@ -679,7 +679,7 @@ public class DataTest {
   public void setAndThenListenForValueEvents()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, "cabbage").timedGet();
     EventRecord event = new ReadFuture(ref).timedGet().get(0);
@@ -690,7 +690,7 @@ public class DataTest {
   @Test
   public void hasChildrenWorksCorrectly()
       throws DatabaseException, TimeoutException, InterruptedException, TestFailure {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(
         new MapBuilder()
@@ -734,7 +734,7 @@ public class DataTest {
   public void setANodeWithChildrenToAPrimitiveThenBack()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     final DatabaseReference writer = refs.get(1);
 
@@ -790,7 +790,7 @@ public class DataTest {
   public void writeLeafNodeRemoveItTryToAddChildToRemovedNode()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -807,7 +807,7 @@ public class DataTest {
   public void listenForValueThenWriteOnANodeWithExistingData()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -826,7 +826,7 @@ public class DataTest {
 
   @Test
   public void setPriorityOnNonexistentNodeFails() throws DatabaseException, InterruptedException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     ref.setPriority(
@@ -845,7 +845,7 @@ public class DataTest {
 
   @Test
   public void setPriorityOnExistingNodeSucceeds() throws DatabaseException, InterruptedException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue("hello!");
     final Semaphore semaphore = new Semaphore(0);
@@ -867,7 +867,7 @@ public class DataTest {
   public void setWithPrioritySetsPriorityAndValue()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -893,7 +893,7 @@ public class DataTest {
   public void setOverwritesPriorityOfTopLevelNodesAndSubnodes()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -912,7 +912,7 @@ public class DataTest {
   public void setWithPriorityOfALeafSavesCorrectly()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -927,7 +927,7 @@ public class DataTest {
   public void setPriorityOfAnObjectSavesCorrectly()
       throws DatabaseException, ExecutionException, TimeoutException, InterruptedException,
           TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -943,7 +943,7 @@ public class DataTest {
   @Test
   public void getPriorityReturnsTheCorrectType()
       throws DatabaseException, TimeoutException, InterruptedException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 7);
 
@@ -970,7 +970,7 @@ public class DataTest {
       throws DatabaseException, InterruptedException, TimeoutException, TestFailure {
     final long intMaxPlusOne = 2147483648L;
 
-    DatabaseReference node = TestHelpers.getRandomNode();
+    DatabaseReference node = IntegrationTestHelpers.getRandomNode();
 
     Object[] writtenValues = {
       intMaxPlusOne,
@@ -1002,7 +1002,7 @@ public class DataTest {
   @Test
   public void exportFormatIncludesPriorities()
       throws DatabaseException, TimeoutException, InterruptedException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> expected =
         new MapBuilder()
@@ -1023,7 +1023,7 @@ public class DataTest {
   @Test
   public void priorityIsOverwrittenByServerPriority()
       throws DatabaseException, TimeoutException, InterruptedException, TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     final DatabaseReference ref2 = refs.get(1);
 
@@ -1060,7 +1060,7 @@ public class DataTest {
   public void largeNumericPrioritiesWork()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException,
           ExecutionException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -1075,7 +1075,7 @@ public class DataTest {
   public void urlEncodingAndDecodingWorks()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
     DatabaseReference ref =
         new DatabaseReference(
@@ -1087,7 +1087,7 @@ public class DataTest {
 
     String child = "" + new Random().nextInt(100000000);
     new WriteFuture(ref.child(child), "testdata").timedGet();
-    DataSnapshot snap = TestHelpers.getSnap(ref.child(child));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.child(child));
     assertEquals("testdata", snap.getValue());
   }
 
@@ -1095,7 +1095,7 @@ public class DataTest {
   public void nameWorksForRootAndNonRootLocations()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
     DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getNamespace(), ctx);
     assertNull(ref.getKey());
@@ -1107,13 +1107,13 @@ public class DataTest {
   public void nameAndRefWorkForSnapshots()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
     DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getNamespace(), ctx);
     // Clear any data there
     new WriteFuture(ref, new MapBuilder().put("foo", 10).build()).timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(ref);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref);
     assertNull(snap.getKey());
     assertEquals(ref.toString(), snap.getRef().toString());
     DataSnapshot childSnap = snap.child("a");
@@ -1126,7 +1126,7 @@ public class DataTest {
 
   @Test
   public void parentWorksForRootAndNonRootLocations() throws DatabaseException {
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
     DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getNamespace(), ctx);
     assertNull(ref.getParent());
@@ -1138,7 +1138,7 @@ public class DataTest {
 
   @Test
   public void rootWorksForRootAndNonRootLocations() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref = ref.getRoot();
     assertEquals(IntegrationTestValues.getNamespace(), ref.toString());
@@ -1154,7 +1154,7 @@ public class DataTest {
   public void setAChildAndListenAtTheRoot()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -1166,12 +1166,12 @@ public class DataTest {
 
   @Test
   public void accessingInvalidPathsShouldThrow() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
     List<String> badPaths = Arrays.asList(".test", "test.", "fo$o", "[what", "ever]", "ha#sh");
 
-    DataSnapshot snap = TestHelpers.getSnap(ref);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref);
 
     for (String path : badPaths) {
       try {
@@ -1213,7 +1213,7 @@ public class DataTest {
 
   @Test
   public void invalidKeysThrowErrors() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     List<String> badKeys =
         Arrays.asList(
@@ -1249,7 +1249,7 @@ public class DataTest {
 
   @Test
   public void invalidUpdateThrowErrors() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     List<Map<String, Object>> badUpdates =
         Arrays.asList(
@@ -1281,11 +1281,11 @@ public class DataTest {
   @Test
   public void asciiControlCharactersIllegal()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference node = TestHelpers.getRandomNode();
+    DatabaseReference node = IntegrationTestHelpers.getRandomNode();
     // Test all controls characters PLUS 0x7F (127).
     for (int i = 0; i <= 32; i++) {
       String ch = new String(Character.toChars(i < 32 ? i : 127));
-      HashMap obj = TestHelpers.buildObjFromPath(new Path(ch), "test_value");
+      HashMap obj = IntegrationTestHelpers.buildObjFromPath(new Path(ch), "test_value");
       try {
         node.setValue(obj);
         fail("Ascii control character should not be allowed in path.");
@@ -1298,7 +1298,7 @@ public class DataTest {
   @Test
   public void invalidDoubleValues()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference node = TestHelpers.getRandomNode();
+    DatabaseReference node = IntegrationTestHelpers.getRandomNode();
     Object[] invalidValues =
         new Object[] {
           Double.NEGATIVE_INFINITY,
@@ -1328,10 +1328,10 @@ public class DataTest {
 
     List<String> goodKeys =
         Arrays.asList(
-            TestHelpers.repeatedString("k", maxPathLengthBytes - 1),
-            TestHelpers.repeatedString(fire, maxPathLengthBytes / 4 - 1),
-            TestHelpers.repeatedString(base, maxPathLengthBytes / 3 - 1),
-            TestHelpers.repeatedString("key/", maxPathDepth - 1) + "key");
+            IntegrationTestHelpers.repeatedString("k", maxPathLengthBytes - 1),
+            IntegrationTestHelpers.repeatedString(fire, maxPathLengthBytes / 4 - 1),
+            IntegrationTestHelpers.repeatedString(base, maxPathLengthBytes / 3 - 1),
+            IntegrationTestHelpers.repeatedString("key/", maxPathDepth - 1) + "key");
 
     class BadGroup {
       String expectedError;
@@ -1348,25 +1348,26 @@ public class DataTest {
             new BadGroup(
                 "key path longer than 768 bytes",
                 Arrays.asList(
-                    TestHelpers.repeatedString("k", maxPathLengthBytes),
-                    TestHelpers.repeatedString(fire, maxPathLengthBytes / 4),
-                    TestHelpers.repeatedString(base, maxPathLengthBytes / 3),
-                    TestHelpers.repeatedString("j", maxPathLengthBytes / 2)
+                    IntegrationTestHelpers.repeatedString("k", maxPathLengthBytes),
+                    IntegrationTestHelpers.repeatedString(fire, maxPathLengthBytes / 4),
+                    IntegrationTestHelpers.repeatedString(base, maxPathLengthBytes / 3),
+                    IntegrationTestHelpers.repeatedString("j", maxPathLengthBytes / 2)
                         + '/'
-                        + TestHelpers.repeatedString("k", maxPathLengthBytes / 2))),
+                        + IntegrationTestHelpers.repeatedString("k", maxPathLengthBytes / 2))),
             new BadGroup(
                 "Path specified exceeds the maximum depth",
-                Arrays.asList(TestHelpers.repeatedString("key/", maxPathDepth) + "key")));
+                Arrays.asList(
+                    IntegrationTestHelpers.repeatedString("key/", maxPathDepth) + "key")));
 
-    DatabaseReference node = TestHelpers.getRandomNode().getRoot();
+    DatabaseReference node = IntegrationTestHelpers.getRandomNode().getRoot();
 
     // Ensure "good keys" work from the root.
     for (String key : goodKeys) {
       Path path = new Path(key);
-      HashMap obj = TestHelpers.buildObjFromPath(path, "test_value");
+      HashMap obj = IntegrationTestHelpers.buildObjFromPath(path, "test_value");
       node.setValue(obj);
       ReadFuture future = ReadFuture.untilNonNull(node);
-      assertEquals("test_value", TestHelpers.applyPath(future.waitForLastValue(), path));
+      assertEquals("test_value", IntegrationTestHelpers.applyPath(future.waitForLastValue(), path));
 
       node.child(key).setValue("another_value");
       future = ReadFuture.untilNonNull(node.child(key));
@@ -1374,13 +1375,13 @@ public class DataTest {
 
       node.updateChildren(obj);
       future = ReadFuture.untilNonNull(node);
-      assertEquals("test_value", TestHelpers.applyPath(future.waitForLastValue(), path));
+      assertEquals("test_value", IntegrationTestHelpers.applyPath(future.waitForLastValue(), path));
     }
 
     // Ensure "good keys" fail when created from child node (relative paths too long).
-    DatabaseReference nodeChild = TestHelpers.getRandomNode();
+    DatabaseReference nodeChild = IntegrationTestHelpers.getRandomNode();
     for (String key : goodKeys) {
-      HashMap obj = TestHelpers.buildObjFromPath(new Path(key), "test_value");
+      HashMap obj = IntegrationTestHelpers.buildObjFromPath(new Path(key), "test_value");
       try {
         nodeChild.setValue(obj);
         fail("Too-long path for setValue should throw exception.");
@@ -1410,43 +1411,43 @@ public class DataTest {
 
     for (BadGroup badGroup : badGroups) {
       for (String key : badGroup.keys) {
-        HashMap obj = TestHelpers.buildObjFromPath(new Path(key), "test_value");
+        HashMap obj = IntegrationTestHelpers.buildObjFromPath(new Path(key), "test_value");
         try {
           node.setValue(obj);
           fail("Expected setValue(bad key) to throw exception: " + key);
         } catch (DatabaseException e) {
-          TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
+          IntegrationTestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
           node.child(key).setValue("another_value");
           fail("Expected child(\"" + key + "\").setValue() to throw exception: " + key);
         } catch (DatabaseException e) {
-          TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
+          IntegrationTestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
           node.updateChildren(obj);
           fail("Expected updateChildrean(bad key) to throw exception: " + key);
         } catch (DatabaseException e) {
-          TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
+          IntegrationTestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
           Map<String, Object> deepUpdate = new MapBuilder().put(key, "test_value").build();
           node.updateChildren(deepUpdate);
           fail("Expected updateChildrean(bad deep update key) to throw exception: " + key);
         } catch (DatabaseException e) {
-          TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
+          IntegrationTestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
           node.onDisconnect().setValue(obj);
           fail("Expected onDisconnect.setValue(bad key) to throw exception: " + key);
         } catch (DatabaseException e) {
-          TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
+          IntegrationTestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
           node.onDisconnect().updateChildren(obj);
           fail("Expected onDisconnect.updateChildren(bad key) to throw exception: " + key);
         } catch (DatabaseException e) {
-          TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
+          IntegrationTestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
           Map<String, Object> deepUpdate = new MapBuilder().put(key, "test_value").build();
@@ -1455,7 +1456,7 @@ public class DataTest {
               "Expected onDisconnect.updateChildren(bad deep update key) to throw exception: "
                   + key);
         } catch (DatabaseException e) {
-          TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
+          IntegrationTestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
       }
     }
@@ -1465,8 +1466,8 @@ public class DataTest {
   public void namespaceAreCaseInsensitive()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseConfig ctx1 = TestHelpers.getContext(0);
-    DatabaseConfig ctx2 = TestHelpers.getContext(1);
+    DatabaseConfig ctx1 = IntegrationTestHelpers.getContext(0);
+    DatabaseConfig ctx2 = IntegrationTestHelpers.getContext(1);
 
     String child = "" + new Random().nextInt(100000000);
     DatabaseReference ref1 =
@@ -1482,13 +1483,13 @@ public class DataTest {
             ctx2);
 
     new WriteFuture(ref1, "testdata").timedGet();
-    DataSnapshot snap = TestHelpers.getSnap(ref2);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref2);
     assertEquals("testdata", snap.getValue());
   }
 
   @Test
   public void namespacesAreCaseInsensitiveInToString() throws DatabaseException {
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     DatabaseReference ref1 = new DatabaseReference(IntegrationTestValues.getNamespace(), ctx);
     DatabaseReference ref2 =
         new DatabaseReference(
@@ -1507,11 +1508,11 @@ public class DataTest {
   public void setANodeWithAQuotedKey()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> expected = new MapBuilder().put("\"herp\"", 1234L).build();
     new WriteFuture(ref, expected).timedGet();
-    DataSnapshot snap = TestHelpers.getSnap(ref);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref);
     DeepEquals.assertEquals(expected, snap.getValue());
   }
 
@@ -1519,7 +1520,7 @@ public class DataTest {
   public void setAChildWithAQuote()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = new ReadFuture(ref);
     new WriteFuture(ref.child("\""), 1).timedGet();
@@ -1530,7 +1531,7 @@ public class DataTest {
   @Test
   public void emptyChildrenGetValueEventBeforeParent()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     EventHelper helper =
         new EventHelper()
@@ -1550,7 +1551,7 @@ public class DataTest {
   public void onAfterSetWaitsForLatestData()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -1565,7 +1566,7 @@ public class DataTest {
   public void onceWaitsForLatestDataEachTime()
       throws DatabaseException, InterruptedException, TestFailure, ExecutionException,
           TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -1584,7 +1585,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     new WriteFuture(ref2, 5).timedGet();
     ref1.addListenerForSingleValueEvent(
@@ -1601,7 +1602,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     new WriteFuture(ref2, 42).timedGet();
 
@@ -1619,17 +1620,17 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void memoryFreeingOnUnlistenDoesNotCorruptData()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException,
           ExecutionException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
-    DatabaseReference other = TestHelpers.getRandomNode();
+    DatabaseReference other = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     final AtomicBoolean hasRun = new AtomicBoolean(false);
@@ -1650,7 +1651,7 @@ public class DataTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     new WriteFuture(ref1, "test").timedGet();
     ref1.removeEventListener(listener);
@@ -1669,7 +1670,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     ref2.addListenerForSingleValueEvent(
         new ValueEventListener() {
@@ -1685,13 +1686,13 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void updateRaisesCorrectLocalEvents()
       throws DatabaseException, InterruptedException, TestFailure, TimeoutException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 2);
 
@@ -1721,7 +1722,7 @@ public class DataTest {
   public void updateRaisesCorrectRemoteEvents()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -1742,7 +1743,7 @@ public class DataTest {
     helper.waitForEvents();
     helper.cleanup();
 
-    DataSnapshot snap = TestHelpers.getSnap(reader);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(reader);
     Map<String, Object> expected =
         new MapBuilder().put("a", 4L).put("b", 2L).put("c", 3L).put("d", 1L).build();
     Object result = snap.getValue();
@@ -1753,7 +1754,7 @@ public class DataTest {
   public void updateRaisesChildEventsOnNewListener()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     EventHelper helper =
         new EventHelper()
             .addValueExpectation(ref.child("a"))
@@ -1775,7 +1776,7 @@ public class DataTest {
   public void updateAfterSetLeafNodeWorks()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore semaphore = new Semaphore(0);
     final Map<String, Object> expected = new MapBuilder().put("a", 1L).put("b", 2L).build();
 
@@ -1794,14 +1795,14 @@ public class DataTest {
     ref.setValue(42);
     ref.updateChildren(expected);
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void updateChangesAreStoredCorrectlyByTheServer()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -1820,9 +1821,9 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
-    DataSnapshot snap = TestHelpers.getSnap(reader);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(reader);
     Map<String, Object> expected =
         new MapBuilder().put("a", 42L).put("b", 2L).put("c", 3L).put("d", 4L).build();
     Object result = snap.getValue();
@@ -1832,7 +1833,7 @@ public class DataTest {
   @Test
   public void updateDoesntAffectPriorityLocally()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 2);
 
@@ -1852,14 +1853,14 @@ public class DataTest {
   public void updateDoesntAffectPriorityRemotely()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
     new WriteFuture(writer, new MapBuilder().put("a", 1).put("b", 2).put("c", 3).build(), "testpri")
         .timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(reader);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(reader);
     assertEquals("testpri", snap.getPriority());
 
     final Semaphore semaphore = new Semaphore(0);
@@ -1873,15 +1874,15 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
-    snap = TestHelpers.getSnap(reader);
+    IntegrationTestHelpers.waitFor(semaphore);
+    snap = IntegrationTestHelpers.getSnap(reader);
     assertEquals("testpri", snap.getPriority());
   }
 
   @Test
   public void updateReplacesChildren()
       throws DatabaseException, InterruptedException, TestFailure, TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -1902,9 +1903,9 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
-    DataSnapshot snap = TestHelpers.getSnap(reader);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(reader);
     DeepEquals.assertEquals(expected, snap.getValue());
 
     snap = readFuture.timedGet().get(1).getSnapshot();
@@ -1914,7 +1915,7 @@ public class DataTest {
   @Test
   public void deepUpdateWorks()
       throws DatabaseException, InterruptedException, TestFailure, TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -1942,9 +1943,9 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
-    DataSnapshot snap = TestHelpers.getSnap(reader);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(reader);
     DeepEquals.assertEquals(expected, snap.getValue());
     assertEquals(3.0, snap.getPriority());
 
@@ -1952,7 +1953,7 @@ public class DataTest {
     DeepEquals.assertEquals(expected, snap.getValue());
     assertEquals(3.0, snap.getPriority());
 
-    snap = TestHelpers.getSnap(reader.child("a/ab"));
+    snap = IntegrationTestHelpers.getSnap(reader.child("a/ab"));
     assertEquals(2.0, snap.getPriority());
   }
 
@@ -1960,7 +1961,7 @@ public class DataTest {
 
   @Test
   public void updateWithNoChangesWorks() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     ref.updateChildren(
@@ -1973,7 +1974,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   // TODO: consider implementing update stress test
@@ -1983,7 +1984,7 @@ public class DataTest {
   public void updateFiresCorrectEventWhenAChildIsDeleted()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2003,7 +2004,7 @@ public class DataTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     writer.updateChildren(new MapBuilder().put("a", null).build());
     DataSnapshot snap = writerFuture.timedGet().get(1).getSnapshot();
@@ -2020,7 +2021,7 @@ public class DataTest {
   public void updateFiresCorrectEventOnNewChildren()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2051,8 +2052,8 @@ public class DataTest {
               }
             });
 
-    TestHelpers.waitFor(readerInitializedSemaphore);
-    TestHelpers.waitFor(writerInitializedSemaphore);
+    IntegrationTestHelpers.waitFor(readerInitializedSemaphore);
+    IntegrationTestHelpers.waitFor(writerInitializedSemaphore);
 
     writer.updateChildren(new MapBuilder().put("a", 42).build());
     DataSnapshot snap = writerFuture.timedGet().get(1).getSnapshot();
@@ -2069,7 +2070,7 @@ public class DataTest {
   public void updateFiresCorrectEventWhenAllChildrenAreDeleted()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2089,7 +2090,7 @@ public class DataTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     writer.updateChildren(new MapBuilder().put("a", null).build());
     DataSnapshot snap = writerFuture.timedGet().get(1).getSnapshot();
@@ -2105,7 +2106,7 @@ public class DataTest {
   public void updateFiresCorrectEventOnChangedChildren()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2125,7 +2126,7 @@ public class DataTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     writer.updateChildren(new MapBuilder().put("a", 11).build());
     DataSnapshot snap = writerFuture.timedGet().get(1).getSnapshot();
@@ -2140,7 +2141,7 @@ public class DataTest {
 
   @Test
   public void updateOfPriorityWorks() throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2164,9 +2165,9 @@ public class DataTest {
             semaphore.release(1);
           }
         });
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
-    DataSnapshot snap = TestHelpers.getSnap(reader);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(reader);
     assertEquals(6L, snap.child("a").getValue());
     assertEquals("pri2", snap.getPriority());
     assertEquals("pri3", snap.child("b").getPriority());
@@ -2182,7 +2183,7 @@ public class DataTest {
   @Test
   public void parentDeleteShadowsChildListeners()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference deleter = refs.get(1);
 
@@ -2213,7 +2214,7 @@ public class DataTest {
                 });
     writer.child(childName).setValue("foo");
     // Make sure we get the data in the listener before we delete it
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     deleter.removeValue(
         new DatabaseReference.CompletionListener() {
@@ -2223,7 +2224,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     assertTrue(called.get());
     deleter.child(childName).removeEventListener(listener);
   }
@@ -2231,7 +2232,7 @@ public class DataTest {
   @Test
   public void parentDeleteShadowsNonDefaultChildListeners()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference deleter = refs.get(1);
 
@@ -2286,7 +2287,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     assertTrue(queryCalled.get());
     assertTrue(deepChildCalled.get());
     deleter.child(childName).startAt(null, "b").removeEventListener(queryListener);
@@ -2296,7 +2297,7 @@ public class DataTest {
   @Test
   public void testServerValuesSetWithPriorityRemoteEvents()
       throws TestFailure, TimeoutException, DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2315,7 +2316,7 @@ public class DataTest {
             });
 
     // Wait for initial (null) value.
-    TestHelpers.waitFor(valSemaphore, 1);
+    IntegrationTestHelpers.waitFor(valSemaphore, 1);
 
     Map<String, Object> initialValues =
         new MapBuilder()
@@ -2337,7 +2338,7 @@ public class DataTest {
             opSemaphore.release();
           }
         });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord readerEventRecord = readerFuture.timedGet().get(1);
     DataSnapshot snap = readerEventRecord.getSnapshot();
@@ -2353,7 +2354,7 @@ public class DataTest {
   @Test
   public void testServerValuesSetPriorityRemoteEvents()
       throws TestFailure, TimeoutException, DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2395,7 +2396,7 @@ public class DataTest {
             opSemaphore.release();
           }
         });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("a")
@@ -2407,9 +2408,9 @@ public class DataTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
 
     assert (Math.abs(System.currentTimeMillis() - priority.get()) < 2000);
   }
@@ -2417,7 +2418,7 @@ public class DataTest {
   @Test
   public void testServerValuesUpdateRemoteEvents()
       throws TestFailure, TimeoutException, DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2435,7 +2436,7 @@ public class DataTest {
             });
 
     // Wait for initial (null) value.
-    TestHelpers.waitFor(valSemaphore, 1);
+    IntegrationTestHelpers.waitFor(valSemaphore, 1);
 
     writer
         .child("a/b/d")
@@ -2448,7 +2449,7 @@ public class DataTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     Map<String, Object> updatedValue =
         new MapBuilder()
@@ -2471,7 +2472,7 @@ public class DataTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord readerEventRecord = readerFuture.timedGet().get(2);
     DataSnapshot snap = readerEventRecord.getSnapshot();
@@ -2485,7 +2486,7 @@ public class DataTest {
   @Test
   public void testServerValuesSetWithPriorityLocalEvents()
       throws TestFailure, TimeoutException, DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference writer = refs.get(0);
 
     final Semaphore opSemaphore = new Semaphore(0);
@@ -2503,7 +2504,7 @@ public class DataTest {
             });
 
     // Wait for initial (null) value.
-    TestHelpers.waitFor(valSemaphore, 1);
+    IntegrationTestHelpers.waitFor(valSemaphore, 1);
 
     Map<String, Object> initialValues =
         new MapBuilder()
@@ -2525,7 +2526,7 @@ public class DataTest {
             opSemaphore.release();
           }
         });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord readerEventRecord = writerFuture.timedGet().get(1);
     DataSnapshot snap = readerEventRecord.getSnapshot();
@@ -2541,7 +2542,7 @@ public class DataTest {
   @Test
   public void testServerValuesSetPriorityLocalEvents()
       throws TestFailure, TimeoutException, DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference writer = refs.get(0);
 
     final Semaphore opSemaphore = new Semaphore(0);
@@ -2582,7 +2583,7 @@ public class DataTest {
             opSemaphore.release();
           }
         });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("a")
@@ -2594,9 +2595,9 @@ public class DataTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
 
     assert (Math.abs(System.currentTimeMillis() - priority.get()) < 2000);
   }
@@ -2604,7 +2605,7 @@ public class DataTest {
   @Test
   public void testServerValuesUpdateLocalEvents()
       throws TestFailure, TimeoutException, DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference writer = refs.get(0);
 
     final Semaphore opSemaphore = new Semaphore(0);
@@ -2621,7 +2622,7 @@ public class DataTest {
             });
 
     // Wait for initial (null) value.
-    TestHelpers.waitFor(valSemaphore, 1);
+    IntegrationTestHelpers.waitFor(valSemaphore, 1);
 
     writer
         .child("a/b/d")
@@ -2634,7 +2635,7 @@ public class DataTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     Map<String, Object> updatedValue =
         new MapBuilder()
@@ -2656,7 +2657,7 @@ public class DataTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord readerEventRecord = writerFuture.timedGet().get(3);
     DataSnapshot snap = readerEventRecord.getSnapshot();
@@ -2670,7 +2671,7 @@ public class DataTest {
   @Test
   public void testServerValuesTransactionLocalEvents()
       throws TestFailure, TimeoutException, DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(0);
 
@@ -2699,8 +2700,8 @@ public class DataTest {
             });
 
     // Wait for local (null) events.
-    TestHelpers.waitFor(valSemaphore1);
-    TestHelpers.waitFor(valSemaphore2);
+    IntegrationTestHelpers.waitFor(valSemaphore1);
+    IntegrationTestHelpers.waitFor(valSemaphore2);
 
     writer.runTransaction(
         new Transaction.Handler() {
@@ -2723,8 +2724,8 @@ public class DataTest {
         });
 
     // Wait for local events.
-    TestHelpers.waitFor(valSemaphore1);
-    TestHelpers.waitFor(valSemaphore2);
+    IntegrationTestHelpers.waitFor(valSemaphore1);
+    IntegrationTestHelpers.waitFor(valSemaphore2);
 
     EventRecord writerEventRecord = writerFuture.timedGet().get(1);
     DataSnapshot snap1 = writerEventRecord.getSnapshot();
@@ -2741,7 +2742,7 @@ public class DataTest {
 
   @Test
   public void testUpdateAfterChildSet() throws DatabaseException, InterruptedException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore doneSemaphore = new Semaphore(0);
 
     Map<String, Object> initial = new MapBuilder().put("a", "a").build();
@@ -2774,7 +2775,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(doneSemaphore);
+    IntegrationTestHelpers.waitFor(doneSemaphore);
   }
 
   @Test
@@ -2786,20 +2787,20 @@ public class DataTest {
       msg += i;
     }
 
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, msg).timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(ref);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref);
     assertEquals(msg, snap.getValue());
   }
 
   @Test
   public void testDeltaSyncNoDataUpdatesAfterReconnect() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     // Create a fresh connection so we can be sure we won't get any other data updates for stuff.
-    DatabaseConfig ctx = TestHelpers.newTestConfig();
+    DatabaseConfig ctx = IntegrationTestHelpers.newTestConfig();
     final DatabaseReference ref2 = new DatabaseReference(ref.toString(), ctx);
 
     final Map data =
@@ -2833,7 +2834,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(gotData);
+    IntegrationTestHelpers.waitFor(gotData);
 
     final Semaphore done = new Semaphore(0);
     assertEquals(1, ref2.repo.dataUpdateCount);
@@ -2869,15 +2870,15 @@ public class DataTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void testDeltaSyncWithQueryNoDataUpdatesAfterReconnect() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     // Create a fresh connection so we can be sure we won't get any other data updates for stuff.
-    DatabaseConfig ctx = TestHelpers.newTestConfig();
+    DatabaseConfig ctx = IntegrationTestHelpers.newTestConfig();
     final DatabaseReference ref2 = new DatabaseReference(ref.toString(), ctx);
 
     final Map data =
@@ -2918,7 +2919,7 @@ public class DataTest {
           }
         });
 
-    TestHelpers.waitFor(gotData);
+    IntegrationTestHelpers.waitFor(gotData);
 
     final Semaphore done = new Semaphore(0);
     assertEquals(1, ref2.repo.dataUpdateCount);
@@ -2954,13 +2955,13 @@ public class DataTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void testDeltaSyncWithUnfilteredQuery()
       throws InterruptedException, ExecutionException, TestFailure, TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writeRef = refs.get(0), readRef = refs.get(1);
 
     // List must be large enough to trigger delta sync.
@@ -2990,7 +2991,7 @@ public class DataTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(readSemaphore);
+    IntegrationTestHelpers.waitFor(readSemaphore);
     DeepEquals.assertEquals(longList, readSnapshots.get(0).getValue());
 
     // Add a new child while readRef is offline.
@@ -3004,7 +3005,7 @@ public class DataTest {
 
     // Go back online and make sure we get the new item.
     readRef.getDatabase().goOnline();
-    TestHelpers.waitFor(readSemaphore);
+    IntegrationTestHelpers.waitFor(readSemaphore);
     DeepEquals.assertEquals(longList, readSnapshots.get(1).getValue());
   }
 
@@ -3012,13 +3013,13 @@ public class DataTest {
   public void negativeIntegersDontCreateArrayValue()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(
             ref, new MapBuilder().put("-1", "minus-one").put("0", "zero").put("1", "one").build())
         .timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(ref);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref);
     Map<String, Object> expected =
         new MapBuilder().put("-1", "minus-one").put("0", "zero").put("1", "one").build();
     Object result = snap.getValue();
@@ -3028,7 +3029,7 @@ public class DataTest {
   @Test
   public void testLocalServerValuesEventuallyButNotImmediatelyMatchServer()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -3068,7 +3069,7 @@ public class DataTest {
 
     writer.setValue(ServerValue.TIMESTAMP, ServerValue.TIMESTAMP);
 
-    TestHelpers.waitFor(completionSemaphore, 3);
+    IntegrationTestHelpers.waitFor(completionSemaphore, 3);
 
     assertEquals(readSnaps.size(), 1);
     assertEquals(writeSnaps.size(), 2);
@@ -3100,7 +3101,7 @@ public class DataTest {
     nestedBean.name = "nested-bean";
     bean.nestedBean = nestedBean;
 
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     new WriteFuture(ref, bean).timedGet();
 
     final Semaphore done = new Semaphore(0);
@@ -3119,7 +3120,7 @@ public class DataTest {
           public void onCancelled(DatabaseError error) {}
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
@@ -3132,7 +3133,7 @@ public class DataTest {
     DumbBean bean2 = new DumbBean();
     bean2.name = "bean2";
 
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore writeComplete = new Semaphore(0);
     ref.updateChildren(
@@ -3143,7 +3144,7 @@ public class DataTest {
             writeComplete.release();
           }
         });
-    TestHelpers.waitFor(writeComplete);
+    IntegrationTestHelpers.waitFor(writeComplete);
 
     final Semaphore done = new Semaphore(0);
     ref.addListenerForSingleValueEvent(
@@ -3161,7 +3162,7 @@ public class DataTest {
           public void onCancelled(DatabaseError error) {}
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
@@ -3174,7 +3175,7 @@ public class DataTest {
     DumbBean bean2 = new DumbBean();
     bean2.name = "bean2";
 
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore writeComplete = new Semaphore(0);
     ref.updateChildren(
@@ -3185,7 +3186,7 @@ public class DataTest {
             writeComplete.release();
           }
         });
-    TestHelpers.waitFor(writeComplete);
+    IntegrationTestHelpers.waitFor(writeComplete);
 
     final Semaphore done = new Semaphore(0);
     ref.addListenerForSingleValueEvent(
@@ -3201,6 +3202,6 @@ public class DataTest {
           public void onCancelled(DatabaseError error) {}
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 }

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/EventTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/EventTest.java
@@ -43,13 +43,13 @@ public class EventTest {
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
   // NOTE: skipping test on valid types.
 
   @Test
   public void writeLeafNodeExpectValue() throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -70,7 +70,7 @@ public class EventTest {
 
   @Test
   public void writeNestedLeafNodeWaitForEvents() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     EventHelper helper =
         new EventHelper()
             .addChildExpectation(ref, Event.EventType.CHILD_ADDED, "foo")
@@ -86,7 +86,7 @@ public class EventTest {
 
   @Test
   public void writeTwoLeafNodeThenChangeThem() throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -129,7 +129,7 @@ public class EventTest {
 
   @Test
   public void writeFloatValueThenChangeToInteger() throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference node = refs.get(0);
 
     EventHelper readHelper =
@@ -145,14 +145,14 @@ public class EventTest {
     node.setValue((float) 1337.0); // This does not fire events.
     node.setValue(1337.1);
 
-    TestHelpers.waitForRoundtrip(node);
+    IntegrationTestHelpers.waitForRoundtrip(node);
     assertTrue(readHelper.waitForEvents());
     ZombieVerifier.verifyRepoZombies(refs);
   }
 
   @Test
   public void writeDoubleValueThenChangeToInteger() throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference node = refs.get(0);
 
     EventHelper readHelper =
@@ -167,7 +167,7 @@ public class EventTest {
     node.setValue(1337); // This does not fire events.
     node.setValue(1337.1);
 
-    TestHelpers.waitForRoundtrip(node);
+    IntegrationTestHelpers.waitForRoundtrip(node);
     assertTrue(readHelper.waitForEvents());
     ZombieVerifier.verifyRepoZombies(refs);
   }
@@ -175,7 +175,7 @@ public class EventTest {
   @Test
   public void writeDoubleValueThenChangeToIntegerWithDifferentPriority()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference node = refs.get(0);
 
     EventHelper readHelper =
@@ -189,14 +189,14 @@ public class EventTest {
     node.setValue(1337.0);
     node.setValue(1337, 1337);
 
-    TestHelpers.waitForRoundtrip(node);
+    IntegrationTestHelpers.waitForRoundtrip(node);
     assertTrue(readHelper.waitForEvents());
     ZombieVerifier.verifyRepoZombies(refs);
   }
 
   @Test
   public void writeIntegerValueThenChangeToDouble() throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference node = refs.get(0);
 
     EventHelper readHelper =
@@ -211,7 +211,7 @@ public class EventTest {
     node.setValue(1337.0); // This does not fire events.
     node.setValue(1337.1);
 
-    TestHelpers.waitForRoundtrip(node);
+    IntegrationTestHelpers.waitForRoundtrip(node);
     assertTrue(readHelper.waitForEvents());
     ZombieVerifier.verifyRepoZombies(refs);
   }
@@ -219,7 +219,7 @@ public class EventTest {
   @Test
   public void writeIntegerValueThenChangeToDoubleWithDifferentPriority()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference node = refs.get(0);
 
     EventHelper readHelper =
@@ -233,14 +233,14 @@ public class EventTest {
     node.setValue(1337);
     node.setValue(1337.0, 1337);
 
-    TestHelpers.waitForRoundtrip(node);
+    IntegrationTestHelpers.waitForRoundtrip(node);
     assertTrue(readHelper.waitForEvents());
     ZombieVerifier.verifyRepoZombies(refs);
   }
 
   @Test
   public void writeLargeLongValueThenIncrement() throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference node = refs.get(0);
 
     EventHelper readHelper =
@@ -253,14 +253,14 @@ public class EventTest {
     node.setValue(Long.MAX_VALUE);
     node.setValue(Long.MAX_VALUE * 2.0);
 
-    TestHelpers.waitForRoundtrip(node);
+    IntegrationTestHelpers.waitForRoundtrip(node);
     assertTrue(readHelper.waitForEvents());
     ZombieVerifier.verifyRepoZombies(refs);
   }
 
   @Test
   public void setMultipleEventListenersOnSameNode() throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -285,7 +285,7 @@ public class EventTest {
   @Test
   public void setDataMultipleTimesEnsureValueIsCalledAppropriately()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = ReadFuture.untilEquals(ref, 2L, /*ignoreFirstNull=*/ true);
     ZombieVerifier.verifyRepoZombies(ref);
@@ -306,7 +306,7 @@ public class EventTest {
   public void unsubscribeEventsAndConfirmEventsNoLongerFire()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final AtomicInteger callbackCount = new AtomicInteger(0);
 
@@ -331,7 +331,7 @@ public class EventTest {
       ref.setValue(i);
     }
 
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     ref.removeEventListener(listener);
     ZombieVerifier.verifyRepoZombies(ref);
 
@@ -349,7 +349,7 @@ public class EventTest {
   @Test
   public void subscribeThenUnsubscribeWithoutProblems()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueEventListener listener =
         new ValueEventListener() {
@@ -375,7 +375,7 @@ public class EventTest {
   @Test
   public void subscribeThenUnsubscribeWithoutProblemsWithLimit()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueEventListener listener =
         new ValueEventListener() {
@@ -401,7 +401,7 @@ public class EventTest {
   @Test
   public void writeChunkOfJSONButGetMoreGranularEventsForIndividualChanges()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -493,18 +493,18 @@ public class EventTest {
     ZombieVerifier.verifyRepoZombies(refs);
 
     writer.setValue(new MapBuilder().put("a", 10).put("b", 20).build());
-    TestHelpers.waitFor(writerReady, 2);
-    TestHelpers.waitFor(readerReady, 2);
+    IntegrationTestHelpers.waitFor(writerReady, 2);
+    IntegrationTestHelpers.waitFor(readerReady, 2);
 
     writer.setValue(new MapBuilder().put("a", 10).put("b", 30).build());
-    TestHelpers.waitFor(writerReady);
-    TestHelpers.waitFor(readerReady);
+    IntegrationTestHelpers.waitFor(writerReady);
+    IntegrationTestHelpers.waitFor(readerReady);
   }
 
   @Test
   public void valueIsTriggeredForEmptyNodes()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     DataSnapshot snap = new ReadFuture(ref).timedGet().get(0).getSnapshot();
     ZombieVerifier.verifyRepoZombies(ref);
@@ -514,7 +514,7 @@ public class EventTest {
   @Test
   public void correctEventsAreRaisedWhenALeafNodeTurnsIntoAnInternalNode()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 4);
 
@@ -538,7 +538,7 @@ public class EventTest {
   public void canRegisterTheSameCallbackMultipleTimesNeedToUnregisterItMultipleTimes()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final AtomicInteger callbackCount = new AtomicInteger(0);
     ValueEventListener listener =
@@ -583,7 +583,7 @@ public class EventTest {
   @Test
   public void unregisterSameCallbackTooManyTimesSilentlyDoesNothing()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueEventListener listener =
         ref.addValueEventListener(
@@ -609,7 +609,7 @@ public class EventTest {
   @Test
   public void removesHappenImmediately()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore blockSem = new Semaphore(0);
     final Semaphore endingSemaphore = new Semaphore(0);
 
@@ -621,7 +621,7 @@ public class EventTest {
             if (snapshot.getValue() != null) {
               assertTrue(called.compareAndSet(false, true));
               try {
-                TestHelpers.waitFor(blockSem);
+                IntegrationTestHelpers.waitFor(blockSem);
               } catch (InterruptedException e) {
                 e.printStackTrace();
               }
@@ -644,17 +644,17 @@ public class EventTest {
     ZombieVerifier.verifyRepoZombies(ref);
 
     ref.setValue(42);
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
     ref.setValue(84);
     blockSem.release();
     new WriteFuture(ref, null).timedGet();
-    TestHelpers.waitFor(endingSemaphore);
+    IntegrationTestHelpers.waitFor(endingSemaphore);
   }
 
   @Test
   public void removesHappenImmediatelyOnOuterRef()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore gotInitialEvent = new Semaphore(0);
     final Semaphore blockSem = new Semaphore(0);
     final Semaphore endingSemaphore = new Semaphore(0);
@@ -669,7 +669,7 @@ public class EventTest {
                 if (snapshot.getValue() != null) {
                   assertTrue(called.compareAndSet(false, true));
                   try {
-                    TestHelpers.waitFor(blockSem);
+                    IntegrationTestHelpers.waitFor(blockSem);
                   } catch (InterruptedException e) {
                     e.printStackTrace();
                   }
@@ -691,20 +691,20 @@ public class EventTest {
             });
     ZombieVerifier.verifyRepoZombies(ref);
 
-    TestHelpers.waitFor(gotInitialEvent);
+    IntegrationTestHelpers.waitFor(gotInitialEvent);
 
     ref.child("a").setValue(42);
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
     ref.child("b").setValue(84);
     blockSem.release();
     new WriteFuture(ref, null).timedGet();
-    TestHelpers.waitFor(endingSemaphore);
+    IntegrationTestHelpers.waitFor(endingSemaphore);
   }
 
   @Test
   public void removesHappenImmediatelyOnMultipleRef()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore gotInitialEvent = new Semaphore(0);
     final Semaphore blockSem = new Semaphore(0);
     final Semaphore endingSemaphore = new Semaphore(0);
@@ -718,7 +718,7 @@ public class EventTest {
             if (snapshot.getValue() != null) {
               assertTrue(called.compareAndSet(false, true));
               try {
-                TestHelpers.waitFor(blockSem);
+                IntegrationTestHelpers.waitFor(blockSem);
               } catch (InterruptedException e) {
                 e.printStackTrace();
               }
@@ -743,19 +743,19 @@ public class EventTest {
     ref.limitToFirst(5).addValueEventListener(listener);
     ZombieVerifier.verifyRepoZombies(ref);
 
-    TestHelpers.waitFor(gotInitialEvent, 2);
+    IntegrationTestHelpers.waitFor(gotInitialEvent, 2);
     ref.child("a").setValue(42);
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
     ref.child("b").setValue(84);
     blockSem.release();
     new WriteFuture(ref, null).timedGet();
-    TestHelpers.waitFor(endingSemaphore);
+    IntegrationTestHelpers.waitFor(endingSemaphore);
   }
 
   @Test
   public void removesHappenImmediatelyChild()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore blockSem = new Semaphore(0);
     final Semaphore endingSemaphore = new Semaphore(0);
 
@@ -767,7 +767,7 @@ public class EventTest {
             if (snapshot.getValue() != null) {
               assertTrue(called.compareAndSet(false, true));
               try {
-                TestHelpers.waitFor(blockSem);
+                IntegrationTestHelpers.waitFor(blockSem);
               } catch (InterruptedException e) {
                 e.printStackTrace();
               }
@@ -798,18 +798,18 @@ public class EventTest {
     ZombieVerifier.verifyRepoZombies(ref);
 
     ref.child("a").setValue(42);
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
     ref.child("b").setValue(84);
     blockSem.release();
     new WriteFuture(ref, null).timedGet();
-    TestHelpers.waitFor(endingSemaphore);
+    IntegrationTestHelpers.waitFor(endingSemaphore);
   }
 
   @Test
   public void onceFiresExactlyOnce()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final AtomicBoolean called = new AtomicBoolean(false);
     ref.addListenerForSingleValueEvent(
@@ -838,7 +838,7 @@ public class EventTest {
   @Test
   public void valueOnEmptyChildFires()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     DataSnapshot snap = new ReadFuture(ref.child("test")).timedGet().get(0).getSnapshot();
     assertNull(snap.getValue());
@@ -848,7 +848,7 @@ public class EventTest {
   @Test
   public void valueOnEmptyChildFiresImmediatelyEvenAfterParentIsSynced()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     // Sync parent
     new ReadFuture(ref).timedGet();
@@ -862,7 +862,7 @@ public class EventTest {
   public void childEventsAreRaised()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> firstValue =
         new MapBuilder()
@@ -948,7 +948,7 @@ public class EventTest {
   public void childEventsAreRaisedWithAQuery()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> firstValue =
         new MapBuilder()
@@ -1034,7 +1034,7 @@ public class EventTest {
   @Test
   public void priorityChangeShouldRaiseChildMovedAndChildChangedAndValueOnParentAndChild()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     EventHelper helper =
         new EventHelper()
@@ -1047,7 +1047,7 @@ public class EventTest {
             .startListening(true);
 
     ref.child("bar").setValue(42, 10);
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     ref.child("foo").setValue(42, 20);
 
     assertTrue(helper.waitForEvents());
@@ -1067,7 +1067,7 @@ public class EventTest {
   @Test
   public void priorityChangeShouldRaiseChildMovedAndChildChangedAndValueOnParentAndChild2()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     EventHelper helper =
         new EventHelper()

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database;
 
-import static com.google.firebase.database.TestHelpers.fromSingleQuotedString;
+import static com.google.firebase.database.IntegrationTestHelpers.fromSingleQuotedString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -46,12 +46,12 @@ public class FirebaseDatabaseTest {
 
   @Before
   public void setup() {
-    TestHelpers.ensureAppInitialized();
+    IntegrationTestHelpers.ensureAppInitialized();
   }
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
 
   @Test
@@ -158,7 +158,7 @@ public class FirebaseDatabaseTest {
 
   @Test
   public void persistenceSettings() {
-    DatabaseConfig config = TestHelpers.newTestConfig();
+    DatabaseConfig config = IntegrationTestHelpers.newTestConfig();
 
     try {
       config.setPersistenceCacheSizeBytes(1 * 1024 * 1024 - 1);
@@ -250,11 +250,11 @@ public class FirebaseDatabaseTest {
   }
 
   private static DatabaseReference rootRefWithEngine(MockPersistenceStorageEngine engine) {
-    DatabaseConfig config = TestHelpers.newTestConfig();
+    DatabaseConfig config = IntegrationTestHelpers.newTestConfig();
     PersistenceManager persistenceManager =
         new DefaultPersistenceManager(config, engine, CachePolicy.NONE);
-    TestHelpers.setForcedPersistentCache(config, persistenceManager);
-    return TestHelpers.rootWithConfig(config);
+    IntegrationTestHelpers.setForcedPersistentCache(config, persistenceManager);
+    return IntegrationTestHelpers.rootWithConfig(config);
   }
 
   @Test
@@ -270,12 +270,12 @@ public class FirebaseDatabaseTest {
     ref.push().setValue("test-value-3");
     ref.push().setValue("test-value-4");
 
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
     Assert.assertEquals(4, engine.loadUserWrites().size());
 
     app.purgeOutstandingWrites();
 
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
     Assert.assertEquals(0, engine.loadUserWrites().size());
   }
 
@@ -332,12 +332,12 @@ public class FirebaseDatabaseTest {
               }
             });
 
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
     Assert.assertEquals(4, engine.loadUserWrites().size());
 
     app.purgeOutstandingWrites();
 
-    TestHelpers.waitForEvents(ref);
+    IntegrationTestHelpers.waitForEvents(ref);
     assertEquals(Arrays.asList("1", "2", "3", "4"), order);
   }
 
@@ -374,11 +374,11 @@ public class FirebaseDatabaseTest {
               }
             });
 
-    TestHelpers.waitForEvents(ref);
+    IntegrationTestHelpers.waitForEvents(ref);
 
     app.purgeOutstandingWrites();
 
-    TestHelpers.waitForEvents(ref);
+    IntegrationTestHelpers.waitForEvents(ref);
     assertEquals(Arrays.asList("1", "2"), order);
   }
 
@@ -484,7 +484,7 @@ public class FirebaseDatabaseTest {
 
     app.purgeOutstandingWrites();
 
-    TestHelpers.waitForEvents(ref);
+    IntegrationTestHelpers.waitForEvents(ref);
 
     assertEquals(Arrays.asList("foo-1", "bar", "foo-2"), cancelOrder);
 
@@ -494,7 +494,7 @@ public class FirebaseDatabaseTest {
 
     app.goOnline();
     // Make sure we're back online and reconnected again
-    TestHelpers.waitForEvents(ref);
+    IntegrationTestHelpers.waitForEvents(ref);
 
     // No events should be reraised...
     assertEquals(expectedFooValues, fooValues);
@@ -522,7 +522,7 @@ public class FirebaseDatabaseTest {
         });
 
     // Make sure the first value event is fired
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
 
     app.goOffline();
 
@@ -558,7 +558,7 @@ public class FirebaseDatabaseTest {
 
     ref.getDatabase().purgeOutstandingWrites();
 
-    TestHelpers.waitForEvents(ref);
+    IntegrationTestHelpers.waitForEvents(ref);
 
     // The order should really be cancel-1 then cancel-2, but too difficult to implement currently.
     assertEquals(

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/InfoTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/InfoTest.java
@@ -35,11 +35,11 @@ public class InfoTest {
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
 
   private DatabaseReference getRootNode() throws DatabaseException {
-    return TestHelpers.getRandomNode().getRoot();
+    return IntegrationTestHelpers.getRandomNode().getRoot();
   }
 
   @Test
@@ -50,7 +50,7 @@ public class InfoTest {
     assertEquals(
         IntegrationTestValues.getNamespace() + "/.info/foo", root.child(".info/foo").toString());
 
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     DatabaseReference ref =
         new DatabaseReference(IntegrationTestValues.getNamespace() + "/.info", ctx);
     assertEquals(IntegrationTestValues.getNamespace() + "/.info", ref.toString());
@@ -132,7 +132,7 @@ public class InfoTest {
   @Test
   public void testManualConnectionManagementWorks()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     // Wait until we're connected to the database
     ReadFuture.untilEquals(ref.getRoot().child(".info/connected"), true).timedGet();
@@ -167,7 +167,7 @@ public class InfoTest {
     // Wait until we're connected
     ReadFuture.untilEquals(ref.child(".info/connected"), true).timedGet();
 
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.interrupt(ctx);
 
     DataSnapshot snap =

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/OrderByTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/OrderByTest.java
@@ -38,10 +38,10 @@ public class OrderByTest {
   @Test
   public void snapshotsAreIteratedInOrder()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> initial =
-        TestHelpers.fromJsonString(
+        IntegrationTestHelpers.fromJsonString(
             "{"
                 + "\"alex\": {\"nuggets\": 60},"
                 + "\"greg\": {\"nuggets\": 52},"
@@ -90,7 +90,7 @@ public class OrderByTest {
     Assert.assertEquals(expectedPrevNames, childPrevNames);
 
     // cleanup
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     ref.removeEventListener(testListener);
     ref.removeEventListener(valueListener);
   }
@@ -98,10 +98,10 @@ public class OrderByTest {
   @Test
   public void canUseDeepPathsForIndex()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> initial =
-        TestHelpers.fromJsonString(
+        IntegrationTestHelpers.fromJsonString(
             "{"
                 + "\"alex\": {\"deep\": {\"nuggets\": 60}},"
                 + "\"greg\": {\"deep\": {\"nuggets\": 52}},"
@@ -145,7 +145,7 @@ public class OrderByTest {
               }
             });
 
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
 
     Assert.assertEquals(expectedOrder, valueOrder);
     Assert.assertEquals(expectedOrder, childOrder);
@@ -159,10 +159,10 @@ public class OrderByTest {
   @Test
   public void snapshotsAreIteratedInOrderForValueIndex()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> initial =
-        TestHelpers.fromJsonString(
+        IntegrationTestHelpers.fromJsonString(
             "{"
                 + "\"alex\": 60,"
                 + "\"greg\": 52,"
@@ -211,16 +211,16 @@ public class OrderByTest {
     Assert.assertEquals(expectedPrevNames, childPrevNames);
 
     // cleanup
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     ref.removeEventListener(testListener);
     ref.removeEventListener(valueListener);
   }
 
   @Test
   public void childMovedEventsAreFired() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     Map<String, Object> initial =
-        TestHelpers.fromJsonString(
+        IntegrationTestHelpers.fromJsonString(
             "{"
                 + "\"alex\": {\"nuggets\": 60},"
                 + "\"greg\": {\"nuggets\": 52},"
@@ -254,7 +254,7 @@ public class OrderByTest {
     ref.setValue(initial);
     ref.child("greg/nuggets").setValue(57);
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     Assert.assertEquals("greg", snapshot[0].getKey());
     Assert.assertEquals("rob", prevName[0]);
@@ -262,13 +262,13 @@ public class OrderByTest {
     expectedValue.put("nuggets", 57L);
     Assert.assertEquals(expectedValue, snapshot[0].getValue());
 
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     ref.removeEventListener(testListener);
   }
 
   @Test
   public void callbackRemovalWorks() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final int[] reads = new int[1];
     final Semaphore semaphore = new Semaphore(0);
@@ -333,30 +333,30 @@ public class OrderByTest {
             });
 
     // wait for initial null events.
-    TestHelpers.waitFor(semaphore, 4);
+    IntegrationTestHelpers.waitFor(semaphore, 4);
     Assert.assertEquals(4, reads[0]);
 
     ref.setValue(1);
 
-    TestHelpers.waitFor(semaphore, 4);
+    IntegrationTestHelpers.waitFor(semaphore, 4);
     Assert.assertEquals(8, reads[0]);
 
     ref.removeEventListener(fooListener);
     ref.setValue(2);
 
-    TestHelpers.waitFor(semaphore, 3);
+    IntegrationTestHelpers.waitFor(semaphore, 3);
     Assert.assertEquals(11, reads[0]);
 
     // Should be a no-op resulting in 3 more reads
     ref.orderByChild("foo").removeEventListener(bazListener);
     ref.setValue(3);
 
-    TestHelpers.waitFor(semaphore, 3);
+    IntegrationTestHelpers.waitFor(semaphore, 3);
     Assert.assertEquals(14, reads[0]);
 
     ref.orderByChild("bar").removeEventListener(barListener);
     ref.setValue(4);
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
     Assert.assertEquals(16, reads[0]);
 
     // Now, remove everything
@@ -365,13 +365,13 @@ public class OrderByTest {
     ref.setValue(5);
 
     // No more reads
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     Assert.assertEquals(16, reads[0]);
   }
 
   @Test
   public void childAddedEventsAreInCorrectOrder() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> initial =
         new MapBuilder()
@@ -395,7 +395,7 @@ public class OrderByTest {
                 });
 
     ref.setValue(initial);
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
     Assert.assertEquals(Arrays.asList("c", "a"), snapshotNames);
     Assert.assertEquals(Arrays.asList(null, "c"), prevNames);
 
@@ -404,7 +404,7 @@ public class OrderByTest {
     updates.put("d", new MapBuilder().put("value", 2).build());
     ref.updateChildren(updates);
 
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
     Assert.assertEquals(Arrays.asList("c", "a", "d", "b"), snapshotNames);
     Assert.assertEquals(Arrays.asList(null, "c", null, "c"), prevNames);
     ref.removeEventListener(testListener);
@@ -413,7 +413,7 @@ public class OrderByTest {
   @Test
   public void updatesForUnindexedQuery()
       throws InterruptedException, ExecutionException, TestFailure, TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -444,7 +444,7 @@ public class OrderByTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     Assert.assertEquals(1, snapshots.size());
 
@@ -455,7 +455,7 @@ public class OrderByTest {
 
     // update child which should trigger value event
     writer.child("one/index").setValue(4);
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     Assert.assertEquals(2, snapshots.size());
     Map<String, Object> expected2 = new HashMap<String, Object>();
@@ -464,7 +464,7 @@ public class OrderByTest {
     Assert.assertEquals(expected2, snapshots.get(1).getValue());
 
     // cleanup
-    TestHelpers.waitForRoundtrip(reader);
+    IntegrationTestHelpers.waitForRoundtrip(reader);
     reader.removeEventListener(listener);
   }
 
@@ -472,7 +472,7 @@ public class OrderByTest {
   public void queriesWorkOnLeafNodes()
       throws DatabaseException, InterruptedException, ExecutionException, TestFailure,
           TimeoutException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore semaphore = new Semaphore(0);
     new WriteFuture(ref, "leaf-node").timedGet();
 
@@ -493,20 +493,20 @@ public class OrderByTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     Assert.assertEquals(1, snapshots.size());
     Assert.assertNull(snapshots.get(0).getValue());
 
     // cleanup
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     ref.removeEventListener(listener);
   }
 
   @Test
   public void serverRespectsKeyIndex()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -539,7 +539,7 @@ public class OrderByTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     Assert.assertEquals(expectedChildren, actualChildren);
 
@@ -549,10 +549,10 @@ public class OrderByTest {
 
   @Test
   public void startAtAndEndAtWorkOnValueIndex() throws Throwable {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> initial =
-        TestHelpers.fromJsonString(
+        IntegrationTestHelpers.fromJsonString(
             "{"
                 + "\"alex\": 60,"
                 + "\"greg\": 52,"
@@ -601,14 +601,14 @@ public class OrderByTest {
     Assert.assertEquals(expectedPrevNames, childPrevNames);
 
     // cleanup
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     ref.removeEventListener(testListener);
     ref.removeEventListener(valueListener);
   }
 
   @Test
   public void removingDefaultListenerRemovesNonDefaultListenWithLoadsAllData() throws Throwable {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Object initialData = new MapBuilder().put("key", "value").build();
     new WriteFuture(ref, initialData).timedGet();

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/OrderTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/OrderTest.java
@@ -42,20 +42,20 @@ public class OrderTest {
   @Before
   public void setUp()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode().getRoot();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode().getRoot();
 
     ReadFuture.untilEquals(ref.child(".info/connected"), true).timedGet();
   }
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
 
   @Test
   public void pushABunchOfDataAndEnumerateItBack()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     for (int i = 0; i < 10; ++i) {
       ref.push().setValue(i);
@@ -75,7 +75,7 @@ public class OrderTest {
   @Test
   public void pushABunchOfDataThenWriteEnsureOrderIsCorrect()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     List<DatabaseReference> paths = new ArrayList<DatabaseReference>(20);
     // Generate children quickly to try to get a few in the same millisecond
@@ -102,7 +102,7 @@ public class OrderTest {
   public void pushABunchOfDataReconnectReadItBack()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
 
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
@@ -112,7 +112,7 @@ public class OrderTest {
     }
     new WriteFuture(writer.push(), 9).timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(writer);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(writer);
     long i = 0;
     for (DataSnapshot child : snap.getChildren()) {
       assertEquals(i, child.getValue());
@@ -120,7 +120,7 @@ public class OrderTest {
     }
     assertEquals(10L, i);
 
-    snap = TestHelpers.getSnap(reader);
+    snap = IntegrationTestHelpers.getSnap(reader);
     i = 0;
     for (DataSnapshot child : snap.getChildren()) {
       assertEquals(i, child.getValue());
@@ -133,7 +133,7 @@ public class OrderTest {
   public void pushABunchOfDataWithExplicitPriorityReconnectReadBackInOrder()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
 
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
@@ -143,7 +143,7 @@ public class OrderTest {
     }
     new WriteFuture(writer.push(), 9, 1).timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(writer);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(writer);
     long i = 9;
     for (DataSnapshot child : snap.getChildren()) {
       assertEquals(i, child.getValue());
@@ -151,7 +151,7 @@ public class OrderTest {
     }
     assertEquals(-1L, i);
 
-    snap = TestHelpers.getSnap(reader);
+    snap = IntegrationTestHelpers.getSnap(reader);
     i = 9;
     for (DataSnapshot child : snap.getChildren()) {
       assertEquals(i, child.getValue());
@@ -164,7 +164,7 @@ public class OrderTest {
   public void pushDataWithExponentialPriorityAndCheckOrder()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
 
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
@@ -175,7 +175,7 @@ public class OrderTest {
     new WriteFuture(writer.push(), 9, 111111111111111111111111111111.0 / Math.pow(10, 9))
         .timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(writer);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(writer);
     long i = 9;
     for (DataSnapshot child : snap.getChildren()) {
       assertEquals(i, child.getValue());
@@ -183,7 +183,7 @@ public class OrderTest {
     }
     assertEquals(-1L, i);
 
-    snap = TestHelpers.getSnap(reader);
+    snap = IntegrationTestHelpers.getSnap(reader);
     i = 9;
     for (DataSnapshot child : snap.getChildren()) {
       assertEquals(i, child.getValue());
@@ -195,12 +195,12 @@ public class OrderTest {
   @Test
   public void verifyNodesWithoutValuesAreNotEnumerated()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.child("foo");
     ref.child("bar").setValue("test");
 
-    DataSnapshot snap = TestHelpers.getSnap(ref);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref);
     int i = 0;
     for (DataSnapshot child : snap.getChildren()) {
       i++;
@@ -212,7 +212,7 @@ public class OrderTest {
   @Test
   public void receiveChildMovedEventWhenPriorityChanges()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     EventHelper helper =
         new EventHelper()
@@ -237,12 +237,12 @@ public class OrderTest {
 
   @Test
   public void canResetPriorityToNull() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.child("a").setValue("a", 1);
     ref.child("b").setValue("b", 2);
 
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
     EventHelper helper =
         new EventHelper()
             .addChildExpectation(ref, Event.EventType.CHILD_ADDED, "a")
@@ -261,7 +261,7 @@ public class OrderTest {
     ref.child("b").setPriority(null);
     assertTrue(helper.waitForEvents());
 
-    DataSnapshot snap = TestHelpers.getSnap(ref);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref);
     assertNull(snap.child("b").getPriority());
     helper.cleanup();
   }
@@ -269,7 +269,7 @@ public class OrderTest {
   @Test
   public void insertingANodeUnderALeafPreservesItsPriority()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 2);
 
@@ -284,7 +284,7 @@ public class OrderTest {
   public void verifyOrderOfMixedNumbersStringAndNoPriorities()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -334,14 +334,14 @@ public class OrderTest {
             "alpha41",
             "alpha42"));
     List<String> actual = new ArrayList<String>(expected.size());
-    DataSnapshot snap = TestHelpers.getSnap(writer);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(writer);
     for (DataSnapshot child : snap.getChildren()) {
       actual.add(child.getKey());
     }
     DeepEquals.assertEquals(expected, actual);
 
     actual.clear();
-    snap = TestHelpers.getSnap(reader);
+    snap = IntegrationTestHelpers.getSnap(reader);
     for (DataSnapshot child : snap.getChildren()) {
       actual.add(child.getKey());
     }
@@ -352,7 +352,7 @@ public class OrderTest {
   public void verifyOrderOfIntegerKeys()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
 
     writer.child("foo").setValue(0);
@@ -369,7 +369,7 @@ public class OrderTest {
     List<String> expected = new ArrayList<String>();
     expected.addAll(Arrays.asList("0", "3", "03", "003", "5", "9", "20", "100", "bar", "foo"));
     List<String> actual = new ArrayList<String>(expected.size());
-    DataSnapshot snap = TestHelpers.getSnap(writer);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(writer);
     for (DataSnapshot child : snap.getChildren()) {
       actual.add(child.getKey());
     }
@@ -380,7 +380,7 @@ public class OrderTest {
   public void verifyOrderOfLargeIntegerKeys()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
 
     writer.child("2000000000").setValue(0);
@@ -389,7 +389,7 @@ public class OrderTest {
     List<String> expected = new ArrayList<String>();
     expected.addAll(Arrays.asList("-2000000000", "2000000000"));
     List<String> actual = new ArrayList<String>(expected.size());
-    DataSnapshot snap = TestHelpers.getSnap(writer);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(writer);
     for (DataSnapshot child : snap.getChildren()) {
       actual.add(child.getKey());
     }
@@ -399,7 +399,7 @@ public class OrderTest {
   @Test
   public void ensurePrevNameIsCorrectOnChildAddedEvent()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> results = new ArrayList<String>();
     final Semaphore semaphore = new Semaphore(0);
@@ -434,7 +434,7 @@ public class OrderTest {
 
     ref.setValue(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).build());
 
-    TestHelpers.waitFor(semaphore, 3);
+    IntegrationTestHelpers.waitFor(semaphore, 3);
     List<String> expected = new ArrayList<String>();
     expected.addAll(Arrays.asList("a", null, "b", "a", "c", "b"));
     DeepEquals.assertEquals(expected, results);
@@ -444,7 +444,7 @@ public class OrderTest {
   @Test
   public void ensurePrevNameIsCorrectWhenAddingNewNodes()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> results = new ArrayList<String>();
     final Semaphore semaphore = new Semaphore(0);
@@ -482,7 +482,7 @@ public class OrderTest {
     ref.child("a").setValue(1);
     ref.child("e").setValue(5);
 
-    TestHelpers.waitFor(semaphore, 5);
+    IntegrationTestHelpers.waitFor(semaphore, 5);
     List<String> expected = new ArrayList<String>();
     expected.addAll(Arrays.asList("b", null, "c", "b", "d", "c", "a", null, "e", "d"));
     DeepEquals.assertEquals(expected, results);
@@ -492,7 +492,7 @@ public class OrderTest {
   @Test
   public void ensurePrevNameIsCorrectWhenAddingNewNodesWithJSON()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> results = new ArrayList<String>();
     final Semaphore semaphore = new Semaphore(0);
@@ -531,7 +531,7 @@ public class OrderTest {
     ref.setValue(
         new MapBuilder().put("a", 1).put("b", 2).put("c", 3).put("d", 4).put("e", 5).build());
 
-    TestHelpers.waitFor(semaphore, 5);
+    IntegrationTestHelpers.waitFor(semaphore, 5);
     List<String> expected = new ArrayList<String>();
     expected.addAll(Arrays.asList("b", null, "c", "b", "d", "c", "a", null, "e", "d"));
     DeepEquals.assertEquals(expected, results);
@@ -541,7 +541,7 @@ public class OrderTest {
   @Test
   public void ensurePrevNameIsCorrectWhenMovingNodes()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> results = new ArrayList<String>();
     final Semaphore semaphore = new Semaphore(0);
@@ -585,7 +585,7 @@ public class OrderTest {
 
     ref.child("c").setPriority(0.5);
 
-    TestHelpers.waitFor(semaphore, 6);
+    IntegrationTestHelpers.waitFor(semaphore, 6);
 
     List<String> expected = new ArrayList<String>();
     expected.add("MOVED:d/null");
@@ -601,7 +601,7 @@ public class OrderTest {
   @Test
   public void ensurePrevNameIsCorrectWhenMovingNodesBySettingWholeJSON()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> results = new ArrayList<String>();
     final Semaphore semaphore = new Semaphore(0);
@@ -666,7 +666,7 @@ public class OrderTest {
             .put("a", new MapBuilder().put(".value", "a").put(".priority", 4).build())
             .build());
 
-    TestHelpers.waitFor(semaphore, 6);
+    IntegrationTestHelpers.waitFor(semaphore, 6);
 
     List<String> expected = new ArrayList<String>();
     expected.add("MOVED:d/null");
@@ -683,7 +683,7 @@ public class OrderTest {
   public void case595ShouldNotGetChildMovedWhenDeletingPrioritizedGrandChild()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ChildEventListener listener =
         ref.addChildEventListener(
@@ -723,7 +723,7 @@ public class OrderTest {
   @Test
   public void canSetValuePriorityToZero()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = new ReadFuture(ref);
     ref.setValue("test", 0);
@@ -736,7 +736,7 @@ public class OrderTest {
   @Test
   public void canSetObjectPriorityToZero()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = new ReadFuture(ref);
     ref.setValue(new MapBuilder().put("x", "test").put("y", 7).build(), 0);
@@ -749,7 +749,7 @@ public class OrderTest {
   @Test
   public void case2003ShouldGetChildMovedForAnyPriorityChangeRegardlessOfOrder()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> results = new ArrayList<String>();
     final Semaphore semaphore = new Semaphore(0);
@@ -791,7 +791,7 @@ public class OrderTest {
             .build());
 
     ref.child("b").setPriority(1.5);
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
 
     assertEquals(2, results.size());
     assertEquals(Arrays.asList("MOVED:b/a", "CHANGED:b/a"), results);
@@ -801,7 +801,7 @@ public class OrderTest {
   @Test
   public void case2003ShouldGetChildMovedForAnyPriorityChangeRegardlessOfOrder2()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> results = new ArrayList<String>();
     final Semaphore semaphore = new Semaphore(0);
@@ -852,7 +852,7 @@ public class OrderTest {
             .put("d", new MapBuilder().put(".value", "d").put(".priority", 3).build())
             .build());
 
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
 
     assertEquals(2, results.size());
     assertEquals(Arrays.asList("MOVED:b/a", "CHANGED:b/a"), results);

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/PerformanceBenchmarks.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/PerformanceBenchmarks.java
@@ -55,7 +55,7 @@ public class PerformanceBenchmarks {
 
   // @Test
   public void queryPerformance() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     System.err.println("Setting up...");
 
@@ -144,7 +144,7 @@ public class PerformanceBenchmarks {
 
   // @Test
   public void largeValuePerformance() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final int approximateObjectSize = 2 * 1024 * 1024;
     final int topLevelChildren = 200;
@@ -211,7 +211,7 @@ public class PerformanceBenchmarks {
 
   // @Test
   public void childObserverPerformance() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final int numberOfChildren = 50000;
 

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/QueryTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/QueryTest.java
@@ -48,13 +48,13 @@ public class QueryTest {
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
 
   @Test
   public void canCreateBasicQueries() throws DatabaseException {
     // Just make sure they don't throw anything
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.limitToLast(10);
     ref.startAt("199").limitToLast(10);
@@ -71,7 +71,7 @@ public class QueryTest {
 
   @Test
   public void invalidPathsToOrderByThrow() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     List<String> badKeys =
         Arrays.asList(
@@ -97,7 +97,7 @@ public class QueryTest {
 
   @Test
   public void invalidQueriesThrow() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     try {
       ref.orderByKey().orderByPriority();
@@ -309,7 +309,7 @@ public class QueryTest {
 
   @Test
   public void passingInvalidKeysToStartAtOrEndAtThrows() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     List<String> badKeys =
         Arrays.asList(
@@ -337,7 +337,7 @@ public class QueryTest {
   public void listenerCanBeRemovedFromSpecificQuery()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     ValueEventListener listener =
@@ -357,7 +357,7 @@ public class QueryTest {
     semaphore.acquire();
     ref.limitToLast(5).removeEventListener(listener);
     new WriteFuture(ref, new MapBuilder().put("a", 6).put("b", 5).build()).timedGet();
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
     assertEquals(0, semaphore.availablePermits());
   }
 
@@ -365,7 +365,7 @@ public class QueryTest {
   public void removingListenersWorks()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     ValueEventListener listener =
@@ -382,10 +382,10 @@ public class QueryTest {
                 });
 
     ref.setValue(new MapBuilder().put("a", 5).put("b", 6).build());
-    TestHelpers.waitFor(semaphore, 1);
+    IntegrationTestHelpers.waitFor(semaphore, 1);
     ref.limitToLast(5).removeEventListener(listener);
     new WriteFuture(ref, new MapBuilder().put("a", 6).put("b", 5).build()).timedGet();
-    TestHelpers.waitForQueue(ref);
+    IntegrationTestHelpers.waitForQueue(ref);
 
     assertEquals(0, semaphore.availablePermits());
   }
@@ -395,7 +395,7 @@ public class QueryTest {
   @Test
   public void limit5ShouldHave5Children()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(
         new MapBuilder()
@@ -419,14 +419,14 @@ public class QueryTest {
   public void serverShouldOnlySend5Items()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     for (int i = 0; i < 9; ++i) {
       ref.push().setValue(i);
     }
     new WriteFuture(ref.push(), 9).timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.limitToLast(5));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.limitToLast(5));
 
     long i = 5;
     for (DataSnapshot child : snap.getChildren()) {
@@ -439,7 +439,7 @@ public class QueryTest {
 
   @Test
   public void setVariousLimitsEnsureDataIsCorrect() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueExpectationHelper expectations = new ValueExpectationHelper();
     expectations.add(ref.limitToLast(1), new MapBuilder().put("c", 3L).build());
@@ -457,7 +457,7 @@ public class QueryTest {
 
   @Test
   public void setVariousLimitsWithStartAtName() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueExpectationHelper expectations = new ValueExpectationHelper();
     expectations.add(ref.startAt(null).limitToFirst(1), new MapBuilder().put("a", 1L).build());
@@ -477,7 +477,7 @@ public class QueryTest {
   public void setVariousLimitsWithStartAtNameWithServerData()
       throws DatabaseException, InterruptedException, TestFailure, ExecutionException,
           TimeoutException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     // TODO: this test kinda has race conditions. The listens are added sequentially, so we get a
     // lot of partial data back from the server. This all correct, and we end up in the correct
@@ -502,7 +502,7 @@ public class QueryTest {
   public void setLimitEnsureChildRemovedAndChildAddedHitWhenLimitIsHit()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> added = new ArrayList<String>();
     final List<String> removed = new ArrayList<String>();
@@ -552,7 +552,7 @@ public class QueryTest {
   public void setLimitEnsureChildRemovedAndChildAddedHitWhenLimitIsHitWithServerData()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> added = new ArrayList<String>();
     final List<String> removed = new ArrayList<String>();
@@ -587,7 +587,7 @@ public class QueryTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
     List<String> expected = new ArrayList<String>();
     expected.add("b");
     expected.add("c");
@@ -605,7 +605,7 @@ public class QueryTest {
   public void setLimitEnsureChildRemovedAndChildAddedHitWhenLimitIsHitFromFront()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> added = new ArrayList<String>();
     final List<String> removed = new ArrayList<String>();
@@ -656,7 +656,7 @@ public class QueryTest {
   public void setLimitEnsureChildRemovedAndChildAddedHitWhenLimitIsHitFromFrontWithServerData()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> added = new ArrayList<String>();
     final List<String> removed = new ArrayList<String>();
@@ -692,7 +692,7 @@ public class QueryTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
     List<String> expected = new ArrayList<String>();
     expected.add("a");
     expected.add("b");
@@ -710,7 +710,7 @@ public class QueryTest {
   public void setStartAndLimitEnsureChildAddedFiredWhenLimitIsntHit()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> added = new ArrayList<String>();
     final List<String> removed = new ArrayList<String>();
@@ -760,7 +760,7 @@ public class QueryTest {
   public void setStartAndLimitEnsureChildAddedFiredWhenLimitIsntHitWithServerData()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, new MapBuilder().put("c", 3).build()).timedGet();
 
@@ -796,7 +796,7 @@ public class QueryTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     List<String> expected = new ArrayList<String>();
     expected.add("c");
     DeepEquals.assertEquals(expected, added);
@@ -813,7 +813,7 @@ public class QueryTest {
   public void setLimitEnsureChildAddedAndChildRemovedAreFiredWhenAnElementIsRemoved()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> added = new ArrayList<String>();
     final List<String> removed = new ArrayList<String>();
@@ -865,7 +865,7 @@ public class QueryTest {
   public void setLimitEnsureChildAddedAndChildRemovedAreFiredWhenAnElementIsRemovedUsingServerData()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, new MapBuilder().put("a", 1).put("b", 2).put("c", 3).build()).timedGet();
     final List<String> added = new ArrayList<String>();
@@ -899,7 +899,7 @@ public class QueryTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
     List<String> expected = new ArrayList<String>();
     expected.add("b");
     expected.add("c");
@@ -919,7 +919,7 @@ public class QueryTest {
   public void setLimitEnsureChildRemovedFiredWhenAllElementsRemoved()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> added = new ArrayList<String>();
     final List<String> removed = new ArrayList<String>();
@@ -973,7 +973,7 @@ public class QueryTest {
   public void setLimitEnsureChildRemovedFiredWhenAllElementsRemovedUsingServerData()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, new MapBuilder().put("b", 2).put("c", 3).build()).timedGet();
     final List<String> added = new ArrayList<String>();
@@ -1008,7 +1008,7 @@ public class QueryTest {
                   public void onCancelled(DatabaseError error) {}
                 });
 
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
     List<String> expected = new ArrayList<String>();
     expected.add("b");
     expected.add("c");
@@ -1029,7 +1029,7 @@ public class QueryTest {
 
   @Test
   public void startAtEndAtWithPriorityWorks() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueExpectationHelper helper = new ValueExpectationHelper();
     helper.add(
@@ -1052,7 +1052,7 @@ public class QueryTest {
   @Test
   public void startAtEndAtWithPriorityWorksWithServerData()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(
         new MapBuilder()
@@ -1075,7 +1075,7 @@ public class QueryTest {
   @Test
   public void startAtEndAtWithPriorityAndNameWorks()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueExpectationHelper helper = new ValueExpectationHelper();
     helper.add(
@@ -1099,7 +1099,7 @@ public class QueryTest {
   @Test
   public void startAtEndAtWithPriorityAndNameWorksWithServerData()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(
         new MapBuilder()
@@ -1123,7 +1123,7 @@ public class QueryTest {
   @Test
   public void startAtEndAtWithPriorityAndNameWorks2()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueExpectationHelper helper = new ValueExpectationHelper();
     helper.add(
@@ -1147,7 +1147,7 @@ public class QueryTest {
   @Test
   public void startAtEndAtWithPriorityAndNameWorksWithServerData2()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(
         new MapBuilder()
@@ -1172,7 +1172,7 @@ public class QueryTest {
   public void ensurePrevNameWorksWithLimit()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> names = new ArrayList<String>();
     ref.limitToLast(2)
@@ -1218,7 +1218,7 @@ public class QueryTest {
   public void setALimitMoveNodesCheckPrevName()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> names = new ArrayList<String>();
     ref.limitToLast(2)
@@ -1273,7 +1273,7 @@ public class QueryTest {
   public void setALimitAddNodesRemotelyWatchForEvents()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -1330,14 +1330,14 @@ public class QueryTest {
             "2 removed",
             "4 added"));
     // Make sure we wait for all the events
-    TestHelpers.waitFor(semaphore, 5);
+    IntegrationTestHelpers.waitFor(semaphore, 5);
     DeepEquals.assertEquals(expected, events);
     reader.limitToLast(2).removeEventListener(listener);
   }
 
   @Test
   public void attachingAListenerReturnsTheListener() throws DatabaseException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueEventListener listener =
         ref.limitToLast(1)
@@ -1358,7 +1358,7 @@ public class QueryTest {
   @Test
   public void limitOnUnsyncedNodeFiresValueEvent()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     // This will timeout if value never fires
     org.junit.Assert.assertEquals(1, new ReadFuture(ref.limitToLast(1)).timedGet().size());
@@ -1366,7 +1366,7 @@ public class QueryTest {
 
   @Test
   public void filteringToOnlyNullPrioritiesWorks() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(
         new MapBuilder()
@@ -1377,7 +1377,7 @@ public class QueryTest {
             .put("e", new MapBuilder().put(".priority", "hi").put(".value", 4).build())
             .build());
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.endAt(null));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.endAt(null));
     Map<String, Object> expected = new MapBuilder().put("a", 0L).put("b", 1L).build();
     Object result = snap.getValue();
     DeepEquals.assertEquals(expected, result);
@@ -1385,7 +1385,7 @@ public class QueryTest {
 
   @Test
   public void nullPrioritiesIncludedInEndAt2() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(
         new MapBuilder()
@@ -1396,7 +1396,7 @@ public class QueryTest {
             .put("e", new MapBuilder().put(".priority", "hi").put(".value", 4).build())
             .build());
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.endAt(2));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.endAt(2));
     Map<String, Object> expected = new MapBuilder().put("a", 0L).put("b", 1L).put("c", 2L).build();
     Object result = snap.getValue();
     DeepEquals.assertEquals(expected, result);
@@ -1404,7 +1404,7 @@ public class QueryTest {
 
   @Test
   public void nullPrioritiesIncludedInStartAt2() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(
         new MapBuilder()
@@ -1415,7 +1415,7 @@ public class QueryTest {
             .put("e", new MapBuilder().put(".priority", "hi").put(".value", 4).build())
             .build());
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.startAt(2));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.startAt(2));
     Map<String, Object> expected = new MapBuilder().put("c", 2L).put("d", 3L).put("e", 4L).build();
     Object result = snap.getValue();
     DeepEquals.assertEquals(expected, result);
@@ -1445,7 +1445,7 @@ public class QueryTest {
   @Test
   @Ignore // TODO: re-enable once dumpListens is implemented again
   public void dedupeListensListenOnParent() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ValueEventListener listener = dummyListener();
 
     assertEquals("[]", dumpListens(ref));
@@ -1473,7 +1473,7 @@ public class QueryTest {
   @Test
   @Ignore // TODO: re-enable once dumpListens is implemented again
   public void dedupeListensListenOnGrandChild() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ValueEventListener listener = dummyListener();
 
     ref.addValueEventListener(listener);
@@ -1497,7 +1497,7 @@ public class QueryTest {
   @Ignore // TODO: re-enable once dumpListens is implemented again
   public void dedupeListensListenOnGrandparentOfTwoChildren()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ValueEventListener listener = dummyListener();
 
     String listens = dumpListens(ref);
@@ -1533,7 +1533,7 @@ public class QueryTest {
   // broken with org.json.  Need to make more robust.
   public void dedupeQueriedListensMultipleListensNoDupes()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ValueEventListener listener = dummyListener();
 
     ref.child("a").limitToLast(1).addValueEventListener(listener);
@@ -1564,7 +1564,7 @@ public class QueryTest {
   @Test
   public void limitWithMixOfNullAndNonNullPrioritiesUsingServerData()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     Map<String, Object> toSet =
         new MapBuilder()
             .put(
@@ -1635,7 +1635,7 @@ public class QueryTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(semaphore, 5);
+    IntegrationTestHelpers.waitFor(semaphore, 5);
     List<String> expected = new ArrayList<String>();
     expected.addAll(Arrays.asList("Sally", "James", "Andrew", "Mike", "Vikrum"));
     DeepEquals.assertEquals(expected, names);
@@ -1643,7 +1643,7 @@ public class QueryTest {
 
   @Test
   public void limitOnNodeWithPriority() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore semaphore = new Semaphore(0);
 
     final Map data = new MapBuilder().put("a", "blah").put(".priority", "priority").build();
@@ -1669,13 +1669,13 @@ public class QueryTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void limitWithMixOfNullAndNonNullPriorities()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     Map<String, Object> toSet =
         new MapBuilder()
             .put(
@@ -1749,7 +1749,7 @@ public class QueryTest {
                   }
                 });
     ref.setValue(toSet);
-    TestHelpers.waitFor(semaphore, 5);
+    IntegrationTestHelpers.waitFor(semaphore, 5);
     List<String> expected = new ArrayList<String>();
     expected.addAll(Arrays.asList("Sally", "James", "Andrew", "Mike", "Vikrum"));
     DeepEquals.assertEquals(expected, names);
@@ -1761,12 +1761,12 @@ public class QueryTest {
   @Test
   public void handlesAnUpdateThatDeletesEntireQueryWindow()
       throws DatabaseException, InterruptedException, TestFailure, TimeoutException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture readFuture = ReadFuture.untilCount(ref.limitToLast(2), 3);
 
     // wait for null event
-    TestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(ref);
 
     ref.setValue(
         new MapBuilder()
@@ -1795,7 +1795,7 @@ public class QueryTest {
   public void handlesAnOutOfViewQueryOnAChild()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture parentFuture = ReadFuture.untilCountAfterNull(ref.limitToLast(1), 2);
 
@@ -1835,7 +1835,7 @@ public class QueryTest {
   public void handlesAChildQueryGoingOutOfViewOfTheParent()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ReadFuture parentFuture = ReadFuture.untilCountAfterNull(ref.limitToLast(1), 3);
 
@@ -1884,7 +1884,7 @@ public class QueryTest {
   public void handlesDivergingViews()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<DataSnapshot> cSnaps = new ArrayList<DataSnapshot>();
     final List<DataSnapshot> dSnaps = new ArrayList<DataSnapshot>();
@@ -1939,7 +1939,7 @@ public class QueryTest {
   public void handlesRemovingAQueriedElement()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<Long> vals = new ArrayList<Long>();
     final Semaphore semaphore = new Semaphore(0);
@@ -1976,7 +1976,7 @@ public class QueryTest {
 
     ref.setValue(new MapBuilder().put("a", 1).put("b", 2).build());
     ref.child("b").removeValue();
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     List<Long> expected = new ArrayList<Long>();
     expected.addAll(Arrays.asList(2L, 1L));
     DeepEquals.assertEquals(expected, vals);
@@ -1984,10 +1984,10 @@ public class QueryTest {
 
   @Test
   public void startAtLimitWorks() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(new MapBuilder().put("a", 1).put("b", 2).build());
-    DataSnapshot snap = TestHelpers.getSnap(ref.limitToFirst(1));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.limitToFirst(1));
 
     assertEquals(1L, snap.child("a").getValue());
   }
@@ -1995,7 +1995,7 @@ public class QueryTest {
   @Test
   public void startAtLimitWorksWhenChildIsRemovedCase1664()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(new MapBuilder().put("a", 1).put("b", 2).build());
     final List<Long> vals = new ArrayList<Long>();
@@ -2030,10 +2030,10 @@ public class QueryTest {
             });
 
     // Wait for first value
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     assertEquals((Long) 1L, vals.get(0));
     ref.child("a").removeValue();
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     assertEquals((Long) 2L, vals.get(1));
   }
 
@@ -2041,7 +2041,7 @@ public class QueryTest {
   public void startAtWithTwoArgumentsWorksCase1169()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(
             ref,
@@ -2063,7 +2063,7 @@ public class QueryTest {
                 .build())
         .timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.startAt(20, "Walker").limitToFirst(2));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.startAt(20, "Walker").limitToFirst(2));
     List<String> expected = Arrays.asList("Walker", "Michael");
     int i = 0;
     for (DataSnapshot child : snap.getChildren()) {
@@ -2077,7 +2077,7 @@ public class QueryTest {
   public void handlesMultipleQueriesOnTheSameNode()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(
             ref,
@@ -2109,9 +2109,9 @@ public class QueryTest {
 
     // Skipping nested calls, no re-entrant APIs in Java
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.limitToLast(1));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.limitToLast(1));
     Map<String, Object> expected = new MapBuilder().put("f", 6L).build();
 
     DeepEquals.assertEquals(expected, snap.getValue());
@@ -2121,7 +2121,7 @@ public class QueryTest {
   public void handlesOnceCalledOnANodeWithADefaultListener()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(
             ref,
@@ -2150,9 +2150,9 @@ public class QueryTest {
           public void onCancelled(DatabaseError error) {}
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.limitToLast(1));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.limitToLast(1));
     Map<String, Object> expected = new MapBuilder().put("f", 6L).build();
 
     DeepEquals.assertEquals(expected, snap.getValue());
@@ -2162,7 +2162,7 @@ public class QueryTest {
   public void handlesOnceCalledOnANodeWithADefaultListenerAndNonCompleteLimit()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, new MapBuilder().put("a", 1).put("b", 2).put("c", 3).build()).timedGet();
 
@@ -2181,7 +2181,7 @@ public class QueryTest {
           public void onCancelled(DatabaseError error) {}
         });
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.limitToLast(5));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.limitToLast(5));
     Map<String, Object> expected = new MapBuilder().put("a", 1L).put("b", 2L).put("c", 3L).build();
 
     DeepEquals.assertEquals(expected, snap.getValue());
@@ -2191,7 +2191,7 @@ public class QueryTest {
   public void remoteRemoveEventTriggers()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     final DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2234,7 +2234,7 @@ public class QueryTest {
   public void endAtWithTwoArgumentsAndLimitWorks()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> toSet =
         new MapBuilder()
@@ -2250,7 +2250,7 @@ public class QueryTest {
 
     new WriteFuture(ref, toSet).timedGet();
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.endAt(null, "f").limitToLast(5));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.endAt(null, "f").limitToLast(5));
     Map<String, Object> expected =
         new MapBuilder()
             .put("b", "b")
@@ -2267,7 +2267,7 @@ public class QueryTest {
   public void complexUpdateAtQueryRootRaisesCorrectValueEvent()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2289,7 +2289,7 @@ public class QueryTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     Map<String, Object> update =
         new MapBuilder()
             .put("b", null)
@@ -2316,7 +2316,7 @@ public class QueryTest {
   public void updateAtQueryRootRaisesCorrectValueEvent()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2338,7 +2338,7 @@ public class QueryTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     Map<String, Object> update =
         new MapBuilder().put("bar", "d").put("bam", null).put("bat", "e").build();
     writer.updateChildren(update);
@@ -2358,7 +2358,7 @@ public class QueryTest {
   public void listenForChildAddedEventsWithLimit()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
     writer.child("a").setValue(1);
@@ -2414,14 +2414,14 @@ public class QueryTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(semaphore, 3);
+    IntegrationTestHelpers.waitFor(semaphore, 3);
   }
 
   @Test
   public void listenForChildChangedEventsWithLimit()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
     new WriteFuture(
@@ -2452,7 +2452,7 @@ public class QueryTest {
             });
 
     // Wait for the read to be initialized
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     reader
         .limitToLast(3)
@@ -2501,14 +2501,14 @@ public class QueryTest {
     writer.child("b").setValue("b");
     writer.child("c").setValue(deepObject);
 
-    TestHelpers.waitFor(semaphore, 3);
+    IntegrationTestHelpers.waitFor(semaphore, 3);
   }
 
   @Test
   public void listenForChildRemoveEventsWithLimit()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
     writer.child("a").setValue(1);
@@ -2538,7 +2538,7 @@ public class QueryTest {
             });
 
     // Wait for the read to be initialized
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     reader
         .limitToLast(3)
@@ -2584,14 +2584,14 @@ public class QueryTest {
     writer.child("b").removeValue();
     writer.child("c").removeValue();
 
-    TestHelpers.waitFor(semaphore, 3);
+    IntegrationTestHelpers.waitFor(semaphore, 3);
   }
 
   @Test
   public void listenForChildRemovedWhenParentRemoved()
       throws DatabaseException, InterruptedException, TestFailure, ExecutionException,
           TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
     writer.child("a").setValue(1);
@@ -2621,7 +2621,7 @@ public class QueryTest {
             });
 
     // Wait for the read to be initialized
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     reader
         .limitToLast(3)
@@ -2665,14 +2665,14 @@ public class QueryTest {
 
     writer.removeValue();
 
-    TestHelpers.waitFor(semaphore, 3);
+    IntegrationTestHelpers.waitFor(semaphore, 3);
   }
 
   @Test
   public void listenForChildRemovedWhenParentSetToScalar()
       throws DatabaseException, InterruptedException, TestFailure, ExecutionException,
           TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
     writer.child("a").setValue(1);
@@ -2702,7 +2702,7 @@ public class QueryTest {
             });
 
     // Wait for the read to be initialized
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     reader
         .limitToLast(3)
@@ -2746,14 +2746,14 @@ public class QueryTest {
 
     writer.setValue("scalar");
 
-    TestHelpers.waitFor(semaphore, 3);
+    IntegrationTestHelpers.waitFor(semaphore, 3);
   }
 
   @Test
   public void queriesBehaveAfterOnce()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2762,7 +2762,7 @@ public class QueryTest {
 
     new WriteFuture(writer, toSet).timedGet();
 
-    TestHelpers.getSnap(reader);
+    IntegrationTestHelpers.getSnap(reader);
 
     final Semaphore semaphore = new Semaphore(0);
     final AtomicInteger queryAddedCount = new AtomicInteger(0);
@@ -2823,7 +2823,7 @@ public class QueryTest {
           public void onCancelled(DatabaseError error) {}
         });
 
-    TestHelpers.waitFor(semaphore, 5);
+    IntegrationTestHelpers.waitFor(semaphore, 5);
     assertEquals(1, queryAddedCount.get());
     assertEquals(4, defaultAddedCount.get());
   }
@@ -2832,7 +2832,7 @@ public class QueryTest {
   public void case2003CorrectlyGetEventsForStartAtEndAtQueriesWhenPriorityChanges()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final List<String> addedFirst = new ArrayList<String>();
     final List<String> removedFirst = new ArrayList<String>();
@@ -2918,7 +2918,7 @@ public class QueryTest {
   public void behavesWithDivergingQueries()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     final DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -2972,7 +2972,7 @@ public class QueryTest {
   @Test
   public void staleItemsRemovedFromTheCache()
       throws InterruptedException, TestFailure, TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference reader = refs.get(0);
     DatabaseReference writer = refs.get(1);
 
@@ -2996,7 +2996,7 @@ public class QueryTest {
               }
             });
 
-    TestHelpers.waitFor(ready);
+    IntegrationTestHelpers.waitFor(ready);
     for (int i = 0; i < 4; ++i) {
       writer.child("k" + i).setValue(i);
     }
@@ -3008,7 +3008,7 @@ public class QueryTest {
   @Test
   public void integerKeysBehaveNumerically1()
       throws InterruptedException, TestFailure, TimeoutException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore done = new Semaphore(0);
     ref.setValue(
         new MapBuilder()
@@ -3045,13 +3045,13 @@ public class QueryTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void integerKeysBehaveNumerically2()
       throws InterruptedException, TestFailure, TimeoutException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore done = new Semaphore(0);
     ref.setValue(
         new MapBuilder()
@@ -3089,13 +3089,13 @@ public class QueryTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void integerKeysBehaveNumerically3()
       throws InterruptedException, TestFailure, TimeoutException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore done = new Semaphore(0);
     ref.setValue(
         new MapBuilder()
@@ -3133,13 +3133,13 @@ public class QueryTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void moveOutsideOfWindowIntoWindow()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     Map<String, Object> initialValue =
         new MapBuilder()
             .put("a", new MapBuilder().put(".priority", 1L).put(".value", "a").build())
@@ -3169,7 +3169,7 @@ public class QueryTest {
           public void onCancelled(DatabaseError error) {}
         });
 
-    TestHelpers.waitFor(ready);
+    IntegrationTestHelpers.waitFor(ready);
 
     ref.child("a")
         .setPriority(
@@ -3181,16 +3181,16 @@ public class QueryTest {
               }
             });
 
-    TestHelpers.waitFor(ready);
+    IntegrationTestHelpers.waitFor(ready);
   }
 
   @Test
   public void emptyLimitWithBadHash() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.getRepo().setHijackHash(true);
 
-    DataSnapshot snap = TestHelpers.getSnap(ref.limitToLast(1));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.limitToLast(1));
     assertNull(snap.getValue());
 
     ref.getRepo().setHijackHash(false);
@@ -3199,7 +3199,7 @@ public class QueryTest {
   @Test
   public void addingQueriesDoesNotAffectOthers()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref.child("0"), "test1").timedGet();
 
@@ -3230,7 +3230,7 @@ public class QueryTest {
 
   @Test
   public void equalToOnlyReturnsChildrenEqualTo() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ValueExpectationHelper expectations = new ValueExpectationHelper();
     expectations.add(ref.equalTo(1), new MapBuilder().put("a", "vala").build());
@@ -3250,7 +3250,7 @@ public class QueryTest {
   @Test
   public void removeListenerOnDefaultQueryRemovesAllQueryListeners()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     new WriteFuture(ref.child("a"), "foo", 100).timedGet();
 
     final Semaphore semaphore = new Semaphore(0);
@@ -3272,7 +3272,7 @@ public class QueryTest {
                   }
                 });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     Map<String, Object> expected = new MapBuilder().put("a", "foo").build();
     DeepEquals.assertEquals(expected, snapshotHolder[0].getValue());
 
@@ -3285,7 +3285,7 @@ public class QueryTest {
 
   @Test
   public void handlesFallbackForOrderBy() throws InterruptedException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore done = new Semaphore(0);
 
     Map<String, Object> initial =
@@ -3304,7 +3304,7 @@ public class QueryTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
 
     final List<String> children = new ArrayList<String>();
     ref.orderByChild("foo")
@@ -3331,7 +3331,7 @@ public class QueryTest {
               public void onCancelled(DatabaseError error) {}
             });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
 
     List<String> expected = new ArrayList<String>();
     expected.add("b");
@@ -3343,8 +3343,8 @@ public class QueryTest {
   @Test
   public void notifiesOfDeletesWhileOffline() throws DatabaseException, InterruptedException {
     // Create a fresh connection so we can be sure we won't get any other data updates for stuff.
-    DatabaseReference writerRef = TestHelpers.getRandomNode();
-    final DatabaseConfig ctx = TestHelpers.newTestConfig();
+    DatabaseReference writerRef = IntegrationTestHelpers.getRandomNode();
+    final DatabaseConfig ctx = IntegrationTestHelpers.newTestConfig();
     final DatabaseReference queryRef = new DatabaseReference(writerRef.toString(), ctx);
     final List<DataSnapshot> readSnaps = new ArrayList<DataSnapshot>();
     final Semaphore semaphore = new Semaphore(0);
@@ -3380,7 +3380,7 @@ public class QueryTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     // Now make the queryRef go offline so we don't get updates.
     RepoManager.interrupt(ctx);
@@ -3398,14 +3398,14 @@ public class QueryTest {
             });
 
     // Now wait for us to get notified that b is deleted.
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void querySnapshotChildrenRespectDefaultOrdering()
       throws DatabaseException, ExecutionException, TimeoutException, TestFailure,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
     final Semaphore semaphore = new Semaphore(0);
@@ -3492,7 +3492,7 @@ public class QueryTest {
               @Override
               public void onCancelled(DatabaseError error) {}
             });
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
@@ -3506,7 +3506,7 @@ public class QueryTest {
     // default view. This left the zombie one-time listener and check failed on the second attempt
     // to create a listener for the same path (asana#61028598952586).
 
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore semaphore = new Semaphore(0);
 
     ValueEventListener dummyListen =
@@ -3520,17 +3520,17 @@ public class QueryTest {
           public void onCancelled(DatabaseError error) {}
         };
 
-    ref.child("child").setValue(TestHelpers.fromJsonString("{\"name\": \"John\"}"));
+    ref.child("child").setValue(IntegrationTestHelpers.fromJsonString("{\"name\": \"John\"}"));
 
     ref.orderByChild("name").equalTo("John").addValueEventListener(dummyListen);
     ref.child("child").addValueEventListener(dummyListen);
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
 
     ref.child("child").child("favoriteToy").addListenerForSingleValueEvent(dummyListen);
-    TestHelpers.waitFor(semaphore, 1);
+    IntegrationTestHelpers.waitFor(semaphore, 1);
 
     ref.child("child").child("favoriteToy").addListenerForSingleValueEvent(dummyListen);
-    TestHelpers.waitFor(semaphore, 1);
+    IntegrationTestHelpers.waitFor(semaphore, 1);
 
     ref.removeEventListener(dummyListen);
     ref.child("child").removeEventListener(dummyListen);

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/RealtimeTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/RealtimeTest.java
@@ -45,7 +45,7 @@ public class RealtimeTest {
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
 
   @Test
@@ -66,10 +66,10 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectSetWorks()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
 
     final Semaphore opSemaphore = new Semaphore(0);
@@ -99,7 +99,7 @@ public class RealtimeTest {
             });
 
     // Wait for initial (null) value on both reader and writer.
-    TestHelpers.waitFor(valSemaphore, 2);
+    IntegrationTestHelpers.waitFor(valSemaphore, 2);
 
     Object expected = "dummy";
     writer
@@ -115,7 +115,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord writerEventRecord = writerFuture.timedGet().get(1);
     EventRecord readerEventRecord = readerFuture.timedGet().get(1);
@@ -129,10 +129,10 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectSetWithPriorityWorks()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
 
     final Semaphore opSemaphore = new Semaphore(0);
@@ -162,7 +162,7 @@ public class RealtimeTest {
             });
 
     // Wait for initial (null) value on both reader and writer.
-    TestHelpers.waitFor(valSemaphore, 2);
+    IntegrationTestHelpers.waitFor(valSemaphore, 2);
 
     Object expected = true;
     String expectedPriority = "12345";
@@ -180,7 +180,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord writerEventRecord = writerFuture.timedGet().get(1);
     EventRecord readerEventRecord = readerFuture.timedGet().get(1);
@@ -197,10 +197,10 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectRemoveWorks()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
 
     final Semaphore opSemaphore = new Semaphore(0);
@@ -228,7 +228,7 @@ public class RealtimeTest {
             });
 
     // Wait for initial (null) value on both reader and writer.
-    TestHelpers.waitFor(valSemaphore, 2);
+    IntegrationTestHelpers.waitFor(valSemaphore, 2);
 
     writer
         .child("foo")
@@ -240,7 +240,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo")
@@ -253,7 +253,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord writerEventRecord = writerFuture.timedGet().get(2);
     EventRecord readerEventRecord = readerFuture.timedGet().get(2);
@@ -268,10 +268,10 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectUpdateWorks()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
 
     final Semaphore opSemaphore = new Semaphore(0);
@@ -299,7 +299,7 @@ public class RealtimeTest {
             });
 
     // Wait for initial (null) value on both reader and writer.
-    TestHelpers.waitFor(valSemaphore, 2);
+    IntegrationTestHelpers.waitFor(valSemaphore, 2);
 
     Map<String, Object> initialValues = new MapBuilder().put("bar", "a").put("baz", "b").build();
     writer
@@ -312,7 +312,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     Map<String, Object> updatedValues = new MapBuilder().put("baz", "c").put("bat", "d").build();
     writer
@@ -328,7 +328,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord writerEventRecord = writerFuture.timedGet().get(3);
     EventRecord readerEventRecord = readerFuture.timedGet().get(2);
@@ -346,9 +346,9 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectTriggersSingleLocalValueEventForWriter()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference writer = refs.get(0);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
 
     final AtomicInteger callbackCount = new AtomicInteger(0);
@@ -364,7 +364,7 @@ public class RealtimeTest {
                 return events.size() == 2;
               }
             });
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
 
     final Semaphore opSemaphore = new Semaphore(0);
     writer
@@ -378,7 +378,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo")
@@ -391,7 +391,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo/baz")
@@ -403,12 +403,12 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     RepoManager.interrupt(ctx);
     ;
 
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
     EventRecord writerEventRecord = writerFuture.timedGet().get(1);
 
     RepoManager.resume(ctx);
@@ -425,10 +425,10 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectTriggersSingleLocalValueEventForReader()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
 
     final AtomicInteger callbackCount = new AtomicInteger(0);
@@ -444,7 +444,7 @@ public class RealtimeTest {
                 return events.size() == 2;
               }
             });
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
 
     final Semaphore opSemaphore = new Semaphore(0);
     writer
@@ -458,7 +458,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo")
@@ -471,7 +471,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo/baz")
@@ -483,12 +483,12 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     RepoManager.interrupt(ctx);
     ;
 
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
     EventRecord readerEventRecord = readerFuture.timedGet().get(1);
 
     RepoManager.resume(ctx);
@@ -505,9 +505,9 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectTriggersSingleLocalValueEventForWriterWithQuery()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference writer = refs.get(0);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
     ;
 
@@ -524,7 +524,7 @@ public class RealtimeTest {
                 return events.size() == 2;
               }
             });
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
 
     final Semaphore opSemaphore = new Semaphore(0);
     writer
@@ -538,7 +538,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo")
@@ -551,7 +551,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo/baz")
@@ -563,12 +563,12 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     RepoManager.interrupt(ctx);
     ;
 
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
     EventRecord writerEventRecord = writerFuture.timedGet().get(1);
 
     RepoManager.resume(ctx);
@@ -585,10 +585,10 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectTriggersSingleLocalValueEventForReaderWithQuery()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
     final AtomicInteger callbackCount = new AtomicInteger(0);
     final Semaphore valSemaphore = new Semaphore(0);
@@ -603,7 +603,7 @@ public class RealtimeTest {
                 return events.size() == 2;
               }
             });
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
 
     final Semaphore opSemaphore = new Semaphore(0);
     writer
@@ -617,7 +617,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo")
@@ -630,7 +630,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo/baz")
@@ -642,12 +642,12 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     RepoManager.interrupt(ctx);
     ;
 
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
     EventRecord readerEventRecord = readerFuture.timedGet().get(1);
 
     RepoManager.resume(ctx);
@@ -664,10 +664,10 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectDeepMergeTriggersOnlyOneValueEventForReaderWithQuery()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
     final AtomicInteger callbackCount = new AtomicInteger(0);
     final Semaphore valSemaphore = new Semaphore(0);
@@ -682,7 +682,7 @@ public class RealtimeTest {
                 return events.size() == 3;
               }
             });
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
 
     final Semaphore opSemaphore = new Semaphore(0);
     Map<String, Object> initialValues =
@@ -704,8 +704,8 @@ public class RealtimeTest {
             opSemaphore.release(1);
           }
         });
-    TestHelpers.waitFor(valSemaphore);
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("b/c")
@@ -718,7 +718,7 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("b/d")
@@ -730,11 +730,11 @@ public class RealtimeTest {
                 opSemaphore.release(1);
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     RepoManager.interrupt(ctx);
 
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
     EventRecord readerEventRecord = readerFuture.timedGet().get(2);
 
     RepoManager.resume(ctx);
@@ -756,10 +756,10 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectCancelWorks()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
     ;
 
@@ -788,7 +788,7 @@ public class RealtimeTest {
             });
 
     // Wait for initial (null) value on both reader and writer.
-    TestHelpers.waitFor(valSemaphore, 2);
+    IntegrationTestHelpers.waitFor(valSemaphore, 2);
 
     Map<String, Object> initialValues = new MapBuilder().put("bar", "a").put("baz", "b").build();
     writer
@@ -801,7 +801,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     Map<String, Object> updatedValues = new MapBuilder().put("baz", "c").put("bat", "d").build();
     writer
@@ -815,7 +815,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     writer
         .child("foo/bat")
@@ -829,7 +829,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord writerEventRecord = writerFuture.timedGet().get(2);
     EventRecord readerEventRecord = readerFuture.timedGet().get(2);
@@ -846,9 +846,9 @@ public class RealtimeTest {
   @Test
   public void testOnDisconnectWithServerValuesWorks()
       throws TestFailure, TimeoutException, DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(1);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(1);
     DatabaseReference writer = refs.get(0);
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
 
     final Semaphore opSemaphore = new Semaphore(0);
@@ -866,7 +866,7 @@ public class RealtimeTest {
             });
 
     // Wait for initial (null) value.
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
 
     Map<String, Object> initialValues =
         new MapBuilder()
@@ -891,7 +891,7 @@ public class RealtimeTest {
                 opSemaphore.release();
               }
             });
-    TestHelpers.waitFor(opSemaphore);
+    IntegrationTestHelpers.waitFor(opSemaphore);
 
     EventRecord readerEventRecord = writerFuture.timedGet().get(1);
     DataSnapshot snap = readerEventRecord.getSnapshot();
@@ -913,7 +913,7 @@ public class RealtimeTest {
   @Ignore
   public void testShutdown()
       throws InterruptedException, ExecutionException, TestFailure, TimeoutException {
-    DatabaseConfig config = TestHelpers.newTestConfig();
+    DatabaseConfig config = IntegrationTestHelpers.newTestConfig();
     config.setLogLevel(Logger.Level.DEBUG);
     DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getNamespace(), config);
 
@@ -949,16 +949,16 @@ public class RealtimeTest {
             });
 
     // Wait for us to be connected so we send the buffered put
-    TestHelpers.waitFor(ready);
+    IntegrationTestHelpers.waitFor(ready);
 
-    DataSnapshot snap = TestHelpers.getSnap(pushed);
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(pushed);
     assertEquals("foo", snap.getValue(String.class));
   }
 
   @Test
   public void testWritesToSameLocationWhileOfflineAreInOrder()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     DatabaseReference.goOffline();
     for (int i = 0; i < 100; i++) {
@@ -984,14 +984,14 @@ public class RealtimeTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void testOnDisconnectIsNotRerunOnReconnect()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
-    final DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
+    final DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     RepoManager.resume(ctx);
 
     final Semaphore semaphore = new Semaphore(0);
@@ -1018,7 +1018,7 @@ public class RealtimeTest {
     RepoManager.resume(ctx);
 
     // Should be complete initially
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     // One onComplete called
     assertEquals(1, counter[0]);
 
@@ -1027,8 +1027,8 @@ public class RealtimeTest {
     RepoManager.resume(ctx);
 
     // Make sure we sent all outstanding onDisconnects
-    TestHelpers.waitForRoundtrip(ref);
-    TestHelpers.waitForRoundtrip(
+    IntegrationTestHelpers.waitForRoundtrip(ref);
+    IntegrationTestHelpers.waitForRoundtrip(
         ref); // Two are needed because writes are restored first, then onDisconnects
     assertEquals(1, counter[0]); // No onComplete should have triggered
   }
@@ -1037,7 +1037,7 @@ public class RealtimeTest {
   @Test
   public void testServerValuesEventualConsistencyBetweenLocalAndRemote() throws DatabaseException,
       InterruptedException {
-      List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+      List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
       DatabaseReference writer = refs.get(0);
       DatabaseReference reader = refs.get(1);
 
@@ -1087,7 +1087,7 @@ public class RealtimeTest {
           }
       });
 
-      TestHelpers.waitFor(valMatchSemaphore);
+      IntegrationTestHelpers.waitFor(valMatchSemaphore);
 
       ctx.resume();
   }*/

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/TransactionTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/TransactionTest.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database;
 
-import static com.google.firebase.database.TestHelpers.fromSingleQuotedString;
+import static com.google.firebase.database.IntegrationTestHelpers.fromSingleQuotedString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -51,13 +51,13 @@ public class TransactionTest {
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
 
   @Test
   public void newValueIsImmediatelyVisible()
       throws DatabaseException, TestFailure, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.child("foo")
         .runTransaction(
@@ -88,7 +88,7 @@ public class TransactionTest {
 
   @Test
   public void eventIsRaisedForNewValue() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     EventHelper helper = new EventHelper().addValueExpectation(ref).startListening();
 
@@ -116,7 +116,7 @@ public class TransactionTest {
   @Test
   public void nonAbortedTransactionSetsCommittedToTrueInCallback()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     ref.runTransaction(
@@ -143,13 +143,13 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void abortedTransactionSetsCommittedToFalseInCallback()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     ref.runTransaction(
@@ -168,14 +168,14 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void setDataReconnectDoTransactionThatAbortsVerifyCorrectEvents()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
 
     new WriteFuture(refs.get(0), 42).timedGet();
 
@@ -243,7 +243,7 @@ public class TransactionTest {
   @Test
   public void useTransactionToCreateANodeMakeSureOneEventReceived()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final AtomicInteger events = new AtomicInteger(0);
     ref.addValueEventListener(
@@ -285,7 +285,7 @@ public class TransactionTest {
             }
           }
         });
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     assertEquals(1, events.get());
   }
 
@@ -293,7 +293,7 @@ public class TransactionTest {
   public void useTransactionToUpdateOneOfTwoExistingChildNodes()
       throws DatabaseException, TestFailure, ExecutionException, TimeoutException,
           InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -336,13 +336,13 @@ public class TransactionTest {
         });
 
     assertTrue(helper.waitForEvents());
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void transactionIsOnlyCalledOnceWhenInitializingAnEmptyNode()
       throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final AtomicInteger called = new AtomicInteger(0);
     final Semaphore semaphore = new Semaphore(0);
@@ -370,14 +370,14 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     assertEquals(1, called.get());
   }
 
   @Test
   public void secondTransactionGetsRunImmediatelyOnPreviousOutputAndOnlyRunsOnce()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref = refs.get(0);
 
     final AtomicBoolean firstRun = new AtomicBoolean(false);
@@ -425,10 +425,10 @@ public class TransactionTest {
             second.release(1);
           }
         });
-    TestHelpers.waitFor(first);
-    TestHelpers.waitFor(second);
+    IntegrationTestHelpers.waitFor(first);
+    IntegrationTestHelpers.waitFor(second);
 
-    DataSnapshot snap = TestHelpers.getSnap(refs.get(1));
+    DataSnapshot snap = IntegrationTestHelpers.getSnap(refs.get(1));
     assertEquals(84L, snap.getValue());
   }
 
@@ -445,7 +445,7 @@ public class TransactionTest {
     // - Transaction #3 should be re-run after #2 is reverted, and then be sent to the server and
     //   succeed.
 
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     final List<DataSnapshot> nodeSnaps = new ArrayList<DataSnapshot>();
@@ -484,7 +484,7 @@ public class TransactionTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     final AtomicBoolean firstRun = new AtomicBoolean(false);
     ref.child("foo")
@@ -560,7 +560,7 @@ public class TransactionTest {
     // so we're left with the last value event
     ref.child("foo").setValue(0);
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     assertTrue(firstDone.get());
     assertTrue(secondDone.get());
@@ -572,7 +572,7 @@ public class TransactionTest {
   @Test
   public void transactionSetSetShouldWork() throws InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ref.runTransaction(
         new Transaction.Handler() {
           @Override
@@ -592,12 +592,12 @@ public class TransactionTest {
 
     ref.setValue("foo");
     ref.setValue("bar");
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void priorityIsNotPreservedWhenSettingData() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore semaphore = new Semaphore(0);
 
     final List<DataSnapshot> snaps = new ArrayList<DataSnapshot>();
@@ -631,7 +631,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     assertEquals(2, snaps.size());
     assertNull(snaps.get(1).getPriority());
@@ -642,7 +642,7 @@ public class TransactionTest {
   @Test
   public void resultingSnapshotIsPassedToOnComplete() throws InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -673,7 +673,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     // Do it again for the aborted case
     ref1.runTransaction(
@@ -692,7 +692,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     // Now on a fresh connection...
     ref2.runTransaction(
@@ -715,13 +715,13 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void transactionsAbortAfter25Retries() throws InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ref.setHijackHash(true);
     final AtomicInteger retries = new AtomicInteger(0);
     ref.runTransaction(
@@ -742,7 +742,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     assertEquals(25, retries.get());
     ref.setHijackHash(false);
   }
@@ -751,7 +751,7 @@ public class TransactionTest {
   public void setShouldCancelAlreadySentTransactionsThatComeBackAsDatastale()
       throws TestFailure, ExecutionException, TimeoutException, InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, 5).timedGet();
 
@@ -782,7 +782,7 @@ public class TransactionTest {
               ref.getRepo().setHijackHash(false);
             }
           });
-      TestHelpers.waitFor(semaphore);
+      IntegrationTestHelpers.waitFor(semaphore);
     } finally {
       ref.getRepo().setHijackHash(false);
     }
@@ -791,7 +791,7 @@ public class TransactionTest {
   @Test
   public void updateShouldNotCancelUnrelatedTransactions()
       throws TestFailure, ExecutionException, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore fooTransaction = new Semaphore(0);
     final Semaphore barTransaction = new Semaphore(0);
@@ -861,14 +861,14 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(barTransaction);
+    IntegrationTestHelpers.waitFor(barTransaction);
   }
 
   @Test
   public void transactionsWorkOnWackyUnicode()
       throws TestFailure, ExecutionException, TimeoutException, InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, "♜♞♝♛♚♝♞♜").timedGet();
 
@@ -892,12 +892,12 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void immediatelyAbortingATransactionWorks() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore semaphore = new Semaphore(0);
 
     ref.runTransaction(
@@ -914,14 +914,14 @@ public class TransactionTest {
             semaphore.release(1);
           }
         });
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void addToAnArrayWithATransaction()
       throws TestFailure, ExecutionException, TimeoutException, InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     new WriteFuture(ref, Arrays.asList("cat", "horse")).timedGet();
     ref.runTransaction(
@@ -952,14 +952,14 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void mergedTransactionsHaveCorrectSnapshotInOnComplete()
       throws TestFailure, ExecutionException, TimeoutException, InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final String nodeName = ref.getKey();
     new WriteFuture(ref, new MapBuilder().put("a", 0).build()).timedGet();
@@ -1012,7 +1012,7 @@ public class TransactionTest {
                 semaphore.release(1);
               }
             });
-    TestHelpers.waitFor(semaphore, 2);
+    IntegrationTestHelpers.waitFor(semaphore, 2);
   }
 
   // Note: skipping tests for reentrant API calls
@@ -1021,9 +1021,9 @@ public class TransactionTest {
   public void pendingTransactionsAreCancelledOnDisconnect()
       throws TestFailure, ExecutionException, TimeoutException, InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
-    DatabaseConfig ctx = TestHelpers.getContext(0);
+    DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
     new WriteFuture(ref, "initial").timedGet();
 
@@ -1045,7 +1045,7 @@ public class TransactionTest {
 
     RepoManager.interrupt(ctx);
     RepoManager.resume(ctx);
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
@@ -1053,7 +1053,7 @@ public class TransactionTest {
     final Semaphore semaphore = new Semaphore(0);
     final Semaphore completeSemaphore = new Semaphore(0);
     final List<DataSnapshot> results = new ArrayList<DataSnapshot>();
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.addValueEventListener(
         new ValueEventListener() {
@@ -1071,7 +1071,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     ref.runTransaction(
         new Transaction.Handler() {
@@ -1085,7 +1085,7 @@ public class TransactionTest {
           @Override
           public void onComplete(DatabaseError error, boolean committed, DataSnapshot currentData) {
             try {
-              TestHelpers.waitFor(semaphore);
+              IntegrationTestHelpers.waitFor(semaphore);
               assertTrue(committed);
               completeSemaphore.release(1);
             } catch (InterruptedException e) {
@@ -1095,12 +1095,12 @@ public class TransactionTest {
         },
         false);
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     assertEquals(1, results.size());
     assertNull(results.get(0).getValue());
     // Let the completion handler run
     semaphore.release(1);
-    TestHelpers.waitFor(completeSemaphore);
+    IntegrationTestHelpers.waitFor(completeSemaphore);
 
     assertEquals(2, results.size());
     assertEquals("hello!", results.get(1).getValue());
@@ -1109,7 +1109,7 @@ public class TransactionTest {
   @Test
   public void transactionWithoutLocalEvents2()
       throws InterruptedException, TestFailure, ExecutionException, TimeoutException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     final DatabaseReference ref1 = refs.get(0);
     DatabaseReference ref2 = refs.get(1);
 
@@ -1124,7 +1124,7 @@ public class TransactionTest {
             done.release();
           }
         });
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
 
     ref1.addValueEventListener(
         new ValueEventListener() {
@@ -1142,7 +1142,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
 
     final AtomicInteger retries = new AtomicInteger(0);
     ref1.runTransaction(
@@ -1173,7 +1173,7 @@ public class TransactionTest {
       new WriteFuture(ref2, i).timedGet();
     }
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
 
     assertTrue(retries.get() > 1);
     int size = events.size();
@@ -1187,10 +1187,10 @@ public class TransactionTest {
   @Test
   public void transactionRunsOnNullOnlyOnceAfterReconnectCase1981()
       throws TestFailure, ExecutionException, TimeoutException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     new WriteFuture(ref, 42).timedGet();
 
-    DatabaseConfig ctx = TestHelpers.newTestConfig();
+    DatabaseConfig ctx = IntegrationTestHelpers.newTestConfig();
     ctx.setLogLevel(Logger.Level.DEBUG);
     DatabaseReference newRef = new DatabaseReference(ref.toString(), ctx);
 
@@ -1223,12 +1223,12 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void transactionRespectsPriority() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore done = new Semaphore(0);
     final List<DataSnapshot> values = new ArrayList<DataSnapshot>();
@@ -1261,7 +1261,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
 
     ref.runTransaction(
         new Transaction.Handler() {
@@ -1281,7 +1281,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
 
     assertEquals(5L, values.get(values.size() - 2).getValue());
     assertEquals(5.0, values.get(values.size() - 2).getPriority());
@@ -1291,7 +1291,7 @@ public class TransactionTest {
 
   @Test
   public void transactionRevertsDataWhenAddADeeperListen() throws InterruptedException {
-    final List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    final List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
 
     final Semaphore gotTest = new Semaphore(0);
     refs.get(0)
@@ -1335,12 +1335,12 @@ public class TransactionTest {
                         });
               }
             });
-    TestHelpers.waitFor(gotTest);
+    IntegrationTestHelpers.waitFor(gotTest);
   }
 
   @Test
   public void transactionWithNumericKeys() throws InterruptedException {
-    final DatabaseReference ref = TestHelpers.getRandomNode();
+    final DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore done = new Semaphore(0);
 
     Map<String, Object> initial =
@@ -1370,13 +1370,13 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void canRemoveChildWithPriority0()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore done = new Semaphore(0);
 
     long value = 1378744239756L;
@@ -1399,12 +1399,12 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void userCodeExceptionsAbortTheTransaction() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore done = new Semaphore(0);
 
@@ -1423,7 +1423,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
 
     // Now try it with a Throwable, rather than exception
     ref.runTransaction(
@@ -1441,13 +1441,13 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   // https://app.asana.com/0/5673976843758/9259161251948
   @Test
   public void bubbleAppTransactionBug() throws InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore done = new Semaphore(0);
     ref.child("a")
@@ -1519,13 +1519,13 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void testLocalServerValuesEventuallyButNotImmediatelyMatchServerWithTxns()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
 
@@ -1583,7 +1583,7 @@ public class TransactionTest {
     Thread.sleep(5);
     writer.getDatabase().goOnline();
 
-    TestHelpers.waitFor(completionSemaphore, 3);
+    IntegrationTestHelpers.waitFor(completionSemaphore, 3);
 
     assertEquals(readSnaps.size(), 1);
     assertEquals(writeSnaps.size(), 2);
@@ -1601,7 +1601,7 @@ public class TransactionTest {
 
   @Test
   public void testTransactionWithQueryListen() throws DatabaseException, InterruptedException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     final Semaphore semaphore = new Semaphore(0);
 
     ref.setValue(
@@ -1648,13 +1648,13 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void testTransactionDoesNotPickUpCachedDataFromPreviousOnce()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     final DatabaseReference me = refs.get(0);
     final DatabaseReference other = refs.get(1);
 
@@ -1669,7 +1669,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     me.addListenerForSingleValueEvent(
         new ValueEventListener() {
@@ -1682,7 +1682,7 @@ public class TransactionTest {
           public void onCancelled(DatabaseError error) {}
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     other.setValue(
         null,
@@ -1693,7 +1693,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     me.runTransaction(
         new Transaction.Handler() {
@@ -1716,13 +1716,13 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void testTransactionDoesNotPickUpCachedDataFromPreviousTransaction()
       throws DatabaseException, InterruptedException {
-    List<DatabaseReference> refs = TestHelpers.getRandomNode(2);
+    List<DatabaseReference> refs = IntegrationTestHelpers.getRandomNode(2);
     final DatabaseReference me = refs.get(0);
     final DatabaseReference other = refs.get(1);
 
@@ -1744,7 +1744,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     other.setValue(
         null,
@@ -1755,7 +1755,7 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     me.runTransaction(
         new Transaction.Handler() {
@@ -1778,13 +1778,13 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
   public void transactionOnQueriedLocationDoesntRunInitiallyOnNull()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     DatabaseReference child = ref.push();
     final Map<String, Object> initialData = new MapBuilder().put("a", 1L).put("b", 2L).build();
     new WriteFuture(child, initialData).timedGet();
@@ -1825,7 +1825,7 @@ public class TransactionTest {
                   public void onChildRemoved(DataSnapshot snapshot) {}
                 });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     // cleanup
     ref.removeEventListener(listener);
@@ -1834,7 +1834,7 @@ public class TransactionTest {
   @Test
   public void transactionsRaiseCorrectChildChangedEventsOnQueries()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     Map<String, Object> value =
         new MapBuilder().put("foo", new MapBuilder().put("value", 1).build()).build();
@@ -1879,7 +1879,7 @@ public class TransactionTest {
             },
             false);
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
 
     Assert.assertEquals(2, snapshots.size());
     DataSnapshot addedSnapshot = snapshots.get(0);
@@ -1896,11 +1896,11 @@ public class TransactionTest {
   @Test
   public void transactionsUseLocalMerges()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
     // Go offline to ensure the update doesn't complete before the transaction runs.
-    TestHelpers.goOffline(TestHelpers.getContext(0));
+    IntegrationTestHelpers.goOffline(IntegrationTestHelpers.getContext(0));
     ref.updateChildren(new MapBuilder().put("foo", "bar").build());
     ref.child("foo")
         .runTransaction(
@@ -1921,8 +1921,8 @@ public class TransactionTest {
               }
             });
 
-    TestHelpers.goOnline(TestHelpers.getContext(0));
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.goOnline(IntegrationTestHelpers.getContext(0));
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   // See https://app.asana.com/0/15566422264127/23303789496881
@@ -1930,7 +1930,7 @@ public class TransactionTest {
   public void outOfOrderRemoveWritesAreHandledCorrectly()
       throws DatabaseException, InterruptedException, ExecutionException, TestFailure,
           TimeoutException {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.setValue(new MapBuilder().put("foo", "bar").build());
     ref.runTransaction(
@@ -1968,12 +1968,12 @@ public class TransactionTest {
           }
         });
 
-    TestHelpers.waitFor(done);
+    IntegrationTestHelpers.waitFor(done);
   }
 
   @Test
   public void returningNullReturnsNullPointerExceptionError() throws Throwable {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     final Semaphore semaphore = new Semaphore(0);
 
@@ -1993,7 +1993,7 @@ public class TransactionTest {
               }
             });
 
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 
   @Test
@@ -2001,7 +2001,7 @@ public class TransactionTest {
     // Hack: To trigger us to disconnect before restoring state, we inject a bad auth token.
     // In real-world usage the much more common case is that we get redirected to a different
     // server, but that's harder to manufacture from a test.
-    final DatabaseConfig cfg = TestHelpers.newTestConfig();
+    final DatabaseConfig cfg = IntegrationTestHelpers.newTestConfig();
     cfg.setAuthTokenProvider(
         new AuthTokenProvider() {
           private int count = 0;
@@ -2009,7 +2009,7 @@ public class TransactionTest {
           @Override
           public void getToken(boolean forceRefresh, final GetTokenCompletionListener listener) {
             // Return "bad-token" once to trigger a disconnect, and then a null token.
-            TestHelpers.getExecutorService(cfg)
+            IntegrationTestHelpers.getExecutorService(cfg)
                 .schedule(
                     new Runnable() {
                       @Override
@@ -2034,7 +2034,7 @@ public class TransactionTest {
         });
 
     // Queue a transaction offline.
-    DatabaseReference ref = TestHelpers.rootWithConfig(cfg);
+    DatabaseReference ref = IntegrationTestHelpers.rootWithConfig(cfg);
     ref.getDatabase().goOffline();
     final Semaphore semaphore = new Semaphore(0);
     ref.push()
@@ -2057,6 +2057,6 @@ public class TransactionTest {
             });
 
     ref.getDatabase().goOnline();
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
   }
 }

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/ValueExpectationHelper.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/ValueExpectationHelper.java
@@ -62,7 +62,7 @@ public class ValueExpectationHelper {
   }
 
   public void waitForEvents() throws InterruptedException {
-    TestHelpers.waitFor(semaphore, count);
+    IntegrationTestHelpers.waitFor(semaphore, count);
     Iterator<QueryAndListener> iter = expectations.iterator();
     while (iter.hasNext()) {
       QueryAndListener pair = iter.next();

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/connection/ConnectionTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/connection/ConnectionTest.java
@@ -17,9 +17,9 @@ package com.google.firebase.database.connection;
 import static org.junit.Assert.assertFalse;
 
 import android.support.test.runner.AndroidJUnit4;
+import com.google.firebase.database.IntegrationTestHelpers;
 import com.google.firebase.database.IntegrationTestValues;
 import com.google.firebase.database.RetryRule;
-import com.google.firebase.database.TestHelpers;
 import com.google.firebase.database.core.DatabaseConfig;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
@@ -65,9 +65,9 @@ public class ConnectionTest {
             IntegrationTestValues.getProjectId() + "." + IntegrationTestValues.getServer(),
             IntegrationTestValues.getProjectId(),
             /*secure=*/ true);
-    DatabaseConfig config = TestHelpers.newFrozenTestConfig();
+    DatabaseConfig config = IntegrationTestHelpers.newFrozenTestConfig();
     Connection conn = new Connection(config.getConnectionContext(), info, null, del, null);
     conn.open();
-    TestHelpers.waitFor(valSemaphore);
+    IntegrationTestHelpers.waitFor(valSemaphore);
   }
 }

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/connection/ListenAggregator.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/connection/ListenAggregator.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database.connection;
 
-import com.google.firebase.database.TestHelpers;
+import com.google.firebase.database.IntegrationTestHelpers;
 import com.google.firebase.database.core.CoreTestHelpers;
 import com.google.firebase.database.core.Path;
 import com.google.firebase.database.core.Repo;
@@ -40,7 +40,7 @@ public class ListenAggregator {
             semaphore.release(1);
           }
         });
-    TestHelpers.waitFor(semaphore);
+    IntegrationTestHelpers.waitFor(semaphore);
     conns.get(0);
     List<List<String>> pathList = new ArrayList<>();
     List<Map<String, Object>> queryParamList = new ArrayList<>();

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/core/AndroidPlatformTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/core/AndroidPlatformTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import android.support.test.runner.AndroidJUnit4;
 import com.google.firebase.database.FirebaseDatabase;
-import com.google.firebase.database.TestHelpers;
+import com.google.firebase.database.IntegrationTestHelpers;
 import org.junit.Test;
 
 @org.junit.runner.RunWith(AndroidJUnit4.class)
@@ -27,7 +27,7 @@ public class AndroidPlatformTest {
 
   @Test
   public void userAgentHasCorrectParts() {
-    Context cfg = TestHelpers.getContext(0);
+    Context cfg = IntegrationTestHelpers.getContext(0);
     cfg.freeze();
     String userAgent = cfg.getUserAgent();
     String[] parts = userAgent.split("/");

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/core/SynchronousConnection.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/core/SynchronousConnection.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database.core;
 
-import static com.google.firebase.database.TestHelpers.newFrozenTestConfig;
+import static com.google.firebase.database.IntegrationTestHelpers.newFrozenTestConfig;
 import static com.google.firebase.database.core.utilities.Utilities.hardAssert;
 
 import com.google.firebase.database.DatabaseError;

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/core/ZombieVerifier.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/core/ZombieVerifier.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import com.google.firebase.database.DatabaseReference;
-import com.google.firebase.database.TestHelpers;
+import com.google.firebase.database.IntegrationTestHelpers;
 import com.google.firebase.database.core.view.View;
 import com.google.firebase.database.core.view.ViewAccess;
 import java.util.HashMap;
@@ -55,7 +55,7 @@ public class ZombieVerifier {
     final Semaphore wait = new Semaphore(0);
 
     verifyRepoZombies(repo, wait);
-    TestHelpers.waitFor(wait);
+    IntegrationTestHelpers.waitFor(wait);
   }
 
   // To verify our state, we:

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/core/persistence/KeepSyncedTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/core/persistence/KeepSyncedTest.java
@@ -19,10 +19,10 @@ import static org.junit.Assert.assertEquals;
 import android.support.test.runner.AndroidJUnit4;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.EventRecord;
+import com.google.firebase.database.IntegrationTestHelpers;
 import com.google.firebase.database.MapBuilder;
 import com.google.firebase.database.Query;
 import com.google.firebase.database.RetryRule;
-import com.google.firebase.database.TestHelpers;
 import com.google.firebase.database.future.ReadFuture;
 import com.google.firebase.database.future.WriteFuture;
 import java.util.List;
@@ -38,7 +38,7 @@ public class KeepSyncedTest {
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    IntegrationTestHelpers.failOnFirstUncaughtException();
   }
 
   static long globalKeepSyncedTestCounter = 0;
@@ -109,7 +109,7 @@ public class KeepSyncedTest {
 
   @Test
   public void keepSynced() throws Exception {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ref.keepSynced(true);
     assertIsKeptSynced(ref);
 
@@ -120,7 +120,7 @@ public class KeepSyncedTest {
   // NOTE: This is not ideal behavior and should be fixed in a future release
   @Test
   public void keepSyncedAffectsQueries() throws Exception {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     ref.keepSynced(true);
     Query query = ref.limitToFirst(5);
     query.keepSynced(true);
@@ -135,7 +135,7 @@ public class KeepSyncedTest {
 
   @Test
   public void manyKeepSyncedCallsDontAccumulate() throws Exception {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.keepSynced(true);
     ref.keepSynced(true);
@@ -160,7 +160,7 @@ public class KeepSyncedTest {
 
   @Test
   public void removeSingleListenerDoesNotAffectKeepSynced() throws Exception {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.keepSynced(true);
     assertIsKeptSynced(ref);
@@ -183,7 +183,7 @@ public class KeepSyncedTest {
 
   @Test
   public void keepSyncedNoDoesNotAffectExistingListener() throws Exception {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref.keepSynced(true);
     assertIsKeptSynced(ref);
@@ -208,7 +208,7 @@ public class KeepSyncedTest {
 
   @Test
   public void differentQueriesAreIndependent() throws Exception {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     Query query1 = ref.limitToFirst(1);
     Query query2 = ref.limitToFirst(2);
 
@@ -231,7 +231,7 @@ public class KeepSyncedTest {
 
   @Test
   public void childIsKeptSynced() throws Exception {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
     DatabaseReference child = ref.child("random-child");
 
     ref.keepSynced(true);
@@ -243,7 +243,7 @@ public class KeepSyncedTest {
 
   @Test
   public void rootIsKeptSynced() throws Exception {
-    DatabaseReference ref = TestHelpers.getRandomNode().getRoot();
+    DatabaseReference ref = IntegrationTestHelpers.getRandomNode().getRoot();
 
     ref.keepSynced(true);
     assertIsKeptSynced(ref);

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/core/persistence/PersistenceTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/core/persistence/PersistenceTest.java
@@ -14,18 +14,18 @@
 
 package com.google.firebase.database.core.persistence;
 
-import static com.google.firebase.database.TestHelpers.childKeySet;
-import static com.google.firebase.database.TestHelpers.defaultQueryAt;
-import static com.google.firebase.database.TestHelpers.failOnFirstUncaughtException;
-import static com.google.firebase.database.TestHelpers.fromSingleQuotedString;
-import static com.google.firebase.database.TestHelpers.goOffline;
-import static com.google.firebase.database.TestHelpers.goOnline;
-import static com.google.firebase.database.TestHelpers.newFrozenTestConfig;
-import static com.google.firebase.database.TestHelpers.path;
-import static com.google.firebase.database.TestHelpers.rootWithConfig;
-import static com.google.firebase.database.TestHelpers.setForcedPersistentCache;
-import static com.google.firebase.database.TestHelpers.waitFor;
-import static com.google.firebase.database.TestHelpers.waitForQueue;
+import static com.google.firebase.database.IntegrationTestHelpers.childKeySet;
+import static com.google.firebase.database.IntegrationTestHelpers.defaultQueryAt;
+import static com.google.firebase.database.IntegrationTestHelpers.failOnFirstUncaughtException;
+import static com.google.firebase.database.IntegrationTestHelpers.fromSingleQuotedString;
+import static com.google.firebase.database.IntegrationTestHelpers.goOffline;
+import static com.google.firebase.database.IntegrationTestHelpers.goOnline;
+import static com.google.firebase.database.IntegrationTestHelpers.newFrozenTestConfig;
+import static com.google.firebase.database.IntegrationTestHelpers.path;
+import static com.google.firebase.database.IntegrationTestHelpers.rootWithConfig;
+import static com.google.firebase.database.IntegrationTestHelpers.setForcedPersistentCache;
+import static com.google.firebase.database.IntegrationTestHelpers.waitFor;
+import static com.google.firebase.database.IntegrationTestHelpers.waitForQueue;
 import static com.google.firebase.database.snapshot.NodeUtilities.NodeFromJSON;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/core/persistence/PruningTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/core/persistence/PruningTest.java
@@ -14,10 +14,10 @@
 
 package com.google.firebase.database.core.persistence;
 
-import static com.google.firebase.database.TestHelpers.asSet;
-import static com.google.firebase.database.TestHelpers.leafNodeOfSize;
-import static com.google.firebase.database.TestHelpers.node;
-import static com.google.firebase.database.TestHelpers.path;
+import static com.google.firebase.database.IntegrationTestHelpers.asSet;
+import static com.google.firebase.database.IntegrationTestHelpers.leafNodeOfSize;
+import static com.google.firebase.database.IntegrationTestHelpers.node;
+import static com.google.firebase.database.IntegrationTestHelpers.path;
 import static org.junit.Assert.assertEquals;
 
 import android.support.test.InstrumentationRegistry;

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/core/persistence/SqlPersistenceStorageEngineTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/core/persistence/SqlPersistenceStorageEngineTest.java
@@ -14,13 +14,13 @@
 
 package com.google.firebase.database.core.persistence;
 
-import static com.google.firebase.database.TestHelpers.asSet;
-import static com.google.firebase.database.TestHelpers.childKeySet;
-import static com.google.firebase.database.TestHelpers.compoundWrite;
-import static com.google.firebase.database.TestHelpers.defaultQueryAt;
-import static com.google.firebase.database.TestHelpers.leafNodeOfSize;
-import static com.google.firebase.database.TestHelpers.node;
-import static com.google.firebase.database.TestHelpers.path;
+import static com.google.firebase.database.IntegrationTestHelpers.asSet;
+import static com.google.firebase.database.IntegrationTestHelpers.childKeySet;
+import static com.google.firebase.database.IntegrationTestHelpers.compoundWrite;
+import static com.google.firebase.database.IntegrationTestHelpers.defaultQueryAt;
+import static com.google.firebase.database.IntegrationTestHelpers.leafNodeOfSize;
+import static com.google.firebase.database.IntegrationTestHelpers.node;
+import static com.google.firebase.database.IntegrationTestHelpers.path;
 import static com.google.firebase.database.snapshot.NodeUtilities.NodeFromJSON;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/future/ReadFuture.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/future/ReadFuture.java
@@ -17,9 +17,9 @@ package com.google.firebase.database.future;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.EventRecord;
+import com.google.firebase.database.IntegrationTestHelpers;
 import com.google.firebase.database.Query;
 import com.google.firebase.database.TestFailure;
-import com.google.firebase.database.TestHelpers;
 import com.google.firebase.database.TestValues;
 import com.google.firebase.database.ValueEventListener;
 import com.google.firebase.database.core.view.Event;
@@ -200,7 +200,7 @@ public class ReadFuture implements Future<List<EventRecord>> {
   public void timedWait(long timeout, TimeUnit timeoutUnit)
       throws InterruptedException, TimeoutException, TestFailure {
     if (!semaphore.tryAcquire(1, timeout, timeoutUnit)) {
-      TestHelpers.failOnFirstUncaughtException();
+      IntegrationTestHelpers.failOnFirstUncaughtException();
       throw new TimeoutException();
     }
     if (exception != null) {

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/future/WriteFuture.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/future/WriteFuture.java
@@ -17,8 +17,8 @@ package com.google.firebase.database.future;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseException;
 import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.IntegrationTestHelpers;
 import com.google.firebase.database.TestFailure;
-import com.google.firebase.database.TestHelpers;
 import com.google.firebase.database.TestValues;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -106,7 +106,7 @@ public class WriteFuture implements Future<DatabaseError> {
       throws InterruptedException, ExecutionException, TimeoutException {
     boolean success = semaphore.tryAcquire(1, timeout, unit);
     if (!success) {
-      TestHelpers.failOnFirstUncaughtException();
+      IntegrationTestHelpers.failOnFirstUncaughtException();
       throw new TimeoutException();
     }
     return error;

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/snapshot/CompoundHashTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/snapshot/CompoundHashTest.java
@@ -14,8 +14,8 @@
 
 package com.google.firebase.database.snapshot;
 
-import static com.google.firebase.database.TestHelpers.fromSingleQuotedString;
-import static com.google.firebase.database.TestHelpers.path;
+import static com.google.firebase.database.IntegrationTestHelpers.fromSingleQuotedString;
+import static com.google.firebase.database.IntegrationTestHelpers.path;
 import static com.google.firebase.database.snapshot.NodeUtilities.NodeFromJSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/tubesock/FirebaseClient.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/tubesock/FirebaseClient.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database.tubesock;
 
-import com.google.firebase.database.TestHelpers;
+import com.google.firebase.database.IntegrationTestHelpers;
 import java.net.URI;
 import java.util.concurrent.Semaphore;
 
@@ -55,7 +55,7 @@ public class FirebaseClient {
   public void start() throws WebSocketException, InterruptedException {
     semaphore = new Semaphore(0);
     URI uri = URI.create("wss://gsoltis.firebaseio-demo.com/.ws?v=5");
-    client = new WebSocket(TestHelpers.getContext(0).getConnectionContext(), uri);
+    client = new WebSocket(IntegrationTestHelpers.getContext(0).getConnectionContext(), uri);
     client.setEventHandler(new Handler());
     client.connect();
     semaphore.acquire(1);

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/tubesock/TestClient.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/tubesock/TestClient.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database.tubesock;
 
-import com.google.firebase.database.TestHelpers;
+import com.google.firebase.database.IntegrationTestHelpers;
 import java.net.URI;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -66,7 +66,7 @@ public class TestClient {
     URI uri = URI.create("ws://localhost:9001/runCase?case=" + testNum + "&agent=tubesock");
     inTest = new AtomicBoolean(true);
     testLatch = new Semaphore(0);
-    client = new WebSocket(TestHelpers.getContext(0).getConnectionContext(), uri);
+    client = new WebSocket(IntegrationTestHelpers.getContext(0).getConnectionContext(), uri);
     client.setEventHandler(new Handler());
     client.connect();
     testLatch.acquire(1);

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/tubesock/UpdateClient.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/tubesock/UpdateClient.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database.tubesock;
 
-import com.google.firebase.database.TestHelpers;
+import com.google.firebase.database.IntegrationTestHelpers;
 import java.net.URI;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -53,7 +53,8 @@ public class UpdateClient {
     URI uri = URI.create("ws://localhost:9001/updateReports?agent=tubesock");
     completed = new AtomicBoolean(false);
     completionLatch = semaphore;
-    WebSocket client = new WebSocket(TestHelpers.getContext(0).getConnectionContext(), uri);
+    WebSocket client =
+        new WebSocket(IntegrationTestHelpers.getContext(0).getConnectionContext(), uri);
     client.setEventHandler(new Handler());
     client.connect();
     semaphore.acquire(1);

--- a/firebase-database/src/test/java/com/google/firebase/database/DataSnapshotTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/DataSnapshotTest.java
@@ -34,7 +34,7 @@ public class DataSnapshotTest {
 
   @Before
   public void setUp() {
-    TestHelpers.ensureAppInitialized();
+    UnitTestHelpers.ensureAppInitialized();
   }
 
   private DataSnapshot snapFor(Object data, DatabaseReference ref) {
@@ -44,7 +44,7 @@ public class DataSnapshotTest {
 
   @Test
   public void basicIterationWorks() {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = UnitTestHelpers.getRandomNode();
     DataSnapshot snap1 = snapFor(null, ref);
 
     assertFalse(snap1.hasChildren());
@@ -71,7 +71,7 @@ public class DataSnapshotTest {
   @Test
   @SuppressWarnings("rawtypes")
   public void existsWorks() {
-    DatabaseReference ref = TestHelpers.getRandomNode();
+    DatabaseReference ref = UnitTestHelpers.getRandomNode();
     DataSnapshot snap;
 
     snap = snapFor(new HashMap(), ref);

--- a/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database;
 
-import static com.google.firebase.database.TestHelpers.fromSingleQuotedString;
+import static com.google.firebase.database.UnitTestHelpers.fromSingleQuotedString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;

--- a/firebase-database/src/test/java/com/google/firebase/database/MutableDataTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MutableDataTest.java
@@ -187,23 +187,23 @@ public class MutableDataTest {
 
     List<String> goodKeys =
         Arrays.asList(
-            TestHelpers.repeatedString("k", maxPathLengthBytes - 1),
-            TestHelpers.repeatedString(fire, maxPathLengthBytes / 4 - 1),
-            TestHelpers.repeatedString(base, maxPathLengthBytes / 3 - 1),
-            TestHelpers.repeatedString("key/", maxPathDepth - 1) + "key");
+            UnitTestHelpers.repeatedString("k", maxPathLengthBytes - 1),
+            UnitTestHelpers.repeatedString(fire, maxPathLengthBytes / 4 - 1),
+            UnitTestHelpers.repeatedString(base, maxPathLengthBytes / 3 - 1),
+            UnitTestHelpers.repeatedString("key/", maxPathDepth - 1) + "key");
 
     List<String> badKeys =
         Arrays.asList(
-            TestHelpers.repeatedString("k", maxPathLengthBytes),
-            TestHelpers.repeatedString(fire, maxPathLengthBytes / 4),
-            TestHelpers.repeatedString(base, maxPathLengthBytes / 3),
-            TestHelpers.repeatedString("key/", maxPathDepth) + "key");
+            UnitTestHelpers.repeatedString("k", maxPathLengthBytes),
+            UnitTestHelpers.repeatedString(fire, maxPathLengthBytes / 4),
+            UnitTestHelpers.repeatedString(base, maxPathLengthBytes / 3),
+            UnitTestHelpers.repeatedString("key/", maxPathDepth) + "key");
 
     // Large but legal paths should all work for manipulating MutableData.
     for (String key : goodKeys) {
       Path path = new Path(key);
-      MutableData data = dataFor(TestHelpers.buildObjFromPath(path, "test_value"));
-      assertEquals("test_value", TestHelpers.applyPath(data.getValue(), path));
+      MutableData data = dataFor(UnitTestHelpers.buildObjFromPath(path, "test_value"));
+      assertEquals("test_value", UnitTestHelpers.applyPath(data.getValue(), path));
 
       data = dataForPath("scalar_value", key);
       assertEquals("scalar_value", data.getValue());
@@ -212,7 +212,7 @@ public class MutableDataTest {
     for (String key : badKeys) {
       Path path = new Path(key);
       try {
-        dataFor(TestHelpers.buildObjFromPath(path, "test_value"));
+        dataFor(UnitTestHelpers.buildObjFromPath(path, "test_value"));
         fail("Invalid path did not throw exception.");
       } catch (DatabaseException e) {
         // expected

--- a/firebase-database/src/test/java/com/google/firebase/database/UnitTestHelpers.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/UnitTestHelpers.java
@@ -14,32 +14,22 @@
 
 package com.google.firebase.database;
 
-import static com.google.firebase.database.snapshot.NodeUtilities.NodeFromJSON;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import android.support.test.InstrumentationRegistry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import com.google.firebase.database.core.CompoundWrite;
 import com.google.firebase.database.core.Context;
 import com.google.firebase.database.core.CoreTestHelpers;
 import com.google.firebase.database.core.DatabaseConfig;
 import com.google.firebase.database.core.EventTarget;
 import com.google.firebase.database.core.Path;
-import com.google.firebase.database.core.persistence.PersistenceManager;
 import com.google.firebase.database.core.utilities.DefaultRunLoop;
 import com.google.firebase.database.core.view.QuerySpec;
-import com.google.firebase.database.future.WriteFuture;
 import com.google.firebase.database.snapshot.ChildKey;
-import com.google.firebase.database.snapshot.Node;
 import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Method;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,7 +38,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -58,87 +47,12 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import org.robolectric.RuntimeEnvironment;
 
-public class TestHelpers {
+public class UnitTestHelpers {
 
   private static List<DatabaseConfig> contexts = new ArrayList<DatabaseConfig>();
-  private static String testSecret = null;
   private static boolean appInitialized = false;
-
-  public static Path path(String path) {
-    return new Path(path);
-  }
-
-  public static ChildKey childKey(String key) {
-    return ChildKey.fromString(key);
-  }
-
-  public static Map<String, Object> mapFromJsonString(String json) {
-    try {
-      ObjectMapper mapper = new ObjectMapper();
-      return mapper.readValue(json, new TypeReference<Map<String, Object>>() {});
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public static Object objectFromJsonString(String json) {
-    try {
-      ObjectMapper mapper = new ObjectMapper();
-      return mapper.readValue(json, new TypeReference<Object>() {});
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public static Map<String, Object> mapFromSingleQuotedString(String json) {
-    return mapFromJsonString(json.replace("'", "\""));
-  }
-
-  public static Object objectFromSingleQuotedString(String json) {
-    return objectFromJsonString(json.replace("'", "\""));
-  }
-
-  public static Node node(String json) {
-    return NodeFromJSON(objectFromSingleQuotedString(json));
-  }
-
-  public static Node leafNodeOfSize(int size) {
-    StringBuilder builder = new StringBuilder();
-    String pattern = "abdefghijklmopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    int patternLength = pattern.length();
-    for (int i = 0; i < size - patternLength; i = i + patternLength) { // 10 MB String
-      builder.append(pattern);
-    }
-    int remainingLength = size - builder.length();
-    builder.append(pattern.substring(0, remainingLength));
-    assert builder.length() == size : "The string size did not match the expected size";
-    return NodeFromJSON(builder.toString());
-  }
-
-  public static CompoundWrite compoundWrite(String json) {
-    return CompoundWrite.fromValue(mapFromSingleQuotedString(json));
-  }
-
-  public static QuerySpec defaultQueryAt(String path) {
-    return QuerySpec.defaultQueryAtPath(new Path(path));
-  }
-
-  public static <T> Set<T> asSet(List<T> list) {
-    return new HashSet<T>(list);
-  }
-
-  public static <T> Set<T> asSet(T... objects) {
-    return new HashSet<T>(Arrays.asList(objects));
-  }
-
-  public static Set<ChildKey> childKeySet(String... keys) {
-    Set<ChildKey> childKeys = new HashSet<ChildKey>();
-    for (String key : keys) {
-      childKeys.add(ChildKey.fromString(key));
-    }
-    return childKeys;
-  }
 
   private static class TestEventTarget implements EventTarget {
     AtomicReference<Throwable> caughtException = new AtomicReference<Throwable>(null);
@@ -218,24 +132,8 @@ public class TestHelpers {
     return contexts.get(i);
   }
 
-  public static DatabaseReference rootWithNewContext() throws DatabaseException {
-    return rootWithConfig(newTestConfig());
-  }
-
-  public static DatabaseReference rootWithConfig(DatabaseConfig config) {
-    return new DatabaseReference(IntegrationTestValues.getNamespace(), config);
-  }
-
   public static DatabaseReference getRandomNode() throws DatabaseException {
     return getRandomNode(1).get(0);
-  }
-
-  public static void goOffline(DatabaseConfig cfg) {
-    DatabaseReference.goOffline(cfg);
-  }
-
-  public static void goOnline(DatabaseConfig cfg) {
-    DatabaseReference.goOnline(cfg);
   }
 
   public static List<DatabaseReference> getRandomNode(int count) throws DatabaseException {
@@ -244,8 +142,7 @@ public class TestHelpers {
     List<DatabaseReference> results = new ArrayList<DatabaseReference>(count);
     String name = null;
     for (int i = 0; i < count; ++i) {
-      DatabaseReference ref =
-          new DatabaseReference(IntegrationTestValues.getNamespace(), contexts.get(i));
+      DatabaseReference ref = new DatabaseReference(TestValues.TEST_NAMESPACE, contexts.get(i));
       if (name == null) {
         name = ref.push().getKey();
       }
@@ -261,7 +158,7 @@ public class TestHelpers {
   }
 
   public static DatabaseConfig newTestConfig() {
-    TestHelpers.ensureAppInitialized();
+    UnitTestHelpers.ensureAppInitialized();
 
     TestRunLoop runLoop = new TestRunLoop();
     DatabaseConfig config = new DatabaseConfig();
@@ -278,17 +175,6 @@ public class TestHelpers {
     return runLoop.getExecutorService();
   }
 
-  public static void setForcedPersistentCache(Context ctx, PersistenceManager manager) {
-    try {
-      Method method =
-          Context.class.getDeclaredMethod("forcePersistenceManager", PersistenceManager.class);
-      method.setAccessible(true);
-      method.invoke(ctx, manager);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   public static void setLogger(
       DatabaseConfig ctx, com.google.firebase.database.logging.Logger logger) {
     ctx.setLogger(logger);
@@ -300,27 +186,12 @@ public class TestHelpers {
     }
   }
 
-  public static String getTestSecret() {
-    if (testSecret == null) {
-      try {
-        InputStream response =
-            new URL(IntegrationTestValues.getNamespace() + "/.nsadmin/.json?key=1234").openStream();
-        TypeReference<Map<String, Object>> t = new TypeReference<Map<String, Object>>() {};
-        Map<String, Object> data = new ObjectMapper().readValue(response, t);
-        testSecret = (String) ((List) data.get("secrets")).get(0);
-      } catch (Throwable e) {
-        fail("Could not get test secret.");
-      }
-    }
-    return testSecret;
-  }
-
   public static void waitFor(Semaphore semaphore) throws InterruptedException {
     waitFor(semaphore, 1);
   }
 
   public static void waitFor(Semaphore semaphore, int count) throws InterruptedException {
-    waitFor(semaphore, count, IntegrationTestValues.getTimeout(), TimeUnit.MILLISECONDS);
+    waitFor(semaphore, count, TestValues.TEST_TIMEOUT, TimeUnit.MILLISECONDS);
   }
 
   public static void waitFor(Semaphore semaphore, int count, long timeout, TimeUnit unit)
@@ -328,62 +199,6 @@ public class TestHelpers {
     boolean success = semaphore.tryAcquire(count, timeout, unit);
     failOnFirstUncaughtException();
     assertTrue("Operation timed out", success);
-  }
-
-  public static DataSnapshot getSnap(Query ref) throws InterruptedException {
-
-    final Semaphore semaphore = new Semaphore(0);
-
-    // Hack to get around final reference issue
-    final List<DataSnapshot> snapshotList = new ArrayList<DataSnapshot>(1);
-
-    ref.addListenerForSingleValueEvent(
-        new ValueEventListener() {
-          @Override
-          public void onDataChange(DataSnapshot snapshot) {
-            snapshotList.add(snapshot);
-            semaphore.release(1);
-          }
-
-          @Override
-          public void onCancelled(DatabaseError error) {
-            semaphore.release(1);
-          }
-        });
-
-    semaphore.tryAcquire(1, IntegrationTestValues.getTimeout(), TimeUnit.MILLISECONDS);
-    return snapshotList.get(0);
-  }
-
-  public static void assertSuccessfulAuth(
-      DatabaseReference ref, TestTokenProvider provider, String credential) {
-    DatabaseReference authRef = ref.getRoot().child(".info/authenticated");
-    final Semaphore semaphore = new Semaphore(0);
-    final List<Boolean> authStates = new ArrayList<>();
-    ValueEventListener listener =
-        authRef.addValueEventListener(
-            new ValueEventListener() {
-              @Override
-              public void onDataChange(DataSnapshot snapshot) {
-                authStates.add(snapshot.getValue(Boolean.class));
-                semaphore.release();
-              }
-
-              @Override
-              public void onCancelled(DatabaseError error) {
-                throw new RuntimeException("Should not happen");
-              }
-            });
-
-    provider.setToken(credential);
-
-    try {
-      TestHelpers.waitFor(semaphore, 2);
-      assertEquals(Arrays.asList(false, true), authStates);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-    authRef.removeEventListener(listener);
   }
 
   public static Map<String, Object> fromJsonString(String json) {
@@ -397,51 +212,6 @@ public class TestHelpers {
 
   public static Map<String, Object> fromSingleQuotedString(String json) {
     return fromJsonString(json.replace("'", "\""));
-  }
-
-  public static void waitForRoundtrip(DatabaseReference reader) {
-    try {
-      new WriteFuture(reader.getRoot().child(UUID.randomUUID().toString()), null, null).timedGet();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public static void waitForQueue(DatabaseReference ref) {
-    try {
-      final Semaphore semaphore = new Semaphore(0);
-      ref.getRepo()
-          .scheduleNow(
-              new Runnable() {
-                @Override
-                public void run() {
-                  semaphore.release();
-                }
-              });
-      semaphore.acquire();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public static void waitForEvents(DatabaseReference ref) {
-    try {
-      // Make sure queue is done and all events are queued
-      TestHelpers.waitForQueue(ref);
-      // Next, all events were queued, make sure all events are done raised
-      final Semaphore semaphore = new Semaphore(0);
-      ref.getRepo()
-          .postEvent(
-              new Runnable() {
-                @Override
-                public void run() {
-                  semaphore.release();
-                }
-              });
-      semaphore.acquire();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public static String repeatedString(String s, int n) {
@@ -486,30 +256,43 @@ public class TestHelpers {
     assertTrue("'" + str + "' does not contain '" + substr + "'.", str.contains(substr));
   }
 
+  public static ChildKey ck(String childKey) {
+    return ChildKey.fromString(childKey);
+  }
+
+  public static Path path(String path) {
+    return new Path(path);
+  }
+
+  public static QuerySpec defaultQueryAt(String path) {
+    return QuerySpec.defaultQueryAtPath(new Path(path));
+  }
+
+  public static <T> Set<T> asSet(List<T> list) {
+    return new HashSet<T>(list);
+  }
+
+  public static <T> Set<T> asSet(T... objects) {
+    return new HashSet<T>(Arrays.asList(objects));
+  }
+
+  public static Set<ChildKey> childKeySet(String... stringKeys) {
+    HashSet<ChildKey> childKeys = new HashSet<ChildKey>();
+    for (String k : stringKeys) {
+      childKeys.add(ChildKey.fromString(k));
+    }
+    return childKeys;
+  }
+
   public static void ensureAppInitialized() {
     if (!appInitialized) {
       appInitialized = true;
-      android.content.Context context = InstrumentationRegistry.getTargetContext();
       FirebaseApp.initializeApp(
-          context,
+          RuntimeEnvironment.application.getApplicationContext(),
           new FirebaseOptions.Builder()
-              .setApiKey(context.getResources().getString(R.string.google_api_key))
-              .setApplicationId("sdflhkj")
-              .setDatabaseUrl(IntegrationTestValues.getNamespace())
-              .build());
-    }
-  }
-
-  public static void ensureConstantsInitialized() {
-    if (!appInitialized) {
-      appInitialized = true;
-      android.content.Context context = InstrumentationRegistry.getTargetContext();
-      FirebaseApp.initializeApp(
-          context,
-          new FirebaseOptions.Builder()
-              .setApiKey("jank")
-              .setApplicationId("jank")
-              .setDatabaseUrl(IntegrationTestValues.getNamespace())
+              .setApiKey("apiKey")
+              .setApplicationId("appId")
+              .setDatabaseUrl(TestValues.TEST_NAMESPACE)
               .build());
     }
   }

--- a/firebase-database/src/test/java/com/google/firebase/database/core/RangeMergeTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/RangeMergeTest.java
@@ -14,8 +14,8 @@
 
 package com.google.firebase.database.core;
 
-import static com.google.firebase.database.TestHelpers.fromSingleQuotedString;
-import static com.google.firebase.database.TestHelpers.path;
+import static com.google.firebase.database.UnitTestHelpers.fromSingleQuotedString;
+import static com.google.firebase.database.UnitTestHelpers.path;
 import static com.google.firebase.database.snapshot.NodeUtilities.NodeFromJSON;
 import static org.junit.Assert.assertEquals;
 

--- a/firebase-database/src/test/java/com/google/firebase/database/core/SyncPointTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/SyncPointTest.java
@@ -20,7 +20,7 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.InternalHelpers;
 import com.google.firebase.database.Query;
-import com.google.firebase.database.TestHelpers;
+import com.google.firebase.database.UnitTestHelpers;
 import com.google.firebase.database.annotations.NotNull;
 import com.google.firebase.database.connection.ListenHashProvider;
 import com.google.firebase.database.core.persistence.NoopPersistenceManager;
@@ -412,8 +412,8 @@ public class SyncPointTest {
 
   @SuppressWarnings("unchecked")
   private static void runTest(Map<String, Object> testSpec, String basePath) {
-    DatabaseConfig config = TestHelpers.newTestConfig();
-    TestHelpers.setLogger(config, new DefaultLogger(Logger.Level.DEBUG, null));
+    DatabaseConfig config = UnitTestHelpers.newTestConfig();
+    UnitTestHelpers.setLogger(config, new DefaultLogger(Logger.Level.DEBUG, null));
     LogWrapper logger = config.getLogger("SyncPointTest");
 
     logger.info("Running \"" + testSpec.get("name") + '"');
@@ -519,7 +519,7 @@ public class SyncPointTest {
 
   @After
   public void tearDown() {
-    TestHelpers.failOnFirstUncaughtException();
+    UnitTestHelpers.failOnFirstUncaughtException();
   }
 
   @SuppressWarnings("unchecked")

--- a/firebase-database/src/test/java/com/google/firebase/database/core/persistence/DefaultPersistenceManagerTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/persistence/DefaultPersistenceManagerTest.java
@@ -14,11 +14,11 @@
 
 package com.google.firebase.database.core.persistence;
 
-import static com.google.firebase.database.TestHelpers.childKeySet;
-import static com.google.firebase.database.TestHelpers.defaultQueryAt;
-import static com.google.firebase.database.TestHelpers.fromSingleQuotedString;
-import static com.google.firebase.database.TestHelpers.newFrozenTestConfig;
-import static com.google.firebase.database.TestHelpers.path;
+import static com.google.firebase.database.UnitTestHelpers.childKeySet;
+import static com.google.firebase.database.UnitTestHelpers.defaultQueryAt;
+import static com.google.firebase.database.UnitTestHelpers.fromSingleQuotedString;
+import static com.google.firebase.database.UnitTestHelpers.newFrozenTestConfig;
+import static com.google.firebase.database.UnitTestHelpers.path;
 import static com.google.firebase.database.snapshot.NodeUtilities.NodeFromJSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/firebase-database/src/test/java/com/google/firebase/database/core/persistence/PruneForestTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/persistence/PruneForestTest.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database.core.persistence;
 
-import static com.google.firebase.database.TestHelpers.ck;
+import static com.google.firebase.database.UnitTestHelpers.ck;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/firebase-database/src/test/java/com/google/firebase/database/core/persistence/RandomPersistenceTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/persistence/RandomPersistenceTest.java
@@ -18,7 +18,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 import com.google.firebase.database.DatabaseError;
-import com.google.firebase.database.TestHelpers;
+import com.google.firebase.database.UnitTestHelpers;
 import com.google.firebase.database.annotations.NotNull;
 import com.google.firebase.database.connection.ListenHashProvider;
 import com.google.firebase.database.core.CompoundWrite;
@@ -213,7 +213,7 @@ public class RandomPersistenceTest {
       currentWriteId = 0;
       currentUnackedWriteId = 0;
 
-      DatabaseConfig cfg = TestHelpers.newFrozenTestConfig();
+      DatabaseConfig cfg = UnitTestHelpers.newFrozenTestConfig();
       MockPersistenceStorageEngine storageEngine = new MockPersistenceStorageEngine();
       DefaultPersistenceManager manager =
           new DefaultPersistenceManager(cfg, storageEngine, CachePolicy.NONE);

--- a/firebase-database/src/test/java/com/google/firebase/database/core/persistence/TrackedQueryManagerTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/persistence/TrackedQueryManagerTest.java
@@ -14,10 +14,10 @@
 
 package com.google.firebase.database.core.persistence;
 
-import static com.google.firebase.database.TestHelpers.asSet;
-import static com.google.firebase.database.TestHelpers.ck;
-import static com.google.firebase.database.TestHelpers.defaultQueryAt;
-import static com.google.firebase.database.TestHelpers.path;
+import static com.google.firebase.database.UnitTestHelpers.asSet;
+import static com.google.firebase.database.UnitTestHelpers.ck;
+import static com.google.firebase.database.UnitTestHelpers.defaultQueryAt;
+import static com.google.firebase.database.UnitTestHelpers.path;
 import static com.google.firebase.database.snapshot.NodeUtilities.NodeFromJSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/firebase-database/src/test/java/com/google/firebase/database/core/view/QueryParamsTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/view/QueryParamsTest.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.database.core.view;
 
-import static com.google.firebase.database.TestHelpers.ck;
+import static com.google.firebase.database.UnitTestHelpers.ck;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
While working on the component registration for the RTDB, I got super confused because we have two TestHelper files in the same package. One is used for Unit Tests and one for Integration Tests. They used to be part of the same package, but I split them up when we moved to GitHub.

This PR:
- Renames them to IntegrationTestHelpers and UnitTestHelpers respectivley
- Moves ReadFuture and WriteFuture from testUtil to androidTest, since they require the IntegrationTestHelpers
- Removes some unused methods from the test helpers