### PR TITLE
Add Proguard Files to Smoke Tests

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -39,6 +39,16 @@ android {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
+  buildTypes {
+    release {
+      minifyEnabled true
+      shrinkResources true
+      signingConfig signingConfigs.debug
+      proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "smoke-test-rules.pro"
+      testProguardFiles "infrastructure-rules.pro"
+    }
+  }
+
   flavorDimensions "systemUnderTest"
 
   // TODO(allisonbm92): Switch to the default flavor.
@@ -58,12 +68,11 @@ apply from: "configure.gradle"
 
 dependencies {
   // Common
-  api "androidx.test:runner:1.2.0"
-  api "com.google.truth:truth:0.45"
-  api "junit:junit:4.12"
-
   implementation "androidx.test:rules:1.2.0"
+  implementation "androidx.test:runner:1.2.0"
   implementation "com.google.firebase:firebase-common"
+  implementation "com.google.truth:truth:0.44"
+  implementation "junit:junit:4.12"
 
   // All
   combinedImplementation "com.google.firebase:firebase-auth"
@@ -73,6 +82,10 @@ dependencies {
 //  combinedImplementation "com.google.firebase:firebase-inappmessaging"
   combinedImplementation "com.google.firebase:firebase-config"
   combinedImplementation "com.google.firebase:firebase-storage"
+
+  androidTestImplementation "androidx.test:core:1.2.0"
+  androidTestImplementation "androidx.test:runner:1.2.0"
+  androidTestImplementation "junit:junit:4.12"
 }
 
 clean.doLast {

--- a/smoke-tests/gradle.properties
+++ b/smoke-tests/gradle.properties
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-android.enableJetifier=true
+android.enableR8=true
 android.useAndroidX=true

--- a/smoke-tests/infrastructure-rules.pro
+++ b/smoke-tests/infrastructure-rules.pro
@@ -1,0 +1,3 @@
+-dontobfuscate
+-dontoptimize
+-dontshrink

--- a/smoke-tests/smoke-test-rules.pro
+++ b/smoke-tests/smoke-test-rules.pro
@@ -1,0 +1,23 @@
+-optimizationpasses 3
+-keepattributes SourceFile, LineNumberTable, *Annotation*
+
+-keep @org.junit.runner.RunWith class *
+-keep class androidx.test.**
+-keep class org.junit.**
+
+-keepclassmembers @org.junit.runner.RunWith class * {
+  public <methods>;
+  public <fields>;
+}
+
+-keepclassmembers class androidx.test.** {
+  public <methods>;
+}
+
+-keepclassmembers class org.junit.** {
+  protected <methods>;
+  public <methods>;
+}
+
+-dontwarn android.**
+-dontwarn okio.**

--- a/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/SmokeTestSuite.java
+++ b/smoke-tests/src/androidTest/java/com/google/firebase/testing/common/SmokeTestSuite.java
@@ -17,7 +17,7 @@ package com.google.firebase.testing.common;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -69,7 +69,7 @@ public class SmokeTestSuite extends ParentRunner<Runner> {
   }
 
   private static List<Class<?>> getTestClasses() throws InitializationError {
-    Context ctx = InstrumentationRegistry.getTargetContext();
+    Context ctx = ApplicationProvider.getApplicationContext();
     return getTestClasses(ctx);
   }
 


### PR DESCRIPTION
This change adds the necessary proguard files and a configuration block
for release builds. However, this change does not yet enable testing
against the release build.