### PR TITLE
Minor fix to error message to match the admin sdk.

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -332,11 +332,7 @@ public class ValidationTest {
     List<String> badFieldPaths =
         asList("foo~bar", "foo*bar", "foo/bar", "foo[1", "foo]1", "foo[1]");
     for (String fieldPath : badFieldPaths) {
-      String reason =
-          "Invalid field path ("
-              + fieldPath
-              + "). Paths must not contain '~', '*', '/', '[', or ']'";
-      verifyFieldPathThrows(fieldPath, reason);
+      verifyFieldPathThrows(fieldPath, "Use FieldPath.of() for field names containing '~*/[]'.");
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldPath.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldPath.java
@@ -84,8 +84,7 @@ public final class FieldPath {
   static FieldPath fromDotSeparatedPath(@NonNull String path) {
     checkNotNull(path, "Provided field path must not be null.");
     checkArgument(
-        !RESERVED.matcher(path).find(),
-        "Invalid field path (" + path + "). Paths must not contain '~', '*', '/', '[', or ']'");
+        !RESERVED.matcher(path).find(), "Use FieldPath.of() for field names containing '~*/[]'.");
     try {
       // By default, split() doesn't return empty leading and trailing segments. This can be enabled
       // by passing "-1" as the  limit.


### PR DESCRIPTION
In particular, it *is* allowed to have slashes, etc in field paths, but you need to use FieldPath.of to do so.