### PR TITLE
Bumping Database Collection Min SDK version to 14

### DIFF
--- a/firebase-database-collection/firebase-database-collection.gradle
+++ b/firebase-database-collection/firebase-database-collection.gradle
@@ -17,7 +17,8 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion project.targetSdkVersion
     defaultConfig {
-        minSdkVersion 9
+        targetSdkVersion project.targetSdkVersion
+        minSdkVersion project.minSdkVersion
     }
 }
 


### PR DESCRIPTION
In https://k8s-gubernator.appspot.com/build/android-ci/pr-logs/pull/firebase_firebase-android-sdk/277/connected-check-changed/1106453736609288192/ I see the following:

```
W0315 07:42:03.894] Execution failed for task ':firebase-database-collection:processDebugAndroidTestManifest'.
W0315 07:42:03.894] > Manifest merger failed : uses-sdk:minSdkVersion 9 cannot be smaller than version 14 declared in library [com.google.android.gms:play-services-base:16.0.1] /root/.gradle/caches/transforms-1/files-1.1/play-services-base-16.0.1.aar/23da706606c2023afc003c824e2c583b/AndroidManifest.xml as the library might be using APIs not available in 9
```