### PR TITLE
Add `android:exported` manifest lint check.

### DIFF
--- a/fiamui-app/src/main/AndroidManifest.xml
+++ b/fiamui-app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
 
     <activity
         android:name=".MainActivity"
-        android:windowSoftInputMode="stateHidden">
+        android:windowSoftInputMode="stateHidden"
+        android:exported="false">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.DEFAULT" />
@@ -24,7 +25,7 @@
       </intent-filter>
     </activity>
 
-    <activity android:name=".TestActivity">
+    <activity android:name=".TestActivity" android:exported="false">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/firebase-common-ktx/src/main/AndroidManifest.xml
+++ b/firebase-common-ktx/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
     <!--<uses-sdk android:minSdkVersion="14"/>-->
     <application>
-        <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+        <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
             <meta-data android:name="com.google.firebase.components:com.google.firebase.ktx.FirebaseCommonKtxRegistrar"
                 android:value="com.google.firebase.components.ComponentRegistrar" />
         </service>

--- a/firebase-database/src/main/AndroidManifest.xml
+++ b/firebase-database/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
-        <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+        <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
             <meta-data android:name="com.google.firebase.components:com.google.firebase.database.DatabaseRegistrar"
                 android:value="com.google.firebase.components.ComponentRegistrar" />
         </service>

--- a/firebase-datatransport/src/main/AndroidManifest.xml
+++ b/firebase-datatransport/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
   <!--<uses-sdk android:minSdkVersion="14"/>-->
   <application>
-    <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+    <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
       <meta-data android:name="com.google.firebase.components:com.google.firebase.datatransport.TransportRegistrar"
           android:value="com.google.firebase.components.ComponentRegistrar" />
     </service>

--- a/firebase-firestore-ktx/src/main/AndroidManifest.xml
+++ b/firebase-firestore-ktx/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
     <!--<uses-sdk android:minSdkVersion="14"/>-->
     <application>
-        <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+        <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
             <meta-data android:name="com.google.firebase.components:com.google.firebase.firestore.ktx.FirebaseFirestoreKtxRegistrar"
                 android:value="com.google.firebase.components.ComponentRegistrar" />
         </service>

--- a/firebase-firestore/src/main/AndroidManifest.xml
+++ b/firebase-firestore/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <application>
-        <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+        <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
             <meta-data android:name="com.google.firebase.components:com.google.firebase.firestore.FirestoreRegistrar"
                 android:value="com.google.firebase.components.ComponentRegistrar" />
         </service>

--- a/firebase-functions/src/main/AndroidManifest.xml
+++ b/firebase-functions/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <!--<uses-sdk android:minSdkVersion="14" />-->
     <uses-permission android:name="android.permission.INTERNET" />
     <application>
-        <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+        <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
             <meta-data android:name="com.google.firebase.components:com.google.firebase.functions.FunctionsRegistrar"
                 android:value="com.google.firebase.components.ComponentRegistrar" />
         </service>

--- a/firebase-inappmessaging-display/src/main/AndroidManifest.xml
+++ b/firebase-inappmessaging-display/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />
   <application>
-    <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+    <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
       <meta-data android:name="com.google.firebase.components:com.google.firebase.inappmessaging.display.FirebaseInAppMessagingDisplayRegistrar"
           android:value="com.google.firebase.components.ComponentRegistrar" />
     </service>

--- a/firebase-storage/src/main/AndroidManifest.xml
+++ b/firebase-storage/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
-        <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+        <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
             <meta-data android:name="com.google.firebase.components:com.google.firebase.storage.StorageRegistrar"
                 android:value="com.google.firebase.components.ComponentRegistrar" />
         </service>

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -131,6 +131,10 @@ configure(subprojects) {
             dependencies {
                 annotationProcessor project(':tools:errorprone')
             }
+        } else if (it.name == 'lintChecks' && project != project(':tools:lint')) {
+            dependencies {
+                lintChecks project(':tools:lint')
+            }
         }
     }
 }

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -16,6 +16,7 @@ transport:transport-runtime
 transport:transport-backend-cct
 
 
