### PR TITLE
Add Remote Config smoke tests.

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -67,10 +67,11 @@ android {
     combined {
       java.srcDirs = [
           "src/combined/java",
-	  "src/database/java",
-	  "src/firestore/java",
-	  "src/functions/java",
-	  "src/storage/java",
+          "src/database/java",
+          "src/firestore/java",
+          "src/functions/java",
+          "src/remoteConfig/java",
+          "src/storage/java",
       ]
     }
   }
@@ -103,6 +104,7 @@ dependencies {
   combinedImplementation "com.google.firebase:firebase-database"
   combinedImplementation "com.google.firebase:firebase-firestore"
   combinedImplementation "com.google.firebase:firebase-functions"
+  combinedImplementation "com.google.firebase:firebase-config"
   combinedImplementation "com.google.firebase:firebase-storage"
 
   // Database

--- a/smoke-tests/configure.gradle
+++ b/smoke-tests/configure.gradle
@@ -14,7 +14,7 @@
 
 
 def configurePlatform() {
-  def bom = "com.google.firebase:firebase-bom:18.1.0"
+  def bom = "com.google.firebase:firebase-bom:20.0.0"
   if (project.hasProperty("firebase-bom")) {
     bom = project.getProperty("firebase-bom")
   }

--- a/smoke-tests/src/combined/java/com/google/firebase/testing/combined/AllTests.java
+++ b/smoke-tests/src/combined/java/com/google/firebase/testing/combined/AllTests.java
@@ -17,6 +17,7 @@ package com.google.firebase.testing.combined;
 import com.google.firebase.testing.database.DatabaseTest;
 import com.google.firebase.testing.firestore.FirestoreTest;
 import com.google.firebase.testing.functions.FunctionsTest;
+import com.google.firebase.testing.remoteconfig.RemoteConfigTest;
 import com.google.firebase.testing.storage.StorageTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -25,5 +26,11 @@ import org.junit.runners.Suite;
  * A test suite combining the individual product flavors.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({DatabaseTest.class, FirestoreTest.class, FunctionsTest.class, StorageTest.class})
+@Suite.SuiteClasses({
+  DatabaseTest.class,
+  FirestoreTest.class,
+  FunctionsTest.class,
+  RemoteConfigTest.class,
+  StorageTest.class,
+})
 public final class AllTests {}

--- a/smoke-tests/src/remoteConfig/java/com/google/firebase/testing/remoteconfig/RemoteConfigTest.java
+++ b/smoke-tests/src/remoteConfig/java/com/google/firebase/testing/remoteconfig/RemoteConfigTest.java
@@ -1,0 +1,67 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.remoteconfig;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.testing.common.Tasks2.waitForSuccess;
+
+import android.app.Activity;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public final class RemoteConfigTest {
+
+  private static final String MODEL_NAME = "Acura/Honda+Mercedes-Benz";
+  private static final boolean COLOR_IS_RED = true;
+
+  @Rule public final ActivityTestRule<Activity> activity = new ActivityTestRule<>(Activity.class);
+
+  @Before
+  public void prepareRemoteConfig() throws Exception {
+    FirebaseRemoteConfig frc = FirebaseRemoteConfig.getInstance();
+
+    waitForSuccess(frc.fetch());
+    waitForSuccess(frc.activate());
+  }
+
+  @Test
+  public void getBooleanConvertsValueSetInConsole() {
+    FirebaseRemoteConfig frc = FirebaseRemoteConfig.getInstance();
+
+    assertThat(frc.getBoolean("COLOR_IS_RED")).isEqualTo(COLOR_IS_RED);
+  }
+
+  @Test
+  public void getStringReturnsValueSetInConsole() {
+    FirebaseRemoteConfig frc = FirebaseRemoteConfig.getInstance();
+
+    assertThat(frc.getString("MODEL_NAME")).isEqualTo(MODEL_NAME);
+  }
+
+  @Test
+  public void getValueNotSetInConsoleYieldsStaticSource() {
+    FirebaseRemoteConfig frc = FirebaseRemoteConfig.getInstance();
+    FirebaseRemoteConfigValue value = frc.getValue("GOOBER_GOOBER");
+
+    assertThat(value.getSource()).isEqualTo(FirebaseRemoteConfig.VALUE_SOURCE_STATIC);
+  }
+}


### PR DESCRIPTION
This change boosts the default smoke test versions for local runs and adds three Remote Config tests to the smoke test suite.