### PR TITLE
Add settings.gradle to prep for Gradle 5

### DIFF
--- a/smoke-tests/settings.gradle
+++ b/smoke-tests/settings.gradle
@@ -1,0 +1,13 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.


### PR DESCRIPTION
Gradle 5 needs this file to distinguish project boundaries. We have no settings at the moment, so this file is blank.