### PR TITLE
Include auto-value-annotations as compileOnly

### DIFF
--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-basement:$playServicesVersion"
     implementation "com.google.android.gms:play-services-tasks:$playServicesVersion"
 
-    api 'com.google.auto.value:auto-value-annotations:1.6.3'
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'com.android.support.test:runner:1.0.2'


### PR DESCRIPTION
auto-value-annotations are only needed at compile-time,
and including them as part of the api can mess up other
builds that only include the annotations at compile-time.

Also bumped it up to the latest vesion (1.6.5)

Fixes #317 