+tools:lint
 tools:measurement:apksize
 tools:measurement:coverage
 tools:errorprone

--- a/tools/lint/lint.gradle
+++ b/tools/lint/lint.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'org.jetbrains.kotlin.jvm'
+}
+
+def lintVersion = '26.3.2'
+
+dependencies {
+  compileOnly "com.android.tools.lint:lint-api:$lintVersion"
+  compileOnly "com.android.tools.lint:lint-checks:$lintVersion"
+
+  testImplementation "junit:junit:4.12"
+  testImplementation "com.android.tools.lint:lint:$lintVersion"
+  testImplementation "com.android.tools.lint:lint-tests:$lintVersion"
+  testImplementation "com.android.tools:testutils:$lintVersion"
+}
+
+jar {
+  manifest {
+    attributes('Lint-Registry-v2': 'com.google.firebase.lint.checks.CheckRegistry')
+  }
+}

--- a/tools/lint/lint.gradle
+++ b/tools/lint/lint.gradle
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 plugins {
   id 'org.jetbrains.kotlin.jvm'
 }

--- a/tools/lint/src/main/kotlin/LintChecks.kt
+++ b/tools/lint/src/main/kotlin/LintChecks.kt
@@ -1,0 +1,65 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.lint.checks
+
+import com.android.SdkConstants
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.XmlContext
+import com.android.tools.lint.detector.api.XmlScanner
+import org.w3c.dom.Element
+
+class CheckRegistry : IssueRegistry() {
+    override val issues: List<Issue>
+        get() = listOf(EXPORTED_MISSING_ISSUE)
+
+    override val api: Int
+        get() = CURRENT_API
+    override val minApi: Int
+        get() = 2
+}
+
+internal val EXPORTED_MISSING_ISSUE: Issue = Issue.create(
+        "ManifestElementHasNoExportedAttribute",
+        "`android:exported` attribute missing on element",
+        "Leaving this attribute out may unintentionally lead to an exported component, please " +
+                "specify the value explicitly.",
+        Category.SECURITY,
+        1,
+        Severity.ERROR,
+        Implementation(ManifestElementHasNoExportedAttributeDetector::class.java, Scope.MANIFEST_SCOPE))
+
+class ManifestElementHasNoExportedAttributeDetector : Detector(), XmlScanner {
+
+    override fun getApplicableElements(): Collection<String>? = listOf("provider", "receiver", "service")
+
+    override fun visitElement(context: XmlContext, element: Element) {
+        val value = element.getAttributeNS(SdkConstants.ANDROID_URI, "exported")
+        value.takeIf { it.isEmpty() }?.let {
+            context.report(
+                    EXPORTED_MISSING_ISSUE,
+                    element,
+                    context.getLocation(element),
+                    "Set `android:exported` attribute explicitly. As the implicit default value " +
+                            "is insecure.")
+        }
+    }
+}

--- a/tools/lint/src/main/kotlin/LintChecks.kt
+++ b/tools/lint/src/main/kotlin/LintChecks.kt
@@ -47,9 +47,17 @@ internal val EXPORTED_MISSING_ISSUE: Issue = Issue.create(
         Severity.ERROR,
         Implementation(ManifestElementHasNoExportedAttributeDetector::class.java, Scope.MANIFEST_SCOPE))
 
