### PR TITLE
Ignore empty message string in FirebaseFunctionsException

### DIFF
--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctionsException.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctionsException.java
@@ -199,7 +199,7 @@ public class FirebaseFunctionsException extends FirebaseException {
         // The default description needs to be updated for the new code.
         description = code.name();
       }
-      if (error.opt("message") instanceof String) {
+      if (error.opt("message") instanceof String && !error.getString("message").isEmpty()) {
         description = error.getString("message");
       }
       details = error.opt("details");


### PR DESCRIPTION
When throwing `new HttpsError('not-found')` in a cloud function (ie: [without specifying `message` parameter](https://firebase.google.com/docs/reference/functions/functions.https.HttpsError)), `error.opt("message")` will be just an empty string, so:

- `error.opt("message") instanceof String` is `true`
- `details` will be assigned to `""`.
- `new FirebaseFunctionsException(description, code, details)` will be called with this empty string
- it will throws a `Detail message must not be empty` exception.

With this change,  `details` will be equal to whatever `code.name()` returns when the cloud function sends an empty string as a message. In the case of `HttpsError('not-found')`, it will be `NOT_FOUND`.