### PR TITLE
Update documentation for Code Formatting plugin and Firestore testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ projects may be published as follows.
 
 Code in this repo is formatted with the google-java-format tool. You can enable
 this formatting in Android Studio by downloading and installing the
-[google-java-format plugin](https://plugins.jetbrains.com/plugin/8527-google-java-format).
+[google-java-format plugin](https://github.com/google/google-java-format#).
+The plugin is disabled by default, but the repo contains configuration information
+and links to additional plugins.
 
 To run formatting on your entire project you can run
 ```bash

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ projects may be published as follows.
 
 Code in this repo is formatted with the google-java-format tool. You can enable
 this formatting in Android Studio by downloading and installing the
-[google-java-format plugin](https://github.com/google/google-java-format#).
+[google-java-format plugin](https://github.com/google/google-java-format).
 The plugin is disabled by default, but the repo contains configuration information
 and links to additional plugins.
 

--- a/firebase-firestore/README.md
+++ b/firebase-firestore/README.md
@@ -16,6 +16,6 @@ publishing/testing Cloud Firestore.
 
 ## Testing
 
-After importing the project into Android Studio and building successfully, you 
-will need to undo the deletion of test files in `.idea/runConfigurations` to
-run integration tests from Android Studio. 
+After importing the project into Android Studio and building successfully
+for the first time, you will need to undo the deletion of xml files in 
+`.idea/runConfigurations` to run Firestore tests from Android Studio. 

--- a/firebase-firestore/README.md
+++ b/firebase-firestore/README.md
@@ -13,3 +13,9 @@ Firebase and Google Cloud Platform products, including Cloud Functions.
 All Gradle commands should be run from the source root (which is one level up
 from this folder). See the README.md in the source root for instructions on
 publishing/testing Cloud Firestore.
+
+## Testing
+
+After importing the project into Android Studio and building successfully, you 
+will need to undo the deletion of test files in `.idea/runConfigurations` to
+run integration tests from Android Studio. 

--- a/firebase-firestore/README.md
+++ b/firebase-firestore/README.md
@@ -17,5 +17,9 @@ publishing/testing Cloud Firestore.
 ## Testing
 
 After importing the project into Android Studio and building successfully
-for the first time, you will need to undo the deletion of xml files in 
-`.idea/runConfigurations` to run Firestore tests from Android Studio. 
+for the first time, Android Studio will delete the run configuration xml files
+in `./idea/runConfigurations`. Undo these changes with the command:
+
+```
+$ git checkout .idea/runConfigurations
+```


### PR DESCRIPTION
* The current link for `google-java-format` points to the IntelliJ site, which does not contain configuration information for setting up and enabling the plugin. The Github repo contains detailed setup instructions and links to other useful plugins as well.
* Importing the project for the first time and building in Android Studio causes the .xml files in `.idea/runConfigurations` to be deleted. Those files allow running Firestore tests from within Android Studio. Adding a message inside the Firestore package to point that out.