+enum class Component(val xmlName: String) {
+    ACTIVITY("activity"),
+    ACTIVITY_ALIAS("activity-alias"),
+    PROVIDER("provider"),
+    RECEIVER("receiver"),
+    SERVICE("service"),
+}
+
 class ManifestElementHasNoExportedAttributeDetector : Detector(), XmlScanner {
 
-    override fun getApplicableElements(): Collection<String>? = listOf("provider", "receiver", "service")
+    override fun getApplicableElements(): Collection<String>? = Component.values().map { it.xmlName }
 
     override fun visitElement(context: XmlContext, element: Element) {
         val value = element.getAttributeNS(SdkConstants.ANDROID_URI, "exported")

--- a/tools/lint/src/test/kotlin/LintChecksTest.kt
+++ b/tools/lint/src/test/kotlin/LintChecksTest.kt
@@ -1,0 +1,122 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.lint.checks
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.TestLintResult
+import com.android.tools.lint.checks.infrastructure.TestResultChecker
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import java.lang.AssertionError
+
+enum class Component {
+    PROVIDER,
+    RECEIVER,
+    SERVICE,
+}
+
+internal fun manifestWith(cmp: Component, exported: Boolean? = null): String {
+    val exportedStr = when (exported) {
+        true, false -> "android:exported=\"$exported\""
+        null -> ""
+    }
+
+    return """
+            <manifest
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                package="com.example.lib">
+              <application>
+                <${cmp.name.toLowerCase()} android:name="foo" $exportedStr/>
+            </application>
+            </manifest>
+            """.trimIndent()
+}
+
+fun TestLintResult.checkContains(expected: String) {
+    this.check(TestResultChecker { output ->
+        if (!output.contains(expected)) {
+            throw AssertionError("Expected:<[$expected]>, but was:<[$output]>")
+        }
+    })
+}
+
+class Test : LintDetectorTest() {
+    fun testProvider_withNoExportedAttr() {
+        lint().files(
+                manifest(manifestWith(Component.PROVIDER)))
+                .run()
+                .checkContains("Error: Set android:exported attribute explicitly")
+    }
+
+    fun testProvider_withExportedAttrTrue() {
+        lint().files(
+                manifest(manifestWith(Component.PROVIDER, true)))
+                .run()
+                .expectClean()
+    }
+
+    fun testProvider_withExportedAttrFalse() {
+        lint().files(
+                manifest(manifestWith(Component.PROVIDER, false)))
+                .run()
+                .expectClean()
+    }
+
+    fun testReceiver_withNoExportedAttr() {
+        lint().files(
+                manifest(manifestWith(Component.RECEIVER)))
+                .run()
+                .checkContains("Error: Set android:exported attribute explicitly")
+    }
+
+    fun testReceiver_withExportedAttrTrue() {
+        lint().files(
+                manifest(manifestWith(Component.RECEIVER, true)))
+                .run()
+                .expectClean()
+    }
+
+    fun testReceiver_withExportedAttrFalse() {
+        lint().files(
+                manifest(manifestWith(Component.RECEIVER, false)))
+                .run()
+                .expectClean()
+    }
+
+    fun testService_withNoExportedAttr() {
+        lint().files(
+                manifest(manifestWith(Component.SERVICE)))
+                .run()
+                .checkContains("Error: Set android:exported attribute explicitly")
+    }
+
+    fun testService_withExportedAttrTrue() {
+        lint().files(
+                manifest(manifestWith(Component.SERVICE, true)))
+                .run()
+                .expectClean()
+    }
+
+    fun testService_withExportedAttrFalse() {
+        lint().files(
+                manifest(manifestWith(Component.SERVICE, false)))
+                .run()
+                .expectClean()
+    }
+
+    override fun getDetector(): Detector = ManifestElementHasNoExportedAttributeDetector()
+
+    override fun getIssues(): MutableList<Issue> = mutableListOf(EXPORTED_MISSING_ISSUE)
+}

--- a/tools/lint/src/test/kotlin/LintChecksTest.kt
+++ b/tools/lint/src/test/kotlin/LintChecksTest.kt
@@ -21,12 +21,6 @@ import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import java.lang.AssertionError
 
-enum class Component {
-    PROVIDER,
-    RECEIVER,
-    SERVICE,
-}
-
 internal fun manifestWith(cmp: Component, exported: Boolean? = null): String {
     val exportedStr = when (exported) {
         true, false -> "android:exported=\"$exported\""
@@ -38,7 +32,7 @@ internal fun manifestWith(cmp: Component, exported: Boolean? = null): String {
                 xmlns:android="http://schemas.android.com/apk/res/android"
                 package="com.example.lib">
               <application>
-                <${cmp.name.toLowerCase()} android:name="foo" $exportedStr/>
+                <${cmp.xmlName} android:name="foo" $exportedStr/>
             </application>
             </manifest>
             """.trimIndent()
@@ -53,67 +47,31 @@ fun TestLintResult.checkContains(expected: String) {
 }
 
 class Test : LintDetectorTest() {
-    fun testProvider_withNoExportedAttr() {
-        lint().files(
-                manifest(manifestWith(Component.PROVIDER)))
-                .run()
-                .checkContains("Error: Set android:exported attribute explicitly")
+    fun testComponents_withNoExportedAttr_shouldFail() {
+        Component.values().forEach {
+            lint().files(
+                    manifest(manifestWith(it)))
+                    .run()
+                    .checkContains("Error: Set android:exported attribute explicitly")
+        }
     }
 
-    fun testProvider_withExportedAttrTrue() {
-        lint().files(
-                manifest(manifestWith(Component.PROVIDER, true)))
-                .run()
-                .expectClean()
+    fun testComponents_withExportedAttrTrue_shouldSucceed() {
+        Component.values().forEach {
+            lint().files(
+                    manifest(manifestWith(it, true)))
+                    .run()
+                    .expectClean()
+        }
     }
 
-    fun testProvider_withExportedAttrFalse() {
-        lint().files(
-                manifest(manifestWith(Component.PROVIDER, false)))
-                .run()
-                .expectClean()
-    }
-
-    fun testReceiver_withNoExportedAttr() {
-        lint().files(
-                manifest(manifestWith(Component.RECEIVER)))
-                .run()
-                .checkContains("Error: Set android:exported attribute explicitly")
-    }
-
-    fun testReceiver_withExportedAttrTrue() {
-        lint().files(
-                manifest(manifestWith(Component.RECEIVER, true)))
-                .run()
-                .expectClean()
-    }
-
-    fun testReceiver_withExportedAttrFalse() {
-        lint().files(
-                manifest(manifestWith(Component.RECEIVER, false)))
-                .run()
-                .expectClean()
-    }
-
-    fun testService_withNoExportedAttr() {
-        lint().files(
-                manifest(manifestWith(Component.SERVICE)))
-                .run()
-                .checkContains("Error: Set android:exported attribute explicitly")
-    }
-
-    fun testService_withExportedAttrTrue() {
-        lint().files(
-                manifest(manifestWith(Component.SERVICE, true)))
-                .run()
-                .expectClean()
-    }
-
-    fun testService_withExportedAttrFalse() {
-        lint().files(
-                manifest(manifestWith(Component.SERVICE, false)))
-                .run()
-                .expectClean()
+    fun testComponents_withExportedAttrFalse_shouldSucceed() {
+        Component.values().forEach {
+            lint().files(
+                    manifest(manifestWith(it, false)))
+                    .run()
+                    .expectClean()
+        }
     }
 
     override fun getDetector(): Detector = ManifestElementHasNoExportedAttributeDetector()

--- a/transport/transport-runtime/src/main/AndroidManifest.xml
+++ b/transport/transport-runtime/src/main/AndroidManifest.xml
@@ -24,7 +24,9 @@
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false">
         </service>
-        <receiver android:name=".scheduling.jobscheduling.AlarmManagerSchedulerBroadcastReceiver"/>
+        <receiver
+            android:name=".scheduling.jobscheduling.AlarmManagerSchedulerBroadcastReceiver"
+            android:exported="false" />
         <service
             android:name=".backends.TransportBackendDiscovery"
             android:exported="false" />


### PR DESCRIPTION
The intent is to make sure teams don't forget to explicitly set the
attribute on Android components.