### PR TITLE
Explicitly add `transport` to enabled projects

### DIFF
--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -12,6 +12,7 @@ firebase-storage
 firebase-storage:test-app
 protolite-well-known-types
 
+transport
 transport:transport-api
 transport:transport-runtime
 transport:transport-backend-cct


### PR DESCRIPTION
This fixes our release pipeline, which fails to pick up maven group id otherwise