### PR TITLE
Add new smoke tests

### DIFF
--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -16,12 +16,13 @@ is a work in progress, and the following list shows what is complete:
 
 Tests on devices usually involve at least two threads: the main thread and the
 testing thread. Either thread should be sufficient for testing, but most users
-will likely invoke Firebase methods from the main thread. As a result, this
-framework provides a simple solution to easily share state between threads. Most
-tests will consist of two methods. Both may be present in the same file for
-simplicity and ease of understanding. One method will be executed by the test
-runner on the testing thread, while the other, is invoked via a lambda on the
-main thread:
+will likely invoke Firebase methods from the main thread. Integration tests
+already verify the use of the testing thread, so it is important to gain
+coverage from the main thread as well. Therefore, this framework provides a
+simple solution to easily share state between threads. Most tests will consist
+of two methods. Both may be present in the same file for simplicity and ease of
+understanding. One method will be executed by the test runner on the testing
+thread, while the other, is invoked via a lambda on the main thread:
 
 ```java
 @Test

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -1,0 +1,81 @@
+# Firebase Smoke Test Suite
+
+This directory contains smoke tests for Firebase on Android. These tests are
+intended to verify the integrations between different components and versions of
+Firebase. The tests should not include additional overhead, such as user
+interfaces. However, the tests should strive to remain similar to real use
+cases. As such, these tests run on devices or emulators (no Robolectric). This
+is a work in progress, and the following list shows what is complete:
+
+- [x] Create first set of tests to replace old test apps.
+- [ ] Reliably run smoke tests on CI.
+- [ ] Support version matrices.
+- [ ] Extend to collect system health metrics.
+
+# Test Synchronization
+
+Tests on devices usually involve at least two threads: the main thread and the
+testing thread. Either thread should be sufficient for testing, but most users
+will likely invoke Firebase methods from the main thread. As a result, this
+framework provides a simple solution to easily share state between threads. Most
+tests will consist of two methods. Both may be present in the same file for
+simplicity and ease of understanding. One method will be executed by the test
+runner on the testing thread, while the other, is invoked via a lambda on the
+main thread:
+
+```java
+@Test
+public void foo() throws Exception {
+  TaskChannel<Foo> channel = new TaskChannel<>();
+  MainThread.run(() -> test_foo(channel));
+
+  Foo foo = channel.waitForSuccess();
+  assertThat(foo)...
+}
+
+private void test_foo(TaskChannel<Foo> channel) {
+  ...
+}
+```
+
+Channels should be used to send results back to the testing thread. The
+`AbstractChannel` class provides the core implementation to send a failure or
+success value back to the test method. Failures are always exceptions, and
+multiple exceptions may be sent per test case. Only one success value may be
+sent. Failures dominate over successful values.
+
+Firebase methods are often difficult to test due to their asynchronous nature.
+This framework provides a few subclasses of `AbstractChannel` to eliminate some
+boilerplate, concentrate the synchronization logic in one place, and shorten the
+tests to focus on the actual Firebase methods under test. The most common
+subclass is `TaskChannel`, and it simplifies chaining and adding listeners to
+Google Play Services tasks. Below is an example (Firebase methods truncated for
+brevity):
+
+```java
+private void test_readAfterSignIn(TaskChannel<Document> channel) {
+  FirebaseAuth auth = FirebaseAuth.getInstance();
+  FirebaseDatabase db = FirebaseDatabase.getInstance();
+
+  channel.trapFailure(auth.signIn()).andThen(a -> {
+    channel.sendOutcome(db.get("path/to/document"));
+  });
+}
+```
+
+Methods like `trapFailure` and `sendOutcome` automatically direct failures from
+tasks to the testing channel. There are also specialized channels for Firestore
+and Database, because they rely on custom listeners. See the source code for
+more details.
+
+# Building the Tests
+
+This Gradle project is split into flavors for each Firebase product. The Android
+plugin adds additional, compound flavors, such as `androidTestDatabase`. All
+test code lives in one of these testing variants. Common infrastructure belongs
+directly in `androidTest`. Do not add any source code to `main` or a non-testing
+variant, such as `firestore`.
+
+As an exception, there is a single activity in the `main` variant. This is used
+to build the APK under test. However, all test logic belongs in the testing
+variants.

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -37,7 +37,6 @@ android {
   defaultConfig {
     minSdkVersion 16
     multiDexEnabled true
-//    applicationId "com.google.firebase.testing.common"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
 
@@ -45,18 +44,14 @@ android {
 
   productFlavors {
     database {
-      //applicationId "com.google.firebase.testing.database"
-//      applicationId "com.google.firebase.testapps.database"
       dimension "systemUnderTest"
     }
 
     firestore {
-//      applicationId "com.google.firebase.testing.firestore"
       dimension "systemUnderTest"
     }
 
     storage {
-//      applicationId "com.google.firebase.testing.storage"
       dimension "systemUnderTest"
     }
   }
@@ -68,6 +63,10 @@ repositories {
 }
 
 dependencies {
+  // Generally, depencies need to be placed under the test variants, such as androidTestDatabase.
+  // However, to ensure we don't have build conflicts and test errors, we also need to put the same
+  // dependencies on the "app" variants.
+
   // Common
   implementation "com.android.support.test:runner:1.0.2"
   implementation "com.google.android.gms:play-services-tasks:16.0.1"

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -1,0 +1,105 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+buildscript {
+  repositories {
+    google()
+    jcenter()
+  }
+
+  dependencies {
+    classpath "com.android.tools.build:gradle:3.3.2"
+    classpath "com.google.gms:google-services:4.1.0"
+  }
+}
+
+apply plugin: "com.android.application"
+
+android {
+  compileSdkVersion 24
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+
+  defaultConfig {
+    minSdkVersion 16
+    multiDexEnabled true
+//    applicationId "com.google.firebase.testing.common"
+    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+  }
+
+  flavorDimensions "systemUnderTest"
+
+  productFlavors {
+    database {
+      //applicationId "com.google.firebase.testing.database"
+//      applicationId "com.google.firebase.testapps.database"
+      dimension "systemUnderTest"
+    }
+
+    firestore {
+//      applicationId "com.google.firebase.testing.firestore"
+      dimension "systemUnderTest"
+    }
+
+    storage {
+//      applicationId "com.google.firebase.testing.storage"
+      dimension "systemUnderTest"
+    }
+  }
+}
+
+repositories {
+  google()
+  jcenter()
+}
+
+dependencies {
+  // Common
+  implementation "com.android.support.test:runner:1.0.2"
+  implementation "com.google.android.gms:play-services-tasks:16.0.1"
+  implementation "com.google.firebase:firebase-core:16.0.7"
+  implementation "com.google.truth:truth:0.43"
+
+  androidTestImplementation "com.android.support.test:runner:1.0.2"
+  androidTestImplementation "com.google.android.gms:play-services-tasks:16.0.1"
+  androidTestImplementation "com.google.firebase:firebase-core:16.0.7"
+  androidTestImplementation "com.google.truth:truth:0.43"
+  androidTestImplementation "junit:junit:4.12"
+
+  // Database
+  databaseImplementation "com.google.firebase:firebase-auth:16.1.0"
+  databaseImplementation "com.google.firebase:firebase-database:16.1.0"
+
+  androidTestDatabaseImplementation "com.google.firebase:firebase-auth:16.1.0"
+  androidTestDatabaseImplementation "com.google.firebase:firebase-database:16.1.0"
+
+  // Firestore
+  firestoreImplementation "com.google.firebase:firebase-auth:16.1.0"
+  firestoreImplementation "com.google.firebase:firebase-firestore:18.1.0"
+
+  androidTestFirestoreImplementation "com.google.firebase:firebase-auth:16.1.0"
+  androidTestFirestoreImplementation "com.google.firebase:firebase-firestore:18.1.0"
+
+  // Storage
+  storageImplementation "com.google.firebase:firebase-auth:16.1.0"
+  storageImplementation "com.google.firebase:firebase-storage:16.1.0"
+
+  androidTestStorageImplementation "com.google.firebase:firebase-auth:16.1.0"
+  androidTestStorageImplementation "com.google.firebase:firebase-storage:16.1.0"
+}
+
+apply plugin: "com.google.gms.google-services"

--- a/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/AbstractChannel.java
+++ b/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/AbstractChannel.java
@@ -1,0 +1,114 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.common;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * An abstract channel for sending test results across threads.
+ *
+ * <p>This enables test code to run on the main thread and signal the test thread when to stop
+ * blocking. Tests may send multiple errors that will then be thrown on the test thread. However, a
+ * test may only send success once. After this is done, nothing else can be sent.
+ */
+public abstract class AbstractChannel<T> {
+
+  private final CountDownLatch latch = new CountDownLatch(1);
+  private final ReentrantLock lock = new ReentrantLock();
+
+  private Exception error = null;
+  private T value = null;
+
+  /**
+   * Sends a failure back to the testing thread.
+   *
+   * <p>This method will always send an exception to the testing thread. If an exception has already
+   * been sent, this method will chain the new exception to the previous. If a successful value has
+   * already been sent, this method will override it with the failure. Note, it is recommended to
+   * send only one value through the channel. This method is safe to invoke from any thread.
+   */
+  protected void fail(Exception err) {
+    // This is explicitly synchronized in case multiple threads are trying to send values.
+    try {
+      lock.lock();
+
+      if (error == null) {
+        error = err;
+      } else {
+        error.addSuppressed(err);
+      }
+
+      latch.countDown();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Sends a successful value back to the testing thread.
+   *
+   * <p>This method will only send the value if no value has been sent. It is an error to invoke
+   * this method multiple times or after invoking {@link #fail}. This method is safe to invoke from
+   * any thread.
+   */
+  protected void succeed(T val) {
+    // This is explicitly synchronized in case multiple threads are trying to send values.
+    try {
+      lock.lock();
+
+      if (latch.getCount() == 0) {
+        // Only a single, successful value is supported. This throws the exception on both the
+        // testing thread and the main thread.
+        IllegalStateException error = new IllegalStateException("Result already completed");
+        fail(error);
+        throw error;
+      }
+
+      value = val;
+      latch.countDown();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Waits 30 seconds to receive the successful value. */
+  public T waitForSuccess() throws InterruptedException {
+    return waitForSuccess(30, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Waits for up to the request time for the sending thread to send a successful value.
+   *
+   * <p>If the sender does not send success within the specified time, this method throws an {@link
+   * AssertionError} and chains any received errors to it. This method is safe to invoke from any
+   * thread.
+   */
+  public T waitForSuccess(long duration, TimeUnit unit) throws InterruptedException {
+    boolean completed = latch.await(duration, unit);
+
+    if (!completed) {
+      String message = String.format("Test did not complete within %s %s", duration, unit);
+      throw new AssertionError(message, error);
+    }
+
+    if (error != null) {
+      throw new AssertionError("Test completed with errors", error);
+    }
+
+    return value;
+  }
+}

--- a/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/MainThread.java
+++ b/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/MainThread.java
@@ -1,0 +1,39 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.common;
+
+import android.os.Handler;
+import android.os.Looper;
+
+/**
+ * Convenience class for interacting with Android.
+ *
+ * <p>For now, this only consists of the {@link #run} method.
+ */
+public final class MainThread {
+
+  private static Handler handler = null;
+
+  private MainThread() {}
+
+  /** Runs the {@link Runnable} on the main thread. */
+  public static void run(Runnable r) throws InterruptedException {
+    if (handler == null) {
+      handler = new Handler(Looper.getMainLooper());
+    }
+
+    handler.post(r);
+  }
+}

--- a/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/Target.java
+++ b/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/Target.java
@@ -14,26 +14,13 @@
 
 package com.google.firebase.testing.common;
 
-import android.os.Handler;
-import android.os.Looper;
-
 /**
- * Convenience class for interacting with Android.
+ * A test target.
  *
- * <p>For now, this only consists of the {@link #run} method.
+ * <p>This interface is similar to {@link Runnable}, but this interface's {@link #run} method takes
+ * an instance of {@link T} as input. This is intended to be a channel.
  */
-public final class MainThread {
+public interface Target<T> {
 
-  private static Handler handler = null;
-
-  private MainThread() {}
-
-  /** Runs the {@link Runnable} on the main thread. */
-  public static void run(Runnable r) {
-    if (handler == null) {
-      handler = new Handler(Looper.getMainLooper());
-    }
-
-    handler.post(r);
-  }
+  void run(T channel);
 }

--- a/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/TaskChannel.java
+++ b/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/TaskChannel.java
@@ -25,6 +25,11 @@ import com.google.android.gms.tasks.Task;
  */
 public class TaskChannel<T> extends AbstractChannel<T> {
 
+  /** Runs the test on the main thread and returns the corresponding channel. */
+  public static <U> TaskChannel<U> runWithTaskChannel(Target<TaskChannel<U>> test) {
+    return AbstractChannel.runTarget(test, new TaskChannel<>());
+  }
+
   /**
    * Sends the outcome of a task over the channel.
    *

--- a/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/TaskChannel.java
+++ b/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/TaskChannel.java
@@ -1,0 +1,105 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.common;
+
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+
+/**
+ * A channel for sending test results across threads.
+ *
+ * <p>This channel adds specializations for {@link Task}. The methods in this class are intended to
+ * be executed from the main thread, but they are safe to execute from any thread.
+ */
+public class TaskChannel<T> extends AbstractChannel<T> {
+
+  /**
+   * Sends the outcome of a task over the channel.
+   *
+   * <p>This is a terminal operation. As long as the task completes, some value will be sent over
+   * the channel. As such, the task must produce an instance of {@code T} on success. This value or
+   * the exception will be sent to the testing thread.
+   *
+   * <p>Invoking this method multiple times in a single test case is usually an error (unless there
+   * are multiple channels).
+   */
+  public void sendOutcome(Task<? extends T> task) {
+    task.addOnCompleteListener(
+        t -> {
+          if (t.isSuccessful()) {
+            succeed(t.getResult());
+          } else {
+            fail(t.getException());
+          }
+        });
+  }
+
+  /**
+   * Returns a fluent API for trapping task failures.
+   *
+   * <p>Asynchronous tasks may fail, and tests may need to execute multiple asynchronous tasks in
+   * series to produce a result. This API automatically captures any failures and sends them to the
+   * testing thread.
+   *
+   * <p>Note, this method does nothing itself. You must invoke a method on the returned {@link
+   * FailureTrap} to do anything meaningful.
+   */
+  public <R> FailureTrap<R> trapFailure(Task<R> task) {
+    return new FailureTrap<>(task);
+  }
+
+  /** A fluent API for trapping task failures. */
+  public final class FailureTrap<R> {
+    private final Task<R> task;
+
+    FailureTrap(Task<R> task) {
+      this.task = task;
+    }
+
+    /**
+     * Traps the task's failure or ignores its result.
+     *
+     * <p>This method ignores any successful result from the task. Generally, this is useful only if
+     * no other logic needs to be executed in series. If the task fails, the exception will be
+     * trapped and sent to the testing thread.
+     */
+    public void andIgnoreResult() {
+      task.addOnFailureListener(error -> fail(error));
+    }
+
+    /**
+     * Traps the task's failure or passes the successful result to a listener.
+     *
+     * <p>If the task succeeds, this method will pass the result to the supplied listener.
+     * Otherwise, the exception will be trapped and sent to the testing thread. The listener is
+     * usually supplied as a lambda. Any exceptions raised by the listener will be caught and sent
+     * to the testing thread.
+     */
+    public void andThen(OnSuccessListener<? super R> listener) {
+      task.addOnCompleteListener(
+          t -> {
+            if (t.isSuccessful()) {
+              try {
+                listener.onSuccess(t.getResult());
+              } catch (RuntimeException ex) {
+                fail(ex);
+              }
+            } else {
+              fail(t.getException());
+            }
+          });
+    }
+  }
+}

--- a/smoke-tests/src/androidTestDatabase/java/com/google/firebase/testing/database/DatabaseChannel.java
+++ b/smoke-tests/src/androidTestDatabase/java/com/google/firebase/testing/database/DatabaseChannel.java
@@ -1,0 +1,53 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.database;
+
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.Query;
+import com.google.firebase.database.ValueEventListener;
+import com.google.firebase.testing.common.TaskChannel;
+
+/**
+ * A specialized channel for sending listen results to the testing thread.
+ *
+ * <p>This channel adds specializations for database. The methods in this class are intended to be
+ * executed from the main thread, but they are safe to execute from any thread. This class extends
+ * {@link TaskChannel}, so it can also used with any of the task-producing methods of database.
+ */
+public class DatabaseChannel extends TaskChannel<DataSnapshot> {
+
+  /**
+   * Adds a listener to the query that sends the results back to the testing thread.
+   *
+   * <p>The listener is only active for a single event. This method performs no mutations, so it
+   * should most likely be followed by asequence of the form: {@code
+   * channel.trapFailure(mutation).andIgnoreResult()}.
+   */
+  public void sendNextValueEvent(Query query) {
+    query.addListenerForSingleValueEvent(
+        new ValueEventListener() {
+          @Override
+          public void onCancelled(DatabaseError error) {
+            fail(error.toException());
+          }
+
+          @Override
+          public void onDataChange(DataSnapshot snapshot) {
+            succeed(snapshot);
+          }
+        });
+  }
+}

--- a/smoke-tests/src/androidTestDatabase/java/com/google/firebase/testing/database/DatabaseChannel.java
+++ b/smoke-tests/src/androidTestDatabase/java/com/google/firebase/testing/database/DatabaseChannel.java
@@ -18,6 +18,8 @@ import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.Query;
 import com.google.firebase.database.ValueEventListener;
+import com.google.firebase.testing.common.AbstractChannel;
+import com.google.firebase.testing.common.Target;
 import com.google.firebase.testing.common.TaskChannel;
 
 /**
@@ -28,6 +30,11 @@ import com.google.firebase.testing.common.TaskChannel;
  * {@link TaskChannel}, so it can also used with any of the task-producing methods of database.
  */
 public class DatabaseChannel extends TaskChannel<DataSnapshot> {
+
+  /** Runs the test on the main thread and returns the corresponding channel. */
+  public static DatabaseChannel runWithDatabaseChannel(Target<DatabaseChannel> test) {
+    return AbstractChannel.runTarget(test, new DatabaseChannel());
+  }
 
   /**
    * Adds a listener to the query that sends the results back to the testing thread.

--- a/smoke-tests/src/androidTestDatabase/java/com/google/firebase/testing/database/DatabaseTest.java
+++ b/smoke-tests/src/androidTestDatabase/java/com/google/firebase/testing/database/DatabaseTest.java
@@ -1,0 +1,59 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.support.test.runner.AndroidJUnit4;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.testing.common.MainThread;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public final class DatabaseTest {
+
+  @Test
+  public void listenForUpdate() throws Exception {
+    DatabaseChannel channel = new DatabaseChannel();
+
+    MainThread.run(() -> test_ListenForUpdate(channel));
+
+    DataSnapshot snapshot = channel.waitForSuccess();
+    assertThat(snapshot.child("location").getValue()).isEqualTo("Google SVL");
+  }
+
+  private void test_ListenForUpdate(DatabaseChannel channel) {
+    FirebaseAuth auth = FirebaseAuth.getInstance();
+    FirebaseDatabase database = FirebaseDatabase.getInstance();
+    database.setPersistenceEnabled(false);
+
+    auth.signOut();
+
+    channel
+        .trapFailure(auth.signInWithEmailAndPassword("test@mailinator.com", "password"))
+        .andThen(
+            authResult -> {
+              DatabaseReference baadal = database.getReference("restaurants").child("Baadal");
+              channel.sendNextValueEvent(baadal);
+              channel
+                  .trapFailure(baadal.child("location").setValue("Google SVL"))
+                  .andIgnoreResult();
+            });
+  }
+}

--- a/smoke-tests/src/androidTestDatabase/java/com/google/firebase/testing/database/DatabaseTest.java
+++ b/smoke-tests/src/androidTestDatabase/java/com/google/firebase/testing/database/DatabaseTest.java
@@ -21,7 +21,6 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
-import com.google.firebase.testing.common.MainThread;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -30,9 +29,7 @@ public final class DatabaseTest {
 
   @Test
   public void listenForUpdate() throws Exception {
-    DatabaseChannel channel = new DatabaseChannel();
-
-    MainThread.run(() -> test_ListenForUpdate(channel));
+    DatabaseChannel channel = DatabaseChannel.runWithDatabaseChannel(c -> test_ListenForUpdate(c));
 
     DataSnapshot snapshot = channel.waitForSuccess();
     assertThat(snapshot.child("location").getValue()).isEqualTo("Google SVL");

--- a/smoke-tests/src/androidTestFirestore/java/com/google/firebase/testing/firestore/FirestoreChannel.java
+++ b/smoke-tests/src/androidTestFirestore/java/com/google/firebase/testing/firestore/FirestoreChannel.java
@@ -1,0 +1,49 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.firestore;
+
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.testing.common.TaskChannel;
+
+/**
+ * A specialized channel for sending listen results to the testing thread.
+ *
+ * <p>This channel adds specializations for Firestore. The methods in this class are intended to be
+ * executed from the main thread, but they are safe to execute from any thread. This class extends
+ * {@link TaskChannel}, so it can also used with any of the task-producing methods of Firestore.
+ */
+public final class FirestoreChannel extends TaskChannel<DocumentSnapshot> {
+
+  /**
+   * Adds a listener to the document that sends the results back to the testing thread.
+   *
+   * <p>The listener is only active for a single snapshot. This method performs no mutations, so it
+   * should most likely be followed by a sequence of the form: {@code
+   * channel.trapFailure(mutation).andIgnoreResult()}.
+   */
+  public void sendNextSnapshot(DocumentReference document) {
+    document.addSnapshotListener(
+        (snapshot, error) -> {
+          if (error != null) {
+            fail(error);
+          } else {
+            if (snapshot.exists()) {
+              succeed(snapshot);
+            }
+          }
+        });
+  }
+}

--- a/smoke-tests/src/androidTestFirestore/java/com/google/firebase/testing/firestore/FirestoreChannel.java
+++ b/smoke-tests/src/androidTestFirestore/java/com/google/firebase/testing/firestore/FirestoreChannel.java
@@ -16,6 +16,8 @@ package com.google.firebase.testing.firestore;
 
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.testing.common.AbstractChannel;
+import com.google.firebase.testing.common.Target;
 import com.google.firebase.testing.common.TaskChannel;
 
 /**
@@ -26,6 +28,11 @@ import com.google.firebase.testing.common.TaskChannel;
  * {@link TaskChannel}, so it can also used with any of the task-producing methods of Firestore.
  */
 public final class FirestoreChannel extends TaskChannel<DocumentSnapshot> {
+
+  /** Runs the test on the main thread and returns the corresponding channel. */
+  public static FirestoreChannel runWithFirestoreChannel(Target<FirestoreChannel> test) {
+    return AbstractChannel.runTarget(test, new FirestoreChannel());
+  }
 
   /**
    * Adds a listener to the document that sends the results back to the testing thread.

--- a/smoke-tests/src/androidTestFirestore/java/com/google/firebase/testing/firestore/FirestoreTest.java
+++ b/smoke-tests/src/androidTestFirestore/java/com/google/firebase/testing/firestore/FirestoreTest.java
@@ -22,7 +22,6 @@ import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;
-import com.google.firebase.testing.common.MainThread;
 import java.util.HashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,9 +31,8 @@ public final class FirestoreTest {
 
   @Test
   public void listenForUpdate() throws Exception {
-    FirestoreChannel channel = new FirestoreChannel();
-
-    MainThread.run(() -> test_ListenForUpdate(channel));
+    FirestoreChannel channel =
+        FirestoreChannel.runWithFirestoreChannel(c -> test_ListenForUpdate(c));
 
     DocumentSnapshot snapshot = channel.waitForSuccess();
     assertThat(snapshot.getString("location")).isEqualTo("Google SVL");

--- a/smoke-tests/src/androidTestFirestore/java/com/google/firebase/testing/firestore/FirestoreTest.java
+++ b/smoke-tests/src/androidTestFirestore/java/com/google/firebase/testing/firestore/FirestoreTest.java
@@ -1,0 +1,63 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.firestore;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.support.test.runner.AndroidJUnit4;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreSettings;
+import com.google.firebase.testing.common.MainThread;
+import java.util.HashMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public final class FirestoreTest {
+
+  @Test
+  public void listenForUpdate() throws Exception {
+    FirestoreChannel channel = new FirestoreChannel();
+
+    MainThread.run(() -> test_ListenForUpdate(channel));
+
+    DocumentSnapshot snapshot = channel.waitForSuccess();
+    assertThat(snapshot.getString("location")).isEqualTo("Google SVL");
+  }
+
+  private void test_ListenForUpdate(FirestoreChannel channel) {
+    FirebaseAuth auth = FirebaseAuth.getInstance();
+    FirebaseFirestore firestore = FirebaseFirestore.getInstance();
+    FirebaseFirestoreSettings.Builder settings = new FirebaseFirestoreSettings.Builder();
+    firestore.setFirestoreSettings(settings.setPersistenceEnabled(false).build());
+
+    auth.signOut();
+
+    channel
+        .trapFailure(auth.signInWithEmailAndPassword("test@mailinator.com", "password"))
+        .andThen(
+            authResult -> {
+              DocumentReference baadal = firestore.collection("restaurants").document("Baadal");
+              channel.sendNextSnapshot(baadal);
+
+              HashMap<String, Object> map = new HashMap<>();
+              map.put("location", "Google SVL");
+              channel.trapFailure(baadal.set(map)).andIgnoreResult();
+            });
+  }
+}

--- a/smoke-tests/src/androidTestStorage/java/com/google/firebase/testing/storage/StorageTest.java
+++ b/smoke-tests/src/androidTestStorage/java/com/google/firebase/testing/storage/StorageTest.java
@@ -22,7 +22,6 @@ import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
-import com.google.firebase.testing.common.MainThread;
 import com.google.firebase.testing.common.TaskChannel;
 import java.nio.charset.StandardCharsets;
 import org.junit.Test;
@@ -33,9 +32,7 @@ public final class StorageTest {
 
   @Test
   public void getSet() throws Exception {
-    TaskChannel<byte[]> channel = new TaskChannel<>();
-
-    MainThread.run(() -> test_GetSet(channel));
+    TaskChannel channel = TaskChannel.runWithTaskChannel(c -> test_GetSet(c));
 
     byte[] bytes = channel.waitForSuccess();
     String text = new String(bytes, StandardCharsets.UTF_8);

--- a/smoke-tests/src/androidTestStorage/java/com/google/firebase/testing/storage/StorageTest.java
+++ b/smoke-tests/src/androidTestStorage/java/com/google/firebase/testing/storage/StorageTest.java
@@ -1,0 +1,67 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.support.test.runner.AndroidJUnit4;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+import com.google.firebase.testing.common.MainThread;
+import com.google.firebase.testing.common.TaskChannel;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public final class StorageTest {
+
+  @Test
+  public void getSet() throws Exception {
+    TaskChannel<byte[]> channel = new TaskChannel<>();
+
+    MainThread.run(() -> test_GetSet(channel));
+
+    byte[] bytes = channel.waitForSuccess();
+    String text = new String(bytes, StandardCharsets.UTF_8);
+    assertThat(text).isEqualTo("Google MTV");
+  }
+
+  private void test_GetSet(TaskChannel<byte[]> channel) {
+    FirebaseAuth auth = FirebaseAuth.getInstance();
+    FirebaseStorage storage = FirebaseStorage.getInstance();
+
+    auth.signOut();
+
+    Task<AuthResult> signIn = auth.signInWithEmailAndPassword("test@mailinator.com", "password");
+    channel
+        .trapFailure(signIn)
+        .andThen(
+            authResult -> {
+              StorageReference baadal = storage.getReference("restaurants/Baadal");
+              byte[] data = "Google MTV".getBytes(StandardCharsets.UTF_8);
+
+              channel
+                  .trapFailure(baadal.putBytes(data))
+                  .andThen(
+                      v -> {
+                        channel.sendOutcome(baadal.getBytes(1024));
+                      });
+            });
+  }
+}

--- a/smoke-tests/src/main/AndroidManifest.xml
+++ b/smoke-tests/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.google.firebase.testing">
+
+  <uses-permission android:name="android.permission.INTERNET" />
+
+  <application>
+    <activity android:name="com.google.firebase.testing.common.TestActivity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/smoke-tests/src/main/java/com/google/firebase/testing/common/TestActivity.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/common/TestActivity.java
@@ -1,0 +1,6 @@
+package com.google.firebase.testing.common;
+
+import android.app.Activity;
+
+/** */
+public final class TestActivity extends Activity {}

--- a/smoke-tests/src/main/java/com/google/firebase/testing/common/TestActivity.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/common/TestActivity.java
@@ -1,6 +1,20 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.testing.common;
 
 import android.app.Activity;
 
-/** */
+/** A simple activity for testing purposes. */
 public final class TestActivity extends Activity {}


### PR DESCRIPTION
This pull request adds the first batch of new tests. These tests replace the test apps for Database, Firestore, and Storage. 

The README briefly outlines how these tests are intended to function. A few more tests will be added in the next few weeks.

These tests currently only support previously released versions of Firebase. This will change when we add our artifact repository.