### PR TITLE
Fix issue for coverage report generation.

### DIFF
--- a/root-project.gradle
+++ b/root-project.gradle
@@ -104,8 +104,8 @@ configure(subprojects) {
           'description': 'Generates JaCoCo unit test coverage reports.'], checkCoverage) {
         def excludes = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**Manifest*.*']
         classDirectories = files([
-            fileTree(dir: "$buildDir/intermediates/javac/debug", excludes: excludes),
-            fileTree(dir: "$buildDir/tmp/kotlin-classes/debug", excludes: excludes)
+            fileTree(dir: "$buildDir/intermediates/javac", excludes: excludes),
+            fileTree(dir: "$buildDir/tmp/kotlin-classes", excludes: excludes)
         ])
         sourceDirectories = files(['src/main/java', 'src/main/kotlin'])
         executionData = fileTree(dir: "$buildDir", includes: ['jacoco/*.exec'])


### PR DESCRIPTION
Build variant of 'debug' was disabled in PR #312. Changed class
file lookup location in coverage calculation to be build type agnostic.