### PR TITLE
Keep all component registrars

### DIFF
--- a/firebase-common/proguard.txt
+++ b/firebase-common/proguard.txt
@@ -1,2 +1,3 @@
 -dontwarn com.google.firebase.components.Component$Instantiation
 -dontwarn com.google.firebase.components.Component$ComponentType
+-keep class * implements com.google.firebase.components.ComponentRegistrar


### PR DESCRIPTION
Component registrars are only referenced from metadata attributes in manifest
files, which can lead to them getting stripped by Proguard otherwise, resulting
in component lookup failures at runtime.