### PR TITLE
Add missing engine param in package.json (functions/tests)

### DIFF
--- a/firebase-functions/src/androidTest/backend/functions/package.json
+++ b/firebase-functions/src/androidTest/backend/functions/package.json
@@ -8,5 +8,8 @@
   "devDependencies": {
     "@google-cloud/functions-emulator": "1.0.0-beta.4"
   },
-  "private": true
+  "private": true,
+  "engines": {
+    "node": "8"
+  }
 }


### PR DESCRIPTION
Functions package.json must specify the engine.

https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version