### PR TITLE
fiamui: Fix PermissionDenial in sample app

### DIFF
--- a/fiamui-app/src/main/AndroidManifest.xml
+++ b/fiamui-app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <activity
         android:name=".MainActivity"
         android:windowSoftInputMode="stateHidden"
-        android:exported="false">
+        android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
When exported is set to false, I get the following error:

04-18 11:58:55.151 1872-4043/system_process W/ActivityManager: Permission Denial: starting Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10000000 cmp=com.example.firebase.fiamui/.MainActivity } from null (pid=10983, uid=2000) not exported from uid 10085