### PR TITLE
Storage Copybara: Fix Javadoc

### DIFF
--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/AdaptiveStreamBuffer.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/AdaptiveStreamBuffer.java
@@ -41,12 +41,12 @@ public class AdaptiveStreamBuffer {
     this.reachedEnd = false;
   }
 
-  /** @return The number of available bytes in the buffer. */
+  /** Returns the number of available bytes in the buffer. */
   public int available() {
     return availableBytes;
   }
 
-  /** @return A direct pointer to the underlying buffer. */
+  /** Returns a direct pointer to the underlying buffer. */
   public byte[] get() {
     return buffer;
   }
@@ -55,8 +55,7 @@ public class AdaptiveStreamBuffer {
    * Moves the buffer forward by 'bytes' and disregards its data.
    *
    * @param bytes Number of bytes to advance.
-   * @return The number of bytes we were able to advance.
-   * @throws IOException
+   * @return The number of bytes we were able to advance
    */
   public int advance(int bytes) throws IOException {
     int bytesAdvanced;
@@ -96,7 +95,6 @@ public class AdaptiveStreamBuffer {
    *
    * @param targetSize Number of bytes that should be loaded into the buffer.
    * @return Number of bytes actually in buffer.
-   * @throws IOException
    */
   public int fill(int targetSize) throws IOException {
     if (targetSize > buffer.length) {
@@ -149,8 +147,6 @@ public class AdaptiveStreamBuffer {
 
   /**
    * Close the underlying stream.
-   *
-   * @throws IOException
    */
   public void close() throws IOException {
     source.close();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/AdaptiveStreamBuffer.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/AdaptiveStreamBuffer.java
@@ -145,9 +145,7 @@ public class AdaptiveStreamBuffer {
     return reachedEnd;
   }
 
-  /**
-   * Close the underlying stream.
-   */
+  /** Close the underlying stream. */
   public void close() throws IOException {
     source.close();
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/AdaptiveStreamBuffer.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/AdaptiveStreamBuffer.java
@@ -55,7 +55,7 @@ public class AdaptiveStreamBuffer {
    * Moves the buffer forward by 'bytes' and disregards its data.
    *
    * @param bytes Number of bytes to advance.
-   * @return The number of bytes we were able to advance
+   * @return The number of bytes we were able to advance.
    */
   public int advance(int bytes) throws IOException {
     int bytesAdvanced;


### PR DESCRIPTION
Fixes:
A summary fragment is required; consider using the value of the @return block as a summary fragment instead.
http://go/java-style#s7.2-summary-fragment

A block tag (@param, @return, @throws, @deprecated) has an empty description. Block tags without descriptions don't add much value for future readers of the code; consider removing the tag entirely or adding a description.
http://go/java-style#s7.1.3-javadoc-block-tags