### PR TITLE
Firestore: Split schema migrations into batches

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed an issue that prevented schema migrations for clients with
+  large offline datasets (#370, #734).
+
+# To be released - 19.0.0
 - [feature] You can now query across all collections in your database with a
   given collection ID using the `FirebaseFirestore.collectionGroup()` method.
 - [changed] The garbage collection process for on-disk persistence that

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [fixed] Fixed an issue that prevented schema migrations for clients with
-  large offline datasets (#370, #734).
+  large offline datasets (#370).
 
 # To be released - 19.0.0
 - [feature] You can now query across all collections in your database with a

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -51,13 +51,13 @@ class SQLiteSchema {
   static final int INDEXING_SUPPORT_VERSION = VERSION + 1;
 
   /**
-   * The batch size for operations that potentially operate on a large result set.
+   * The batch size for the sequence number migration in `ensureSequenceNumbers()`.
    *
    * <p>This addresses https://github.com/firebase/firebase-android-sdk/issues/370, where a customer
    * reported that schema migrations failed for clients with thousands of documents. The number has
    * been chosen arbitrarily.
    */
-  static final int REMOTE_DOCUMENTS_BATCH_SIZE = 1000;
+  private static final int SEQUENCE_NUMBER_BATCH_SIZE = 1000;
 
   private final SQLiteDatabase db;
 
@@ -376,7 +376,7 @@ class SQLiteSchema {
                     + "SELECT TD.path FROM target_documents AS TD "
                     + "WHERE RD.path = TD.path AND TD.target_id = 0"
                     + ") LIMIT ?")
-            .binding(REMOTE_DOCUMENTS_BATCH_SIZE);
+            .binding(SEQUENCE_NUMBER_BATCH_SIZE);
 
     boolean[] resultsRemaining = new boolean[1];
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -55,9 +55,9 @@ class SQLiteSchema {
    *
    * <p>This addresses https://github.com/firebase/firebase-android-sdk/issues/370, where a customer
    * reported that schema migrations failed for clients with thousands of documents. The number has
-   * been chosen arbitrarily.
+   * been chosen based on manual experiments.
    */
-  private static final int SEQUENCE_NUMBER_BATCH_SIZE = 1000;
+  private static final int SEQUENCE_NUMBER_BATCH_SIZE = 100;
 
   private final SQLiteDatabase db;
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -308,12 +308,15 @@ public class SQLiteSchemaTest {
   }
 
   @Test
-  public void addsSequenceNumberInBatches() {
+  public void addsSentinelRowsForLargeNumberOfDocuments() {
+    // PORTING NOTE: This test only exists on Android since other clients do not need to split
+    // large data sets during schema migration.
+
     schema.runMigrations(0, 6);
 
     // Set up some documents (we only need the keys). Note this count is higher than the batch size
-    // during migration, which is 1000.
-    int documentCount = 2500;
+    // during migration, which is 100.
+    int documentCount = 250;
     for (int i = 0; i < documentCount; i++) {
       String path = "coll/doc_" + i;
       db.execSQL(

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -312,8 +312,8 @@ public class SQLiteSchemaTest {
     schema.runMigrations(0, 6);
 
     // Set up some documents (we only need the keys). Note this count is higher than the batch size
-    // during migration, which is 100.
-    int documentCount = 250;
+    // during migration, which is 1000.
+    int documentCount = 2500;
     for (int i = 0; i < documentCount; i++) {
       String path = "coll/doc_" + i;
       db.execSQL(
@@ -384,31 +384,6 @@ public class SQLiteSchemaTest {
     }
 
     assertEquals(expectedParents, actualParents);
-  }
-
-  @Test
-  public void addsCollectionParentsInBatches() {
-    schema.runMigrations(0, 7);
-
-    // Set up some collections (we only need the keys). Note this count is higher than the batch
-    // size during migration, which is 100.
-    int collectionCount = 500;
-    for (int i = 0; i < collectionCount / 2; i++) {
-      db.execSQL(
-          "INSERT INTO remote_documents (path) VALUES (?)",
-          new String[] {encode(path("docs_" + i + "/doc"))});
-      db.execSQL(
-          "INSERT INTO document_mutations (path) VALUES (?)",
-          new String[] {encode(path("mutations_" + i + "/doc"))});
-    }
-
-    schema.runMigrations(7, 8);
-
-    new SQLitePersistence.Query(db, "SELECT COUNT(*) FROM collection_parents")
-        .first(
-            row -> {
-              assertEquals(collectionCount, row.getLong(0));
-            });
   }
 
   private void assertNoResultsForQuery(String query, String[] args) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -309,6 +309,11 @@ public class SQLiteSchemaTest {
 
   @Test
   public void addsSentinelRowsForLargeNumberOfDocuments() {
+    // This test only verifies that we add sentinal rows for documents even if the number of
+    // documents exceed our batch size. It does not verify that we do not hit a
+    // `SQLiteBlobTooBigException`, since this exception is not thrown when using SQLite through
+    // Robolectric.
+
     // PORTING NOTE: This test only exists on Android since other clients do not need to split
     // large data sets during schema migration.
 


### PR DESCRIPTION
Fixes: https://github.com/firebase/firebase-android-sdk/issues/370

When we migrate schemas with large datasets, we need to split our operations into multiple batches. Otherwise, we can exceed SQLite's CursorWindow.

This PR splits the three operations that potentially iterate through large datasets into batches. I have added tests that verify that the batching works, but I was not able to reproduce the original issue using the unit test. 

With this PR, I have been able to successfully migrate a schema in a test app that stored 10,000 documents. Without it, this migration fails with:

```
   Caused by: java.lang.RuntimeException: android.database.sqlite.SQLiteBlobTooBigException: Row too big to fit into CursorWindow requiredPos=15935, totalRows=4065
        at com.google.firebase.firestore.util.AsyncQueue.lambda$enqueue$3(com.google.firebase:firebase-firestore@@18.2.0:290)
        at com.google.firebase.firestore.util.AsyncQueue$$Lambda$3.run(Unknown Source:4)
...
```
