### PR TITLE
Enable importing Bill of Materials from local Maven.

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -74,6 +74,12 @@ android {
 repositories {
   google()
   jcenter()
+
+  // This is necessary for Bill of Materials injection. This repository is created by running the
+  // `publishAllToBuildDir` task on the main firebase-android-sdk project.
+  maven {
+    url "../build/m2repository/"
+  }
 }
 
 apply from: "configure.gradle"


### PR DESCRIPTION
This change allows the smoke tests to pull Bill of Materials files from
the local Maven repository used by the main Firebase project.