### PR TITLE
Move SSL initialization to a separate thread

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/LicenseResolverPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/license/LicenseResolverPlugin.groovy
@@ -14,6 +14,7 @@
 
 package com.google.firebase.gradle.plugins.license
 
+import com.android.build.gradle.tasks.BundleAar
 import com.google.firebase.gradle.plugins.license.RemoteLicenseFetcher.AnotherMITLicenseFetcher
 import com.google.firebase.gradle.plugins.license.RemoteLicenseFetcher.AndroidSdkTermsFetcher
 import com.google.firebase.gradle.plugins.license.RemoteLicenseFetcher.AnotherApache2LicenseFetcher
@@ -90,7 +91,7 @@ class LicenseResolverPlugin implements Plugin<Project> {
                     outputDir = licensesDir
                 }
 
-                project.tasks.getByName("bundleReleaseAar") {
+                project.tasks.withType(BundleAar) {
                     dependsOn licensesTask
                     from licensesTask.outputDir
                 }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/publish/Publisher.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/publish/Publisher.groovy
@@ -16,6 +16,9 @@ package com.google.firebase.gradle.plugins.publish
 
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.publish.maven.MavenPublication
 
 /** Handles publication versioning and pom validation upon release. */
@@ -26,7 +29,7 @@ class Publisher {
         SNAPSHOT
     }
     private final Mode mode;
-    private final Set<Project> projectsToPublish;
+    private final Set<Project> projectsToPublish
 
     Publisher(Mode mode, Set<Project> projectsToPublish) {
         this.mode = mode
@@ -37,6 +40,7 @@ class Publisher {
         publication.pom.withXml {
             def rootNode = asNode()
             validatePomXml(project, rootNode)
+            processDependencies(project, rootNode)
         }
     }
 
@@ -51,7 +55,7 @@ class Publisher {
         return UNRELEASED_VERSION
     }
 
-    private void validatePomXml(Project p, Node pom) {
+    private static void validatePomXml(Project p, Node pom) {
         def unreleased = pom.dependencies.dependency.findAll { it.version.text() == UNRELEASED_VERSION }
                 .collect { "${it.groupId.text()}:${it.artifactId.text()}"}
         if(unreleased) {
@@ -61,6 +65,55 @@ class Publisher {
 
     private static String renderVersion(String baseVersion, Mode mode) {
         return "${baseVersion}${mode == Mode.SNAPSHOT ? '-SNAPSHOT' : ''}"
+    }
+
+    private static void processDependencies(Project project, Node pom) {
+        def deps = getDependencyTypes(project)
+
+        pom.dependencies.dependency.each {
+            // remove multidex as it is supposed to be added by final applications and is needed for
+            // some libraries only for instrumentation tests to build.
+            if (it.groupId.text() in ['com.android.support', 'androidx'] && it.artifactId.text() == 'multidex') {
+                it.parent().remove(it)
+            }
+            it.appendNode('type', [:], deps["${it.groupId.text()}:${it.artifactId.text()}"])
+
+            // change scope to compile to preserve existing behavior
+            it.scope.replaceNode {
+                createNode('scope', 'compile')
+            }
+        }
+    }
+
+    private static Map<String, String> getDependencyTypes(Project project) {
+        def dummyDependencyConfiguration = project.configurations.create('publisherDummyConfig')
+        def nonProjectDependencies = project.configurations.releaseRuntimeClasspath.allDependencies.findAll {
+            !(it instanceof ProjectDependency)
+        }
+        dummyDependencyConfiguration.dependencies.addAll(nonProjectDependencies)
+        try {
+            return project.configurations.releaseRuntimeClasspath.getAllDependencies().collectEntries {
+                [("$it.group:$it.name" as String): getType(dummyDependencyConfiguration, it)]
+            }
+        } finally {
+            project.configurations.remove(dummyDependencyConfiguration)
+        }
+
+    }
+
+    private static String getType(Configuration config, Dependency d) {
+        if (d instanceof ProjectDependency) {
+            // we currently only support aar libraries to be produced in this repository
+            return 'aar'
+        }
+        String path = config.find {
+            it.absolutePath.matches(".*\\Q$d.group/$d.name/$d.version/\\E[a-zA-Z0-9]+/\\Q$d.name-$d.version.\\E[aj]ar")
+        }?.absolutePath
+        if (path && path.endsWith (".aar")) {
+            return "aar"
+        } else {
+            return "jar"
+        }
     }
 
 }

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-- [changed] SSL initialization now happens on a separate thread, which should
-  improve query performance during client startup.
+- [changed] SSL initialization now happens on a separate thread, which reduces
+  the time taken to produce the first query result.
 
 # Unreleased (19.0.1)
 - [fixed] Fixed an issue that prevented schema migrations for clients with

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [changed] SSL initialization now happens on a separate thread, which should
+  improve query performance during client startup.
+
+# Unreleased (19.0.1)
 - [fixed] Fixed an issue that prevented schema migrations for clients with
   large offline datasets (#370).
 

--- a/firebase-firestore/README.md
+++ b/firebase-firestore/README.md
@@ -10,12 +10,84 @@ responsive apps that work regardless of network latency or Internet
 connectivity. Cloud Firestore also offers seamless integration with other
 Firebase and Google Cloud Platform products, including Cloud Functions.
 
+## Building
+
 All Gradle commands should be run from the source root (which is one level up
 from this folder). See the README.md in the source root for instructions on
 publishing/testing Cloud Firestore.
 
-## Testing
+To build Cloud Firestore, from the source root run:
+```bash
+./gradlew :firebase-firestore:assembleRelease
+```
 
+## Unit Testing
+
+To run unit tests for Cloud Firestore, from the source root run:
+```bash
+./gradlew :firebase-firestore:check
+```
+
+## Integration Testing
+
+Running integration tests requires a Firebase project because they would try
+to connect to the Firestore backends.
+
+See [here](../README.md#project-setup) for how to setup a project.
+
+Once you setup the project, download `google-services.json` and place it in
+the source root.
+
+Make sure you have created a Firestore instance for your project, before
+you proceed.
+
+### Run on Local Emulator
+
+Then simply run:
+```bash
+./gradlew :firebase-firestore:connectedCheck
+```
+
+### Run on Firebase Test Lab
+
+You can also test on Firebase Test Lab, which allow you to run the integration
+tests on devices hosted in Google data center.
+
+See [here](../README.md#running-integration-tests-on-firebase-test-lab) for
+instructions of how to setup Firebase Test Lab for your project.
+
+Run:
+```bash
+./gradlew :firebase-firestore:deviceCheck
+```
+
+## Code Formatting
+
+Run below to format Java code:
+```bash
+./gradlew :firebase-firestore:googleJavaFormat
+```
+
+See [here](../README.md#code-formatting) if you want to be able to format code
+from within Android Studio.
+
+## Build Local Jar of Firestore SDK
+
+Run:
+```bash
+./gradlew publishAllToLocal
+```
+
+This will publish firebase SDK at SNAPSHOT versions. All pom level dependencies
+within the published artifacts will also point to SNAPSHOT versions that are
+co-published. The results will be built into your local maven repo.
+
+Developers may then take a dependency on these locally published versions by adding
+the `mavenLocal()` repository to your [repositories
+block](https://docs.gradle.org/current/userguide/declaring_repositories.html) in
+your app module's build.gradle.
+
+## Misc
 After importing the project into Android Studio and building successfully
 for the first time, Android Studio will delete the run configuration xml files
 in `./idea/runConfigurations`. Undo these changes with the command:

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/remote/RemoteStoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/remote/RemoteStoreTest.java
@@ -70,7 +70,13 @@ public class RemoteStoreTest {
     persistence.start();
     LocalStore localStore = new LocalStore(persistence, User.UNAUTHENTICATED);
     RemoteStore remoteStore =
-        new RemoteStore(callback, localStore, datastore, testQueue, connectivityMonitor);
+        new RemoteStore(
+            callback,
+            InstrumentationRegistry.getContext(),
+            localStore,
+            datastore,
+            testQueue,
+            connectivityMonitor);
 
     waitFor(testQueue.enqueue(() -> remoteStore.forceEnableNetwork()));
     drain(testQueue);

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/remote/RemoteStoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/remote/RemoteStoreTest.java
@@ -18,6 +18,7 @@ import static com.google.firebase.firestore.testutil.IntegrationTestUtil.waitFor
 
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.core.OnlineState;
@@ -66,17 +67,13 @@ public class RemoteStoreTest {
         };
 
     FakeConnectivityMonitor connectivityMonitor = new FakeConnectivityMonitor();
+    SslProvider sslProvider = () -> Tasks.forResult(null);
     Persistence persistence = MemoryPersistence.createEagerGcMemoryPersistence();
     persistence.start();
     LocalStore localStore = new LocalStore(persistence, User.UNAUTHENTICATED);
     RemoteStore remoteStore =
         new RemoteStore(
-            callback,
-            InstrumentationRegistry.getContext(),
-            localStore,
-            datastore,
-            testQueue,
-            connectivityMonitor);
+            callback, localStore, datastore, testQueue, sslProvider, connectivityMonitor);
 
     waitFor(testQueue.enqueue(() -> remoteStore.forceEnableNetwork()));
     drain(testQueue);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -200,7 +200,9 @@ public class DocumentSnapshot {
     checkNotNull(
         serverTimestampBehavior, "Provided serverTimestampBehavior value must not be null.");
     Map<String, Object> data = getData(serverTimestampBehavior);
-    return data == null ? null : CustomClassMapper.convertToCustomClass(data, valueType);
+    return data == null
+        ? null
+        : CustomClassMapper.convertToCustomClass(data, valueType, getReference());
   }
 
   /**
@@ -353,7 +355,9 @@ public class DocumentSnapshot {
       @NonNull Class<T> valueType,
       @NonNull ServerTimestampBehavior serverTimestampBehavior) {
     Object data = get(fieldPath, serverTimestampBehavior);
-    return data == null ? null : CustomClassMapper.convertToCustomClass(data, valueType);
+    return data == null
+        ? null
+        : CustomClassMapper.convertToCustomClass(data, valueType, getReference());
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -20,9 +20,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
-import com.google.android.gms.common.GooglePlayServicesRepairableException;
-import com.google.android.gms.security.ProviderInstaller;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
@@ -113,16 +110,6 @@ public class FirebaseFirestore {
     } else {
       provider = new FirebaseAuthCredentialsProvider(authProvider);
     }
-
-    queue.enqueueAndForget(
-        () -> {
-          try {
-            ProviderInstaller.installIfNeeded(context);
-          } catch (GooglePlayServicesNotAvailableException
-              | GooglePlayServicesRepairableException e) {
-            Logger.warn("Firestore", "Failed to update ssl context");
-          }
-        });
 
     // Firestore uses a different database for each app name. Note that we don't use
     // app.getPersistenceKey() here because it includes the application ID which is related

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -73,14 +73,23 @@ public final class UserDataConverter {
     this.databaseId = databaseId;
   }
 
-  /** Parse document data from a non-merge set() call. */
+  /**
+   * Parse document data from a non-merge set() call.
+   *
+   * @param input A map or POJO object representing document data.
+   */
   public ParsedSetData parseSetData(Object input) {
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.Set);
     ObjectValue updateData = convertAndParseDocumentData(input, accumulator.rootContext());
     return accumulator.toSetData(updateData);
   }
 
-  /** Parse document data from a set() call with SetOptions.merge() set. */
+  /**
+   * Parse document data from a set() call with SetOptions.merge() set.
+   *
+   * @param input A map or POJO object representing document data.
+   * @param fieldMask A {@link FieldMask} object representing the fields to be merged.
+   */
   public ParsedSetData parseMergeData(Object input, @Nullable FieldMask fieldMask) {
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.MergeSet);
     ObjectValue updateData = convertAndParseDocumentData(input, accumulator.rootContext());

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -260,7 +260,8 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
 
     Datastore datastore = new Datastore(databaseInfo, asyncQueue, credentialsProvider, context);
     ConnectivityMonitor connectivityMonitor = new AndroidConnectivityMonitor(context);
-    remoteStore = new RemoteStore(this, localStore, datastore, asyncQueue, connectivityMonitor);
+    remoteStore =
+        new RemoteStore(this, context, localStore, datastore, asyncQueue, connectivityMonitor);
 
     syncEngine = new SyncEngine(localStore, remoteStore, user);
     eventManager = new EventManager(syncEngine);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -45,11 +45,13 @@ import com.google.firebase.firestore.model.NoDocument;
 import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.model.mutation.MutationBatchResult;
 import com.google.firebase.firestore.remote.AndroidConnectivityMonitor;
+import com.google.firebase.firestore.remote.AndroidSslProvider;
 import com.google.firebase.firestore.remote.ConnectivityMonitor;
 import com.google.firebase.firestore.remote.Datastore;
 import com.google.firebase.firestore.remote.RemoteEvent;
 import com.google.firebase.firestore.remote.RemoteSerializer;
 import com.google.firebase.firestore.remote.RemoteStore;
+import com.google.firebase.firestore.remote.SslProvider;
 import com.google.firebase.firestore.util.AsyncQueue;
 import com.google.firebase.firestore.util.Logger;
 import io.grpc.Status;
@@ -260,8 +262,9 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
 
     Datastore datastore = new Datastore(databaseInfo, asyncQueue, credentialsProvider, context);
     ConnectivityMonitor connectivityMonitor = new AndroidConnectivityMonitor(context);
+    SslProvider sslProvider = new AndroidSslProvider(context);
     remoteStore =
-        new RemoteStore(this, context, localStore, datastore, asyncQueue, connectivityMonitor);
+        new RemoteStore(this, localStore, datastore, asyncQueue, sslProvider, connectivityMonitor);
 
     syncEngine = new SyncEngine(localStore, remoteStore, user);
     eventManager = new EventManager(syncEngine);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidSslProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidSslProvider.java
@@ -25,7 +25,7 @@ import com.google.firebase.firestore.util.Logger;
 /**
  * Android implementation of the SSL Provider. Attempts to fetch GMSCore's SSL Ciphers if available.
  *
- * Note: `initializeSsl()` starts a separate thread to load GMSCore. This allows the rest of the
+ * <p>Note: `initializeSsl()` starts a separate thread to load GMSCore. This allows the rest of the
  * client initialization to proceed without blocking on the SSL stack.
  */
 public class AndroidSslProvider implements SslProvider {
@@ -51,7 +51,7 @@ public class AndroidSslProvider implements SslProvider {
           // Mark the SSL initialization as done, even though we may be using outdated SSL ciphers.
           // GRPC-Java recommends obtaining updated ciphers from GMSCore, but we allow the device
           // to fall back to other SSL ciphers if GMSCore is not available.
-         taskCompletionSource.setResult(null);
+          taskCompletionSource.setResult(null);
         }
       }
     }.start();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidSslProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidSslProvider.java
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.remote;
+
+import android.content.Context;
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+import com.google.android.gms.security.ProviderInstaller;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.firebase.firestore.util.Logger;
+
+/**
+ * Android implementation of the SSL Provider. Attempts to fetch GMSCore's SSL Ciphers if available.
+ *
+ * Note: `initializeSsl()` starts a separate thread to load GMSCore. This allows the rest of the
+ * client initialization to proceed without blocking on the SSL stack.
+ */
+public class AndroidSslProvider implements SslProvider {
+  private static final String LOG_TAG = "AndroidSslProvider";
+
+  private final Context context;
+
+  public AndroidSslProvider(Context context) {
+    this.context = context;
+  }
+
+  @Override
+  public Task<Void> initializeSsl() {
+    TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+    new Thread() {
+      public void run() {
+        try {
+          ProviderInstaller.installIfNeeded(context);
+        } catch (GooglePlayServicesNotAvailableException
+            | GooglePlayServicesRepairableException e) {
+          Logger.warn(LOG_TAG, "Failed to update ssl context: %s", e);
+        } finally {
+          // Mark the SSL initialization as done, even though we may be using outdated SSL ciphers.
+          // GRPC-Java recommends obtaining updated ciphers from GMSCore, but we allow the device
+          // to fall back to other SSL ciphers if GMSCore is not available.
+         taskCompletionSource.setResult(null);
+        }
+      }
+    }.start();
+    return taskCompletionSource.getTask();
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
@@ -227,11 +227,14 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
     sslProvider
         .initializeSsl()
         .addOnCompleteListener(
-            result -> workerQueue.enqueueAndForget(() -> {
-              hardAssert(result.isSuccessful(), "SSL Provider initialization failed unexpectedly");
-              sslReady = true;
-              RemoteStore.this.tryInitializeStreams();
-            }));
+            result ->
+                workerQueue.enqueueAndForget(
+                    () -> {
+                      hardAssert(
+                          result.isSuccessful(), "SSL Provider initialization failed unexpectedly");
+                      sslReady = true;
+                      RemoteStore.this.tryInitializeStreams();
+                    }));
   }
 
   /** Re-enables the network. Only to be called as the counterpart to disableNetwork(). */
@@ -242,8 +245,8 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
 
   /**
    * Initializes the outgoing streams if the network is enabled and the SSL ciphers have been
-   * loaded. If the ciphers have not yet been loaded, this method is invoked again
-   * when loading completes.
+   * loaded. If the ciphers have not yet been loaded, this method is invoked again when loading
+   * completes.
    */
   private boolean tryInitializeStreams() {
     if (canUseNetwork()) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
@@ -648,12 +648,12 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
     try {
       sslBarrier.await();
     } catch (InterruptedException e) {
-      // On API Level 21+, an SSL connection can be established even if the installation of
+      // On API Level 21+, an SSL connection can be established even if the installation of the
       // SecurityProvider failed.
       Logger.warn(
           LOG_TAG,
-          "Interrupted while waiting for the SSL Provider. Firestore may not be able to connect "
-              + "to the backend: %s",
+          "Interrupted while waiting for the SSL Provider. Firestore may not be able to"
+              + " establish a connection to the backend: %s",
           e);
     }
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/SslProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/SslProvider.java
@@ -1,0 +1,25 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.remote;
+
+import com.google.android.gms.tasks.Task;
+
+/** A class that encapsulates the platform-specific initialization of the SSL context. */
+public interface SslProvider {
+  // PORTING NOTE: This class only exists on Android.
+
+  /** Initializes the SSL context and resolves Task on completion. */
+  Task<Void> initializeSsl();
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
@@ -91,9 +91,12 @@ public class CustomClassMapper {
    *
    * @param object The representation of the JSON data
    * @param clazz The class of the object to convert to
+   * @param docRef The value to set to {@link DocumentId} annotated fields in the custom class.
    * @return The POJO object.
    */
-  public static <T> T convertToCustomClass(Object object, Class<T> clazz) {
+  public static <T> T convertToCustomClass(
+      Object object, Class<T> clazz, DocumentReference docRef) {
+    // TODO(wuandy): Use DeserializeContext to encapsulate ErrorPath and docRef.
     return deserializeToClass(object, clazz, ErrorPath.EMPTY);
   }
 
@@ -754,6 +757,7 @@ public class CustomClassMapper {
     }
 
     Map<String, Object> serialize(T object, ErrorPath path) {
+      // TODO(wuandy): Add logic to skip @DocumentId annotated fields in serialization.
       if (!clazz.isAssignableFrom(object.getClass())) {
         throw new IllegalArgumentException(
             "Can't serialize object of class "

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/DocumentId.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/DocumentId.java
@@ -1,0 +1,38 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.util;
+
+import com.google.firebase.annotations.PublicApi;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to mark a POJO field to be automatically populated with the document's ID when
+ * the POJO is created from a Firestore document (e.g. via {@link DocumentSnapshot#toObject}).
+ *
+ * <p>This annotation can only be applied to fields of String or {@link DocumentReference},
+ * otherwise a runtime exception will be thrown.
+ *
+ * <p>When writing a POJO to Firestore, the @DocumentId-annotated field will be ignored, to allow
+ * writing to any documents that are not the origin of the POJO.
+ */
+@PublicApi
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+@interface DocumentId {}

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.fail;
 import android.util.Pair;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.android.gms.tasks.Tasks;
 import com.google.common.collect.Sets;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.auth.User;
@@ -63,6 +64,7 @@ import com.google.firebase.firestore.remote.MockDatastore;
 import com.google.firebase.firestore.remote.RemoteEvent;
 import com.google.firebase.firestore.remote.RemoteStore;
 import com.google.firebase.firestore.remote.RemoteStore.RemoteStoreCallback;
+import com.google.firebase.firestore.remote.SslProvider;
 import com.google.firebase.firestore.remote.WatchChange;
 import com.google.firebase.firestore.remote.WatchChange.DocumentChange;
 import com.google.firebase.firestore.remote.WatchChange.ExistenceFilterWatchChange;
@@ -271,14 +273,9 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
 
     ConnectivityMonitor connectivityMonitor =
         new AndroidConnectivityMonitor(RuntimeEnvironment.application);
+    SslProvider sslProvider = () -> Tasks.forResult(null);
     remoteStore =
-        new RemoteStore(
-            this,
-            RuntimeEnvironment.systemContext,
-            localStore,
-            datastore,
-            queue,
-            connectivityMonitor);
+        new RemoteStore(this, localStore, datastore, queue, sslProvider, connectivityMonitor);
     syncEngine = new SyncEngine(localStore, remoteStore, currentUser);
     eventManager = new EventManager(syncEngine);
     localStore.start();

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -271,7 +271,14 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
 
     ConnectivityMonitor connectivityMonitor =
         new AndroidConnectivityMonitor(RuntimeEnvironment.application);
-    remoteStore = new RemoteStore(this, localStore, datastore, queue, connectivityMonitor);
+    remoteStore =
+        new RemoteStore(
+            this,
+            RuntimeEnvironment.systemContext,
+            localStore,
+            datastore,
+            queue,
+            connectivityMonitor);
     syncEngine = new SyncEngine(localStore, remoteStore, currentUser);
     eventManager = new EventManager(syncEngine);
     localStore.start();

--- a/firebase-functions/src/androidTest/backend/functions/package.json
+++ b/firebase-functions/src/androidTest/backend/functions/package.json
@@ -8,5 +8,8 @@
   "devDependencies": {
     "@google-cloud/functions-emulator": "1.0.0-beta.4"
   },
-  "private": true
+  "private": true,
+  "engines": {
+    "node": "8"
+  }
 }

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -74,6 +74,12 @@ android {
 repositories {
   google()
   jcenter()
+
+  // This is necessary for Bill of Materials injection. This repository is created by running the
+  // `publishAllToBuildDir` task on the main firebase-android-sdk project.
+  maven {
+    url "../build/m2repository/"
+  }
 }
 
 apply from: "configure.gradle"


### PR DESCRIPTION
This PR moves the SSL Provider installation (which attempts to load Play Services) to a separate thread. Operations that do not require network should now be faster when run immediately after client startup.

First query performance number for reading a single document before this change:
724ms 43 ms 604ms 684ms 308ms (avg 550 ms)

With this change:
495ms 637ms 297ms 433ms 628ms (avg 498 ms)

This is on a Nexus 5X.  I verified that the client is able to connect to the backend on API Level 18 with GMS Core Play Services installed.