### PR TITLE
Copybara Storage: Fix Storage Lint

### DIFF
--- a/firebase-storage/src/androidTest/java/com/google/firebase/storage/IntegrationTest.java
+++ b/firebase-storage/src/androidTest/java/com/google/firebase/storage/IntegrationTest.java
@@ -37,7 +37,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/** Integration tests for Firebase Storage. */
+/** Integration tests for {@link FirebaseStorage}. */
 @RunWith(AndroidJUnit4.class)
 public class IntegrationTest {
   @Rule

--- a/firebase-storage/src/androidTest/java/com/google/firebase/storage/IntegrationTest.java
+++ b/firebase-storage/src/androidTest/java/com/google/firebase/storage/IntegrationTest.java
@@ -37,6 +37,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+/** Integration tests for Firebase Storage. */
 @RunWith(AndroidJUnit4.class)
 public class IntegrationTest {
   @Rule

--- a/firebase-storage/src/test/java/com/google/firebase/storage/ListTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/ListTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+/** Tests for {@link FirebaseStorage}. */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
 public class ListTest {
@@ -62,18 +63,21 @@ public class ListTest {
       reference.list(-1);
       fail();
     } catch (IllegalArgumentException e) {
+      // Expected.
     }
 
     try {
       reference.list(1001);
       fail();
     } catch (IllegalArgumentException e) {
+      // Expected.
     }
 
     try {
       reference.list(1000, null);
       fail();
     } catch (IllegalArgumentException e) {
+      // Expected.
     }
   }
 

--- a/firebase-storage/src/test/java/com/google/firebase/storage/RetryRule.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/RetryRule.java
@@ -18,7 +18,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-/** Retries tests that fail due to the test harnesses unpredictable threading behavior. */
+/** Retries tests that fail due to the test harnesses' unpredictable threading behavior. */
 public class RetryRule implements TestRule {
   private int retryCount;
 

--- a/firebase-storage/src/test/java/com/google/firebase/storage/RetryRule.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/RetryRule.java
@@ -18,6 +18,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+/** Retries tests that fail due to the test harnesses unpredictable threading behavior. */
 public class RetryRule implements TestRule {
   private int retryCount;
 

--- a/firebase-storage/src/test/java/com/google/firebase/storage/network/NetworkLayerMock.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/network/NetworkLayerMock.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.storage.network;
 
+/** Installs the Network Mock used by the unit tests. */
 public class NetworkLayerMock {
   public static MockConnectionFactory ensureNetworkMock(String testName, boolean isBinary) {
     MockConnectionFactory mockConnectionFactory = new MockConnectionFactory(testName, isBinary);

--- a/firebase-storage/src/testUtil/java/com/google/firebase/storage/TestDownloadHelper.java
+++ b/firebase-storage/src/testUtil/java/com/google/firebase/storage/TestDownloadHelper.java
@@ -272,7 +272,8 @@ public class TestDownloadHelper {
         StorageTaskManager.getInstance().getDownloadTasksUnder(reference.getParent());
     Preconditions.checkState(
         downloadTasksAtParent.size() == expectedTasks,
-        "Expected active download task at location %s to contain %s item(s), but contained %s item(s)",
+        "Expected active download task at location %s to contain %s item(s), "
+            + "but contained %s item(s)",
         reference.getParent(),
         downloadTasksAtParent.size());
   }

--- a/firebase-storage/src/testUtil/java/com/google/firebase/storage/TestUploadHelper.java
+++ b/firebase-storage/src/testUtil/java/com/google/firebase/storage/TestUploadHelper.java
@@ -694,7 +694,8 @@ public class TestUploadHelper {
         StorageTaskManager.getInstance().getUploadTasksUnder(reference.getParent());
     Preconditions.checkState(
         uploadTasksAtParent.size() == expectedTasks,
-        "Expected active upload task at location %s to contain %s item(s), but contained %s item(s)",
+        "Expected active upload task at location %s to contain %s item(s), "
+            + "but contained %s item(s)",
         reference.getParent(),
         uploadTasksAtParent.size());
   }


### PR DESCRIPTION
This fixes `g4 lint` errors.