### PR TITLE
Disable "debug" buildType in all android subprojects.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/ContinuousIntegrationPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/ContinuousIntegrationPlugin.groovy
@@ -45,21 +45,21 @@ class ContinuousIntegrationPlugin implements Plugin<Project> {
             def deviceCheckDependents = it.task('deviceCheckDependents')
 
             configurations.all {
-                if (it.name == 'debugUnitTestRuntimeClasspath') {
+                if (it.name == 'releaseUnitTestRuntimeClasspath') {
                     checkDependents.dependsOn(configurations
-                            .debugUnitTestRuntimeClasspath.getTaskDependencyFromProjectDependency(
+                            .releaseUnitTestRuntimeClasspath.getTaskDependencyFromProjectDependency(
                             false, "checkDependents"))
                     checkDependents.dependsOn 'check'
                 }
 
-                if (it.name == 'debugAndroidTestRuntimeClasspath') {
+                if (it.name == 'releaseAndroidTestRuntimeClasspath') {
                     connectedCheckDependents.dependsOn(configurations
-                            .debugAndroidTestRuntimeClasspath.getTaskDependencyFromProjectDependency(
+                            .releaseAndroidTestRuntimeClasspath.getTaskDependencyFromProjectDependency(
                             false, "connectedCheckDependents"))
                     connectedCheckDependents.dependsOn 'connectedCheck'
 
                     deviceCheckDependents.dependsOn(configurations
-                            .debugAndroidTestRuntimeClasspath.getTaskDependencyFromProjectDependency(
+                            .releaseAndroidTestRuntimeClasspath.getTaskDependencyFromProjectDependency(
                             false, "deviceCheckDependents"))
                     deviceCheckDependents.dependsOn 'deviceCheck'
                 }
@@ -82,8 +82,8 @@ class ContinuousIntegrationPlugin implements Plugin<Project> {
                 // getTaskDependencyFromProjectDependency works.
                 if (!isAndroidProject(it)) {
                     configurations {
-                        debugUnitTestRuntimeClasspath
-                        debugAndroidTestRuntimeClasspath
+                        releaseUnitTestRuntimeClasspath
+                        releaseAndroidTestRuntimeClasspath
                         annotationProcessor
                     }
                     // noop task to avoid having to handle the edge-case of tasks not being

--- a/firebase-functions/firebase-functions.gradle
+++ b/firebase-functions/firebase-functions.gradle
@@ -84,7 +84,7 @@ task stopFunctionsEmulator(type: Exec) {
 // This is neccesary because the connectedAndroidTest task doesn't exist yet. It is added later
 // by the android plugin.
 tasks.all { Task t ->
-    if (t.name == 'connectedAndroidTest' || t.name == 'connectedDebugAndroidTest') {
+    if (t.name == 'connectedAndroidTest' || t.name == 'connectedReleaseAndroidTest') {
         t.dependsOn(startFunctionsEmulator)
         t.finalizedBy(stopFunctionsEmulator)
     }

--- a/gradle/googleServices.gradle
+++ b/gradle/googleServices.gradle
@@ -32,8 +32,8 @@ task copyRootGoogleServices(type: Copy) {
 // Before the google-services plugin tries to process the JSON file, attempt
 // to copy it from the root project.
 afterEvaluate {
-    if (tasks.findByName("processDebugGoogleServices")) {
-        processDebugGoogleServices.dependsOn 'copyRootGoogleServices'
+    if (tasks.findByName("processReleaseGoogleServices")) {
+        processReleaseGoogleServices.dependsOn 'copyRootGoogleServices'
     }
 }
 

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -135,6 +135,35 @@ configure(subprojects) {
 }
 
 /**
+ * Disable "debug" build type for all subprojects.
+ *
+ * They are identical to "release" and are not used in either release or smoke tests. Disabling them
+ * to reduce the number of tests we run on pre/post-submit.
+ */
+configure(subprojects) {
+    afterEvaluate { Project sub ->
+        if (!sub.plugins.hasPlugin('com.android.library') && !sub.plugins.hasPlugin('com.android.application')) {
+            return
+        }
+
+        sub.android {
+            testBuildType "release"
+            variantFilter { variant ->
+                def buildTypeName = variant.buildType*.name
+                if (buildTypeName.contains('debug')) {
+                    setIgnore(true)
+                }
+            }
+            buildTypes {
+                // In the case of and android library signing config only affects instrumentation test APK.
+                // We need it signed with default debug credentials in order for FTL to accept the APK.
+                release.signingConfig = debug.signingConfig
+            }
+        }
+    }
+}
+
+/**
  * Configure "Preguarding" and Desugaring for the subprojects.
  *
  * <p>Desugaring is enabled with the 'me.tatarka:gradle-retrolambda' plugin as the built-in Android


### PR DESCRIPTION
They are identical to "release" and not used by either our release or
smoke tests tooling.