### PR TITLE
Update APK Size Tool to use release builds.

### DIFF
--- a/tools/measurement/apksize/sdks.csv
+++ b/tools/measurement/apksize/sdks.csv
@@ -1,4 +1,8 @@
 database-aggressive:4
+database-release:8
 firestore-aggressive:1
+firestore-release:5
 functions-aggressive:2
 storage-aggressive:3
+functions-release:6
+storage-release:7


### PR DESCRIPTION
Gradle is now building both the release and aggressive variants, so we need to accommodate that.