### PR TITLE
Metrics Collection Refactoring (2)

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/coverage/GenerateMeasurementsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/coverage/GenerateMeasurementsTask.groovy
@@ -17,13 +17,12 @@ package com.google.firebase.gradle.plugins.measurement.coverage
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
 
-public class GenerateCoveragePercentsTask extends DefaultTask {
+public class GenerateMeasurementsTask extends DefaultTask {
 
     @OutputFile
     File reportFile
@@ -32,7 +31,7 @@ public class GenerateCoveragePercentsTask extends DefaultTask {
 
     String coverageTaskName
 
-    GenerateCoveragePercentsTask() {
+    GenerateMeasurementsTask() {
         parser = new XmlSlurper()
         parser.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
         parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeJsonBuilderTest.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeJsonBuilderTest.groovy
@@ -18,7 +18,6 @@ package com.google.firebase.gradle.plugins.measurement.apksize
 import static org.junit.Assert.assertEquals
 
 import org.json.JSONObject
-import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeTableBuilderTest.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeTableBuilderTest.groovy
@@ -17,7 +17,6 @@ package com.google.firebase.gradle.plugins.measurement.apksize
 
 import static org.junit.Assert.assertEquals
 
-import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeTestProject.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeTestProject.groovy
@@ -34,7 +34,7 @@ class ApkSizeTestProject extends ExternalResource {
         buildscript {
             repositories {
                 google()
-        jcenter()
+                jcenter()
             }
 
             dependencies {
@@ -53,46 +53,46 @@ class ApkSizeTestProject extends ExternalResource {
             compileSdkVersion 26
             defaultConfig {
                 minSdkVersion 26
-        targetSdkVersion 26
+                targetSdkVersion 26
             }
 
             flavorDimensions "apkSize"
 
             buildTypes {
                 aggressive {
-            debuggable false
-        }
+                    debuggable false
+                }
             }
 
             productFlavors {
                 horseshoe {
-            dimension "apkSize"
-            applicationId "com.google.testapk.horseshoe"
-        }
+                    dimension "apkSize"
+                    applicationId "com.google.testapk.horseshoe"
+                }
 
                 vanilla {
-            dimension "apkSize"
-            applicationId "com.google.testapk.vanilla"
-        }
+                    dimension "apkSize"
+                    applicationId "com.google.testapk.vanilla"
+                }
 
                 furball {
-            dimension "apkSize"
-            applicationId "com.google.testapk.furball"
-        }
+                    dimension "apkSize"
+                    applicationId "com.google.testapk.furball"
+                }
             }
 
             sourceSets {
                 horseshoe {
-            java.srcDirs = ["src/horseshoe/java"]
-        }
+                    java.srcDirs = ["src/horseshoe/java"]
+                }
 
                 vanilla {
-            java.srcDirs = ["src/vanilla/java"]
-        }
+                    java.srcDirs = ["src/vanilla/java"]
+                }
 
                 furball {
-            java.srcDirs = ["src/furball/java"]
-        }
+                    java.srcDirs = ["src/furball/java"]
+                }
             }
         }
 

--- a/tools/measurement/apksize/apksize.gradle
+++ b/tools/measurement/apksize/apksize.gradle
@@ -33,6 +33,9 @@ apply from: "src/functions/functions.gradle"
  * @param -Ppull_request the pull request number to be included in the report
  */
 task generateMeasurements(type: GenerateMeasurementsTask) {
+    description 'Builds all supported variants and calculates APK sizes.'
+    group 'ApkSize'
+
     sdkMapFile = file("sdks.csv")
     reportFile = file("$buildDir/size-report.json")
 }
@@ -44,6 +47,9 @@ task generateMeasurements(type: GenerateMeasurementsTask) {
  * @param -Ppull_request the pull request number to be included in the report
  */
 task uploadMeasurements(type: UploadMeasurementsTask) {
+    description 'Uploads APK size measurements to a database via the uploader tool.'
+    group 'ApkSize'
+
     dependsOn generateMeasurements
 
     reportFile = file("$buildDir/size-report.json")

--- a/tools/measurement/apksize/apksize.gradle
+++ b/tools/measurement/apksize/apksize.gradle
@@ -32,9 +32,9 @@ apply from: "src/functions/functions.gradle"
  *
  * @param -Ppull_request the pull request number to be included in the report
  */
-task generateMeasurements(type: GenerateMeasurementsTask) {
+task generateApkSizeMeasurements(type: GenerateMeasurementsTask) {
     description 'Builds all supported variants and calculates APK sizes.'
-    group 'ApkSize'
+    group 'Measurements'
 
     sdkMapFile = file("sdks.csv")
     reportFile = file("$buildDir/size-report.json")
@@ -46,11 +46,11 @@ task generateMeasurements(type: GenerateMeasurementsTask) {
  * @param -Pdatabase_config the file with the database configuration
  * @param -Ppull_request the pull request number to be included in the report
  */
-task uploadMeasurements(type: UploadMeasurementsTask) {
+task uploadApkSizeMeasurements(type: UploadMeasurementsTask) {
     description 'Uploads APK size measurements to a database via the uploader tool.'
-    group 'ApkSize'
+    group 'Measurements'
 
-    dependsOn generateMeasurements
+    dependsOn generateApkSizeMeasurements
 
     reportFile = file("$buildDir/size-report.json")
     uploader = "https://storage.googleapis.com/firebase-engprod-metrics/upload_tool.jar"

--- a/tools/measurement/coverage/coverage.gradle
+++ b/tools/measurement/coverage/coverage.gradle
@@ -13,20 +13,22 @@
 // limitations under the License.
 
 
-import com.google.firebase.gradle.plugins.measurement.coverage.GenerateCoveragePercentsTask
+import com.google.firebase.gradle.plugins.measurement.coverage.GenerateMeasurementsTask
 import com.google.firebase.gradle.plugins.measurement.UploadMeasurementsTask
 
 
-task generateMeasurements(type: GenerateCoveragePercentsTask) {
+task generateMeasurements(type: GenerateMeasurementsTask) {
     description 'Runs checkCoverage task in all projects and calculates coverage percents.'
     group 'Coverage'
+
     dependsOn rootProject.allprojects.collect { it.tasks.withType(JacocoReport) }.flatten()
     reportFile = file("$buildDir/coverage-report.json")
 }
 
 task uploadMeasurements(type: UploadMeasurementsTask) {
-    description 'Uploads coverage numbers to a database.'
+    description 'Uploads coverage measurements to a database via the uploader tool.'
     group 'Coverage'
+
     dependsOn generateMeasurements
     reportFile = file("$buildDir/coverage-report.json")
     uploader = "https://storage.googleapis.com/firebase-engprod-metrics/upload_tool.jar"

--- a/tools/measurement/coverage/coverage.gradle
+++ b/tools/measurement/coverage/coverage.gradle
@@ -17,19 +17,19 @@ import com.google.firebase.gradle.plugins.measurement.coverage.GenerateMeasureme
 import com.google.firebase.gradle.plugins.measurement.UploadMeasurementsTask
 
 
-task generateMeasurements(type: GenerateMeasurementsTask) {
+task generateCoverageMeasurements(type: GenerateMeasurementsTask) {
     description 'Runs checkCoverage task in all projects and calculates coverage percents.'
-    group 'Coverage'
+    group 'Measurements'
 
     dependsOn rootProject.allprojects.collect { it.tasks.withType(JacocoReport) }.flatten()
     reportFile = file("$buildDir/coverage-report.json")
 }
 
-task uploadMeasurements(type: UploadMeasurementsTask) {
+task uploadCoverageMeasurements(type: UploadMeasurementsTask) {
     description 'Uploads coverage measurements to a database via the uploader tool.'
-    group 'Coverage'
+    group 'Measurements'
 
-    dependsOn generateMeasurements
+    dependsOn generateCoverageMeasurements
     reportFile = file("$buildDir/coverage-report.json")
     uploader = "https://storage.googleapis.com/firebase-engprod-metrics/upload_tool.jar"
 }


### PR DESCRIPTION
- Rename coverage gradle tasks.
- Assign apk size gradle tasks into a new category "ApkSize"
  to make them discoverable via `./gradlew tasks`.
- Misc clean up.