### PR TITLE
Simplified synchronization guard interface.

### DIFF
--- a/transport/transport-runtime/src/androidTest/aidl/com/google/android/datatransport/runtime/ITestRemoteLockRpc.aidl
+++ b/transport/transport-runtime/src/androidTest/aidl/com/google/android/datatransport/runtime/ITestRemoteLockRpc.aidl
@@ -4,7 +4,7 @@ package com.google.android.datatransport.runtime;
 interface ITestRemoteLockRpc {
 
     /** Try to acuire lock or timeout. */
-    boolean tryAcquireLock(long lockTimeoutMs);
+    boolean tryAcquireLock();
 
     /** Release held lock. If lock is not held - undefined behavior. */
     void releaseLock();

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/SynchronizationComponent.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/SynchronizationComponent.java
@@ -15,14 +15,14 @@
 package com.google.android.datatransport.runtime;
 
 import android.content.Context;
-import com.google.android.datatransport.runtime.scheduling.persistence.EventStoreModule;
+import com.google.android.datatransport.runtime.scheduling.persistence.TestEventStoreModule;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
 import com.google.android.datatransport.runtime.time.TimeModule;
 import dagger.BindsInstance;
 import dagger.Component;
 import javax.inject.Singleton;
 
-@Component(modules = {EventStoreModule.class, TimeModule.class})
+@Component(modules = {TestEventStoreModule.class, TimeModule.class})
 @Singleton
 public abstract class SynchronizationComponent {
   private static SynchronizationGuard INSTANCE;

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/SynchronizationComponent.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/SynchronizationComponent.java
@@ -15,6 +15,7 @@
 package com.google.android.datatransport.runtime;
 
 import android.content.Context;
+import com.google.android.datatransport.runtime.scheduling.persistence.SQLiteEventStore;
 import com.google.android.datatransport.runtime.scheduling.persistence.TestEventStoreModule;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
 import com.google.android.datatransport.runtime.time.TimeModule;
@@ -25,9 +26,9 @@ import javax.inject.Singleton;
 @Component(modules = {TestEventStoreModule.class, TimeModule.class})
 @Singleton
 public abstract class SynchronizationComponent {
-  private static SynchronizationGuard INSTANCE;
+  private static SQLiteEventStore INSTANCE;
 
-  abstract SynchronizationGuard getGuard();
+  abstract SQLiteEventStore getGuard();
 
   public static SynchronizationGuard getGuard(Context applicationContext) {
     synchronized (SynchronizationComponent.class) {
@@ -35,6 +36,15 @@ public abstract class SynchronizationComponent {
         INSTANCE = DaggerSynchronizationComponent.factory().create(applicationContext).getGuard();
       }
       return INSTANCE;
+    }
+  }
+
+  public static void shutdown() {
+    synchronized (SynchronizationComponent.class) {
+      if (INSTANCE == null) {
+        return;
+      }
+      INSTANCE.close();
     }
   }
 

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/MultiProcessSynchronizationGuardTest.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/MultiProcessSynchronizationGuardTest.java
@@ -19,14 +19,11 @@ import static org.junit.Assert.fail;
 
 import android.app.Service;
 import android.content.Intent;
-import android.os.IBinder;
 import android.os.RemoteException;
-import android.os.SystemClock;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.ServiceTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import com.google.android.datatransport.runtime.ITestRemoteLockRpc;
-import com.google.android.datatransport.runtime.scheduling.persistence.SQLiteEventStore;
 import java.util.concurrent.TimeoutException;
 import org.junit.Before;
 import org.junit.Test;
@@ -92,7 +89,7 @@ public class MultiProcessSynchronizationGuardTest {
 
   private static void lockAndRunOrFail(ITestRemoteLockRpc rpc, ThrowingRunnable runnable)
       throws RemoteException {
-    assertThat(rpc.tryAcquireLock(0)).isTrue();
+    assertThat(rpc.tryAcquireLock()).isTrue();
     try {
       runnable.run();
     } finally {
@@ -101,7 +98,7 @@ public class MultiProcessSynchronizationGuardTest {
   }
 
   private static void assertCanLock(ITestRemoteLockRpc rpc, boolean can) throws RemoteException {
-    boolean locked = rpc.tryAcquireLock(0);
+    boolean locked = rpc.tryAcquireLock();
 
     try {
       if (locked) {
@@ -123,38 +120,6 @@ public class MultiProcessSynchronizationGuardTest {
     ITestRemoteLockRpc rpc =
         ITestRemoteLockRpc.Stub.asInterface(
             rule.bindService(new Intent(InstrumentationRegistry.getTargetContext(), serviceClass)));
-    return new WaitingRpc(rpc);
-  }
-
-  static class WaitingRpc implements ITestRemoteLockRpc {
-    private final ITestRemoteLockRpc delegate;
-
-    WaitingRpc(ITestRemoteLockRpc delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public boolean tryAcquireLock(long timeout) throws RemoteException {
-      boolean result = delegate.tryAcquireLock(timeout);
-      if (!result) {
-        SystemClock.sleep(SQLiteEventStore.LOCK_RETRY_BACK_OFF_MILLIS * 2);
-      }
-      return result;
-    }
-
-    @Override
-    public void releaseLock() throws RemoteException {
-      delegate.releaseLock();
-    }
-
-    @Override
-    public long getPid() throws RemoteException {
-      return delegate.getPid();
-    }
-
-    @Override
-    public IBinder asBinder() {
-      return delegate.asBinder();
-    }
+    return rpc;
   }
 }

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/MultiProcessSynchronizationGuardTest.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/MultiProcessSynchronizationGuardTest.java
@@ -25,6 +25,7 @@ import android.support.test.rule.ServiceTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import com.google.android.datatransport.runtime.ITestRemoteLockRpc;
 import java.util.concurrent.TimeoutException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +44,11 @@ public class MultiProcessSynchronizationGuardTest {
     process2 = bindTestingRpc(TestService.Remote.class);
 
     assertThat(process1.getPid()).isNotEqualTo(process2.getPid());
+  }
+
+  @After
+  public void after() {
+    rule.unbindService();
   }
 
   @Test

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/RemoteLockRpc.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/RemoteLockRpc.java
@@ -35,13 +35,12 @@ class RemoteLockRpc extends ITestRemoteLockRpc.Stub {
   }
 
   @Override
-  public boolean tryAcquireLock(long lockTimeoutMs) {
+  public boolean tryAcquireLock() {
     Locker<Boolean> sectionEnteredLocker = new Locker<>();
     executor.execute(
         () -> {
           try {
             guard.runCriticalSection(
-                lockTimeoutMs,
                 () -> {
                   sectionEnteredLocker.setResult(true);
                   acquireReleaseLocker.await();

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/TestService.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/TestService.java
@@ -31,6 +31,12 @@ public abstract class TestService extends Service {
         DaggerSynchronizationComponent.getGuard(getApplicationContext()));
   }
 
+  @Override
+  public boolean onUnbind(Intent intent) {
+    DaggerSynchronizationComponent.shutdown();
+    return false;
+  }
+
   /** Service instance that runs in the main process of the Android application. */
   public static class Local extends TestService {}
 

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
@@ -20,10 +20,18 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-public abstract class EventStoreModule {
+public abstract class TestEventStoreModule {
+  private static final long MAX_DB_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+  private static final int LOAD_BATCH_SIZE = 200;
+  private static final int LOCK_TIME_OUT_MS = 0;
+
   @Provides
   static EventStoreConfig storeConfig() {
-    return EventStoreConfig.DEFAULT;
+    return EventStoreConfig.builder()
+        .setMaxStorageSizeInBytes(MAX_DB_STORAGE_SIZE_IN_BYTES)
+        .setLoadBatchSize(LOAD_BATCH_SIZE)
+        .setCriticalSectionEnterTimeoutMs(LOCK_TIME_OUT_MS)
+        .build();
   }
 
   @Binds

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntimeComponent.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntimeComponent.java
@@ -17,10 +17,13 @@ package com.google.android.datatransport.runtime;
 import android.content.Context;
 import com.google.android.datatransport.runtime.backends.BackendRegistryModule;
 import com.google.android.datatransport.runtime.scheduling.SchedulingModule;
+import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStoreModule;
 import com.google.android.datatransport.runtime.time.TimeModule;
 import dagger.BindsInstance;
 import dagger.Component;
+import java.io.Closeable;
+import java.io.IOException;
 import javax.inject.Singleton;
 
 @Component(
@@ -32,8 +35,15 @@ import javax.inject.Singleton;
       TimeModule.class,
     })
 @Singleton
-interface TransportRuntimeComponent {
-  TransportRuntime getTransportRuntime();
+abstract class TransportRuntimeComponent implements Closeable {
+  abstract TransportRuntime getTransportRuntime();
+
+  abstract EventStore getEventStore();
+
+  @Override
+  public void close() throws IOException {
+    getEventStore().close();
+  }
 
   @Component.Builder
   interface Builder {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/DefaultScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/DefaultScheduler.java
@@ -38,7 +38,6 @@ public class DefaultScheduler implements Scheduler {
   private final BackendRegistry backendRegistry;
   private final EventStore eventStore;
   private final SynchronizationGuard guard;
-  private final int LOCK_TIME_OUT = 10000; // 10 seconds lock timeout
 
   @Inject
   DefaultScheduler(
@@ -74,7 +73,6 @@ public class DefaultScheduler implements Scheduler {
           }
           EventInternal decoratedEvent = transportBackend.decorate(event);
           guard.runCriticalSection(
-              LOCK_TIME_OUT,
               () -> {
                 eventStore.persist(transportContext, decoratedEvent);
                 workScheduler.schedule(transportContext, 0);

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStore.java
@@ -18,6 +18,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
+import java.io.Closeable;
 
 /**
  * Persistence layer.
@@ -25,7 +26,7 @@ import com.google.android.datatransport.runtime.TransportContext;
  * <p>Responsible for storing events and backend-specific metadata.
  */
 @WorkerThread
-public interface EventStore {
+public interface EventStore extends Closeable {
 
   /** Persist a new event. */
   @Nullable

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreConfig.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreConfig.java
@@ -18,23 +18,42 @@ import com.google.auto.value.AutoValue;
 
 @AutoValue
 abstract class EventStoreConfig {
+  private static final long MAX_DB_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+  private static final int LOAD_BATCH_SIZE = 200;
+  private static final int LOCK_TIME_OUT_MS = 10000;
+
+  static final EventStoreConfig DEFAULT =
+      EventStoreConfig.builder()
+          .setMaxStorageSizeInBytes(MAX_DB_STORAGE_SIZE_IN_BYTES)
+          .setLoadBatchSize(LOAD_BATCH_SIZE)
+          .setCriticalSectionEnterTimeoutMs(LOCK_TIME_OUT_MS)
+          .build();
+
   abstract long getMaxStorageSizeInBytes();
 
   abstract int getLoadBatchSize();
 
-  static EventStoreConfig create(long maxStorageSizeInBytes, int loadBatchSize) {
-    if (maxStorageSizeInBytes < 0) {
-      throw new IllegalArgumentException(
-          "Cannot set max storage size to a negative number of bytes");
-    }
-    if (loadBatchSize < 0) {
-      throw new IllegalArgumentException(
-          "Cannot set load batch size to a negative number of bytes");
-    }
-    return new AutoValue_EventStoreConfig(maxStorageSizeInBytes, loadBatchSize);
+  abstract int getCriticalSectionEnterTimeoutMs();
+
+  static EventStoreConfig.Builder builder() {
+    return new AutoValue_EventStoreConfig.Builder();
   }
 
-  EventStoreConfig withMaxStorageSizeInBytes(long newVaue) {
-    return create(newVaue, getLoadBatchSize());
+  Builder toBuilder() {
+    return builder()
+        .setMaxStorageSizeInBytes(getMaxStorageSizeInBytes())
+        .setLoadBatchSize(getLoadBatchSize())
+        .setCriticalSectionEnterTimeoutMs(getCriticalSectionEnterTimeoutMs());
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder setMaxStorageSizeInBytes(long value);
+
+    abstract Builder setLoadBatchSize(int value);
+
+    abstract Builder setCriticalSectionEnterTimeoutMs(int value);
+
+    abstract EventStoreConfig build();
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -252,6 +252,11 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
         });
   }
 
+  @Override
+  public void close() {
+    openHelper.close();
+  }
+
   /** Loads all events for a backend. */
   private List<PersistedEvent> loadEvents(SQLiteDatabase db, TransportContext transportContext) {
     List<PersistedEvent> events = new ArrayList<>();

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -25,7 +25,6 @@ import android.os.SystemClock;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.support.annotation.WorkerThread;
-import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationException;
@@ -50,14 +49,11 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
 
   static final int MAX_RETRIES = 10;
 
-  private static final Priority[] ALL_PRIORITIES = Priority.values();
-
-  @VisibleForTesting public static final int LOCK_RETRY_BACK_OFF_MILLIS = 50;
+  private static final int LOCK_RETRY_BACK_OFF_MILLIS = 50;
 
   private final OpenHelper openHelper;
   private final Clock monotonicClock;
   private final EventStoreConfig config;
-  private SQLiteDatabase db;
 
   @Inject
   SQLiteEventStore(Context applicationContext, @Monotonic Clock clock, EventStoreConfig config) {
@@ -68,16 +64,11 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
   }
 
   private SQLiteDatabase getDb() {
-    if (db == null) {
-      db =
-          retryIfDbLocked(
-              1000,
-              openHelper::getWritableDatabase,
-              ex -> {
-                throw new SynchronizationException("Timed out while trying to open db.", ex);
-              });
-    }
-    return db;
+    return retryIfDbLocked(
+        openHelper::getWritableDatabase,
+        ex -> {
+          throw new SynchronizationException("Timed out while trying to open db.", ex);
+        });
   }
 
   @Override
@@ -348,14 +339,13 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
     return events;
   }
 
-  private <T> T retryIfDbLocked(
-      long lockTimeoutMs, Producer<T> retriable, Function<Throwable, T> failureHandler) {
+  private <T> T retryIfDbLocked(Producer<T> retriable, Function<Throwable, T> failureHandler) {
     long startTime = monotonicClock.getTime();
     do {
       try {
         return retriable.produce();
       } catch (SQLiteDatabaseLockedException ex) {
-        if (monotonicClock.getTime() >= startTime + lockTimeoutMs) {
+        if (monotonicClock.getTime() >= startTime + config.getCriticalSectionEnterTimeoutMs()) {
           return failureHandler.apply(ex);
         }
         SystemClock.sleep(LOCK_RETRY_BACK_OFF_MILLIS);
@@ -372,9 +362,8 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
   }
 
   /** Tries to start a transaction until it succeeds or times out. */
-  private void ensureBeginTransaction(SQLiteDatabase db, long lockTimeoutMs) {
+  private void ensureBeginTransaction(SQLiteDatabase db) {
     retryIfDbLocked(
-        lockTimeoutMs,
         () -> {
           db.beginTransaction();
           return null;
@@ -385,9 +374,9 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
   }
 
   @Override
-  public <T> T runCriticalSection(long lockTimeoutMs, CriticalSection<T> criticalSection) {
+  public <T> T runCriticalSection(CriticalSection<T> criticalSection) {
     SQLiteDatabase db = getDb();
-    ensureBeginTransaction(db, lockTimeoutMs);
+    ensureBeginTransaction(db);
     try {
       T result = criticalSection.execute();
       db.setTransactionSuccessful();
@@ -419,15 +408,7 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
     }
   }
 
-  private static Priority toPriority(int value) {
-    if (value < 0 || value >= ALL_PRIORITIES.length) {
-      return Priority.DEFAULT;
-    }
-    return ALL_PRIORITIES[value];
-  }
-
-  @VisibleForTesting
-  boolean isStorageAtLimit() {
+  private boolean isStorageAtLimit() {
     long byteSize = getPageCount() * getPageSize();
 
     return byteSize >= config.getMaxStorageSizeInBytes();

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/synchronization/SynchronizationGuard.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/synchronization/SynchronizationGuard.java
@@ -29,16 +29,15 @@ public interface SynchronizationGuard {
    * <p>Example usage:
    *
    * <pre>{@code
-   * store.atomically(() -> {
+   * int result = guard.runCriticalSection(() -> {
    *   store.persist("foo", event);
    *   store.recordSuccess(Collections.singleton(event));
+   *   return 1;
    * });
    * }</pre>
    *
-   * @param lockTimeoutMs how long to wait to acquire the lock before throwing {@link
-   *     SynchronizationException}.
    * @param criticalSection Critical section to run while holding the lock.
    * @throws SynchronizationException if unable to enter critical section.
    */
-  <T> T runCriticalSection(long lockTimeoutMs, CriticalSection<T> criticalSection);
+  <T> T runCriticalSection(CriticalSection<T> criticalSection);
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
@@ -45,7 +45,7 @@ public class UploaderTest {
   private static final SynchronizationGuard guard =
       new SynchronizationGuard() {
         @Override
-        public <T> T runCriticalSection(long lockTimeoutMs, CriticalSection<T> criticalSection) {
+        public <T> T runCriticalSection(CriticalSection<T> criticalSection) {
           return criticalSection.execute();
         }
       };

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/InMemoryEventStore.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/InMemoryEventStore.java
@@ -96,4 +96,7 @@ public class InMemoryEventStore implements EventStore {
     }
     return events;
   }
+
+  @Override
+  public void close() {}
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
@@ -41,7 +41,8 @@ public class SQLiteEventStoreTest {
           .addMetadata("key1", "value1")
           .addMetadata("key2", "value2")
           .build();
-  private static final EventStoreConfig CONFIG = EventStoreConfig.create(10 * 1024 * 1024, 5);
+  private static final EventStoreConfig CONFIG =
+      EventStoreConfig.DEFAULT.toBuilder().setLoadBatchSize(5).build();
 
   private final SQLiteEventStore store = newStoreWithConfig(CONFIG);
 
@@ -143,10 +144,13 @@ public class SQLiteEventStoreTest {
   @Test
   public void persist_whenDbSizeOnDiskIsAtLimit_shouldNotPersistNewEvents() {
     SQLiteEventStore storeUnderTest =
-        newStoreWithConfig(CONFIG.withMaxStorageSizeInBytes(store.getByteSize()));
+        newStoreWithConfig(
+            CONFIG.toBuilder().setMaxStorageSizeInBytes(store.getByteSize()).build());
     assertThat(storeUnderTest.persist(TRANSPORT_CONTEXT, EVENT)).isNull();
 
-    storeUnderTest = newStoreWithConfig(CONFIG.withMaxStorageSizeInBytes(store.getByteSize() + 1));
+    storeUnderTest =
+        newStoreWithConfig(
+            CONFIG.toBuilder().setMaxStorageSizeInBytes(store.getByteSize() + 1).build());
     assertThat(storeUnderTest.persist(TRANSPORT_CONTEXT, EVENT)).isNotNull();
   }
 


### PR DESCRIPTION
Lock timeout is no longer part of the interface and instead is an
implementation detail of SqliteEventStore.