### PR TITLE
Adds the concept of TransportContext.

### DIFF
--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
@@ -24,7 +24,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.Assert.assertEquals;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.cct.proto.LogResponse;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.backends.BackendRequest;
@@ -42,7 +41,6 @@ public class CctTransportBackendTest {
   private static String TEST_ENDPOINT = "http://localhost:8999/api";
   private static CctTransportBackend BACKEND =
       new CctTransportBackend(TEST_ENDPOINT, () -> 3, () -> 1);
-  private static String TRANSPORT_NAME = "3";
 
   @Rule public WireMockRule wireMockRule = new WireMockRule(8999);
 
@@ -53,8 +51,7 @@ public class CctTransportBackendTest {
                 EventInternal.builder()
                     .setEventMillis(3)
                     .setUptimeMillis(1)
-                    .setTransportName(TRANSPORT_NAME)
-                    .setPriority(Priority.DEFAULT)
+                    .setTransportName("3")
                     .setPayload("TelemetryData".getBytes())
                     .build())));
   }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/EventInternal.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/EventInternal.java
@@ -14,7 +14,6 @@
 
 package com.google.android.datatransport.runtime;
 
-import com.google.android.datatransport.Priority;
 import com.google.auto.value.AutoValue;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,8 +25,6 @@ public abstract class EventInternal {
   public abstract String getTransportName();
 
   public abstract byte[] getPayload();
-
-  public abstract Priority getPriority();
 
   public abstract long getEventMillis();
 
@@ -43,7 +40,6 @@ public abstract class EventInternal {
     return new AutoValue_EventInternal.Builder()
         .setTransportName(getTransportName())
         .setPayload(getPayload())
-        .setPriority(getPriority())
         .setEventMillis(getEventMillis())
         .setUptimeMillis(getUptimeMillis())
         .setAutoMetadata(new HashMap<>(getAutoMetadata()));
@@ -58,8 +54,6 @@ public abstract class EventInternal {
     public abstract Builder setTransportName(String value);
 
     public abstract Builder setPayload(byte[] value);
-
-    public abstract Builder setPriority(Priority value);
 
     public abstract Builder setEventMillis(long value);
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/SendRequest.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/SendRequest.java
@@ -20,7 +20,7 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class SendRequest {
-  public abstract String getBackendName();
+  public abstract TransportContext getTransportContext();
 
   public abstract String getTransportName();
 
@@ -38,7 +38,7 @@ public abstract class SendRequest {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder setBackendName(String name);
+    public abstract Builder setTransportContext(TransportContext transportContext);
 
     public abstract Builder setTransportName(String name);
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportContext.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportContext.java
@@ -1,0 +1,65 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.android.datatransport.runtime;
+
+import android.support.annotation.RestrictTo;
+import com.google.android.datatransport.Priority;
+import com.google.auto.value.AutoValue;
+
+/**
+ * Represents the context which {@link com.google.android.datatransport.Event}s are associated with.
+ */
+@AutoValue
+public abstract class TransportContext {
+  /** Backend events are sent to. */
+  public abstract String getBackendName();
+
+  /**
+   * Priority of the event.
+   *
+   * <p>For internal use by the library and backend implementations. Not for use by users of the
+   * library.
+   *
+   * @hide
+   */
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+  public abstract Priority getPriority();
+
+  /** Returns a new builder for {@link TransportContext}. */
+  public static Builder builder() {
+    return new AutoValue_TransportContext.Builder().setPriority(Priority.DEFAULT);
+  }
+
+  /**
+   * Returns a copy of the context with modified {@link Priority}.
+   *
+   * @hide
+   */
+  @RestrictTo(RestrictTo.Scope.LIBRARY)
+  public TransportContext withPriority(Priority priority) {
+    return builder().setBackendName(getBackendName()).setPriority(priority).build();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setBackendName(String name);
+
+    /** @hide */
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    abstract Builder setPriority(Priority priority);
+
+    public abstract TransportContext build();
+  }
+}

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportFactoryImpl.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportFactoryImpl.java
@@ -19,17 +19,17 @@ import com.google.android.datatransport.Transport;
 import com.google.android.datatransport.TransportFactory;
 
 final class TransportFactoryImpl implements TransportFactory {
-  private final String backendName;
+  private final TransportContext transportContext;
   private final TransportInternal transportInternal;
 
-  TransportFactoryImpl(String backendName, TransportInternal transportInternal) {
-    this.backendName = backendName;
+  TransportFactoryImpl(TransportContext transportContext, TransportInternal transportInternal) {
+    this.transportContext = transportContext;
     this.transportInternal = transportInternal;
   }
 
   @Override
   public <T> Transport<T> getTransport(
       String name, Class<T> payloadType, Transformer<T, byte[]> payloadTransformer) {
-    return new TransportImpl<>(backendName, name, payloadTransformer, transportInternal);
+    return new TransportImpl<>(transportContext, name, payloadTransformer, transportInternal);
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportImpl.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportImpl.java
@@ -19,17 +19,17 @@ import com.google.android.datatransport.Transformer;
 import com.google.android.datatransport.Transport;
 
 class TransportImpl<T> implements Transport<T> {
-  private final String backendName;
+  private final TransportContext transportContext;
   private final String name;
   private final Transformer<T, byte[]> transformer;
   private final TransportInternal transportInternal;
 
   TransportImpl(
-      String backendName,
+      TransportContext transportContext,
       String name,
       Transformer<T, byte[]> transformer,
       TransportInternal transportInternal) {
-    this.backendName = backendName;
+    this.transportContext = transportContext;
     this.name = name;
     this.transformer = transformer;
     this.transportInternal = transportInternal;
@@ -39,7 +39,7 @@ class TransportImpl<T> implements Transport<T> {
   public void send(Event<T> event) {
     transportInternal.send(
         SendRequest.builder()
-            .setBackendName(backendName)
+            .setTransportContext(transportContext)
             .setEvent(event)
             .setTransportName(name)
             .setTransformer(transformer)

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntime.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntime.java
@@ -91,7 +91,8 @@ public class TransportRuntime implements TransportInternal {
 
   /** Returns a {@link TransportFactory} for a given {@code backendName}. */
   public TransportFactory newFactory(String backendName) {
-    return new TransportFactoryImpl(backendName, this);
+    return new TransportFactoryImpl(
+        TransportContext.builder().setBackendName(backendName).build(), this);
   }
 
   @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -101,7 +102,9 @@ public class TransportRuntime implements TransportInternal {
 
   @Override
   public void send(SendRequest request) {
-    scheduler.schedule(request.getBackendName(), convert(request));
+    scheduler.schedule(
+        request.getTransportContext().withPriority(request.getEvent().getPriority()),
+        convert(request));
   }
 
   private EventInternal convert(SendRequest request) {
@@ -109,7 +112,6 @@ public class TransportRuntime implements TransportInternal {
         .setEventMillis(eventClock.getTime())
         .setUptimeMillis(uptimeClock.getTime())
         .setTransportName(request.getTransportName())
-        .setPriority(request.getEvent().getPriority())
         .setPayload(request.getPayload())
         .build();
   }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/ImmediateScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/ImmediateScheduler.java
@@ -15,6 +15,7 @@
 package com.google.android.datatransport.runtime.scheduling;
 
 import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.TransportRuntime;
 import com.google.android.datatransport.runtime.backends.BackendRegistry;
 import com.google.android.datatransport.runtime.backends.BackendRequest;
@@ -42,12 +43,14 @@ public class ImmediateScheduler implements Scheduler {
   }
 
   @Override
-  public void schedule(String backendName, EventInternal event) {
+  public void schedule(TransportContext transportContext, EventInternal event) {
     executor.execute(
         () -> {
-          TransportBackend backend = backendRegistry.get(backendName);
+          TransportBackend backend = backendRegistry.get(transportContext.getBackendName());
           if (backend == null) {
-            LOGGER.warning(String.format("Transport backend '%s' is not registered", backendName));
+            LOGGER.warning(
+                String.format(
+                    "Transport backend '%s' is not registered", transportContext.getBackendName()));
             return;
           }
           backend.send(BackendRequest.create(Collections.singleton(backend.decorate(event))));

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/Scheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/Scheduler.java
@@ -15,6 +15,7 @@
 package com.google.android.datatransport.runtime.scheduling;
 
 import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
 
 /**
  * Responsible for scheduling an event to be transmitted to a backend.
@@ -23,5 +24,5 @@ import com.google.android.datatransport.runtime.EventInternal;
  * dependent.
  */
 public interface Scheduler {
-  void schedule(String backendName, EventInternal event);
+  void schedule(TransportContext transportContext, EventInternal event);
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -15,6 +15,7 @@
 package com.google.android.datatransport.runtime.scheduling.jobscheduling;
 
 import android.content.Context;
+import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
 import com.google.android.datatransport.runtime.time.Clock;
 import javax.inject.Inject;
@@ -38,5 +39,5 @@ public class AlarmManagerScheduler implements WorkScheduler {
   }
 
   @Override
-  public void schedule(String backendName, int attemptNumber) {}
+  public void schedule(TransportContext transportContext, int attemptNumber) {}
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/WorkScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/WorkScheduler.java
@@ -14,7 +14,9 @@
 
 package com.google.android.datatransport.runtime.scheduling.jobscheduling;
 
+import com.google.android.datatransport.runtime.TransportContext;
+
 /** Schedules the services to be able to eventually log events to their respective backends. */
 public interface WorkScheduler {
-  void schedule(String backendName, int attemptNumber);
+  void schedule(TransportContext transportContext, int attemptNumber);
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStore.java
@@ -17,6 +17,7 @@ package com.google.android.datatransport.runtime.scheduling.persistence;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
 
 /**
  * Persistence layer.
@@ -27,7 +28,7 @@ import com.google.android.datatransport.runtime.EventInternal;
 public interface EventStore {
 
   /** Persist a new event. */
-  PersistedEvent persist(String backendName, EventInternal event);
+  PersistedEvent persist(TransportContext transportContext, EventInternal event);
 
   /** Communicate to the store that events have failed to get sent. */
   void recordFailure(Iterable<PersistedEvent> events);
@@ -37,14 +38,14 @@ public interface EventStore {
 
   /** Returns the timestamp when the backend is allowed to be called next time or null. */
   @Nullable
-  Long getNextCallTime(String backendName);
+  Long getNextCallTime(TransportContext transportContext);
 
   /** Record the timestamp when the backend is allowed to be called next time. */
-  void recordNextCallTime(String backendName, long timestampMs);
+  void recordNextCallTime(TransportContext transportContext, long timestampMs);
 
   /** Returns true if the store contains any pending events for a give backend. */
-  boolean hasPendingEventsFor(String backendName);
+  boolean hasPendingEventsFor(TransportContext transportContext);
 
   /** Load all pending events for a given backend. */
-  Iterable<PersistedEvent> loadAll(String backendName);
+  Iterable<PersistedEvent> loadAll(TransportContext transportContext);
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/PersistedEvent.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/PersistedEvent.java
@@ -15,6 +15,7 @@
 package com.google.android.datatransport.runtime.scheduling.persistence;
 
 import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
 import com.google.auto.value.AutoValue;
 
 /** Holds an {@link EventInternal} with additional information. */
@@ -22,11 +23,12 @@ import com.google.auto.value.AutoValue;
 public abstract class PersistedEvent {
   public abstract long getId();
 
-  public abstract String getBackendName();
+  public abstract TransportContext getTransportContext();
 
   public abstract EventInternal getEvent();
 
-  public static PersistedEvent create(long id, String backendName, EventInternal object) {
-    return new AutoValue_PersistedEvent(id, backendName, object);
+  public static PersistedEvent create(
+      long id, TransportContext transportContext, EventInternal object) {
+    return new AutoValue_PersistedEvent(id, transportContext, object);
   }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.android.datatransport.Event;
-import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.Transformer;
 import com.google.android.datatransport.Transport;
 import com.google.android.datatransport.TransportFactory;
@@ -48,16 +47,17 @@ public class TransportRuntimeTest {
 
   @Test
   public void testTransportInternalSend() {
-    String mockBackendName = "backendMock";
+    TransportContext transportContext =
+        TransportContext.builder().setBackendName("backendMock").build();
     String testTransport = "testTransport";
-    TransportFactory factory = new TransportFactoryImpl(mockBackendName, transportInternalMock);
+    TransportFactory factory = new TransportFactoryImpl(transportContext, transportInternalMock);
     Event<String> event = Event.ofTelemetry("TelemetryData");
     Transformer<String, byte[]> transformer = String::getBytes;
     Transport<String> transport = factory.getTransport(testTransport, String.class, transformer);
     transport.send(event);
     SendRequest request =
         SendRequest.builder()
-            .setBackendName(mockBackendName)
+            .setTransportContext(transportContext)
             .setEvent(event, transformer)
             .setTransportName(testTransport)
             .build();
@@ -104,7 +104,6 @@ public class TransportRuntimeTest {
             .setEventMillis(eventMillis)
             .setUptimeMillis(uptimeMillis)
             .setTransportName(testTransport)
-            .setPriority(Priority.DEFAULT)
             .setPayload("TelemetryData".getBytes())
             .build();
     transport.send(stringEvent);

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/InMemoryEventStoreTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/InMemoryEventStoreTest.java
@@ -16,8 +16,8 @@ package com.google.android.datatransport.runtime.scheduling.persistence;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
 import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,48 +25,48 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class InMemoryEventStoreTest {
-  private static final String BACKEND_NAME = "backend1";
+  private static final TransportContext TRANSPORT_CONTEXT =
+      TransportContext.builder().setBackendName("backend1").build();
 
   private static final EventInternal TEST_EVENT =
       EventInternal.builder()
           .setTransportName("transport")
-          .setPriority(Priority.DEFAULT)
           .setEventMillis(1)
           .setUptimeMillis(2)
           .setPayload("hello".getBytes())
           .build();
   private static final PersistedEvent TEST_PERSISTED_EVENT =
-      PersistedEvent.create(1, BACKEND_NAME, TEST_EVENT);
+      PersistedEvent.create(1, TRANSPORT_CONTEXT, TEST_EVENT);
 
   private final EventStore store = new InMemoryEventStore();
 
   @Test
   public void test_emptyStore_shouldReturnNothingUponLoadAll() {
-    assertThat(store.loadAll("foo")).isEmpty();
+    assertThat(store.loadAll(TRANSPORT_CONTEXT)).isEmpty();
   }
 
   @Test
   public void test_nonEmptyStore_shouldReturnItsStoredEvents() {
-    store.persist(BACKEND_NAME, TEST_EVENT);
+    store.persist(TRANSPORT_CONTEXT, TEST_EVENT);
 
-    assertThat(store.loadAll(BACKEND_NAME)).containsExactly(TEST_PERSISTED_EVENT);
+    assertThat(store.loadAll(TRANSPORT_CONTEXT)).containsExactly(TEST_PERSISTED_EVENT);
   }
 
   @Test
   public void recordSuccess_shouldRemoveEventsFromStorage() {
-    store.persist(BACKEND_NAME, TEST_EVENT);
+    store.persist(TRANSPORT_CONTEXT, TEST_EVENT);
 
     store.recordSuccess(Collections.singleton(TEST_PERSISTED_EVENT));
 
-    assertThat(store.loadAll(BACKEND_NAME)).isEmpty();
+    assertThat(store.loadAll(TRANSPORT_CONTEXT)).isEmpty();
   }
 
   @Test
   public void recordFailure_shouldRemoveEventsFromStorage() {
-    store.persist(BACKEND_NAME, TEST_EVENT);
+    store.persist(TRANSPORT_CONTEXT, TEST_EVENT);
 
     store.recordFailure(Collections.singleton(TEST_PERSISTED_EVENT));
 
-    assertThat(store.loadAll(BACKEND_NAME)).isEmpty();
+    assertThat(store.loadAll(TRANSPORT_CONTEXT)).isEmpty();
   }
 }


### PR DESCRIPTION
TransportContext generalizes the grouping of events that was previously
done by "backend". This is not sufficient as we'd want to start grouping
events by additional dimensions like: priority, api_key, etc.

The change is mostly forward-looking as it will allow us to simplify
storage upgrades as we implement more dimensions, priority being the
main one. And it boils down to modifying the table structure by:
 * Rename the `backends` table to `transport_contexts`.
 * Change its primary key from `backend_name` to auto increment integer.
 * Change `events` foreign key to the new pk of `transport_contexts`.
 * `events` no longer have `priority`.