### PR TITLE
Make QueryMatching immutable

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryMatcher.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryMatcher.java
@@ -1,0 +1,109 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.core;
+
+import com.google.firebase.firestore.model.Document;
+import com.google.firebase.firestore.model.DocumentKey;
+import com.google.firebase.firestore.model.FieldPath;
+import com.google.firebase.firestore.model.ResourcePath;
+import java.util.List;
+
+/** A QueryMatcher executes a Query against a Firestore Document. */
+public class QueryMatcher {
+  private final String collectionGroup;
+  private final ResourcePath path;
+  private final List<Filter> filters;
+  private final List<OrderBy> orderBy;
+  private final Bound startAt;
+  private final Bound endAt;
+
+  /** Creates a new QueryMatcher based on the current state of the query. */
+  static QueryMatcher fromQuery(Query query) {
+    return new QueryMatcher(
+        query.getCollectionGroup(),
+        query.getPath(),
+        query.getFilters(),
+        query.getOrderBy(),
+        query.getStartAt(),
+        query.getEndAt());
+  }
+
+  private QueryMatcher(
+      String collectionGroup,
+      ResourcePath path,
+      List<Filter> filters,
+      List<OrderBy> orderBy,
+      Bound startAt,
+      Bound endAt) {
+    this.collectionGroup = collectionGroup;
+    this.path = path;
+    this.filters = filters;
+    this.orderBy = orderBy;
+    this.startAt = startAt;
+    this.endAt = endAt;
+  }
+
+  private boolean matchesPathAndCollectionGroup(Document doc) {
+    ResourcePath docPath = doc.getKey().getPath();
+    if (collectionGroup != null) {
+      // NOTE: this.path is currently always empty since we don't expose Collection
+      // Group queries rooted at a document path yet.
+      return doc.getKey().hasCollectionId(collectionGroup) && path.isPrefixOf(docPath);
+    } else if (DocumentKey.isDocumentKey(path)) {
+      return path.equals(docPath);
+    } else {
+      return path.isPrefixOf(docPath) && path.length() == docPath.length() - 1;
+    }
+  }
+
+  private boolean matchesFilters(Document doc) {
+    for (Filter filter : filters) {
+      if (!filter.matches(doc)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** A document must have a value for every ordering clause in order to show up in the results. */
+  private boolean matchesOrderBy(Document doc) {
+    for (OrderBy order : orderBy) {
+      // order by key always matches
+      if (!order.getField().equals(FieldPath.KEY_PATH) && (doc.getField(order.field) == null)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Makes sure a document is within the bounds, if provided. */
+  private boolean matchesBounds(Document doc) {
+    if (startAt != null && !startAt.sortsBeforeDocument(orderBy, doc)) {
+      return false;
+    }
+    if (endAt != null && endAt.sortsBeforeDocument(orderBy, doc)) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Returns true if the document matches the constraints of this query. */
+  public boolean matches(Document doc) {
+    return matchesPathAndCollectionGroup(doc)
+        && matchesOrderBy(doc)
+        && matchesFilters(doc)
+        && matchesBounds(doc);
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
@@ -72,6 +72,8 @@ public class View {
 
   private final Query query;
 
+  private final QueryMatcher queryMatcher;
+
   private SyncState syncState;
 
   /**
@@ -94,6 +96,7 @@ public class View {
 
   public View(Query query, ImmutableSortedSet<DocumentKey> remoteDocuments) {
     this.query = query;
+    queryMatcher = query.matcher();
     syncState = SyncState.NONE;
     documentSet = DocumentSet.emptySet(query.comparator());
     syncedDocuments = remoteDocuments;
@@ -164,7 +167,7 @@ public class View {
             "Mismatching key in doc change %s != %s",
             key,
             newDoc.getKey());
-        if (!query.matches(newDoc)) {
+        if (!queryMatcher.matches(newDoc)) {
           newDoc = null;
         }
       }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexedQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexedQueryEngine.java
@@ -25,6 +25,7 @@ import com.google.firebase.firestore.core.IndexRange;
 import com.google.firebase.firestore.core.NaNFilter;
 import com.google.firebase.firestore.core.NullFilter;
 import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.core.QueryMatcher;
 import com.google.firebase.firestore.core.RelationFilter;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentCollections;
@@ -133,17 +134,16 @@ public class IndexedQueryEngine implements QueryEngine {
    */
   private ImmutableSortedMap<DocumentKey, Document> performQueryUsingIndex(
       Query query, IndexRange indexRange) {
+    QueryMatcher matcher = query.matcher();
     ImmutableSortedMap<DocumentKey, Document> results = DocumentCollections.emptyDocumentMap();
-    IndexCursor cursor = collectionIndex.getCursor(query.getPath(), indexRange);
-    try {
+
+    try (IndexCursor cursor = collectionIndex.getCursor(query.getPath(), indexRange)) {
       while (cursor.next()) {
         Document document = (Document) localDocuments.getDocument(cursor.getDocumentKey());
-        if (query.matches(document)) {
+        if (matcher.matches(document)) {
           results = results.insert(cursor.getDocumentKey(), document);
         }
       }
-    } finally {
-      cursor.close();
     }
 
     return results;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -20,6 +20,7 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.core.QueryMatcher;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
@@ -202,8 +203,9 @@ final class LocalDocumentsView {
     }
 
     // Finally, filter out any documents that don't actually match the query.
+    QueryMatcher matcher = query.matcher();
     for (Map.Entry<DocumentKey, Document> docEntry : results) {
-      if (!query.matches(docEntry.getValue())) {
+      if (!matcher.matches(docEntry.getValue())) {
         results = results.remove(docEntry.getKey());
       }
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -20,6 +20,7 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.core.QueryMatcher;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
@@ -79,6 +80,7 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
         !query.isCollectionGroupQuery(),
         "CollectionGroup queries should be handled in LocalDocumentsView");
     ImmutableSortedMap<DocumentKey, Document> result = emptyDocumentMap();
+    QueryMatcher matcher = query.matcher();
 
     // Documents are ordered by key, so we can use a prefix scan to narrow down the documents
     // we need to match the query against.
@@ -98,7 +100,7 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
       }
 
       Document doc = (Document) maybeDoc;
-      if (query.matches(doc)) {
+      if (matcher.matches(doc)) {
         result = result.insert(doc.getKey(), doc);
       }
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -19,6 +19,7 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.core.QueryMatcher;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
@@ -118,6 +119,8 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
     String prefixPath = EncodedPath.encode(prefix);
     String prefixSuccessorPath = EncodedPath.prefixSuccessor(prefixPath);
 
+    QueryMatcher queryMatcher = query.matcher();
+
     Map<DocumentKey, Document> results = new HashMap<>();
 
     db.query("SELECT path, contents FROM remote_documents WHERE path >= ? AND path < ?")
@@ -142,7 +145,7 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
               }
 
               Document doc = (Document) maybeDoc;
-              if (!query.matches(doc)) {
+              if (!queryMatcher.matches(doc)) {
                 return;
               }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/BasePath.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/BasePath.java
@@ -19,6 +19,7 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 import androidx.annotation.NonNull;
 import com.google.firebase.firestore.util.Util;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -29,7 +30,7 @@ public abstract class BasePath<B extends BasePath<B>> implements Comparable<B> {
   final List<String> segments;
 
   BasePath(List<String> segments) {
-    this.segments = segments;
+    this.segments = Collections.unmodifiableList(segments);
   }
 
   public String getSegment(int index) {


### PR DESCRIPTION
The goal of this PR is to make Query.matches() thread-safe. It does this by creating an immutable view of the Query state that we use for matching and memoizes the Query's orderBy constraint only once and before the Query's execution.

There are many other ways to achieve this, but this one seemed the most straightforward to me and simplifies the code in the Query class a bit. Apart from creating the new QueryMatcher class, this PR mostly moves code to the new class.