### PR TITLE
Restructure docs for KTX

### DIFF
--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -4,13 +4,22 @@
     "platforms": [
         "Android"
     ],
-    "content": "README.md",
-    "pages": [
-        "firebase-common/README.md",
-        "firebase-firestore/README.md",
-        "protolite-well-known-types/README.md"
-    ],
+    "content": "docs/README.md",
+    "pages": {
+        "README.md": "Development Guide",
+        "docs/ktx/firestore.md": "Firestore KTX"
+    },
     "related": [
         "firebase/quickstart-android"
+    ],
+    "tabs": [
+        {
+            "title": "Main Reference",
+            "href": "https://firebase.google.com/docs/reference/android/"
+        },
+        {
+            "title": "KTX Reference",
+            "href": "https://firebase.github.io/firebase-android-sdk/reference/kotlin/firebase-ktx/"
+        }
     ]
 }

--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -7,6 +7,7 @@
     "content": "docs/README.md",
     "pages": {
         "README.md": "Development Guide",
+        "docs/ktx/common.md": "Common KTX",
         "docs/ktx/firestore.md": "Firestore KTX"
     },
     "related": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Firebase Android SDK
+
+The Firebase SDK for Android is the official way to add Firebase to your
+Android app. To get started, visit the [setup instructions][android-setup].
+
+## Open Source
+
+The following Firebase SDKs for Android are developed in this
+repository:
+
+  * `firebase-common`
+  * `firebase-database`
+  * `firebase-firestore`
+  * `firebase-functions`
+  * `firebase-inappmessaging-display`
+  * `firebase-storage`
+
+For more information on building the SDKs from source or contributing,
+visit the [main README][main-readme].
+
+## Kotlin Extensions
+
+
+
+[android-setup]: https://firebase.google.com/docs/android/setup
+[main-readme]: https://github.com/firebase/firebase-android-sdk/blob/master/README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,7 @@ Android app. To get started, visit the [setup instructions][android-setup].
 
 ## Open Source
 
-The following Firebase SDKs for Android are developed in this
-repository:
+This repository includes the following Firebase SDKs for Android:
 
   * `firebase-common`
   * `firebase-database`

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,11 @@ visit the [main README][main-readme].
 
 ## Kotlin Extensions
 
+The following Firebase SDKs for Android have Kotlin extension libraries
+that allow you to write more idiomatic Kotlin code when using Firebase
+in your app:
 
+  * [`firebase-firestore`](./ktx/firestore.md)
 
 [android-setup]: https://firebase.google.com/docs/android/setup
 [main-readme]: https://github.com/firebase/firebase-android-sdk/blob/master/README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ The following Firebase SDKs for Android have Kotlin extension libraries
 that allow you to write more idiomatic Kotlin code when using Firebase
 in your app:
 
+  * [`firebase-common`](./ktx/common.md)
   * [`firebase-firestore`](./ktx/firestore.md)
 
 [android-setup]: https://firebase.google.com/docs/android/setup

--- a/docs/ktx/common.md
+++ b/docs/ktx/common.md
@@ -1,0 +1,42 @@
+# Firebase Common Kotlin Extensions
+
+## Getting Started
+
+To use the Firebase Common Android SDK with Kotlin Extenstions, add the following
+to your app's `build.gradle` file:
+
+```groovy
+// See maven.google.com for the latest versions
+// This library transitively includes the firebase-common library
+implementation 'com.google.firebase:firebase-common-ktx:$VERSION'
+```
+
+## Features
+
+### Get the default FirebaseApp and FirebaseOptions
+
+**Kotlin**
+```kotlin
+val defaultApp = FirebaseApp.getInstance()
+val defaultOptions = defaultApp.options
+```
+
+**Kotlin + KTX**
+```kotlin
+val defaultApp = Firebase.app
+val defaultOptions = Firebase.options
+```
+
+### Initialize a FirebaseApp
+
+**Kotlin**
+```kotlin
+val options = FirebaseApp.getInstance().options
+val anotherApp = FirebaseApp.initializeApp(context, options, "myApp")
+```
+
+**Kotlin + KTX**
+```kotlin
+var anotherApp = Firebase.initialize(context, Firebase.options, "myApp")
+```
+

