### PR TITLE
Storage Copybara: Fixing lint errors

### DIFF
--- a/firebase-storage/src/main/java/com/google/firebase/storage/CancellableTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/CancellableTask.java
@@ -24,11 +24,11 @@ import java.util.concurrent.Executor;
 /**
  * Represents an asynchronous operation that can be canceled.
  *
- * @param <TState> the type of state this operation returns in events.
+ * @param <StateT> the type of state this operation returns in events.
  */
 @SuppressWarnings("unused")
 @PublicApi
-public abstract class CancellableTask<TState> extends Task<TState> {
+public abstract class CancellableTask<StateT> extends Task<StateT> {
   /**
    * Attempts to cancel the task. A canceled task cannot be resumed later. A canceled task calls
    * back on listeners subscribed to {@link Task#addOnFailureListener(OnFailureListener)} with an
@@ -55,8 +55,8 @@ public abstract class CancellableTask<TState> extends Task<TState> {
    * @return this Task
    */
   @PublicApi
-  public abstract CancellableTask<TState> addOnProgressListener(
-      @NonNull OnProgressListener<? super TState> listener);
+  public abstract CancellableTask<StateT> addOnProgressListener(
+      @NonNull OnProgressListener<? super StateT> listener);
 
   /**
    * Adds a listener that is called periodically while the ControllableTask executes.
@@ -65,8 +65,8 @@ public abstract class CancellableTask<TState> extends Task<TState> {
    * @return this Task
    */
   @PublicApi
-  public abstract CancellableTask<TState> addOnProgressListener(
-      @NonNull Executor executor, @NonNull OnProgressListener<? super TState> listener);
+  public abstract CancellableTask<StateT> addOnProgressListener(
+      @NonNull Executor executor, @NonNull OnProgressListener<? super StateT> listener);
 
   /**
    * Adds a listener that is called periodically while the ControllableTask executes.
@@ -76,6 +76,6 @@ public abstract class CancellableTask<TState> extends Task<TState> {
    * @return this Task
    */
   @PublicApi
-  public abstract CancellableTask<TState> addOnProgressListener(
-      @NonNull Activity activity, @NonNull OnProgressListener<? super TState> listener);
+  public abstract CancellableTask<StateT> addOnProgressListener(
+      @NonNull Activity activity, @NonNull OnProgressListener<? super StateT> listener);
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/ControllableTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/ControllableTask.java
@@ -23,11 +23,11 @@ import java.util.concurrent.Executor;
  * Represents an asynchronous operation that can be paused, resumed and canceled. This task also
  * receives progress and other state change notifications.
  *
- * @param <TState> the type of state this operation returns in events.
+ * @param <StateT> the type of state this operation returns in events.
  */
 @SuppressWarnings("unused")
 @PublicApi
-public abstract class ControllableTask<TState> extends CancellableTask<TState> {
+public abstract class ControllableTask<StateT> extends CancellableTask<StateT> {
 
   /**
    * Attempts to pause the task. A paused task can later be resumed.
@@ -57,8 +57,8 @@ public abstract class ControllableTask<TState> extends CancellableTask<TState> {
    * @return this Task
    */
   @PublicApi
-  public abstract ControllableTask<TState> addOnPausedListener(
-      @NonNull OnPausedListener<? super TState> listener);
+  public abstract ControllableTask<StateT> addOnPausedListener(
+      @NonNull OnPausedListener<? super StateT> listener);
 
   /**
    * Adds a listener that is called when the Task becomes paused.
@@ -67,8 +67,8 @@ public abstract class ControllableTask<TState> extends CancellableTask<TState> {
    * @return this Task
    */
   @PublicApi
-  public abstract ControllableTask<TState> addOnPausedListener(
-      @NonNull Executor executor, @NonNull OnPausedListener<? super TState> listener);
+  public abstract ControllableTask<StateT> addOnPausedListener(
+      @NonNull Executor executor, @NonNull OnPausedListener<? super StateT> listener);
 
   /**
    * Adds a listener that is called when the Task becomes paused.
@@ -78,6 +78,6 @@ public abstract class ControllableTask<TState> extends CancellableTask<TState> {
    * @return this Task
    */
   @PublicApi
-  public abstract ControllableTask<TState> addOnPausedListener(
-      @NonNull Activity activity, @NonNull OnPausedListener<? super TState> listener);
+  public abstract ControllableTask<StateT> addOnPausedListener(
+      @NonNull Activity activity, @NonNull OnPausedListener<? super StateT> listener);
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/OnPausedListener.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/OnPausedListener.java
@@ -18,7 +18,7 @@ import com.google.firebase.annotations.PublicApi;
 
 /** A listener that is called if the Task is paused via {@link ControllableTask#pause()}. */
 @PublicApi
-public interface OnPausedListener<TProgress> {
+public interface OnPausedListener<ProgressT> {
   @PublicApi
-  void onPaused(TProgress snapshot);
+  void onPaused(ProgressT snapshot);
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/OnProgressListener.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/OnProgressListener.java
@@ -18,7 +18,7 @@ import com.google.firebase.annotations.PublicApi;
 
 /** A listener that is called periodically during execution of the {@link ControllableTask}. */
 @PublicApi
-public interface OnProgressListener<TProgress> {
+public interface OnProgressListener<ProgressT> {
   @PublicApi
-  void onProgress(TProgress snapshot);
+  void onProgress(ProgressT snapshot);
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageException.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageException.java
@@ -22,7 +22,6 @@ import com.google.android.gms.common.api.Status;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.firebase.FirebaseException;
 import com.google.firebase.annotations.PublicApi;
-import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -42,28 +41,27 @@ public class StorageException extends FirebaseException {
   @PublicApi public static final int ERROR_INVALID_CHECKSUM = -13031;
   @PublicApi public static final int ERROR_CANCELED = -13040;
   private static final int NETWORK_UNAVAILABLE = -2;
-  static IOException sCancelException = new IOException("The operation was canceled.");
 
-  private final int mErrorCode;
-  private final int mHttpResultCode;
-  private String mDetailMessage;
-  private Throwable mCause;
+  private final int errorCode;
+  private final int httpResultCode;
+  private String detailMessage;
+  private Throwable cause;
 
   StorageException(@ErrorCode int errorCode, Throwable inner, int httpResultCode) {
-    mDetailMessage = getErrorMessageForCode(errorCode);
-    mCause = inner;
-    this.mErrorCode = errorCode;
-    this.mHttpResultCode = httpResultCode;
+    this.detailMessage = getErrorMessageForCode(errorCode);
+    this.cause = inner;
+    this.errorCode = errorCode;
+    this.httpResultCode = httpResultCode;
     Log.e(
         TAG,
         "StorageException has occurred.\n"
-            + mDetailMessage
+            + detailMessage
             + "\n Code: "
-            + Integer.toString(mErrorCode)
+            + Integer.toString(this.errorCode)
             + " HttpResult: "
-            + Integer.toString(mHttpResultCode));
-    if (mCause != null) {
-      Log.e(TAG, mCause.getMessage(), mCause);
+            + Integer.toString(this.httpResultCode));
+    if (cause != null) {
+      Log.e(TAG, cause.getMessage(), cause);
     }
   }
 
@@ -169,30 +167,30 @@ public class StorageException extends FirebaseException {
   @Override
   @PublicApi
   public String getMessage() {
-    return mDetailMessage;
+    return detailMessage;
   }
 
   /** Returns the cause of this {@code Throwable}, or {@code null} if there is no cause. */
   @Override
   @PublicApi
   public synchronized Throwable getCause() {
-    if (mCause == this) {
+    if (cause == this) {
       return null;
     }
-    return mCause;
+    return cause;
   }
 
   @ErrorCode
   @PublicApi
   public int getErrorCode() {
-    return mErrorCode;
+    return errorCode;
   }
 
   /** @return the Http result code (if one exists) from a network operation. */
   @SuppressWarnings("unused")
   @PublicApi
   public int getHttpResultCode() {
-    return mHttpResultCode;
+    return httpResultCode;
   }
 
   /**

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageTask.java
@@ -41,8 +41,8 @@ import java.util.concurrent.Executor;
 /** A controllable Task that has a synchronized state machine. */
 @SuppressWarnings({"unused", "TypeParameterUnusedInFormals"})
 @PublicApi
-public abstract class StorageTask<TResult extends StorageTask.ProvideError>
-    extends ControllableTask<TResult> {
+public abstract class StorageTask<ResultT extends StorageTask.ProvideError>
+    extends ControllableTask<ResultT> {
   private static final String TAG = "StorageTask";
   static final int INTERNAL_STATE_NOT_STARTED = 1;
   static final int INTERNAL_STATE_QUEUED = 2;
@@ -113,10 +113,10 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
                 INTERNAL_STATE_CANCELED, INTERNAL_STATE_FAILURE, INTERNAL_STATE_SUCCESS)));
   }
 
-  protected final Object mSyncObject = new Object();
+  protected final Object syncObject = new Object();
 
   @VisibleForTesting
-  final TaskListenerImpl<OnSuccessListener<? super TResult>, TResult> successManager =
+  final TaskListenerImpl<OnSuccessListener<? super ResultT>, ResultT> successManager =
       new TaskListenerImpl<>(
           this,
           STATES_SUCCESS,
@@ -126,7 +126,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
           });
 
   @VisibleForTesting
-  final TaskListenerImpl<OnFailureListener, TResult> failureManager =
+  final TaskListenerImpl<OnFailureListener, ResultT> failureManager =
       new TaskListenerImpl<>(
           this,
           STATES_FAILURE,
@@ -136,7 +136,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
           });
 
   @VisibleForTesting
-  final TaskListenerImpl<OnCompleteListener<TResult>, TResult> completeListener =
+  final TaskListenerImpl<OnCompleteListener<ResultT>, ResultT> completeListener =
       new TaskListenerImpl<>(
           this,
           STATES_COMPLETE,
@@ -146,7 +146,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
           });
 
   @VisibleForTesting
-  final TaskListenerImpl<OnCanceledListener, TResult> cancelManager =
+  final TaskListenerImpl<OnCanceledListener, ResultT> cancelManager =
       new TaskListenerImpl<>(
           this,
           STATES_CANCELED,
@@ -156,15 +156,15 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
           });
 
   @VisibleForTesting
-  final TaskListenerImpl<OnProgressListener<? super TResult>, TResult> progressManager =
+  final TaskListenerImpl<OnProgressListener<? super ResultT>, ResultT> progressManager =
       new TaskListenerImpl<>(this, STATES_INPROGRESS, OnProgressListener::onProgress);
 
   @VisibleForTesting
-  final TaskListenerImpl<OnPausedListener<? super TResult>, TResult> pausedManager =
+  final TaskListenerImpl<OnPausedListener<? super ResultT>, ResultT> pausedManager =
       new TaskListenerImpl<>(this, STATES_PAUSED, OnPausedListener::onPaused);
 
   private volatile int currentState;
-  private TResult finalResult;
+  private ResultT finalResult;
 
   protected StorageTask() {
     currentState = INTERNAL_STATE_NOT_STARTED;
@@ -279,7 +279,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    */
   @Override
   @PublicApi
-  public TResult getResult() {
+  public ResultT getResult() {
     if (getFinalResult() == null) {
       throw new IllegalStateException();
     }
@@ -299,7 +299,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    */
   @Override
   @PublicApi
-  public <X extends Throwable> TResult getResult(@NonNull Class<X> exceptionType) throws X {
+  public <X extends Throwable> ResultT getResult(@NonNull Class<X> exceptionType) throws X {
     if (getFinalResult() == null) {
       throw new IllegalStateException();
     }
@@ -332,7 +332,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    * execution and may not be the final result..
    */
   @PublicApi
-  public TResult getSnapshot() {
+  public ResultT getSnapshot() {
     return snapState();
   }
 
@@ -344,20 +344,20 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
 
   @VisibleForTesting
   Object getSyncObject() {
-    return mSyncObject;
+    return syncObject;
   }
 
   @NonNull
   @VisibleForTesting
-  TResult snapState() {
-    synchronized (mSyncObject) {
+  ResultT snapState() {
+    synchronized (syncObject) {
       return snapStateImpl();
     }
   }
 
   @NonNull
   @VisibleForTesting
-  abstract TResult snapStateImpl();
+  abstract ResultT snapStateImpl();
 
   /**
    * Tries to change the current state into one of the requested states. State transitions are
@@ -370,7 +370,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
     HashMap<Integer, HashSet<Integer>> table =
         userInitiated ? ValidUserInitiatedStateChanges : ValidTaskInitiatedStateChanges;
 
-    synchronized (mSyncObject) {
+    synchronized (syncObject) {
       for (int newState : requestedStates) {
         HashSet<Integer> validStates = table.get(getInternalState());
         if (validStates != null && validStates.contains(newState)) {
@@ -455,7 +455,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @PublicApi
   protected void onCanceled() {}
 
-  private TResult getFinalResult() {
+  private ResultT getFinalResult() {
     if (finalResult != null) {
       return finalResult;
     }
@@ -477,8 +477,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    */
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnPausedListener(
-      @NonNull OnPausedListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnPausedListener(
+      @NonNull OnPausedListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     pausedManager.addListener(null, null, listener);
     return this;
@@ -492,8 +492,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    */
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnPausedListener(
-      @NonNull Executor executor, @NonNull OnPausedListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnPausedListener(
+      @NonNull Executor executor, @NonNull OnPausedListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(executor);
     pausedManager.addListener(null, executor, listener);
@@ -511,8 +511,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    */
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnPausedListener(
-      @NonNull Activity activity, @NonNull OnPausedListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnPausedListener(
+      @NonNull Activity activity, @NonNull OnPausedListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(activity);
     pausedManager.addListener(activity, null, listener);
@@ -521,8 +521,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
 
   /** Removes a listener. */
   @PublicApi
-  public StorageTask<TResult> removeOnPausedListener(
-      @NonNull OnPausedListener<? super TResult> listener) {
+  public StorageTask<ResultT> removeOnPausedListener(
+      @NonNull OnPausedListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     pausedManager.removeListener(listener);
     return this;
@@ -535,8 +535,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    */
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnProgressListener(
-      @NonNull OnProgressListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnProgressListener(
+      @NonNull OnProgressListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     progressManager.addListener(null, null, listener);
     return this;
@@ -550,8 +550,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    */
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnProgressListener(
-      @NonNull Executor executor, @NonNull OnProgressListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnProgressListener(
+      @NonNull Executor executor, @NonNull OnProgressListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(executor);
     progressManager.addListener(null, executor, listener);
@@ -567,8 +567,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    */
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnProgressListener(
-      @NonNull Activity activity, @NonNull OnProgressListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnProgressListener(
+      @NonNull Activity activity, @NonNull OnProgressListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(activity);
     progressManager.addListener(activity, null, listener);
@@ -577,8 +577,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
 
   /** Removes a listener. */
   @PublicApi
-  public StorageTask<TResult> removeOnProgressListener(
-      @NonNull OnProgressListener<? super TResult> listener) {
+  public StorageTask<ResultT> removeOnProgressListener(
+      @NonNull OnProgressListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     progressManager.removeListener(listener);
     return this;
@@ -595,8 +595,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnSuccessListener(
-      @NonNull OnSuccessListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnSuccessListener(
+      @NonNull OnSuccessListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     successManager.addListener(null, null, listener);
     return this;
@@ -617,8 +617,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnSuccessListener(
-      @NonNull Executor executor, @NonNull OnSuccessListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnSuccessListener(
+      @NonNull Executor executor, @NonNull OnSuccessListener<? super ResultT> listener) {
     Preconditions.checkNotNull(executor);
     Preconditions.checkNotNull(listener);
     successManager.addListener(null, executor, listener);
@@ -641,8 +641,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnSuccessListener(
-      @NonNull Activity activity, @NonNull OnSuccessListener<? super TResult> listener) {
+  public StorageTask<ResultT> addOnSuccessListener(
+      @NonNull Activity activity, @NonNull OnSuccessListener<? super ResultT> listener) {
     Preconditions.checkNotNull(activity);
     Preconditions.checkNotNull(listener);
     successManager.addListener(activity, null, listener);
@@ -651,8 +651,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
 
   /** Removes a listener. */
   @PublicApi
-  public StorageTask<TResult> removeOnSuccessListener(
-      @NonNull OnSuccessListener<? super TResult> listener) {
+  public StorageTask<ResultT> removeOnSuccessListener(
+      @NonNull OnSuccessListener<? super ResultT> listener) {
     Preconditions.checkNotNull(listener);
     successManager.removeListener(listener);
     return this;
@@ -672,7 +672,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnFailureListener(@NonNull OnFailureListener listener) {
+  public StorageTask<ResultT> addOnFailureListener(@NonNull OnFailureListener listener) {
     Preconditions.checkNotNull(listener);
     failureManager.addListener(null, null, listener);
     return this;
@@ -692,7 +692,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnFailureListener(
+  public StorageTask<ResultT> addOnFailureListener(
       @NonNull Executor executor, @NonNull OnFailureListener listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(executor);
@@ -716,7 +716,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnFailureListener(
+  public StorageTask<ResultT> addOnFailureListener(
       @NonNull Activity activity, @NonNull OnFailureListener listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(activity);
@@ -727,7 +727,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
 
   /** Removes a listener. */
   @PublicApi
-  public StorageTask<TResult> removeOnFailureListener(@NonNull OnFailureListener listener) {
+  public StorageTask<ResultT> removeOnFailureListener(@NonNull OnFailureListener listener) {
     Preconditions.checkNotNull(listener);
     failureManager.removeListener(listener);
     return this;
@@ -747,7 +747,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnCompleteListener(@NonNull OnCompleteListener<TResult> listener) {
+  public StorageTask<ResultT> addOnCompleteListener(@NonNull OnCompleteListener<ResultT> listener) {
     Preconditions.checkNotNull(listener);
     completeListener.addListener(null, null, listener);
     return this;
@@ -767,24 +767,14 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnCompleteListener(
-      @NonNull Executor executor, @NonNull OnCompleteListener<TResult> listener) {
+  public StorageTask<ResultT> addOnCompleteListener(
+      @NonNull Executor executor, @NonNull OnCompleteListener<ResultT> listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(executor);
 
     completeListener.addListener(null, executor, listener);
     return this;
   }
-
-  /** Removes a listener. */
-  @PublicApi
-  public StorageTask<TResult> removeOnCompleteListener(
-      @NonNull OnCompleteListener<TResult> listener) {
-    Preconditions.checkNotNull(listener);
-    completeListener.removeListener(listener);
-    return this;
-  }
-
   /**
    * Adds a listener that is called when the Task succeeds or fails.
    *
@@ -800,12 +790,21 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @Override
   @NonNull
   @PublicApi
-  public StorageTask<TResult> addOnCompleteListener(
-      @NonNull Activity activity, @NonNull OnCompleteListener<TResult> listener) {
+  public StorageTask<ResultT> addOnCompleteListener(
+      @NonNull Activity activity, @NonNull OnCompleteListener<ResultT> listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(activity);
 
     completeListener.addListener(activity, null, listener);
+    return this;
+  }
+
+  /** Removes a listener. */
+  @PublicApi
+  public StorageTask<ResultT> removeOnCompleteListener(
+      @NonNull OnCompleteListener<ResultT> listener) {
+    Preconditions.checkNotNull(listener);
+    completeListener.removeListener(listener);
     return this;
   }
 
@@ -821,7 +820,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @NonNull
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnCanceledListener(@NonNull OnCanceledListener listener) {
+  public StorageTask<ResultT> addOnCanceledListener(@NonNull OnCanceledListener listener) {
     Preconditions.checkNotNull(listener);
     cancelManager.addListener(null, null, listener);
     return this;
@@ -839,7 +838,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @NonNull
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnCanceledListener(
+  public StorageTask<ResultT> addOnCanceledListener(
       @NonNull Executor executor, @NonNull OnCanceledListener listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(executor);
@@ -861,7 +860,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @NonNull
   @Override
   @PublicApi
-  public StorageTask<TResult> addOnCanceledListener(
+  public StorageTask<ResultT> addOnCanceledListener(
       @NonNull Activity activity, @NonNull OnCanceledListener listener) {
     Preconditions.checkNotNull(listener);
     Preconditions.checkNotNull(activity);
@@ -871,7 +870,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
 
   /** Removes a listener. */
   @PublicApi
-  public StorageTask<TResult> removeOnCanceledListener(@NonNull OnCanceledListener listener) {
+  public StorageTask<ResultT> removeOnCanceledListener(@NonNull OnCanceledListener listener) {
     Preconditions.checkNotNull(listener);
     cancelManager.removeListener(listener);
     return this;
@@ -888,8 +887,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @NonNull
   @Override
   @PublicApi
-  public <TContinuationResult> Task<TContinuationResult> continueWith(
-      @NonNull Continuation<TResult, TContinuationResult> continuation) {
+  public <ContinuationResultT> Task<ContinuationResultT> continueWith(
+      @NonNull Continuation<ResultT, ContinuationResultT> continuation) {
     return continueWithImpl(null, continuation);
   }
 
@@ -903,23 +902,22 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @NonNull
   @Override
   @PublicApi
-  public <TContinuationResult> Task<TContinuationResult> continueWith(
+  public <ContinuationResultT> Task<ContinuationResultT> continueWith(
       @NonNull final Executor executor,
-      @NonNull final Continuation<TResult, TContinuationResult> continuation) {
+      @NonNull final Continuation<ResultT, ContinuationResultT> continuation) {
     return continueWithImpl(executor, continuation);
   }
 
   @NonNull
-  private <TContinuationResult> Task<TContinuationResult> continueWithImpl(
-      @Nullable final Executor executor,
-      @NonNull final Continuation<TResult, TContinuationResult> continuation) {
+  private <ContinuationResultT> Task<ContinuationResultT> continueWithImpl(
+      @Nullable final Executor executor, @NonNull final Continuation< ResultT, ContinuationResultT> continuation) {
 
-    final TaskCompletionSource<TContinuationResult> source = new TaskCompletionSource<>();
+    final TaskCompletionSource<ContinuationResultT> source = new TaskCompletionSource<>();
     completeListener.addListener(
         null,
         executor,
         task -> {
-          TContinuationResult result;
+          ContinuationResultT result;
           try {
             result = continuation.then(StorageTask.this);
           } catch (RuntimeExecutionException e) {
@@ -951,8 +949,8 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @NonNull
   @Override
   @PublicApi
-  public <TContinuationResult> Task<TContinuationResult> continueWithTask(
-      @NonNull Continuation<TResult, Task<TContinuationResult>> continuation) {
+  public <ContinuationResultT> Task<ContinuationResultT> continueWithTask(
+      @NonNull Continuation<ResultT, Task<ContinuationResultT>> continuation) {
     return continueWithTaskImpl(null, continuation);
   }
 
@@ -966,9 +964,9 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   @NonNull
   @Override
   @PublicApi
-  public <TContinuationResult> Task<TContinuationResult> continueWithTask(
+  public <ContinuationResultT> Task<ContinuationResultT> continueWithTask(
       @NonNull final Executor executor,
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation) {
+      @NonNull final Continuation<ResultT, Task<ContinuationResultT>> continuation) {
     return continueWithTaskImpl(executor, continuation);
   }
 
@@ -982,13 +980,13 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    * <p>If the previous Task is canceled, the returned Task will also be canceled and the
    * SuccessContinuation would not execute.
    *
-   * @see SuccessContinuation#then(TResult)
+   * @see SuccessContinuation#then(ResultT)
    */
   @NonNull
   @Override
   @PublicApi
-  public <TContinuationResult> Task<TContinuationResult> onSuccessTask(
-      @NonNull SuccessContinuation<TResult, TContinuationResult> continuation) {
+  public <ContinuationResultT> Task<ContinuationResultT> onSuccessTask(
+      @NonNull SuccessContinuation<ResultT, ContinuationResultT> continuation) {
     return successTaskImpl(null, continuation);
   }
 
@@ -1001,30 +999,30 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
    * SuccessContinuation would not execute.
    *
    * @param executor the executor to use to call the SuccessContinuation
-   * @see SuccessContinuation#then(TResult)
+   * @see SuccessContinuation#then(ResultT)
    */
   @NonNull
   @Override
   @PublicApi
-  public <TContinuationResult> Task<TContinuationResult> onSuccessTask(
+  public <ContinuationResultT> Task<ContinuationResultT> onSuccessTask(
       @NonNull Executor executor,
-      @NonNull SuccessContinuation<TResult, TContinuationResult> continuation) {
+      @NonNull SuccessContinuation<ResultT, ContinuationResultT> continuation) {
     return successTaskImpl(executor, continuation);
   }
 
   @NonNull
-  private <TContinuationResult> Task<TContinuationResult> continueWithTaskImpl(
+  private <ContinuationResultT> Task<ContinuationResultT> continueWithTaskImpl(
       @Nullable final Executor executor,
-      @NonNull final Continuation<TResult, Task<TContinuationResult>> continuation) {
+      @NonNull final Continuation<ResultT, Task<ContinuationResultT>> continuation) {
     final CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
     final CancellationToken cancellationToken = cancellationTokenSource.getToken();
-    final TaskCompletionSource<TContinuationResult> source =
+    final TaskCompletionSource<ContinuationResultT> source =
         new TaskCompletionSource<>(cancellationToken);
     completeListener.addListener(
         null,
         executor,
         task -> {
-          Task<TContinuationResult> resultTask;
+          Task<ContinuationResultT> resultTask;
           try {
             resultTask = continuation.then(StorageTask.this);
           } catch (RuntimeExecutionException e) {
@@ -1055,19 +1053,19 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
   }
 
   @NonNull
-  private <TContinuationResult> Task<TContinuationResult> successTaskImpl(
+  private <ContinuationResultT> Task<ContinuationResultT> successTaskImpl(
       @Nullable final Executor executor,
-      @NonNull final SuccessContinuation<TResult, TContinuationResult> continuation) {
+      @NonNull final SuccessContinuation<ResultT, ContinuationResultT> continuation) {
     final CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
     final CancellationToken cancellationToken = cancellationTokenSource.getToken();
-    final TaskCompletionSource<TContinuationResult> source =
+    final TaskCompletionSource<ContinuationResultT> source =
         new TaskCompletionSource<>(cancellationToken);
 
     successManager.addListener(
         null,
         executor,
         result -> {
-          Task<TContinuationResult> resultTask;
+          Task<ContinuationResultT> resultTask;
           try {
             resultTask = continuation.then(result);
           } catch (RuntimeExecutionException e) {
@@ -1190,7 +1188,7 @@ public abstract class StorageTask<TResult extends StorageTask.ProvideError>
     /** Returns the {@link StorageTask} for this state. */
     @NonNull
     @PublicApi
-    public StorageTask<TResult> getTask() {
+    public StorageTask<ResultT> getTask() {
       return StorageTask.this;
     }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageTask.java
@@ -910,7 +910,8 @@ public abstract class StorageTask<ResultT extends StorageTask.ProvideError>
 
   @NonNull
   private <ContinuationResultT> Task<ContinuationResultT> continueWithImpl(
-      @Nullable final Executor executor, @NonNull final Continuation< ResultT, ContinuationResultT> continuation) {
+      @Nullable final Executor executor,
+      @NonNull final Continuation<ResultT, ContinuationResultT> continuation) {
 
     final TaskCompletionSource<ContinuationResultT> source = new TaskCompletionSource<>();
     completeListener.addListener(

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageTaskManager.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageTaskManager.java
@@ -34,14 +34,14 @@ import java.util.Map;
 
   private final Map<String, WeakReference<StorageTask>> mInProgressTasks = new HashMap<>();
 
-  private final Object mSyncObject = new Object();
+  private final Object syncObject = new Object();
 
   static StorageTaskManager getInstance() {
     return _instance;
   }
 
   public List<UploadTask> getUploadTasksUnder(@NonNull StorageReference parent) {
-    synchronized (mSyncObject) {
+    synchronized (syncObject) {
       ArrayList<UploadTask> inProgressList = new ArrayList<>();
       String parentPath = parent.toString();
       for (Map.Entry<String, WeakReference<StorageTask>> entry : mInProgressTasks.entrySet()) {
@@ -57,7 +57,7 @@ import java.util.Map;
   }
 
   public List<FileDownloadTask> getDownloadTasksUnder(@NonNull StorageReference parent) {
-    synchronized (mSyncObject) {
+    synchronized (syncObject) {
       ArrayList<FileDownloadTask> inProgressList = new ArrayList<>();
       String parentPath = parent.toString();
       for (Map.Entry<String, WeakReference<StorageTask>> entry : mInProgressTasks.entrySet()) {
@@ -73,14 +73,14 @@ import java.util.Map;
   }
 
   public void ensureRegistered(StorageTask targetTask) {
-    synchronized (mSyncObject) {
+    synchronized (syncObject) {
       // ensure *this* is added to the in progress list
       mInProgressTasks.put(targetTask.getStorage().toString(), new WeakReference<>(targetTask));
     }
   }
 
   public void unRegister(StorageTask targetTask) {
-    synchronized (mSyncObject) {
+    synchronized (syncObject) {
       // ensure *this* is added to the in progress list
       String key = targetTask.getStorage().toString();
       WeakReference<StorageTask> weakReference = mInProgressTasks.get(key);

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageTaskManager.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageTaskManager.java
@@ -32,7 +32,7 @@ import java.util.Map;
 /*package*/ class StorageTaskManager {
   private static final StorageTaskManager _instance = new StorageTaskManager();
 
-  private final Map<String, WeakReference<StorageTask>> mInProgressTasks = new HashMap<>();
+  private final Map<String, WeakReference<StorageTask>> inProgressTasks = new HashMap<>();
 
   private final Object syncObject = new Object();
 
@@ -44,7 +44,7 @@ import java.util.Map;
     synchronized (syncObject) {
       ArrayList<UploadTask> inProgressList = new ArrayList<>();
       String parentPath = parent.toString();
-      for (Map.Entry<String, WeakReference<StorageTask>> entry : mInProgressTasks.entrySet()) {
+      for (Map.Entry<String, WeakReference<StorageTask>> entry : inProgressTasks.entrySet()) {
         if (entry.getKey().startsWith(parentPath)) {
           StorageTask task = entry.getValue().get();
           if (task instanceof UploadTask) {
@@ -60,7 +60,7 @@ import java.util.Map;
     synchronized (syncObject) {
       ArrayList<FileDownloadTask> inProgressList = new ArrayList<>();
       String parentPath = parent.toString();
-      for (Map.Entry<String, WeakReference<StorageTask>> entry : mInProgressTasks.entrySet()) {
+      for (Map.Entry<String, WeakReference<StorageTask>> entry : inProgressTasks.entrySet()) {
         if (entry.getKey().startsWith(parentPath)) {
           StorageTask task = entry.getValue().get();
           if (task instanceof FileDownloadTask) {
@@ -75,7 +75,7 @@ import java.util.Map;
   public void ensureRegistered(StorageTask targetTask) {
     synchronized (syncObject) {
       // ensure *this* is added to the in progress list
-      mInProgressTasks.put(targetTask.getStorage().toString(), new WeakReference<>(targetTask));
+      inProgressTasks.put(targetTask.getStorage().toString(), new WeakReference<>(targetTask));
     }
   }
 
@@ -83,10 +83,10 @@ import java.util.Map;
     synchronized (syncObject) {
       // ensure *this* is added to the in progress list
       String key = targetTask.getStorage().toString();
-      WeakReference<StorageTask> weakReference = mInProgressTasks.get(key);
+      WeakReference<StorageTask> weakReference = inProgressTasks.get(key);
       StorageTask task = weakReference != null ? weakReference.get() : null;
       if (task == null || task == targetTask) {
-        mInProgressTasks.remove(key);
+        inProgressTasks.remove(key);
       }
     }
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/TaskListenerImpl.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/TaskListenerImpl.java
@@ -30,44 +30,44 @@ import java.util.concurrent.Executor;
 /** Helper class to manage listener subscriptions on executor/activity. */
 /*package*/
 @PublicApi
-class TaskListenerImpl<TListenerType, TResult extends StorageTask.ProvideError> {
-  private final Queue<TListenerType> mListenerQueue = new ConcurrentLinkedQueue<>();
-  private final HashMap<TListenerType, SmartHandler> mHandlerMap = new HashMap<>();
-  private StorageTask<TResult> mTask;
-  private int mTargetStates;
-  private OnRaise<TListenerType, TResult> mOnRaise;
+class TaskListenerImpl<ListenerTypeT, ResultT extends StorageTask.ProvideError> {
+  private final Queue<ListenerTypeT> listenerQueue = new ConcurrentLinkedQueue<>();
+  private final HashMap<ListenerTypeT, SmartHandler> handlerMap = new HashMap<>();
+  private StorageTask<ResultT> task;
+  private int targetStates;
+  private OnRaise<ListenerTypeT, ResultT> onRaise;
 
   @PublicApi
   public TaskListenerImpl(
-      @NonNull StorageTask<TResult> task,
+      @NonNull StorageTask<ResultT> task,
       int targetInternalStates,
-      @NonNull OnRaise<TListenerType, TResult> onRaise) {
-    mTask = task;
-    mTargetStates = targetInternalStates;
-    mOnRaise = onRaise;
+      @NonNull OnRaise<ListenerTypeT, ResultT> onRaise) {
+    this.task = task;
+    this.targetStates = targetInternalStates;
+    this.onRaise = onRaise;
   }
 
   /* For Test Only*/
   public int getListenerCount() {
-    return Math.max(mListenerQueue.size(), mHandlerMap.size());
+    return Math.max(listenerQueue.size(), handlerMap.size());
   }
 
   @PublicApi
   public void addListener(
       @Nullable Activity activity,
       @Nullable Executor executor,
-      @NonNull final TListenerType listener) {
+      @NonNull final ListenerTypeT listener) {
     Preconditions.checkNotNull(listener);
 
     boolean shouldFire = false;
     SmartHandler handler;
-    synchronized (mTask.getSyncObject()) {
-      if ((mTask.getInternalState() & mTargetStates) != 0) {
+    synchronized (task.getSyncObject()) {
+      if ((task.getInternalState() & targetStates) != 0) {
         shouldFire = true;
       }
-      mListenerQueue.add(listener);
+      listenerQueue.add(listener);
       handler = new SmartHandler(executor);
-      mHandlerMap.put(listener, handler);
+      handlerMap.put(listener, handler);
       if (activity != null) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
           Preconditions.checkArgument(!activity.isDestroyed(), "Activity is already destroyed!");
@@ -78,20 +78,20 @@ class TaskListenerImpl<TListenerType, TResult extends StorageTask.ProvideError> 
     }
 
     if (shouldFire) {
-      final TResult snappedState = mTask.snapState();
-      handler.callBack(() -> mOnRaise.raise(listener, snappedState));
+      final ResultT snappedState = task.snapState();
+      handler.callBack(() -> onRaise.raise(listener, snappedState));
     }
   }
 
   @PublicApi
   public void onInternalStateChanged() {
-    if ((mTask.getInternalState() & mTargetStates) != 0) {
-      final TResult snappedState = mTask.snapState();
-      for (TListenerType c : mListenerQueue) {
-        final TListenerType finalCallback = c;
-        SmartHandler handler = mHandlerMap.get(c);
+    if ((task.getInternalState() & targetStates) != 0) {
+      final ResultT snappedState = task.snapState();
+      for (ListenerTypeT c : listenerQueue) {
+        final ListenerTypeT finalCallback = c;
+        SmartHandler handler = handlerMap.get(c);
         if (handler != null) {
-          handler.callBack(() -> mOnRaise.raise(finalCallback, snappedState));
+          handler.callBack(() -> onRaise.raise(finalCallback, snappedState));
         }
       }
     }
@@ -99,17 +99,17 @@ class TaskListenerImpl<TListenerType, TResult extends StorageTask.ProvideError> 
 
   /** Removes a listener. */
   @PublicApi
-  public void removeListener(@NonNull TListenerType listener) {
+  public void removeListener(@NonNull ListenerTypeT listener) {
     Preconditions.checkNotNull(listener);
 
-    synchronized (mTask.getSyncObject()) {
-      mHandlerMap.remove(listener);
-      mListenerQueue.remove(listener);
+    synchronized (task.getSyncObject()) {
+      handlerMap.remove(listener);
+      listenerQueue.remove(listener);
       ActivityLifecycleListener.getInstance().removeCookie(listener);
     }
   }
 
-  interface OnRaise<TListenerType, TResult> {
-    void raise(@NonNull TListenerType listener, @NonNull TResult snappedState);
+  interface OnRaise<ListenerTypeT, ResultT> {
+    void raise(@NonNull ListenerTypeT listener, @NonNull ResultT snappedState);
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
@@ -22,14 +22,14 @@ import com.google.firebase.FirebaseApp;
 
 /** Cancels an upload request in progress. */
 public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
-  @VisibleForTesting public static boolean CANCEL_CALLED = false;
+  @VisibleForTesting public static boolean cancelCalled = false;
 
   private final String uploadURL;
 
   public ResumableUploadCancelRequest(
       @NonNull Uri gsUri, @NonNull FirebaseApp app, @NonNull String uploadURL) {
     super(gsUri, app);
-    CANCEL_CALLED = true;
+    cancelCalled = true;
     if (TextUtils.isEmpty(uploadURL)) {
       super.mException = new IllegalArgumentException("uploadURL is null or empty");
     }

--- a/firebase-storage/src/test/java/com/google/firebase/storage/UploadTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/UploadTest.java
@@ -346,7 +346,7 @@ public class UploadTest {
   public void fileUploadWithPauseCancel() throws Exception {
     System.out.println("Starting test fileUploadWithPauseCancel.");
 
-    ResumableUploadCancelRequest.CANCEL_CALLED = false;
+    ResumableUploadCancelRequest.cancelCalled = false;
 
     MockConnectionFactory factory =
         NetworkLayerMock.ensureNetworkMock("fileUploadWithPauseCancel", true);
@@ -369,7 +369,7 @@ public class UploadTest {
     TestUtil.await(task, 20, TimeUnit.SECONDS);
 
     TestUtil.verifyTaskStateChanges("fileUploadWithPauseCancel", task.getResult().toString());
-    Assert.assertTrue(ResumableUploadCancelRequest.CANCEL_CALLED);
+    Assert.assertTrue(ResumableUploadCancelRequest.cancelCalled);
   }
 
   @Test
@@ -403,7 +403,7 @@ public class UploadTest {
   public void fileUploadWithQueueCancel() throws Exception {
     System.out.println("Starting test fileUploadWithQueueCancel.");
 
-    ResumableUploadCancelRequest.CANCEL_CALLED = false;
+    ResumableUploadCancelRequest.cancelCalled = false;
 
     final StringBuilder taskOutput = new StringBuilder();
     NetworkLayerMock.ensureNetworkMock("fileUploadWithPauseCancel", true);
@@ -422,7 +422,7 @@ public class UploadTest {
     TestUtil.await(task, 2, TimeUnit.SECONDS);
 
     TestUtil.verifyTaskStateChanges("fileUploadWithQueueCancel", taskOutput.toString());
-    Assert.assertFalse(ResumableUploadCancelRequest.CANCEL_CALLED);
+    Assert.assertFalse(ResumableUploadCancelRequest.cancelCalled);
   }
 
   @Test


### PR DESCRIPTION
This fixes all Google3 Lint errors in this code:

Field name is CONSTANT_CASE, but field is not static and final
http://go/errorprone/bugpattern/ConstantField

Type Parameter TListenerType must be a single letter with an optional numeric suffix, or an UpperCamelCase name followed by the letter 'T'.
http://go/java-style#s5.2.8-type-variable-names

In Google Style, unlike Android Style, field names with special prefixes like mName and sName are not used.  Google3 Android code must follow Google Style.
http://go/errorprone/bugpattern/FieldPrefixes

Overloads of '*' are not grouped together; found ungrouped overloads on line(s): 800
http://go/java-style#s3.4.2.1-overloads-never-split
