### PR TITLE
Add combined flavor to smoke tests

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -38,6 +38,11 @@ android {
   flavorDimensions "systemUnderTest"
 
   productFlavors {
+    combined {
+      dimension "systemUnderTest"
+      applicationId "com.google.firebase.testing.combined"
+    }
+
     database {
       dimension "systemUnderTest"
       applicationId "com.google.firebase.testing.database"
@@ -51,6 +56,17 @@ android {
     storage {
       dimension "systemUnderTest"
       applicationId "com.google.firebase.testing.storage"
+    }
+  }
+
+  sourceSets {
+    combined {
+      java.srcDirs = [
+          "src/combined/java",
+	  "src/database/java",
+	  "src/firestore/java",
+	  "src/storage/java",
+      ]
     }
   }
 }
@@ -68,6 +84,12 @@ dependencies {
 
   implementation "androidx.test:rules:1.1.0"
   implementation "com.google.firebase:firebase-common:16.0.7"
+
+  // All
+  combinedImplementation "com.google.firebase:firebase-auth:16.1.0"
+  combinedImplementation "com.google.firebase:firebase-database:16.1.0"
+  combinedImplementation "com.google.firebase:firebase-firestore:18.1.0"
+  combinedImplementation "com.google.firebase:firebase-storage:16.1.0"
 
   // Database
   databaseImplementation "com.google.firebase:firebase-auth:16.1.0"

--- a/smoke-tests/src/combined/AndroidManifest.xml
+++ b/smoke-tests/src/combined/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.google.firebase.testing">
+
+  <uses-permission android:name="android.permission.INTERNET" />
+
+  <application>
+    <activity android:name="android.app.Activity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+
+    <meta-data android:name="com.google.firebase.testing.classes"
+      android:value="com.google.firebase.testing.combined.AllTests" />
+  </application>
+</manifest>

--- a/smoke-tests/src/combined/java/com/google/firebase/testing/combined/AllTests.java
+++ b/smoke-tests/src/combined/java/com/google/firebase/testing/combined/AllTests.java
@@ -1,0 +1,28 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.combined;
+
+import com.google.firebase.testing.database.DatabaseTest;
+import com.google.firebase.testing.firestore.FirestoreTest;
+import com.google.firebase.testing.storage.StorageTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * A test suite combining the individual product flavors.
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({DatabaseTest.class, FirestoreTest.class, StorageTest.class})
+public final class AllTests {}


### PR DESCRIPTION
This adds a new build flavor to the smoke tests. The combined flavor includes the other flavors enabling us to test with a single executable and verify they build together. The individual variants can still be used to test products individually.