### PR TITLE
Future-proof TransportBackend.

### DIFF
--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/GoogleTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/GoogleTransportBackend.java
@@ -23,6 +23,7 @@ import com.google.android.datatransport.cct.proto.LogEvent;
 import com.google.android.datatransport.cct.proto.LogRequest;
 import com.google.android.datatransport.cct.proto.LogResponse;
 import com.google.android.datatransport.cct.proto.QosTierConfiguration;
+import com.google.android.datatransport.runtime.BackendRequest;
 import com.google.android.datatransport.runtime.BackendResponse;
 import com.google.android.datatransport.runtime.BackendResponse.Status;
 import com.google.android.datatransport.runtime.EventInternal;
@@ -105,9 +106,9 @@ public class GoogleTransportBackend implements TransportBackend {
         .build();
   }
 
-  private BatchedLogRequest getRequestBody(Iterable<EventInternal> eventInternals) {
+  private BatchedLogRequest getRequestBody(BackendRequest backendRequest) {
     HashMap<String, List<EventInternal>> eventInternalMap = new HashMap<>();
-    for (EventInternal eventInternal : eventInternals) {
+    for (EventInternal eventInternal : backendRequest.getEvents()) {
       String key = eventInternal.getTransportName();
       if (!eventInternalMap.containsKey(key)) {
         List<EventInternal> eventInternalList = new ArrayList<EventInternal>();
@@ -192,8 +193,8 @@ public class GoogleTransportBackend implements TransportBackend {
   }
 
   @Override
-  public BackendResponse send(Iterable<EventInternal> events) {
-    BatchedLogRequest requestBody = getRequestBody(events);
+  public BackendResponse send(BackendRequest request) {
+    BatchedLogRequest requestBody = getRequestBody(request);
     try {
       return doSend(requestBody);
     } catch (IOException e) {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/BackendRequest.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/BackendRequest.java
@@ -14,8 +14,16 @@
 
 package com.google.android.datatransport.runtime;
 
-public interface TransportBackend {
-  EventInternal decorate(EventInternal event);
+import com.google.auto.value.AutoValue;
 
-  BackendResponse send(BackendRequest backendRequest);
+/** Encapsulates a send request made to an individual {@link TransportBackend}. */
+@AutoValue
+public abstract class BackendRequest {
+  /** Events to be sent to the backend. */
+  public abstract Iterable<EventInternal> getEvents();
+
+  /** Creates a new instance of the request. */
+  public static BackendRequest create(Iterable<EventInternal> events) {
+    return new AutoValue_BackendRequest(events);
+  }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportFactoryImpl.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportFactoryImpl.java
@@ -18,8 +18,8 @@ import com.google.android.datatransport.Transformer;
 import com.google.android.datatransport.Transport;
 import com.google.android.datatransport.TransportFactory;
 
-public final class TransportFactoryImpl implements TransportFactory {
-  private String backendName;
+final class TransportFactoryImpl implements TransportFactory {
+  private final String backendName;
   private final TransportInternal transportInternal;
 
   TransportFactoryImpl(String backendName, TransportInternal transportInternal) {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportImpl.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportImpl.java
@@ -19,9 +19,9 @@ import com.google.android.datatransport.Transformer;
 import com.google.android.datatransport.Transport;
 
 class TransportImpl<T> implements Transport<T> {
-  private String backendName;
-  private String name;
-  private Transformer<T, byte[]> transformer;
+  private final String backendName;
+  private final String name;
+  private final Transformer<T, byte[]> transformer;
   private final TransportInternal transportInternal;
 
   TransportImpl(

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/ImmediateScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/ImmediateScheduler.java
@@ -15,6 +15,7 @@
 package com.google.android.datatransport.runtime.scheduling;
 
 import com.google.android.datatransport.runtime.BackendRegistry;
+import com.google.android.datatransport.runtime.BackendRequest;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportBackend;
 import com.google.android.datatransport.runtime.TransportRuntime;
@@ -49,7 +50,7 @@ public class ImmediateScheduler implements Scheduler {
             LOGGER.warning(String.format("Transport backend '%s' is not registered", backendName));
             return;
           }
-          backend.send(Collections.singleton(backend.decorate(event)));
+          backend.send(BackendRequest.create(Collections.singleton(backend.decorate(event))));
         });
   }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
@@ -109,7 +109,8 @@ public class TransportRuntimeTest {
     verify(mockBackend, times(1))
         .send(
             eq(
-                Collections.singleton(
-                    expectedEvent.toBuilder().addMetadata(TEST_KEY, TEST_VALUE).build())));
+                BackendRequest.create(
+                    Collections.singleton(
+                        expectedEvent.toBuilder().addMetadata(TEST_KEY, TEST_VALUE).build()))));
   }
 }


### PR DESCRIPTION
The PR changes the signature of `send()` to take `BackendRequest` as
parameter. This allows us to evolve the API in a backwards compatible
way in the furure.

prerequisite for b/128916710, b/129045832