### PR TITLE
Throw last failed attempt's error in failed transactions

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -11,8 +11,8 @@
 - [feature] Added a `@DocumentId` annotation which can be used on a
   `DocumentReference` or `String` property in a POJO to indicate that the SDK
   should automatically populate it with the document's ID.
-- [changed] Failed transactions now throw the failure from the last attempt,
-  instead of `ABORTED.` 
+- [changed] Failed transactions now fail with the exception from the last 
+  attempt instead of an always failing with an exception with code `ABORTED`.
 
 # 20.1.0
 - [changed] SSL and gRPC initialization now happens on a separate thread, which

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -12,7 +12,7 @@
   `DocumentReference` or `String` property in a POJO to indicate that the SDK
   should automatically populate it with the document's ID.
 - [changed] Failed transactions now fail with the exception from the last 
-  attempt instead of an always failing with an exception with code `ABORTED`.
+  attempt instead of always failing with an exception with code `ABORTED`.
 
 # 20.1.0
 - [changed] SSL and gRPC initialization now happens on a separate thread, which

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -11,6 +11,8 @@
 - [feature] Added a `@DocumentId` annotation which can be used on a
   `DocumentReference` or `String` property in a POJO to indicate that the SDK
   should automatically populate it with the document's ID.
+- [changed] Failed transactions now throw the failure from the last attempt,
+  instead of `ABORTED.` 
 
 # 20.1.0
 - [changed] SSL and gRPC initialization now happens on a separate thread, which

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
@@ -325,9 +325,7 @@ public class ServerTimestampTest {
     Exception e = waitForException(completion);
     assertNotNull(e);
     assertTrue(e instanceof FirebaseFirestoreException);
-    // TODO: This should be a NOT_FOUND, but right now we retry transactions on any
-    // error and so this turns into ABORTED instead.
-    assertEquals(Code.ABORTED, ((FirebaseFirestoreException) e).getCode());
+    assertEquals(Code.NOT_FOUND, ((FirebaseFirestoreException) e).getCode());
   }
 
   @Test

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -435,7 +435,7 @@ public class TransactionTest {
     // assertEquals(1234, snapshot.getDouble("count"));
     // snapshot = waitFor(doc2.get());
     // assertEquals(16, snapshot.getDouble("count"));
-    assertEquals(Code.FAILED_PRECONDITION, ((FirebaseFirestoreException) e).getCode());
+    assertEquals(Code.INVALID_ARGUMENT, ((FirebaseFirestoreException) e).getCode());
     assertEquals("Every document read in a transaction must also be written.", e.getMessage());
   }
 
