### PR TITLE
Add a limit on the maximum amount of storage the `events` database uses.

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntimeModule.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntimeModule.java
@@ -16,7 +16,6 @@ package com.google.android.datatransport.runtime;
 
 import android.content.Context;
 import android.os.Build;
-import com.google.android.datatransport.runtime.backends.BackendRegistry;
 import com.google.android.datatransport.runtime.backends.CreationContext;
 import com.google.android.datatransport.runtime.scheduling.ImmediateScheduler;
 import com.google.android.datatransport.runtime.scheduling.Scheduler;
@@ -24,6 +23,7 @@ import com.google.android.datatransport.runtime.scheduling.jobscheduling.AlarmMa
 import com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoScheduler;
 import com.google.android.datatransport.runtime.scheduling.jobscheduling.WorkScheduler;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
+import com.google.android.datatransport.runtime.scheduling.persistence.MaxStorageSize;
 import com.google.android.datatransport.runtime.scheduling.persistence.SQLiteEventStore;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
 import com.google.android.datatransport.runtime.time.Clock;
@@ -40,6 +40,15 @@ import javax.inject.Singleton;
 
 @Module
 abstract class TransportRuntimeModule {
+
+  private static final long MAX_DB_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+
+  @Provides
+  @MaxStorageSize
+  static long maxStorageSize() {
+    return MAX_DB_STORAGE_SIZE_IN_BYTES;
+  }
+
   @Singleton
   @Provides
   static Executor executor() {
@@ -68,15 +77,8 @@ abstract class TransportRuntimeModule {
     }
   }
 
-  @Provides
-  static Scheduler scheduler(
-      Executor executor,
-      BackendRegistry registry,
-      WorkScheduler workScheduler,
-      EventStore eventStore,
-      SynchronizationGuard guard) {
-    return new ImmediateScheduler(executor, registry);
-  }
+  @Binds
+  abstract Scheduler scheduler(ImmediateScheduler scheduler);
 
   @Binds
   abstract EventStore eventStore(SQLiteEventStore store);

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStore.java
@@ -28,6 +28,7 @@ import com.google.android.datatransport.runtime.TransportContext;
 public interface EventStore {
 
   /** Persist a new event. */
+  @Nullable
   PersistedEvent persist(TransportContext transportContext, EventInternal event);
 
   /** Communicate to the store that events have failed to get sent. */

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/MaxStorageSize.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/MaxStorageSize.java
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.android.datatransport.runtime.scheduling.persistence;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.inject.Qualifier;
+
+@Retention(RetentionPolicy.SOURCE)
+@Qualifier
+public @interface MaxStorageSize {}

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/InMemoryEventStore.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/InMemoryEventStore.java
@@ -14,6 +14,7 @@
 
 package com.google.android.datatransport.runtime.scheduling.persistence;
 
+import android.support.annotation.Nullable;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
 import java.util.ArrayList;
@@ -30,8 +31,10 @@ public class InMemoryEventStore implements EventStore {
   private final Map<TransportContext, Long> backendCallTime = new HashMap<>();
 
   @Override
+  @Nullable
   public synchronized PersistedEvent persist(
       TransportContext transportContext, EventInternal event) {
+
     long newId = idCounter.incrementAndGet();
     getOrCreateBackendStore(transportContext).put(newId, event);
 

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
@@ -135,4 +135,13 @@ public class SQLiteEventStoreTest {
     assertThat(store.hasPendingEventsFor(TRANSPORT_CONTEXT)).isTrue();
     assertThat(store.hasPendingEventsFor(ANOTHER_TRANSPORT_CONTEXT)).isFalse();
   }
+
+  @Test
+  public void persist_whenDbSizeOnDiskIsAtLimit_shouldNotPersistNewEvents() {
+    store.setMaxDbSizeOnDisk(store.getByteSize());
+    assertThat(store.persist(TRANSPORT_CONTEXT, EVENT)).isNull();
+
+    store.setMaxDbSizeOnDisk(store.getByteSize() + 1);
+    assertThat(store.persist(TRANSPORT_CONTEXT, EVENT)).isNotNull();
+  }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
@@ -42,8 +42,11 @@ public class SQLiteEventStoreTest {
           .addMetadata("key2", "value2")
           .build();
 
-  private final SQLiteEventStore store =
-      new SQLiteEventStore(RuntimeEnvironment.application, new UptimeClock());
+  private final SQLiteEventStore store = newStoreWithCapacity(10 * 1024 * 1024);
+
+  private static SQLiteEventStore newStoreWithCapacity(long capacity) {
+    return new SQLiteEventStore(RuntimeEnvironment.application, new UptimeClock(), capacity);
+  }
 
   @Test
   public void persist_correctlyRoundTrips() {
@@ -138,10 +141,10 @@ public class SQLiteEventStoreTest {
 
   @Test
   public void persist_whenDbSizeOnDiskIsAtLimit_shouldNotPersistNewEvents() {
-    store.setMaxDbSizeOnDisk(store.getByteSize());
-    assertThat(store.persist(TRANSPORT_CONTEXT, EVENT)).isNull();
+    SQLiteEventStore storeUnderTest = newStoreWithCapacity(store.getByteSize());
+    assertThat(storeUnderTest.persist(TRANSPORT_CONTEXT, EVENT)).isNull();
 
-    store.setMaxDbSizeOnDisk(store.getByteSize() + 1);
-    assertThat(store.persist(TRANSPORT_CONTEXT, EVENT)).isNotNull();
+    storeUnderTest = newStoreWithCapacity(store.getByteSize() + 1);
+    assertThat(storeUnderTest.persist(TRANSPORT_CONTEXT, EVENT)).isNotNull();
   }
 }


### PR DESCRIPTION
New events are dropped until old ones are discarded.