### PR TITLE
Add support for Bill of Materials to smoke tests.

### DIFF
--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -7,10 +7,20 @@ interfaces. However, the tests should strive to remain similar to real use
 cases. As such, these tests run on devices or emulators (no Robolectric). This
 is a work in progress, and the following list shows what is complete:
 
-- [ ] Create first set of tests to replace old test apps.
-- [ ] Reliably run smoke tests on CI.
+- [x] Create first set of tests to replace old test apps.
+- [x] Reliably run smoke tests on CI.
 - [ ] Support version matrices.
 - [ ] Extend to collect system health metrics.
+
+# Running the Tests
+
+The tests may be run locally with the command `../gradlew
+connectedCombinedDebugCheck`. The combined flavor includes all supported test
+cases. Optionally, other flavors (explained below) may be used to run a subset
+of the tests. Additionally, the test suite uses a Bill of Materials to specify
+Firebase versions. This may be configured using the `-Pfirebase-bom`
+command-line parameter. The value must be a valid Bill of Materials artifact.
+The default is `com.google.firebase:firebase-bom:18.1.0`.
 
 # Project Structure
 

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -76,6 +76,8 @@ repositories {
   jcenter()
 }
 
+apply from: "configure.gradle"
+
 dependencies {
   // Common
   api "androidx.test:runner:1.1.0"
@@ -83,25 +85,25 @@ dependencies {
   api "junit:junit:4.12"
 
   implementation "androidx.test:rules:1.1.0"
-  implementation "com.google.firebase:firebase-common:16.0.7"
+  implementation "com.google.firebase:firebase-common"
 
   // All
-  combinedImplementation "com.google.firebase:firebase-auth:16.1.0"
-  combinedImplementation "com.google.firebase:firebase-database:16.1.0"
-  combinedImplementation "com.google.firebase:firebase-firestore:18.1.0"
-  combinedImplementation "com.google.firebase:firebase-storage:16.1.0"
+  combinedImplementation "com.google.firebase:firebase-auth"
+  combinedImplementation "com.google.firebase:firebase-database"
+  combinedImplementation "com.google.firebase:firebase-firestore"
+  combinedImplementation "com.google.firebase:firebase-storage"
 
   // Database
-  databaseImplementation "com.google.firebase:firebase-auth:16.1.0"
-  databaseImplementation "com.google.firebase:firebase-database:16.1.0"
+  databaseImplementation "com.google.firebase:firebase-auth"
+  databaseImplementation "com.google.firebase:firebase-database"
 
   // Firestore
-  firestoreImplementation "com.google.firebase:firebase-auth:16.1.0"
-  firestoreImplementation "com.google.firebase:firebase-firestore:18.1.0"
+  firestoreImplementation "com.google.firebase:firebase-auth"
+  firestoreImplementation "com.google.firebase:firebase-firestore"
 
   // Storage
-  storageImplementation "com.google.firebase:firebase-auth:16.1.0"
-  storageImplementation "com.google.firebase:firebase-storage:16.1.0"
+  storageImplementation "com.google.firebase:firebase-auth"
+  storageImplementation "com.google.firebase:firebase-storage"
 }
 
 apply plugin: "com.google.gms.google-services"

--- a/smoke-tests/configure.gradle
+++ b/smoke-tests/configure.gradle
@@ -12,4 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-enableFeaturePreview("IMPROVED_POM_SUPPORT")
+
+def configurePlatform() {
+  def bom = "com.google.firebase:firebase-bom:18.1.0"
+  if (project.hasProperty("firebase-bom")) {
+    bom = project.getProperty("firebase-bom")
+  }
+
+  def version = project.gradle.gradleVersion
+  if (version.startsWith("4.")) {
+    project.dependencies.add("implementation", bom)
+  } else {
+    def platform = project.dependencies.platform(bom)
+    project.dependencies.add("implementation", platform)
+    logger.warn("Congrats on switching to Gradle 5.y!")
+    logger.warn("Perhaps remove the Gradle 4.x compat layer?")
+  }
+}
+
+configurePlatform()


### PR DESCRIPTION
This change adds support to use a Bill of Materials to run the smoke tests. The Bill of Materials contains the versions of the Firebase libraries that should be used.