### PR TITLE
Add ACCESS_NETWORK_STATE to androidTest build.

### DIFF
--- a/firebase-firestore/src/androidTest/AndroidManifest.xml
+++ b/firebase-firestore/src/androidTest/AndroidManifest.xml
@@ -2,6 +2,7 @@
   package="com.google.firebase.firestore">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
   <!--<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="23" />-->
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET"/>
   <application>
     <uses-library android:name="android.test.runner" />


### PR DESCRIPTION
Without this, the integration tests fail within google3.