### PR TITLE
WIP: Calculate coverage measurements and upload to database.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/GenerateCoveragePercentsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/GenerateCoveragePercentsTask.groovy
@@ -39,6 +39,8 @@ public class GenerateCoveragePercentsTask extends DefaultTask {
 
     @TaskAction
     def generate() {
+        // We would not have a pull request number unless running on Prow.
+        // Using 777 as a place holder when running locally for purpose such as debugging.
         def pullRequestNumber = project.properties["pull_request"] ?: 777
         generateJson(pullRequestNumber, packages)
     }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/GenerateCoveragePercentsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/GenerateCoveragePercentsTask.groovy
@@ -1,0 +1,109 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.google.firebase.gradle.plugins.measurement
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+
+public class GenerateCoveragePercentsTask extends DefaultTask {
+
+    @OutputFile
+    File reportFile
+
+    @Input
+    List<String> packages
+
+    XmlSlurper parser
+
+    GenerateCoveragePercentsTask() {
+        parser = new XmlSlurper()
+        parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+        parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+    }
+
+    @TaskAction
+    def generate() {
+        def pullRequestNumber = project.properties["pull_request"] ?: 777
+        generateJson(pullRequestNumber, packages)
+    }
+
+    private def getCoveragePercentFromReport(path) {
+        println "Parsing coverage file: $path"
+        def report = parser.parse(path)
+        def name = report.@name
+
+        def lineCoverage = report.counter.find {it.@type == 'LINE'}
+        def covered = Double.parseDouble(lineCoverage.@covered.text())
+        def missed = Double.parseDouble(lineCoverage.@missed.text())
+        def percent = covered / (covered + missed)
+
+        return new Tuple(name, percent)
+    }
+
+
+    private def generateJson(pullRequestNumber, packages) {
+        def coverages = [:]
+
+        // TODO(yifany@): Consolidate mappings with apksize and iOS.
+        def sdkMap = [
+                'firebase-common':1,
+                'firebase-database':2,
+                'firebase-database-collection':3,
+                'firebase-firestore':4,
+                'firebase-functions':5,
+                'firebase-inappmessaging-display':6,
+                'firebase-storage':7
+        ]
+
+        for (String p: packages) {
+            def path = p + '/build/reports/jacoco/checkCoverage/checkCoverage.xml'
+            def (name, percent) = getCoveragePercentFromReport(path)
+            coverages[sdkMap[name]] = percent
+        }
+
+        def replacements = coverages.collect {
+            "[$pullRequestNumber, $it.key, $it.value]"
+        }.join(", ")
+
+        // TODO(yifany@): Better way of formatting json. No hard code names.
+        def json = """
+            {
+                tables: [
+                    {
+                        table_name: "PullRequests",
+                        column_names: ["pull_request_id"],
+                        replace_measurements: [[$pullRequestNumber]],
+                    },
+                    {
+                        table_name: "Coverage2",
+                        column_names: ["pull_request_id", "sdk_id", "coverage_percent"],
+                        replace_measurements: [$replacements],
+                    },
+                ],
+            }
+        """
+
+        println(json)
+
+        reportFile.withWriter {
+            it.write(json)
+        }
+    }
+
+}

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -101,12 +101,13 @@ configure(subprojects) {
         toolVersion = '0.8.3'
     }
     task(['type': JacocoReport, 'dependsOn': 'check', 'group': 'Coverage',
-          'description': 'Generates JaCoCo unit test coverage reports.'], 'checkCoverage') {
+          'description': 'Generates JaCoCo unit test coverage reports.'], checkCoverage) {
         def excludes = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**Manifest*.*']
         classDirectories = files([
-            fileTree(dir: "$buildDir/intermediates/javac/debug", excludes: excludes)
+            fileTree(dir: "$buildDir/intermediates/javac/debug", excludes: excludes),
+            fileTree(dir: "$buildDir/tmp/kotlin-classes/debug", excludes: excludes)
         ])
-        sourceDirectories = files(['src/main/java'])
+        sourceDirectories = files(['src/main/java', 'src/main/kotlin'])
         executionData = fileTree(dir: "$buildDir", includes: ['jacoco/*.exec'])
         reports {
             html.enabled true

--- a/tools/apksize/apksize.gradle
+++ b/tools/apksize/apksize.gradle
@@ -53,23 +53,7 @@ task uploadMeasurements(type: UploadMeasurementsTask) {
 
 // TODO(yifany@): Move below 2 tasks out of apksize.gradle.
 task generateCoverageMeasurements(type: GenerateCoveragePercentsTask, group: 'Coverage') {
-
-    // TODO(yifany@): Find a more concise way to express dependencies.
-    dependsOn ':firebase-common:checkCoverage'
-    dependsOn ':firebase-database:checkCoverage'
-    dependsOn ':firebase-database-collection:checkCoverage'
-    dependsOn ':firebase-firestore:checkCoverage'
-    dependsOn ':firebase-functions:checkCoverage'
-    dependsOn ':firebase-inappmessaging-display:checkCoverage'
-    dependsOn ':firebase-storage:checkCoverage'
-
-    packages = ["firebase-common",
-                "firebase-database",
-                "firebase-database-collection",
-                "firebase-firestore",
-                "firebase-functions",
-                "firebase-inappmessaging-display",
-                "firebase-storage"]
+    dependsOn rootProject.allprojects.collect { it.tasks.withType(JacocoReport) }.flatten()
 
     reportFile = file("$buildDir/coverage-report.json")
 }

--- a/tools/apksize/apksize.gradle
+++ b/tools/apksize/apksize.gradle
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import com.google.firebase.gradle.plugins.measurement.GenerateCoveragePercentsTask
 import com.google.firebase.gradle.plugins.measurement.GenerateMeasurementsTask
 import com.google.firebase.gradle.plugins.measurement.UploadMeasurementsTask
 
@@ -47,6 +48,35 @@ task uploadMeasurements(type: UploadMeasurementsTask) {
     dependsOn generateMeasurements
 
     reportFile = file("$buildDir/size-report.json")
+    uploader = "https://storage.googleapis.com/firebase-engprod-metrics/upload_tool.jar"
+}
+
+task generateCoverageMeasurements(type: GenerateCoveragePercentsTask, group: 'Coverage') {
+
+    // TODO(yifany@): Way too cumbersome.
+    dependsOn ':firebase-common:checkCoverage'
+    dependsOn ':firebase-database:checkCoverage'
+    dependsOn ':firebase-database-collection:checkCoverage'
+    dependsOn ':firebase-firestore:checkCoverage'
+    dependsOn ':firebase-functions:checkCoverage'
+    dependsOn ':firebase-inappmessaging-display:checkCoverage'
+    dependsOn ':firebase-storage:checkCoverage'
+
+    packages = ["firebase-common",
+                "firebase-database",
+                "firebase-database-collection",
+                "firebase-firestore",
+                "firebase-functions",
+                "firebase-inappmessaging-display",
+                "firebase-storage"]
+
+    reportFile = file("$buildDir/coverage-report.json")
+}
+
+task uploadCoverageMeasurements(type: UploadMeasurementsTask, group: 'Coverage') {
+    dependsOn generateCoverageMeasurements
+
+    reportFile = file("$buildDir/coverage-report.json")
     uploader = "https://storage.googleapis.com/firebase-engprod-metrics/upload_tool.jar"
 }
 

--- a/tools/apksize/apksize.gradle
+++ b/tools/apksize/apksize.gradle
@@ -51,9 +51,10 @@ task uploadMeasurements(type: UploadMeasurementsTask) {
     uploader = "https://storage.googleapis.com/firebase-engprod-metrics/upload_tool.jar"
 }
 
+// TODO(yifany@): Move below 2 tasks out of apksize.gradle.
 task generateCoverageMeasurements(type: GenerateCoveragePercentsTask, group: 'Coverage') {
 
-    // TODO(yifany@): Way too cumbersome.
+    // TODO(yifany@): Find a more concise way to express dependencies.
     dependsOn ':firebase-common:checkCoverage'
     dependsOn ':firebase-database:checkCoverage'
     dependsOn ':firebase-database-collection:checkCoverage'


### PR DESCRIPTION
Parse xml coverage reports. Extracts numbers and uploads to database.

Tested locally with below command:
```
./gradlew uploadCoverageMeasurements -Pdatabase_config=<path-to-database-config-file>
```

Note:
- Requires a new entry in Prow config to be enabled on CI.
- Needs some refactoring once we have a better idea on how to consolidate measurement collecting and uploading for different products on different platforms.