### PR TITLE
Add Inapp Messaging smoke test.

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -48,6 +48,10 @@ android {
       applicationId "com.google.firebase.testing.combined"
     }
   }
+
+  // TODO(allisonbm92): Enable the Inapp Messaging test after the next release. The current release
+  // is incompatible with the head state of AB Testing (required by Remote Config).
+  sourceSets.combined.java.filter.exclude "**/inappmessaging/**"
 }
 
 apply from: "configure.gradle"
@@ -66,6 +70,7 @@ dependencies {
   combinedImplementation "com.google.firebase:firebase-database"
   combinedImplementation "com.google.firebase:firebase-firestore"
   combinedImplementation "com.google.firebase:firebase-functions"
+//  combinedImplementation "com.google.firebase:firebase-inappmessaging"
   combinedImplementation "com.google.firebase:firebase-config"
   combinedImplementation "com.google.firebase:firebase-storage"
 }

--- a/smoke-tests/src/combined/java/com/google/firebase/testing/inappmessaging/InappMessagingTest.java
+++ b/smoke-tests/src/combined/java/com/google/firebase/testing/inappmessaging/InappMessagingTest.java
@@ -1,0 +1,31 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.testing.inappmessaging;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.inappmessaging.FirebaseInAppMessaging;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class InappMessagingTest {
+
+  @Test
+  public void getInstanceReturnsNotNull() {
+    assertThat(FirebaseInAppMessaging.getInstance()).isNotNull();
+  }
+}


### PR DESCRIPTION
Inapp Messaging does not have an interface to trigger updates from the
device. As a result, this test simply verifies intialization and build
compatibility.

However, the latest release of Inapp Messaging is build incompatible
with the head state of AB Testing. As such, this test is disabled for
now.