### PR TITLE
Set test type to release only in CI.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
@@ -31,6 +31,9 @@ public class FirebaseLibraryPlugin implements Plugin<Project> {
         project.getExtensions().create("firebaseLibrary", FirebaseLibraryExtension.class, project);
 
     LibraryExtension android = project.getExtensions().getByType(LibraryExtension.class);
+
+    // In the case of and android library signing config only affects instrumentation test APK.
+    // We need it signed with default debug credentials in order for FTL to accept the APK.
     android.buildTypes(
         types ->
             types

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -140,38 +140,6 @@ configure(subprojects) {
     }
 }
 
-/**
- * Disable "debug" build type for all subprojects.
- *
- * They are identical to "release" and are not used in either release or smoke tests. Disabling them
- * to reduce the number of tests we run on pre/post-submit.
- */
-configure(subprojects) {
-    afterEvaluate { Project sub ->
-        if (!sub.plugins.hasPlugin('com.android.library') && !sub.plugins.hasPlugin('com.android.application')) {
-            return
-        }
-
-        // skip debug unit tests in CI
-        // TODO(vkryachko): provide ability for teams to control this if needed
-        if (System.getenv().containsKey("FIREBASE_CI")) {
-            sub.tasks.all {Task task ->
-                if (task.name == 'testDebugUnitTest') {
-                    task.enabled = false
-                }
-            }
-        }
-        sub.android {
-            testBuildType "release"
-
-            buildTypes {
-                // In the case of and android library signing config only affects instrumentation test APK.
-                // We need it signed with default debug credentials in order for FTL to accept the APK.
-                release.signingConfig = debug.signingConfig
-            }
-        }
-    }
-}
 
 /**
  * Configure "Preguarding" and Desugaring for the subprojects.


### PR DESCRIPTION
This fixes Android Studio issue, where it is impossible to run
integration tests in debug mode.

Additionally move build type configuration to FirebaseLibraryPlugin to
avoid projects.all configuration in gradle.