### PR TITLE
Fix direct boot mode handling (b/116149732).

### DIFF
--- a/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
@@ -29,7 +29,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.support.annotation.VisibleForTesting;
-import android.support.v4.content.ContextCompat;
+import android.support.v4.os.UserManagerCompat;
 import android.support.v4.util.ArrayMap;
 import android.text.TextUtils;
 import android.util.Log;
@@ -694,8 +694,8 @@ public class FirebaseApp {
 
   /** Initializes all appropriate APIs for this instance. */
   private void initializeAllApis() {
-    boolean isDeviceProtectedStorage = ContextCompat.isDeviceProtectedStorage(applicationContext);
-    if (isDeviceProtectedStorage) {
+    boolean inDirectBoot = !UserManagerCompat.isUserUnlocked(applicationContext);
+    if (inDirectBoot) {
       // Ensure that all APIs are initialized once the user unlocks the phone.
       UserUnlockReceiver.ensureReceiverRegistered(applicationContext);
     } else {

--- a/firebase-common/src/main/java/com/google/firebase/internal/DataCollectionConfigStorage.java
+++ b/firebase-common/src/main/java/com/google/firebase/internal/DataCollectionConfigStorage.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.content.ContextCompat;
 import com.google.firebase.DataCollectionDefaultChange;
@@ -49,7 +50,8 @@ public class DataCollectionConfigStorage {
   }
 
   private static Context directBootSafe(Context applicationContext) {
-    if (ContextCompat.isDeviceProtectedStorage(applicationContext)) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N
+        || ContextCompat.isDeviceProtectedStorage(applicationContext)) {
       return applicationContext;
     }
     return ContextCompat.createDeviceProtectedStorageContext(applicationContext);

--- a/firebase-common/src/main/java/com/google/firebase/internal/DataCollectionConfigStorage.java
+++ b/firebase-common/src/main/java/com/google/firebase/internal/DataCollectionConfigStorage.java
@@ -19,6 +19,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.support.annotation.VisibleForTesting;
+import android.support.v4.content.ContextCompat;
 import com.google.firebase.DataCollectionDefaultChange;
 import com.google.firebase.events.Event;
 import com.google.firebase.events.Publisher;
@@ -39,12 +40,19 @@ public class DataCollectionConfigStorage {
 
   public DataCollectionConfigStorage(
       Context applicationContext, String persistenceKey, Publisher publisher) {
-    this.applicationContext = applicationContext;
+    this.applicationContext = directBootSafe(applicationContext);
     this.sharedPreferences =
         applicationContext.getSharedPreferences(
             FIREBASE_APP_PREFS + persistenceKey, Context.MODE_PRIVATE);
     this.publisher = publisher;
     this.dataCollectionDefaultEnabled = new AtomicBoolean(readAutoDataCollectionEnabled());
+  }
+
+  private static Context directBootSafe(Context applicationContext) {
+    if (ContextCompat.isDeviceProtectedStorage(applicationContext)) {
+      return applicationContext;
+    }
+    return ContextCompat.createDeviceProtectedStorageContext(applicationContext);
   }
 
   public boolean isEnabled() {


### PR DESCRIPTION
The problem was that we were checking for direct boot with a call to
`Context#isDeviceProtectedStorage()` which would always return false as we
never requested a "device protected storage" context. The correct way to
detect direct boot mode is via `UserManager#isUserUnlocked()`.

Additionally the change switches data collection configuration
to use "direct boot" safe storage. It is fine from a security
perspective as we don't store any sensitive information in the config.