### PR TITLE
Migrate from is(Not)SameAs to is(Not)SameInstanceAs.

### DIFF
--- a/firebase-common/ktx/src/test/kotlin/com/google/firebase/ktx/Tests.kt
+++ b/firebase-common/ktx/src/test/kotlin/com/google/firebase/ktx/Tests.kt
@@ -53,7 +53,7 @@ class KtxTests {
     @Test
     fun `Firebase#app should delegate to FirebaseApp#getInstance()`() {
         withApp(FirebaseApp.DEFAULT_APP_NAME) {
-            assertThat(Firebase.app).isSameAs(FirebaseApp.getInstance())
+            assertThat(Firebase.app).isSameInstanceAs(FirebaseApp.getInstance())
         }
     }
 
@@ -61,14 +61,14 @@ class KtxTests {
     fun `Firebase#app(String) should delegate to FirebaseApp#getInstance(String)`() {
         val appName = "testApp"
         withApp(appName) {
-            assertThat(Firebase.app(appName)).isSameAs(FirebaseApp.getInstance(appName))
+            assertThat(Firebase.app(appName)).isSameInstanceAs(FirebaseApp.getInstance(appName))
         }
     }
 
     @Test
     fun `Firebase#options should delegate to FirebaseApp#getInstance()#options`() {
         withApp(FirebaseApp.DEFAULT_APP_NAME) {
-            assertThat(Firebase.options).isSameAs(FirebaseApp.getInstance().options)
+            assertThat(Firebase.options).isSameInstanceAs(FirebaseApp.getInstance().options)
         }
     }
 
@@ -79,8 +79,8 @@ class KtxTests {
         try {
             assertThat(app).isNotNull()
             assertThat(app.name).isEqualTo(FirebaseApp.DEFAULT_APP_NAME)
-            assertThat(app.options).isSameAs(options)
-            assertThat(app.applicationContext).isSameAs(RuntimeEnvironment.application)
+            assertThat(app.options).isSameInstanceAs(options)
+            assertThat(app.applicationContext).isSameInstanceAs(RuntimeEnvironment.application)
         } finally {
             app.delete()
         }
@@ -94,8 +94,8 @@ class KtxTests {
         try {
             assertThat(app).isNotNull()
             assertThat(app.name).isEqualTo(name)
-            assertThat(app.options).isSameAs(options)
-            assertThat(app.applicationContext).isSameAs(RuntimeEnvironment.application)
+            assertThat(app.options).isSameInstanceAs(options)
+            assertThat(app.applicationContext).isSameInstanceAs(RuntimeEnvironment.application)
         } finally {
             app.delete()
         }

--- a/firebase-common/src/androidTest/java/com/google/firebase/FirebaseAppTest.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/FirebaseAppTest.java
@@ -349,18 +349,18 @@ public class FirebaseAppTest {
 
     Context appContext = mockContext.getApplicationContext();
 
-    assertThat(firebaseApp.get(Context.class)).isSameAs(appContext);
-    assertThat(firebaseApp.get(FirebaseApp.class)).isSameAs(firebaseApp);
+    assertThat(firebaseApp.get(Context.class)).isSameInstanceAs(appContext);
+    assertThat(firebaseApp.get(FirebaseApp.class)).isSameInstanceAs(firebaseApp);
 
     TestComponentOne one = firebaseApp.get(TestComponentOne.class);
     assertThat(one).isNotNull();
-    assertThat(one.getContext()).isSameAs(appContext);
+    assertThat(one.getContext()).isSameInstanceAs(appContext);
 
     TestComponentTwo two = firebaseApp.get(TestComponentTwo.class);
     assertThat(two).isNotNull();
-    assertThat(two.getApp()).isSameAs(firebaseApp);
-    assertThat(two.getOptions()).isSameAs(firebaseApp.getOptions());
-    assertThat(two.getOne()).isSameAs(one);
+    assertThat(two.getApp()).isSameInstanceAs(firebaseApp);
+    assertThat(two.getOptions()).isSameInstanceAs(firebaseApp.getOptions());
+    assertThat(two.getOne()).isSameInstanceAs(one);
   }
 
   @Test

--- a/firebase-common/src/androidTest/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/FirebaseOptionsTest.java
@@ -79,7 +79,7 @@ public class FirebaseOptionsTest {
   @Test
   public void checkToBuilderCreatesNewEquivalentInstance() {
     FirebaseOptions allValuesOptionsCopy = new FirebaseOptions.Builder(ALL_VALUES_OPTIONS).build();
-    assertThat(allValuesOptionsCopy).isNotSameAs(ALL_VALUES_OPTIONS);
+    assertThat(allValuesOptionsCopy).isNotSameInstanceAs(ALL_VALUES_OPTIONS);
     assertThat(allValuesOptionsCopy).isEqualTo(ALL_VALUES_OPTIONS);
   }
 }

--- a/firebase-common/src/test/java/com/google/firebase/components/ComponentRuntimeTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/components/ComponentRuntimeTest.java
@@ -114,7 +114,7 @@ public final class ComponentRuntimeTest {
 
     ComponentTwo componentTwo = runtime.get(ComponentTwo.class);
     assertThat(componentTwo.getOne()).isNotNull();
-    assertThat(componentTwo.getOne().getTracker()).isSameAs(initTracker);
+    assertThat(componentTwo.getOne().getTracker()).isSameInstanceAs(initTracker);
 
     assertThat(initTracker.isInitialized()).isTrue();
   }
@@ -193,7 +193,7 @@ public final class ComponentRuntimeTest {
     assertThat(one.cyclicTwo).isNotNull();
     Provider<CyclicOne> oneProvider = one.cyclicTwo.cyclicOne;
     assertThat(oneProvider).isNotNull();
-    assertThat(oneProvider.get()).isSameAs(one);
+    assertThat(oneProvider.get()).isSameInstanceAs(one);
   }
 
   @Test
@@ -230,8 +230,8 @@ public final class ComponentRuntimeTest {
     Provider<Parent> parent = runtime.getProvider(Parent.class);
     assertThat(parent).isNotNull();
 
-    assertThat(child).isSameAs(parent);
-    assertThat(child.get()).isSameAs(parent.get());
+    assertThat(child).isSameInstanceAs(parent);
+    assertThat(child.get()).isSameInstanceAs(parent.get());
   }
 
   @Test

--- a/firebase-common/src/test/java/com/google/firebase/components/ComponentTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/components/ComponentTest.java
@@ -42,7 +42,7 @@ public class ComponentTest {
     assertThat(component.isAlwaysEager()).isFalse();
     assertThat(component.isEagerInDefaultApp()).isFalse();
     assertThat(component.getDependencies()).isEmpty();
-    assertThat(component.getFactory().create(null)).isSameAs(testClass);
+    assertThat(component.getFactory().create(null)).isSameInstanceAs(testClass);
   }
 
   @Test
@@ -193,6 +193,6 @@ public class ComponentTest {
   public void getFactory_shouldReturnFactorySetInBuilder() {
     Component<TestClass> component =
         Component.builder(TestClass.class).factory(nullFactory).build();
-    assertThat(component.getFactory()).isSameAs(nullFactory);
+    assertThat(component.getFactory()).isSameInstanceAs(nullFactory);
   }
 }

--- a/firebase-common/src/test/java/com/google/firebase/components/LazyTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/components/LazyTest.java
@@ -46,7 +46,7 @@ public final class LazyTest {
     Object instance = new Object();
     Lazy<Object> lazy = new Lazy<>(instance);
 
-    assertThat(lazy.get()).isSameAs(instance);
+    assertThat(lazy.get()).isSameInstanceAs(instance);
   }
 
   @Test
@@ -56,7 +56,7 @@ public final class LazyTest {
 
     when(mockProvider.get()).thenReturn(instance);
 
-    assertThat(lazy.get()).isSameAs(instance);
+    assertThat(lazy.get()).isSameInstanceAs(instance);
 
     verify(mockProvider, times(1)).get();
   }

--- a/firebase-common/src/test/java/com/google/firebase/components/RestrictedComponentContainerTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/components/RestrictedComponentContainerTest.java
@@ -57,7 +57,7 @@ public final class RestrictedComponentContainerTest {
     Float value = 1.0f;
     when(delegate.get(Float.class)).thenReturn(value);
 
-    assertThat(container.get(Float.class)).isSameAs(value);
+    assertThat(container.get(Float.class)).isSameInstanceAs(value);
     verify(delegate).get(Float.class);
   }
 
@@ -96,7 +96,7 @@ public final class RestrictedComponentContainerTest {
     Double value = 3.0d;
     when(delegate.getProvider(Double.class)).thenReturn(new Lazy<>(value));
 
-    assertThat(container.getProvider(Double.class).get()).isSameAs(value);
+    assertThat(container.getProvider(Double.class).get()).isSameInstanceAs(value);
     verify(delegate).getProvider(Double.class);
   }
 
@@ -125,7 +125,7 @@ public final class RestrictedComponentContainerTest {
     Set<Long> set = Collections.emptySet();
     when(delegate.setOf(Long.class)).thenReturn(set);
 
-    assertThat(container.setOf(Long.class)).isSameAs(set);
+    assertThat(container.setOf(Long.class)).isSameInstanceAs(set);
     verify(delegate).setOf(Long.class);
   }
 
@@ -144,7 +144,7 @@ public final class RestrictedComponentContainerTest {
     Set<Boolean> set = Collections.emptySet();
     when(delegate.setOfProvider(Boolean.class)).thenReturn(new Lazy<>(set));
 
-    assertThat(container.setOfProvider(Boolean.class).get()).isSameAs(set);
+    assertThat(container.setOfProvider(Boolean.class).get()).isSameInstanceAs(set);
     verify(delegate).setOfProvider(Boolean.class);
   }
 

--- a/firebase-firestore/ktx/src/test/kotlin/com/google/firebase/firestore/ktx/FirestoreTests.kt
+++ b/firebase-firestore/ktx/src/test/kotlin/com/google/firebase/firestore/ktx/FirestoreTests.kt
@@ -75,13 +75,13 @@ class FirestoreTests : BaseTestCase() {
 
     @Test
     fun `firestore should delegate to FirebaseFirestore#getInstance()`() {
-        assertThat(Firebase.firestore).isSameAs(FirebaseFirestore.getInstance())
+        assertThat(Firebase.firestore).isSameInstanceAs(FirebaseFirestore.getInstance())
     }
 
     @Test
     fun `FirebaseApp#firestore should delegate to FirebaseFirestore#getInstance(FirebaseApp)`() {
         val app = Firebase.app(EXISTING_APP)
-        assertThat(Firebase.firestore(app)).isSameAs(FirebaseFirestore.getInstance(app))
+        assertThat(Firebase.firestore(app)).isSameInstanceAs(FirebaseFirestore.getInstance(app))
     }
 }
 

--- a/firebase-functions/ktx/src/test/kotlin/com/google/firebase/functions/ktx/FunctionsTests.kt
+++ b/firebase-functions/ktx/src/test/kotlin/com/google/firebase/functions/ktx/FunctionsTests.kt
@@ -68,26 +68,26 @@ class FunctionsTests : BaseTestCase() {
 
     @Test
     fun `functions should delegate to FirebaseFunctions#getInstance()`() {
-        assertThat(Firebase.functions).isSameAs(FirebaseFunctions.getInstance())
+        assertThat(Firebase.functions).isSameInstanceAs(FirebaseFunctions.getInstance())
     }
 
     @Test
     fun `FirebaseApp#functions should delegate to FirebaseFunctions#getInstance(FirebaseApp)`() {
         val app = Firebase.app(EXISTING_APP)
-        assertThat(Firebase.functions(app)).isSameAs(FirebaseFunctions.getInstance(app))
+        assertThat(Firebase.functions(app)).isSameInstanceAs(FirebaseFunctions.getInstance(app))
     }
 
     @Test
     fun `Firebase#functions should delegate to FirebaseFunctions#getInstance(region)`() {
         val region = "valid_region"
-        assertThat(Firebase.functions(region)).isSameAs(FirebaseFunctions.getInstance(region))
+        assertThat(Firebase.functions(region)).isSameInstanceAs(FirebaseFunctions.getInstance(region))
     }
 
     @Test
     fun `Firebase#functions should delegate to FirebaseFunctions#getInstance(FirebaseApp, region)`() {
         val app = Firebase.app(EXISTING_APP)
         val region = "valid_region"
-        assertThat(Firebase.functions(app, region)).isSameAs(FirebaseFunctions.getInstance(app, region))
+        assertThat(Firebase.functions(app, region)).isSameInstanceAs(FirebaseFunctions.getInstance(app, region))
     }
 }
 

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -46,7 +46,7 @@ ext {
     supportAnnotationsVersion = '28.0.0'
     errorproneVersion = '2.3.2'
     errorproneJavacVersion = '9+181-r4173-1'
-    googleTruthVersion = '0.40'
+    googleTruthVersion = '0.45'
     robolectricVersion = '4.1'
 }
 

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -88,7 +88,7 @@ apply from: "configure.gradle"
 dependencies {
   // Common
   api "androidx.test:runner:1.2.0"
-  api "com.google.truth:truth:0.44"
+  api "com.google.truth:truth:0.45"
   api "junit:junit:4.12"
 
   implementation "androidx.test:rules:1.2.0"


### PR DESCRIPTION
They behave identically, and the old names are being removed.

This requires updating to Truth 0.44 or higher, so I've gone straight to 0.45.