### PR TITLE
Re-implement 3p license inference implementation.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -35,7 +35,6 @@ sourceSets {
 
 dependencies {
     implementation 'org.jsoup:jsoup:1.11.2'
-    implementation "com.jaredsburrows:gradle-license-plugin:0.8.1"
     implementation 'digital.wup:android-maven-publish:3.6.2'
 
     implementation 'io.opencensus:opencensus-api:0.18.0'

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/GenerateLicensesTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/GenerateLicensesTask.groovy
@@ -15,20 +15,25 @@
 package com.google.firebase.gradle.plugins.license
 
 import groovy.json.JsonBuilder
-import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 
+import javax.inject.Inject
+
+@CompileStatic
 class GenerateLicensesTask extends DefaultTask {
-    def NEW_LINE_LENGTH = "\n".getBytes().length;
+    private static final int NEW_LINE_LENGTH = "\n".getBytes().length
+
+    private final LicenseResolver licenseResolver
+    private final Configuration inputConfiguration
+
 
     @Input
     List<ProjectLicense> additionalLicenses
-
-    @InputFile
-    File licenseReportFile
 
     @InputDirectory
     File licenseDownloadDir
@@ -36,16 +41,28 @@ class GenerateLicensesTask extends DefaultTask {
     @OutputDirectory
     File outputDir
 
+    @Inject
+    GenerateLicensesTask(Configuration configuration) {
+        this(configuration, new LicenseResolver())
+    }
+
+    GenerateLicensesTask(Configuration configuration, LicenseResolver licenseResolver) {
+        this.inputConfiguration = configuration
+        this.licenseResolver = licenseResolver
+        outputs.upToDateWhen { false }
+    }
+
+
     @TaskAction
     void execute(IncrementalTaskInputs inputs) {
-        List<ProjectLicense> licenses = extractLicensesFromReport() + additionalLicenses
+        Set<ProjectLicense> licenses = licenseResolver.resolve(project, inputConfiguration) + additionalLicenses
 
-        Set<URI> licenseUris = licenses.collect { it.licenseUris }.flatten().toSet()
+        Set<URI> licenseUris = licenses.collectMany { it.licenseUris } as Set
 
         //Fetch local licenses into memory
         Map<URI, String> licenseCache = licenseUris.collectEntries {
 
-            final File file
+            File file
             if (it.getScheme() == "file") {
                 file = new File(it)
                 if (!file.exists()) {
@@ -89,7 +106,6 @@ class GenerateLicensesTask extends DefaultTask {
                 long licenseByteLength = 0
                 writer.println ""
                 licenseByteLength += NEW_LINE_LENGTH
-                println name
 
                 // Write all licenses for the project seperated by newlines
                 uris.each { uri ->
@@ -102,22 +118,11 @@ class GenerateLicensesTask extends DefaultTask {
 
                 writeOffset += licenseByteLength
 
-                String key = projectLicense.isExplicit ? projectLicense.name
-                        : projectLicense.name.toLowerCase()
-                ["$key": [length: licenseByteLength,
+                [(projectLicense.name): [length: licenseByteLength,
                           start : writeOffset - licenseByteLength]]
             })
         }
 
         jsonFile.withPrintWriter { writer -> writer.println(jsonBuilder.toString()) }
-    }
-
-    private List<ProjectLicense> extractLicensesFromReport() {
-        new JsonSlurper().parseText(licenseReportFile.text).
-                collect { report ->
-                    new ProjectLicense(name: report.project,
-                            licenseUris: report.licenses.collect { URI.create(it.license_url) },
-                            isExplicit: false)
-                }
     }
 }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/GenerateLicensesTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/GenerateLicensesTask.groovy
@@ -49,6 +49,9 @@ class GenerateLicensesTask extends DefaultTask {
     GenerateLicensesTask(Configuration configuration, LicenseResolver licenseResolver) {
         this.inputConfiguration = configuration
         this.licenseResolver = licenseResolver
+
+        // it's impossible to tell if the configuration we depend on changed without resolving it, but
+        // the configuration is most likely not resolvable.
         outputs.upToDateWhen { false }
     }
 

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/LicenseResolver.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/LicenseResolver.groovy
@@ -1,0 +1,91 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins.license
+
+import groovy.transform.CompileStatic
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.publish.Publication
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.internal.publication.DefaultMavenPom
+
+@CompileStatic
+class LicenseResolver {
+
+    /** Resolve all transitive licenses. */
+    Set<ProjectLicense> resolve(Project project, Configuration configuration) {
+        return determineExternalLicenses(project, configuration) + determineProjectLicenses(configuration)
+
+    }
+
+    private static Set<ProjectLicense> determineProjectLicenses(Configuration configuration) {
+        configuration.allDependencies.findAll {
+            it instanceof ProjectDependency
+        }.collectMany {
+            Project depProject = ((ProjectDependency) it).dependencyProject
+            Set<ProjectLicense> transitive = determineProjectLicenses(depProject.configurations.getByName(configuration.name))
+            return [determineLicense(depProject)] + transitive
+        }.findAll { it != null } as Set
+    }
+
+    private static Set<ProjectLicense> determineExternalLicenses(Project project, Configuration configuration) {
+        def conf = project.configurations.create('internalAllExternalArtifacts')
+
+        configuration.allDependencies.each {
+            if (it instanceof ProjectDependency) {
+                conf.dependencies.addAll determineDependencies(it, configuration)
+            } else {
+                conf.dependencies.add it
+            }
+        }
+
+        return conf.resolve().collect { ProjectLicense.inferProjectLicenseFromArtifact(it) }.findAll {
+            it != null
+        }.collect {
+            new ProjectLicense(name: it.name, explicitLicenseUris: it.licenseUris)
+        } as Set
+    }
+
+    private static Set<Dependency> determineDependencies(Dependency dep, Configuration configuration) {
+        if (dep instanceof ProjectDependency) {
+            return dep.dependencyProject.configurations.getByName(configuration.name).allDependencies.collectMany {
+                determineDependencies(it, configuration)
+            } as Set
+        } else {
+            return [dep] as Set
+        }
+    }
+
+    private static ProjectLicense determineLicense(Project p) {
+        PublishingExtension publishing = p.extensions.findByType(PublishingExtension)
+        if (publishing == null) {
+            return null
+        }
+        Publication pub = publishing.publications.findByName('mavenAar')
+        if (pub == null || !(pub instanceof MavenPublication)) {
+            return null
+        }
+        MavenPublication publication = (MavenPublication) pub
+
+        DefaultMavenPom pom = (DefaultMavenPom) publication.pom
+
+        return new ProjectLicense(name: publication.artifactId, explicitLicenseUris: pom.licenses.collect {
+            URI.create(it.url.get())
+        })
+    }
+}

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/LicenseResolver.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/LicenseResolver.groovy
@@ -46,6 +46,10 @@ class LicenseResolver {
     private static Set<ProjectLicense> determineExternalLicenses(Project project, Configuration configuration) {
         def conf = project.configurations.create('internalAllExternalArtifacts')
 
+        // here we are not adding Project-level dependencies to the configuration but instead
+        // recursively determine non-project dependencies. The reason for not including project
+        // dependencies is that it causes resolution to fail due to variant ambiguity. Instead
+        // project licenses are determined in a separate method.
         configuration.allDependencies.each {
             if (it instanceof ProjectDependency) {
                 conf.dependencies.addAll determineDependencies(it, configuration)

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/ProjectLicense.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/ProjectLicense.groovy
@@ -12,10 +12,69 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins.license;
+package com.google.firebase.gradle.plugins.license
+
+import groovy.util.slurpersupport.GPathResult
 
 class ProjectLicense implements Serializable {
+    private static final FileNameFinder FINDER = new FileNameFinder()
+
     String name
-    List<URI> licenseUris
-    boolean isExplicit = true
+    List<URI> explicitLicenseUris
+    ProjectLicense parent
+
+    List<URI> getLicenseUris() {
+        return getUris(this)
+    }
+
+    private static List<URI> getUris(ProjectLicense license) {
+        if (license == null) {
+            return []
+        }
+        return license.explicitLicenseUris ?: getUris(license.parent)
+    }
+
+    static ProjectLicense inferProjectLicenseFromArtifact(File artifact) {
+        return parsePom(findPomRelativeToArtifact(artifact))
+    }
+
+    /**
+     * According to gradle's dependency cache layout(files-2.1), the artifacts are stored in the following way:
+     *
+     * <ul>
+     *   <li>${groupId}/${artifactId}/${version}/sha1(file)/*.{jar|aar}
+     *   <li>${groupId}/${artifactId}/${version}/sha1(file)/*.pom
+     * <ul>
+     *
+     * <p>So to get to a pom file based on the aar, we need to look for it based on the following
+     * pattern: `../{@literal *}/*.pom`
+     */
+    private static File findPomRelativeToArtifact(File artifact) {
+        return FINDER.getFileNames(artifact.parentFile.parentFile.absolutePath, '*/*.pom').collect {
+            new File(it)
+        }.find()
+    }
+
+    private static ProjectLicense parsePom(File pomFile) {
+        if (pomFile == null) return null
+        pomFile.withReader {
+            def project = new XmlSlurper().parse(it)
+            def name = project.name
+            def licenses = project.licenses.license.collect { URI.create(it.url as String) }
+            return new ProjectLicense(
+                    name: name,
+                    explicitLicenseUris: licenses,
+                    parent: determineParent(pomFile.parentFile.parentFile.parentFile.parentFile.parentFile, project.parent))
+        }
+    }
+
+    private static ProjectLicense determineParent(File baseDir, GPathResult parentNode) {
+        if (!parentNode.childNodes()) {
+            return null
+        }
+        def pomFile = FINDER.getFileNames(baseDir.absolutePath, "$parentNode.groupId/$parentNode.artifactId/$parentNode.version/*/*.pom").collect {
+            new File(it)
+        }.find()
+        return parsePom(pomFile)
+    }
 }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/ProjectLicense.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/ProjectLicense.groovy
@@ -68,6 +68,8 @@ class ProjectLicense implements Serializable {
         }
     }
 
+    // some poms don't include their license directly but instead declare themselves as inheriting
+    // it from their parent pom.
     private static ProjectLicense determineParent(File baseDir, GPathResult parentNode) {
         if (!parentNode.childNodes()) {
             return null

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/ThirdPartyLicensesExtension.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/ThirdPartyLicensesExtension.groovy
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins.license;
+package com.google.firebase.gradle.plugins.license
 
 class ThirdPartyLicensesExtension {
-  private final File baseDir;
-  private final List<ProjectLicense> additionalLicenses = new ArrayList<>()
+    private final File baseDir
+    private final List<ProjectLicense> additionalLicenses = new ArrayList<>()
 
-  ThirdPartyLicensesExtension(File baseDir) {
-    this.baseDir = baseDir;
-  }
+    ThirdPartyLicensesExtension(File baseDir) {
+        this.baseDir = baseDir
+    }
 
-  /** Add a library with its licenses in passed-in files(relative to rootDir). */
-  void add(String name, String... licenseUris) throws IOException {
-    additionalLicenses.add(
-        new ProjectLicense(name: name, licenseUris: licenseUris.collect { URI.create(it) }))
-  }
+    /** Add a library with its licenses in passed-in files(relative to rootDir). */
+    void add(String name, String... licenseUris) throws IOException {
+        additionalLicenses.add(
+                new ProjectLicense(name: name, explicitLicenseUris: licenseUris.collect {
+                    URI.create(it)
+                }))
+    }
 
-  List<ProjectLicense> getLibraries() {
-    return additionalLicenses;
-  }
+    List<ProjectLicense> getLibraries() {
+        return additionalLicenses
+    }
 }

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/license/LicenseResolverPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/license/LicenseResolverPluginSpec.groovy
@@ -80,7 +80,7 @@ class LicenseResolverPluginSpec extends Specification {
 
         def json = getLicenseJson()
         def txt = getLicenseText()
-        def picassoIndex = new JsonSlurper().parseText(json).picasso
+        def picassoIndex = new JsonSlurper().parseText(json).Picasso
         def customLibIndex1 = new JsonSlurper().parseText(json).customLib1
         def customLibIndex2 = new JsonSlurper().parseText(json).customLib2
 
@@ -137,15 +137,6 @@ class LicenseResolverPluginSpec extends Specification {
         result.output.count(
                 'Downloading license from http://www.apache.org/licenses/LICENSE-2.0.txt') == 1
 
-    }
-
-    def "License tasks honor gradle build cache"() {
-        when: "The build is run twice"
-        def result1 = build("generateLicenses")
-        def result2 = build("generateLicenses")
-
-        then: "The second deems the task UP-TO-DATE"
-        result2.output.contains("generateLicenses UP-TO-DATE")
     }
 
     def "License tasks throw a useful exception when license is not parsable"() {


### PR DESCRIPTION
The implementation relied on an oss gradle plugin. The plugin had
several issues:

* Did not respect project level dependencies
* Did not respect some gradle configurations that propagate to the pom,
  like runtimeOnly
* Had resolution issues where the order of task execution would affect
  the outcome of the license report
* Failed the build for projects that have debug buildType disabled.