@@ -486,7 +486,7 @@ public class TransactionTest {
     // We currently require every document read to also be written.
     // TODO: Add this check back once we drop that.
     // assertEquals("bar", snapshot.getString("foo"));
-    assertEquals(Code.FAILED_PRECONDITION, ((FirebaseFirestoreException) e).getCode());
+    assertEquals(Code.INVALID_ARGUMENT, ((FirebaseFirestoreException) e).getCode());
     assertEquals("Every document read in a transaction must also be written.", e.getMessage());
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -55,9 +55,7 @@ public class TransactionTest {
     Exception e = waitForException(firestore.runTransaction(transaction -> transaction.get(doc)));
     // We currently require every document read to also be written.
     // TODO: Fix this check once we drop that requirement.
-    assertEquals("Transaction failed all retries.", e.getMessage());
-    assertEquals(
-        "Every document read in a transaction must also be written.", e.getCause().getMessage());
+    assertEquals("Every document read in a transaction must also be written.", e.getMessage());
   }
 
   @Test
@@ -239,8 +237,7 @@ public class TransactionTest {
     assertFalse(transactionTask.isSuccessful());
     Exception e = transactionTask.getException();
     assertTrue(e instanceof FirebaseFirestoreException);
-    assertEquals(
-        FirebaseFirestoreException.Code.ABORTED, ((FirebaseFirestoreException) e).getCode());
+    assertEquals(Code.INVALID_ARGUMENT, ((FirebaseFirestoreException) e).getCode());
   }
 
   @Test
@@ -437,9 +434,7 @@ public class TransactionTest {
     // assertEquals(1234, snapshot.getDouble("count"));
     // snapshot = waitFor(doc2.get());
     // assertEquals(16, snapshot.getDouble("count"));
-    assertEquals("Transaction failed all retries.", e.getMessage());
-    assertEquals(
-        "Every document read in a transaction must also be written.", e.getCause().getMessage());
+    assertEquals("Every document read in a transaction must also be written.", e.getMessage());
   }
 
   @Test
@@ -489,9 +484,7 @@ public class TransactionTest {
     // We currently require every document read to also be written.
     // TODO: Add this check back once we drop that.
     // assertEquals("bar", snapshot.getString("foo"));
-    assertEquals("Transaction failed all retries.", e.getMessage());
-    assertEquals(
-        "Every document read in a transaction must also be written.", e.getCause().getMessage());
+    assertEquals("Every document read in a transaction must also be written.", e.getMessage());
   }
 
   @Test

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -182,6 +182,7 @@ public class TransactionTest {
     waitForException(transactionTask);
     assertFalse(transactionTask.isSuccessful());
     Exception e = transactionTask.getException();
+    assertEquals(Code.INVALID_ARGUMENT, ((FirebaseFirestoreException) e).getCode());
     assertEquals("Can't update a document that doesn't exist.", e.getMessage());
   }
 
@@ -207,6 +208,7 @@ public class TransactionTest {
     waitForException(transactionTask);
     assertFalse(transactionTask.isSuccessful());
     Exception e = transactionTask.getException();
+    assertEquals(Code.INVALID_ARGUMENT, ((FirebaseFirestoreException) e).getCode());
     assertEquals("Can't update a document that doesn't exist.", e.getMessage());
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -181,9 +181,9 @@ public class TransactionTest {
     waitForException(transactionTask);
     assertFalse(transactionTask.isSuccessful());
     Exception e = transactionTask.getException();
-    // TODO: should this really be raised as a FirebaseFirestoreException?
-    // Note that this test might change if transaction.get throws a FirebaseFirestoreException.
-    assertTrue(e instanceof IllegalStateException);
+    assertTrue(e instanceof FirebaseFirestoreException);
+    // This is the error surfaced by the backend.
+    assertEquals(Code.NOT_FOUND, ((FirebaseFirestoreException) e).getCode());
   }
 
   @Test
@@ -208,9 +208,9 @@ public class TransactionTest {
     waitForException(transactionTask);
     assertFalse(transactionTask.isSuccessful());
     Exception e = transactionTask.getException();
-    // TODO: should this really be raised as a FirebaseFirestoreException?
-    // Note that this test might change if transaction.update throws a FirebaseFirestoreException.
-    assertTrue(e instanceof IllegalStateException);
+    assertTrue(e instanceof FirebaseFirestoreException);
+    // This is the error surfaced by the backend.
+    assertEquals(Code.INVALID_ARGUMENT, ((FirebaseFirestoreException) e).getCode());
   }
 
   @Test
@@ -237,6 +237,7 @@ public class TransactionTest {
     assertFalse(transactionTask.isSuccessful());
     Exception e = transactionTask.getException();
     assertTrue(e instanceof FirebaseFirestoreException);
+    // This is the error surfaced by the backend.
     assertEquals(Code.INVALID_ARGUMENT, ((FirebaseFirestoreException) e).getCode());
   }
 
@@ -434,6 +435,7 @@ public class TransactionTest {
     // assertEquals(1234, snapshot.getDouble("count"));
     // snapshot = waitFor(doc2.get());
     // assertEquals(16, snapshot.getDouble("count"));
+    assertEquals(Code.FAILED_PRECONDITION, ((FirebaseFirestoreException) e).getCode());
     assertEquals("Every document read in a transaction must also be written.", e.getMessage());
   }
 
@@ -484,6 +486,7 @@ public class TransactionTest {
     // We currently require every document read to also be written.
     // TODO: Add this check back once we drop that.
     // assertEquals("bar", snapshot.getString("foo"));
+    assertEquals(Code.FAILED_PRECONDITION, ((FirebaseFirestoreException) e).getCode());
     assertEquals("Every document read in a transaction must also be written.", e.getMessage());
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -24,8 +24,6 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.common.base.Function;
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.database.collection.ImmutableSortedSet;
-import com.google.firebase.firestore.FirebaseFirestoreException;
-import com.google.firebase.firestore.FirebaseFirestoreException.Code;
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.local.LocalStore;
 import com.google.firebase.firestore.local.LocalViewChanges;
@@ -276,12 +274,7 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
                         }
                         // TODO: Only retry on real transaction failures.
                         if (retries == 0) {
-                          Exception e =
-                              new FirebaseFirestoreException(
-                                  "Transaction failed all retries.",
-                                  Code.ABORTED,
-                                  commitTask.getException());
-                          return Tasks.forException(e);
+                          return Tasks.forException(commitTask.getException());
                         }
                         return transaction(asyncQueue, updateFunction, retries - 1);
                       });

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Transaction.java
@@ -73,7 +73,7 @@ public class Transaction {
       if (!existingVersion.equals(doc.getVersion())) {
         // This transaction will fail no matter what.
         throw new FirebaseFirestoreException(
-            "Document version changed between two reads.", Code.FAILED_PRECONDITION);
+            "Document version changed between two reads.", Code.INVALID_ARGUMENT);
       }
     } else {
       readVersions.put(doc.getKey(), docVersion);
@@ -88,13 +88,13 @@ public class Transaction {
     if (committed) {
       return Tasks.forException(
           new FirebaseFirestoreException(
-              "Transaction has already completed.", Code.FAILED_PRECONDITION));
+              "Transaction has already completed.", Code.INVALID_ARGUMENT));
     }
     if (mutations.size() != 0) {
       return Tasks.forException(
           new FirebaseFirestoreException(
               "Firestore transactions require all reads to be executed before all writes.",
-              Code.FAILED_PRECONDITION));
+              Code.INVALID_ARGUMENT));
     }
     return datastore
         .lookup(keys)
