### PR TITLE
Changing error message for missing google-services from DEBUG to WARN

### DIFF
--- a/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
@@ -258,7 +258,7 @@ public class FirebaseApp {
       }
       FirebaseOptions firebaseOptions = FirebaseOptions.fromResource(context);
       if (firebaseOptions == null) {
-        Log.d(
+        Log.w(
             LOG_TAG,
             "Default FirebaseApp failed to initialize because no default "
                 + "options were found. This usually means that com.google.gms:google-services was "


### PR DESCRIPTION
The error for a misconfigured default app should at least be a warning.