--- a/docs/ktx/common.md
+++ b/docs/ktx/common.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-To use the Firebase Common Android SDK with Kotlin Extenstions, add the following
+To use the Firebase Common Android SDK with Kotlin Extensions, add the following
 to your app's `build.gradle` file:
 
 ```groovy

--- a/docs/ktx/firestore.md
+++ b/docs/ktx/firestore.md
@@ -1,0 +1,5 @@
+# Firestore Kotlin Extensions
+
+```
+// TODO: Finish this page
+```

--- a/docs/ktx/firestore.md
+++ b/docs/ktx/firestore.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-To use the Cloud Firestore Android SDK with Kotlin Extenstions, add the following
+To use the Cloud Firestore Android SDK with Kotlin Extensions, add the following
 to your app's `build.gradle` file:
 
 ```groovy

--- a/docs/ktx/firestore.md
+++ b/docs/ktx/firestore.md
@@ -6,11 +6,26 @@ To use the Cloud Firestore Android SDK with Kotlin Extenstions, add the followin
 to your app's `build.gradle` file:
 
 ```groovy
-// This library transitively includes the Firestore Android SDK
-implementation 'com.google.firebase:firebase-firestore-ktx:18.1.0
+// See maven.google.com for the latest versions
+// This library transitively includes the firebase-firestore library
+implementation 'com.google.firebase:firebase-firestore-ktx:$VERSION'
 ```
 
 ## Features
+
+### Get an instance of FirebaseFirestore
+
+**Kotlin**
+```kotlin
+val firestore = FirebaseFirestore.getInstance()
+val anotherFirestore = FirebaseFirestore.getInstance(FirebaseApp.getInstance("myApp"))
+```
+
+**Kotlin + KTX**
+```kotlin
+val firestore = Firebase.firestore
+val anotherFirestore = Firebase.firestore(Firebase.app("myApp"))
+```
 
 ### Convert a DocumentSnapshot field to a POJO
 
@@ -24,18 +39,6 @@ val myObject = snapshot.get("fieldPath", MyClass::class.java)
 ```kotlin
 val snapshot: DocumentSnapshot = ...
 val myObject = snapshot.get<MyClass>("fieldPath")
-```
-
-### Get an instance of FirebaseFirestore
-
-**Kotlin**
-```kotlin
-val firestore = FirebaseFirestore.getInstance()
-```
-
-**Kotlin + KTX**
-```kotlin
-val firestore = Firebase.firestore
 ```
 
 ### Convert a DocumentSnapshot to a POJO

--- a/docs/ktx/firestore.md
+++ b/docs/ktx/firestore.md
@@ -1,5 +1,67 @@
 # Firestore Kotlin Extensions
 
+## Getting Started
+
+To use the Cloud Firestore Android SDK with Kotlin Extenstions, add the following
+to your app's `build.gradle` file:
+
+```groovy
+// This library transitively includes the Firestore Android SDK
+implementation 'com.google.firebase:firebase-firestore-ktx:18.1.0
 ```
-// TODO: Finish this page
+
+## Features
+
+### Convert a DocumentSnapshot field to a POJO
+
+**Kotlin**
+```kotlin
+val snapshot: DocumentSnapshot = ...
+val myObject = snapshot.get("fieldPath", MyClass::class.java)
+```
+
+**Kotlin + KTX**
+```kotlin
+val snapshot: DocumentSnapshot = ...
+val myObject = snapshot.get<MyClass>("fieldPath")
+```
+
+### Get an instance of FirebaseFirestore
+
+**Kotlin**
+```kotlin
+val firestore = FirebaseFirestore.getInstance()
+```
+
+**Kotlin + KTX**
+```kotlin
+val firestore = Firebase.firestore
+```
+
+### Convert a DocumentSnapshot to a POJO
+
+**Kotlin**
+```kotlin
+val snapshot: DocumentSnapshot = ...
+val myObject = snapshot.toObject(MyClass::class.java)
+```
+
+**Kotlin + KTX**
+```kotlin
+val snapshot: DocumentSnapshot = ...
+val myObject = snapshot.toObject<MyClass>()
+```
+
+### Convert a QuerySnapshot to a list of POJOs
+
+**Kotlin**
+```kotlin
+val snapshot: QuerySnapshot = ...
+val objectList = snapshot.toObjects(MyClass::class.java)
+```
+
+**Kotlin + KTX**
+```kotlin
+val snapshot: QuerySnapshot = ...
+val objectList = snapshot.toObjects<MyClass>()
 ```


### PR DESCRIPTION
Main changes:

  * Move the main page for this repo on firebaseopensource.com to be `docs/README.md` so we can present a less-technical overview.
  * Add a new folder `docs` with subpages
  * Add links to the main and KTX reference docs

cc @ashwinraghav @vkryachko we will need to actually fill out the content on KTX