### PR TITLE
Add firebase-datatransport library.

### DIFF
--- a/.idea/copyright/Apache_2___Google.xml
+++ b/.idea/copyright/Apache_2___Google.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
     <option name="myName" value="Apache 2 - Google" />
-    <option name="notice" value="Copyright 2018 Google LLC&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;     http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="notice" value="Copyright 2019 Google LLC&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;     http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
   </copyright>
 </component>

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -1,0 +1,51 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+apply plugin: 'com.android.library'
+
+android {
+    adbOptions {
+        timeOutInMs 60 * 1000
+    }
+
+    compileSdkVersion project.targetSdkVersion
+    defaultConfig {
+        minSdkVersion project.minSdkVersion
+        targetSdkVersion project.targetSdkVersion
+        versionName version
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    implementation project(':firebase-common')
+    implementation project(':transport:transport-api')
+    implementation project(':transport:transport-runtime')
+    implementation project(':transport:transport-backend-cct')
+    implementation 'com.android.support:support-annotations:28.0.0'
+
+    testImplementation 'com.android.support.test:runner:1.0.2'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+}

--- a/firebase-datatransport/gradle.properties
+++ b/firebase-datatransport/gradle.properties
@@ -1,0 +1,2 @@
+version=16.0.0
+android.enableUnitTestBinaryResources=true

--- a/firebase-datatransport/src/main/AndroidManifest.xml
+++ b/firebase-datatransport/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.datatransport">
+  <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
+  <!--<uses-sdk android:minSdkVersion="14"/>-->
+  <application>
+    <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.datatransport.TransportRegistrar"
+          android:value="com.google.firebase.components.ComponentRegistrar" />
+    </service>
+  </application>
+</manifest>

--- a/firebase-datatransport/src/main/java/com/google/firebase/datatransport/TransportRegistrar.java
+++ b/firebase-datatransport/src/main/java/com/google/firebase/datatransport/TransportRegistrar.java
@@ -1,0 +1,41 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.datatransport;
+
+import android.content.Context;
+import android.support.annotation.Keep;
+import com.google.android.datatransport.TransportFactory;
+import com.google.android.datatransport.runtime.TransportRuntime;
+import com.google.firebase.components.Component;
+import com.google.firebase.components.ComponentRegistrar;
+import com.google.firebase.components.Dependency;
+import java.util.Collections;
+import java.util.List;
+
+@Keep
+public class TransportRegistrar implements ComponentRegistrar {
+  @Override
+  public List<Component<?>> getComponents() {
+    return Collections.singletonList(
+        Component.builder(TransportFactory.class)
+            .add(Dependency.required(Context.class))
+            .factory(
+                c -> {
+                  TransportRuntime.initialize(c.get(Context.class));
+                  return TransportRuntime.getInstance().newFactory("cct");
+                })
+            .build());
+  }
+}

--- a/firebase-datatransport/src/main/java/com/google/firebase/datatransport/package-info.java
+++ b/firebase-datatransport/src/main/java/com/google/firebase/datatransport/package-info.java
@@ -1,0 +1,16 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @hide */
+package com.google.firebase.datatransport;

--- a/firebase-datatransport/src/test/java/com/google/firebase/datatransport/TransportRegistrationTest.java
+++ b/firebase-datatransport/src/test/java/com/google/firebase/datatransport/TransportRegistrationTest.java
@@ -1,0 +1,55 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.datatransport;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.support.test.runner.AndroidJUnit4;
+import com.google.android.datatransport.TransportFactory;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import java.util.function.Consumer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(AndroidJUnit4.class)
+public class TransportRegistrationTest {
+  private static void withApp(Consumer<FirebaseApp> consumer) {
+    FirebaseApp app =
+        FirebaseApp.initializeApp(
+            RuntimeEnvironment.application,
+            new FirebaseOptions.Builder()
+                .setApplicationId("appId")
+                .setProjectId("123")
+                .setApiKey("apiKey")
+                .build(),
+            "datatransport-test-app");
+    try {
+      consumer.accept(app);
+    } finally {
+      app.delete();
+    }
+  }
+
+  @Test
+  public void test_componentIsRegisteredAndAvailable() {
+    withApp(
+        app -> {
+          TransportFactory transportFactory = app.get(TransportFactory.class);
+          assertThat(transportFactory).isNotNull();
+        });
+  }
+}

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -6,6 +6,7 @@ firebase-firestore
 firebase-firestore-ktx
 firebase-functions
 firebase-inappmessaging-display
+firebase-datatransport
 fiamui-app
 firebase-storage
 protolite-well-known-types


### PR DESCRIPTION
The library registers a `TransportFactory` as a component for other SDKs
to use.