### PR TITLE
Add type arguments in StorageTaskManager

### DIFF
--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageTaskManager.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageTaskManager.java
@@ -32,7 +32,7 @@ import java.util.Map;
 /*package*/ class StorageTaskManager {
   private static final StorageTaskManager _instance = new StorageTaskManager();
 
-  private final Map<String, WeakReference<StorageTask>> inProgressTasks = new HashMap<>();
+  private final Map<String, WeakReference<StorageTask<?>>> inProgressTasks = new HashMap<>();
 
   private final Object syncObject = new Object();
 
@@ -44,7 +44,7 @@ import java.util.Map;
     synchronized (syncObject) {
       ArrayList<UploadTask> inProgressList = new ArrayList<>();
       String parentPath = parent.toString();
-      for (Map.Entry<String, WeakReference<StorageTask>> entry : inProgressTasks.entrySet()) {
+      for (Map.Entry<String, WeakReference<StorageTask<?>>> entry : inProgressTasks.entrySet()) {
         if (entry.getKey().startsWith(parentPath)) {
           StorageTask task = entry.getValue().get();
           if (task instanceof UploadTask) {
@@ -60,9 +60,9 @@ import java.util.Map;
     synchronized (syncObject) {
       ArrayList<FileDownloadTask> inProgressList = new ArrayList<>();
       String parentPath = parent.toString();
-      for (Map.Entry<String, WeakReference<StorageTask>> entry : inProgressTasks.entrySet()) {
+      for (Map.Entry<String, WeakReference<StorageTask<?>>> entry : inProgressTasks.entrySet()) {
         if (entry.getKey().startsWith(parentPath)) {
-          StorageTask task = entry.getValue().get();
+          StorageTask<?> task = entry.getValue().get();
           if (task instanceof FileDownloadTask) {
             inProgressList.add((FileDownloadTask) task);
           }
@@ -72,19 +72,19 @@ import java.util.Map;
     }
   }
 
-  public void ensureRegistered(StorageTask targetTask) {
+  public void ensureRegistered(StorageTask<?> targetTask) {
     synchronized (syncObject) {
       // ensure *this* is added to the in progress list
       inProgressTasks.put(targetTask.getStorage().toString(), new WeakReference<>(targetTask));
     }
   }
 
-  public void unRegister(StorageTask targetTask) {
+  public void unRegister(StorageTask<?> targetTask) {
     synchronized (syncObject) {
       // ensure *this* is added to the in progress list
       String key = targetTask.getStorage().toString();
-      WeakReference<StorageTask> weakReference = inProgressTasks.get(key);
-      StorageTask task = weakReference != null ? weakReference.get() : null;
+      WeakReference<StorageTask<?>> weakReference = inProgressTasks.get(key);
+      StorageTask<?> task = weakReference != null ? weakReference.get() : null;
       if (task == null || task == targetTask) {
         inProgressTasks.remove(key);
       }


### PR DESCRIPTION
Fixes a couple of build warnings:

third_party/firebase/android/firebase_storage_api/src/com/google/firebase/storage/StorageTaskManager.java:75: warning: [rawtypes] found raw type: StorageTask
  public void ensureRegistered(StorageTask targetTask) {
                               ^
  missing type arguments for generic class StorageTask<ResultT>