### PR TITLE
Fix for coverage collection.

### DIFF
--- a/tools/measurement/apksize/apksize.gradle
+++ b/tools/measurement/apksize/apksize.gradle
@@ -21,6 +21,10 @@ android {
     flavorDimensions "apkSize"
 }
 
+dependencies {
+    implementation("com.google.android.gms:play-services-basement:16.1.0")
+}
+
 apply from: "src/database/database.gradle"
 apply from: "src/storage/storage.gradle"
 apply from: "src/firestore/firestore.gradle"

--- a/tools/measurement/apksize/apksize.gradle
+++ b/tools/measurement/apksize/apksize.gradle
@@ -21,10 +21,6 @@ android {
     flavorDimensions "apkSize"
 }
 
-dependencies {
-    implementation("com.google.android.gms:play-services-basement:16.1.0")
-}
-
 apply from: "src/database/database.gradle"
 apply from: "src/storage/storage.gradle"
 apply from: "src/firestore/firestore.gradle"

--- a/tools/measurement/coverage/coverage.gradle
+++ b/tools/measurement/coverage/coverage.gradle
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 
+import com.google.firebase.gradle.plugins.FirebaseLibraryExtension
 import com.google.firebase.gradle.plugins.measurement.coverage.GenerateMeasurementsTask
 import com.google.firebase.gradle.plugins.measurement.UploadMeasurementsTask
 
@@ -21,7 +22,11 @@ task generateCoverageMeasurements(type: GenerateMeasurementsTask) {
     description 'Runs checkCoverage task in all projects and calculates coverage percents.'
     group 'Measurements'
 
-    dependsOn rootProject.allprojects.collect { it.tasks.withType(JacocoReport) }.flatten()
+    dependsOn rootProject.allprojects.findAll {
+        it.extensions.findByType(FirebaseLibraryExtension) != null
+    }.collect {
+        it.tasks.withType(JacocoReport)
+    }.flatten()
     reportFile = file("$buildDir/coverage-report.json")
 }
 


### PR DESCRIPTION
Fix failing task `:tools:measurement:apksize:preFirestoreAggressiveBuild`.
Make coverage task depend on only firebase product check tasks.

The tasks dependency graph previously looks like:
```
:tools:measurement:coverage:uploadCoverageMeasurements
\--- :tools:measurement:coverage:generateCoverageMeasurements
     +--- :fiamui-app:checkCoverage
     |    \--- :fiamui-app:check ..>
     +--- :firebase-common:checkCoverage
     |    \--- :firebase-common:check ..>
     +--- :firebase-database:checkCoverage
     |    \--- :firebase-database:check ..>
     +--- :firebase-database-collection:checkCoverage
     |    \--- :firebase-database-collection:check ..>
     +--- :firebase-datatransport:checkCoverage
     |    \--- :firebase-datatransport:check ..>
     +--- :firebase-firestore:checkCoverage
     |    \--- :firebase-firestore:check ..>
     +--- :firebase-functions:checkCoverage
     |    \--- :firebase-functions:check ..>
     +--- :firebase-inappmessaging-display:checkCoverage
     |    \--- :firebase-inappmessaging-display:check ..>
     +--- :firebase-storage:checkCoverage
     |    \--- :firebase-storage:check ..>
     +--- :protolite-well-known-types:checkCoverage
     |    \--- :protolite-well-known-types:check ..>
     +--- :tools:checkCoverage
     |    \--- :tools:check ..>
     +--- :transport:checkCoverage
     |    \--- :transport:check ..>
     +--- :firebase-common:ktx:checkCoverage
     |    \--- :firebase-common:ktx:check ..>
     +--- :firebase-firestore:ktx:checkCoverage
     |    \--- :firebase-firestore:ktx:check ..>
     +--- :firebase-functions:ktx:checkCoverage
     |    \--- :firebase-functions:ktx:check ..>
     +--- :firebase-storage:test-app:checkCoverage
     |    \--- :firebase-storage:test-app:check ..>
     +--- :tools:errorprone:checkCoverage
     |    \--- :tools:errorprone:check ..>
     +--- :tools:errorprone:jacocoTestReport
     |    \--- :tools:errorprone:classes ..>
     +--- :tools:lint:checkCoverage
     |    \--- :tools:lint:check ..>
     +--- :tools:lint:jacocoTestReport
     |    +--- :tools:lint:classes ..>
     |    \--- :tools:lint:compileKotlin
     +--- :tools:measurement:checkCoverage
     |    \--- :tools:measurement:check ..>
     +--- :transport:transport-api:checkCoverage
     |    \--- :transport:transport-api:check ..>
     +--- :transport:transport-backend-cct:checkCoverage
     |    \--- :transport:transport-backend-cct:check ..>
     +--- :transport:transport-runtime:checkCoverage
     |    \--- :transport:transport-runtime:check ..>
     +--- :tools:measurement:apksize:checkCoverage
     |    \--- :tools:measurement:apksize:check ..>
     \--- :tools:measurement:coverage:checkCoverage
          \--- :tools:measurement:coverage:check ..>
```

Now it looks like:
```
:tools:measurement:coverage:uploadCoverageMeasurements
\--- :tools:measurement:coverage:generateCoverageMeasurements
     +--- :firebase-common:checkCoverage
     |    \--- :firebase-common:check ..>
     +--- :firebase-database:checkCoverage
     |    \--- :firebase-database:check ..>
     +--- :firebase-database-collection:checkCoverage
     |    \--- :firebase-database-collection:check ..>
     +--- :firebase-datatransport:checkCoverage
     |    \--- :firebase-datatransport:check ..>
     +--- :firebase-firestore:checkCoverage
     |    \--- :firebase-firestore:check ..>
     +--- :firebase-functions:checkCoverage
     |    \--- :firebase-functions:check ..>
     +--- :firebase-inappmessaging-display:checkCoverage
     |    \--- :firebase-inappmessaging-display:check ..>
     +--- :firebase-storage:checkCoverage
     |    \--- :firebase-storage:check ..>
     +--- :protolite-well-known-types:checkCoverage
     |    \--- :protolite-well-known-types:check ..>
     +--- :firebase-common:ktx:checkCoverage
     |    \--- :firebase-common:ktx:check ..>
     +--- :firebase-firestore:ktx:checkCoverage
     |    \--- :firebase-firestore:ktx:check ..>
     +--- :firebase-functions:ktx:checkCoverage
     |    \--- :firebase-functions:ktx:check ..>
     +--- :transport:transport-api:checkCoverage
     |    \--- :transport:transport-api:check ..>
     +--- :transport:transport-backend-cct:checkCoverage
     |    \--- :transport:transport-backend-cct:check ..>
     \--- :transport:transport-runtime:checkCoverage
          \--- :transport:transport-runtime:check ..>
```