@@ -169,7 +169,7 @@ public class Transaction {
     if (committed) {
       return Tasks.forException(
           new FirebaseFirestoreException(
-              "Transaction has already completed.", Code.FAILED_PRECONDITION));
+              "Transaction has already completed.", Code.INVALID_ARGUMENT));
     }
     HashSet<DocumentKey> unwritten = new HashSet<>(readVersions.keySet());
     // For each mutation, note that the doc was written.
@@ -179,8 +179,7 @@ public class Transaction {
     if (unwritten.size() > 0) {
       return Tasks.forException(
           new FirebaseFirestoreException(
-              "Every document read in a transaction must also be written.",
-              Code.FAILED_PRECONDITION));
+              "Every document read in a transaction must also be written.", Code.INVALID_ARGUMENT));
     }
     committed = true;
     return datastore

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Transaction.java
@@ -136,7 +136,10 @@ public class Transaction {
    */
   private Precondition preconditionForUpdate(DocumentKey key) {
     @Nullable SnapshotVersion version = this.readVersions.get(key);
-    if (version != null && !version.equals(SnapshotVersion.NONE)) {
+    if (version != null && version.equals(SnapshotVersion.NONE)) {
+      // The document to update doesn't exist, so fail the transaction.
+      throw new IllegalStateException("Can't update a document that doesn't exist.");
+    } else if (version != null) {
       // Document exists, just base precondition on document update time.
       return Precondition.updateTime(version);
     } else {
@@ -171,6 +174,7 @@ public class Transaction {
           new FirebaseFirestoreException(
               "Transaction has already completed.", Code.INVALID_ARGUMENT));
     }
+
     HashSet<DocumentKey> unwritten = new HashSet<>(readVersions.keySet());
     // For each mutation, note that the doc was written.
     for (Mutation mutation : mutations) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Transaction.java
@@ -137,6 +137,7 @@ public class Transaction {
   private Precondition preconditionForUpdate(DocumentKey key) {
     @Nullable SnapshotVersion version = this.readVersions.get(key);
     if (version != null && !version.equals(SnapshotVersion.NONE)) {
+      // Document exists, just base precondition on document update time.
       return Precondition.updateTime(version);
     } else {
       // Document was not read, so we just use the preconditions for a blind write.


### PR DESCRIPTION
- Standardize errors based on the spreadsheet.
- Remove local validation for document not found in transactions.
- Checking that the transaction hasn't been committed should be an assert.