### PR TITLE
Restrict coverage collection to release builds.

### DIFF
--- a/root-project.gradle
+++ b/root-project.gradle
@@ -105,8 +105,10 @@ configure(subprojects) {
           'description': 'Generates JaCoCo unit test coverage reports.'], checkCoverage) {
         def excludes = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**Manifest*.*']
         classDirectories = files([
-            fileTree(dir: "$buildDir/intermediates/javac", excludes: excludes),
-            fileTree(dir: "$buildDir/tmp/kotlin-classes", excludes: excludes)
+            fileTree(dir: "$buildDir/intermediates/javac/release", excludes: excludes),
+            fileTree(dir: "$buildDir/intermediates/javac/releaseUnitTest", excludes: excludes),
+            fileTree(dir: "$buildDir/tmp/kotlin-classes/release", excludes: excludes),
+            fileTree(dir: "$buildDir/tmp/kotlin-classes/releaseUnitTest", excludes: excludes),
         ])
         sourceDirectories = files(['src/main/java', 'src/main/kotlin'])
         executionData = fileTree(dir: "$buildDir", includes: ['jacoco/*.exec'])


### PR DESCRIPTION
Code coverage can fail for local builds, becuase there are multiple
definitions for the same classes (debug and release). On CI, debug is
disabled. This change forces the coverage check to use on release
builds, thus making it compatible with both local and CI use cases.

This fixes the problem presented in #531.