### PR TITLE
docs: fix ktx docs urls for firebaseopensource.com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,8 @@ The following Firebase SDKs for Android have Kotlin extension libraries
 that allow you to write more idiomatic Kotlin code when using Firebase
 in your app:
 
-  * [`firebase-common`](./ktx/common.md)
-  * [`firebase-firestore`](./ktx/firestore.md)
+  * [`firebase-common`](ktx/common.md)
+  * [`firebase-firestore`](ktx/firestore.md)
 
 [android-setup]: https://firebase.google.com/docs/android/setup
 [main-readme]: https://github.com/firebase/firebase-android-sdk/blob/master/README.md


### PR DESCRIPTION
### Previous behavior:
Clicking on the "firebase-common" or the "firebase-firestore" links from the [firebase-android-sdk page](https://firebaseopensource.com/projects/firebase/firebase-android-sdk/) would redirect the user to GitHub to be able to see these pages.

### New behavior:
Now, clicking on these links shows the respective pages, but still inside firebaseopensource.com (not redirecting to GitHub).