### PR TITLE
Storage: Remove PublicApi from package-private classes

### DIFF
--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
@@ -27,7 +27,6 @@ import com.google.firebase.storage.network.NetworkRequest;
 import org.json.JSONObject;
 
 /** A Task that retrieves the download URL for a {@link StorageReference} object */
-@PublicApi
 class GetDownloadUrlTask implements Runnable {
   private static final String TAG = "GetMetadataTask";
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
@@ -25,7 +25,6 @@ import com.google.firebase.storage.network.NetworkRequest;
 import org.json.JSONException;
 
 /** A Task that retrieves metadata for a {@link StorageReference} object */
-@PublicApi
 class GetMetadataTask implements Runnable {
   private static final String TAG = "GetMetadataTask";
 


### PR DESCRIPTION
This PR removes two `@PublicApi` annotations that annotate package-private classes.