### PR TITLE
Add FIAM to build test

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -63,10 +63,11 @@ dependencies {
 
   // All
   combinedImplementation "com.google.firebase:firebase-auth"
+  combinedImplementation "com.google.firebase:firebase-config"
   combinedImplementation "com.google.firebase:firebase-database"
   combinedImplementation "com.google.firebase:firebase-firestore"
   combinedImplementation "com.google.firebase:firebase-functions"
-  combinedImplementation "com.google.firebase:firebase-config"
+  combinedImplementation "com.google.firebase:firebase-inappmessaging"
   combinedImplementation "com.google.firebase:firebase-storage"
 }
 


### PR DESCRIPTION
This change does not add any new test cases, but it does add In-app Messaging to the list of test dependencies. This ensures that In-app Messaging, and all of its dependencies, may be built with the other libraries used by the smoke tests.

In the future, we may be able to produce some tests here for In-app Messaging.