### PR TITLE
Add new smoke tests for Storage and Database.

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -38,9 +38,19 @@ android {
   flavorDimensions "systemUnderTest"
 
   productFlavors {
+    database {
+      dimension "systemUnderTest"
+      applicationId "com.google.firebase.testing.database"
+    }
+
     firestore {
       dimension "systemUnderTest"
       applicationId "com.google.firebase.testing.firestore"
+    }
+
+    storage {
+      dimension "systemUnderTest"
+      applicationId "com.google.firebase.testing.storage"
     }
   }
 }
@@ -52,19 +62,24 @@ repositories {
 
 dependencies {
   // Common
-
   api "androidx.test:runner:1.1.0"
+  api "com.google.truth:truth:0.43"
   api "junit:junit:4.12"
 
   implementation "androidx.test:rules:1.1.0"
   implementation "com.google.firebase:firebase-common:16.0.7"
 
+  // Database
+  databaseImplementation "com.google.firebase:firebase-auth:16.1.0"
+  databaseImplementation "com.google.firebase:firebase-database:16.1.0"
+
   // Firestore
-  firestoreImplementation "com.google.android.gms:play-services-tasks:16.0.1"
   firestoreImplementation "com.google.firebase:firebase-auth:16.1.0"
   firestoreImplementation "com.google.firebase:firebase-firestore:18.1.0"
-  firestoreImplementation "com.google.truth:truth:0.43"
 
+  // Storage
+  storageImplementation "com.google.firebase:firebase-auth:16.1.0"
+  storageImplementation "com.google.firebase:firebase-storage:16.1.0"
 }
 
 apply plugin: "com.google.gms.google-services"

--- a/smoke-tests/src/database/AndroidManifest.xml
+++ b/smoke-tests/src/database/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.google.firebase.testing">
+
+  <uses-permission android:name="android.permission.INTERNET" />
+
+  <application>
+    <activity android:name="android.app.Activity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+
+    <meta-data android:name="com.google.firebase.testing.classes"
+      android:value="com.google.firebase.testing.database.DatabaseTest" />
+  </application>
+</manifest>

--- a/smoke-tests/src/database/java/com/google/firebase/testing/database/DatabaseTest.java
+++ b/smoke-tests/src/database/java/com/google/firebase/testing/database/DatabaseTest.java
@@ -1,0 +1,84 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.app.Activity;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
+import com.google.firebase.testing.common.Tasks2;
+import java.util.HashMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Database smoke tests. */
+@RunWith(AndroidJUnit4.class)
+public final class DatabaseTest {
+
+  @Rule public final ActivityTestRule<Activity> activity = new ActivityTestRule<>(Activity.class);
+
+  @Test
+  public void listenForUpdate() throws Exception {
+    FirebaseAuth auth = FirebaseAuth.getInstance();
+    FirebaseDatabase database = FirebaseDatabase.getInstance();
+
+    auth.signOut();
+    Task<?> signInTask = auth.signInWithEmailAndPassword("test@mailinator.com", "password");
+    Tasks2.waitForSuccess(signInTask);
+
+    DatabaseReference doc = database.getReference("restaurants").child("Baadal");
+    SnapshotListener listener = new SnapshotListener();
+    doc.addListenerForSingleValueEvent(listener);
+
+    HashMap<String, Object> data = new HashMap<>();
+    data.put("location", "Google NYC");
+
+    Task<?> setTask = doc.setValue(new HashMap<>(data));
+    Task<DataSnapshot> snapshotTask = listener.toTask();
+    Tasks2.waitForSuccess(setTask);
+    Tasks2.waitForSuccess(snapshotTask);
+
+    DataSnapshot result = snapshotTask.getResult();
+    assertThat(result.getValue()).isEqualTo(data);
+  }
+
+  private static class SnapshotListener implements ValueEventListener {
+    private final TaskCompletionSource<DataSnapshot> taskFactory = new TaskCompletionSource<>();
+
+    @Override
+    public void onCancelled(DatabaseError error) {
+      taskFactory.trySetException(error.toException());
+    }
+
+    @Override
+    public void onDataChange(DataSnapshot snapshot) {
+      taskFactory.trySetResult(snapshot);
+    }
+
+    public Task<DataSnapshot> toTask() {
+      return taskFactory.getTask();
+    }
+  }
+}

--- a/smoke-tests/src/database/java/com/google/firebase/testing/database/DatabaseTest.java
+++ b/smoke-tests/src/database/java/com/google/firebase/testing/database/DatabaseTest.java
@@ -40,7 +40,7 @@ public final class DatabaseTest {
   @Rule public final ActivityTestRule<Activity> activity = new ActivityTestRule<>(Activity.class);
 
   @Test
-  public void listenForUpdate() throws Exception {
+  public void setValueShouldTriggerListenerWithNewlySetData() throws Exception {
     FirebaseAuth auth = FirebaseAuth.getInstance();
     FirebaseDatabase database = FirebaseDatabase.getInstance();
 

--- a/smoke-tests/src/storage/AndroidManifest.xml
+++ b/smoke-tests/src/storage/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.google.firebase.testing">
+
+  <uses-permission android:name="android.permission.INTERNET" />
+
+  <application>
+    <activity android:name="android.app.Activity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+
+    <meta-data android:name="com.google.firebase.testing.classes"
+      android:value="com.google.firebase.testing.storage.StorageTest" />
+  </application>
+</manifest>

--- a/smoke-tests/src/storage/java/com/google/firebase/testing/storage/StorageTest.java
+++ b/smoke-tests/src/storage/java/com/google/firebase/testing/storage/StorageTest.java
@@ -37,7 +37,7 @@ public final class StorageTest {
   @Rule public final ActivityTestRule<Activity> activity = new ActivityTestRule<>(Activity.class);
 
   @Test
-  public void getSet() throws Exception {
+  public void getShouldReturnNewlyPutData() throws Exception {
     FirebaseAuth auth = FirebaseAuth.getInstance();
     FirebaseStorage storage = FirebaseStorage.getInstance();
 

--- a/smoke-tests/src/storage/java/com/google/firebase/testing/storage/StorageTest.java
+++ b/smoke-tests/src/storage/java/com/google/firebase/testing/storage/StorageTest.java
@@ -1,0 +1,61 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.app.Activity;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+import com.google.firebase.testing.common.Tasks2;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Storage smoke tests. */
+@RunWith(AndroidJUnit4.class)
+public final class StorageTest {
+
+  @Rule public final ActivityTestRule<Activity> activity = new ActivityTestRule<>(Activity.class);
+
+  @Test
+  public void getSet() throws Exception {
+    FirebaseAuth auth = FirebaseAuth.getInstance();
+    FirebaseStorage storage = FirebaseStorage.getInstance();
+
+    auth.signOut();
+    Task<?> signInTask = auth.signInWithEmailAndPassword("test@mailinator.com", "password");
+    Tasks2.waitForSuccess(signInTask);
+
+    StorageReference blob = storage.getReference("restaurants/Baadal");
+
+    byte[] data = "Google NYC".getBytes(StandardCharsets.UTF_8);
+
+    Task<?> putTask = blob.putBytes(Arrays.copyOf(data, data.length));
+    Tasks2.waitForSuccess(putTask);
+
+    Task<byte[]> getTask = blob.getBytes(128);
+    Tasks2.waitForSuccess(getTask);
+
+    byte[] result = getTask.getResult();
+    assertThat(result).isEqualTo(data);
+  }
+}


### PR DESCRIPTION
This pull request adds new smoke tests for Database and Storage in a similar fashion as #319 did for Firestore.