### PR TITLE
Discard coverage info if sdk name not defined in mappings.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/UploadMeasurementsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/UploadMeasurementsTask.groovy
@@ -65,6 +65,8 @@ public class UploadMeasurementsTask extends DefaultTask {
                 Files.copy(it, jar, StandardCopyOption.REPLACE_EXISTING)
             }
 
+            project.logger.info("Running uploader with flags: --config_path=${configuration} --json_path=${reportFile}")
+
             project.exec {
                 executable("java")
 

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/coverage/GenerateMeasurementsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/coverage/GenerateMeasurementsTask.groovy
@@ -83,13 +83,18 @@ public class GenerateMeasurementsTask extends DefaultTask {
                 'firebase-firestore-ktx': 5,
                 'firebase-functions': 6,
                 'firebase-inappmessaging-display': 7,
-                'firebase-storage': 8
+                'firebase-storage': 8,
+                'firebase-datatransport': 9
         ]
 
         for (Project p: project.rootProject.subprojects) {
             if (p.name.startsWith('firebase')) {
                 def (name, percent) = getCoveragePercentFromReport(p)
-                coverages[sdkMap[name]] = percent
+                if (sdkMap.containsKey(name)) {
+                    coverages[sdkMap[name]] = percent
+                } else {
+                    project.logger.warn("Find SDK with name: $name not defined in the SDK to ID mapping.")
+                }
             }
         }
 


### PR DESCRIPTION
Log the shell command executed for uploading metrics.