### PR TITLE
Add Kotlin Interop lint checks.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
@@ -38,8 +38,8 @@ public class FirebaseLibraryExtension {
   /** Indicates whether sources are published alongside the library. */
   public boolean publishSources;
 
-  /** Indicates whether Kotlin Interop Lint checks are enabled for public APIs of the library. */
-  public boolean kotlinInteropLint = false;
+  /** Static analysis configuration. */
+  public final FirebaseStaticAnalysis staticAnalysis = new FirebaseStaticAnalysis();
 
   /** Firebase Test Lab configuration/ */
   public final FirebaseTestLabExtension testLab;

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
@@ -129,4 +129,8 @@ public class FirebaseLibraryExtension {
       customizePomAction.execute(pom);
     }
   }
+
+  public void staticAnalysis(Action<FirebaseStaticAnalysis> action) {
+    action.execute(staticAnalysis);
+  }
 }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
@@ -38,6 +38,9 @@ public class FirebaseLibraryExtension {
   /** Indicates whether sources are published alongside the library. */
   public boolean publishSources;
 
+  /** Indicates whether Kotlin Interop Lint checks are enabled for public APIs of the library. */
+  public boolean kotlinInteropLint = false;
+
   /** Firebase Test Lab configuration/ */
   public final FirebaseTestLabExtension testLab;
 

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
@@ -77,16 +77,20 @@ public class FirebaseLibraryPlugin implements Plugin<Project> {
         .all(
             c -> {
               if ("annotationProcessor".equals(c.getName())) {
-                project
-                    .getDependencies()
-                    .add("annotationProcessor", project.project(":tools:errorprone"));
+                for (String checkProject : library.staticAnalysis.errorproneCheckProjects) {
+                  project
+                      .getDependencies()
+                      .add("annotationProcessor", project.project(checkProject));
+                }
               }
               if ("lintChecks".equals(c.getName())) {
-                project.getDependencies().add("lintChecks", project.project(":tools:lint"));
+                for (String checkProject : library.staticAnalysis.androidLintCheckProjects) {
+                  project.getDependencies().add("lintChecks", project.project(checkProject));
+                }
               }
             });
 
-    if (!library.kotlinInteropLint) {
+    if (!library.staticAnalysis.kotlinInteropLint) {
       android.lintOptions(
           lintOptions ->
               lintOptions.disable(

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
@@ -83,23 +83,28 @@ public class FirebaseLibraryPlugin implements Plugin<Project> {
 
   private static void setupStaticAnalysis(
       Project project, LibraryExtension android, FirebaseLibraryExtension library) {
-    project
-        .getConfigurations()
-        .all(
-            c -> {
-              if ("annotationProcessor".equals(c.getName())) {
-                for (String checkProject : library.staticAnalysis.errorproneCheckProjects) {
-                  project
-                      .getDependencies()
-                      .add("annotationProcessor", project.project(checkProject));
-                }
-              }
-              if ("lintChecks".equals(c.getName())) {
-                for (String checkProject : library.staticAnalysis.androidLintCheckProjects) {
-                  project.getDependencies().add("lintChecks", project.project(checkProject));
-                }
-              }
-            });
+    project.afterEvaluate(
+        p ->
+            project
+                .getConfigurations()
+                .all(
+                    c -> {
+                      if ("annotationProcessor".equals(c.getName())) {
+                        for (String checkProject : library.staticAnalysis.errorproneCheckProjects) {
+                          project
+                              .getDependencies()
+                              .add("annotationProcessor", project.project(checkProject));
+                        }
+                      }
+                      if ("lintChecks".equals(c.getName())) {
+                        for (String checkProject :
+                            library.staticAnalysis.androidLintCheckProjects) {
+                          project
+                              .getDependencies()
+                              .add("lintChecks", project.project(checkProject));
+                        }
+                      }
+                    }));
 
     library.staticAnalysis.subscribeToKotlinInteropLintDisabled(
         () ->

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseStaticAnalysis.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseStaticAnalysis.java
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+public class FirebaseStaticAnalysis {
+  public Set<String> errorproneCheckProjects;
+  public Set<String> androidLintCheckProjects;
+
+  /** Indicates whether Kotlin Interop Lint checks are enabled for public APIs of the library. */
+  public boolean kotlinInteropLint;
+
+  public FirebaseStaticAnalysis() {
+    this(ImmutableSet.of(":tools:errorprone"), ImmutableSet.of(":tools:lint"));
+  }
+
+  public FirebaseStaticAnalysis(Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
+    this.errorproneCheckProjects = errorproneCheckProjects;
+    this.androidLintCheckProjects = androidLintCheckProjects;
+  }
+}

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseStaticAnalysis.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseStaticAnalysis.java
@@ -16,14 +16,18 @@ package com.google.firebase.gradle.plugins;
 
 import com.google.common.collect.ImmutableSet;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 public class FirebaseStaticAnalysis {
   public Set<String> errorproneCheckProjects;
   public Set<String> androidLintCheckProjects;
 
-  /** Indicates whether Kotlin Interop Lint checks are enabled for public APIs of the library. */
-  public boolean kotlinInteropLint;
+
+  private boolean disableKotlinInteropLint;
+
+  private final Set<Runnable> kotlinInteropLintDisabledSubscribers = new HashSet<>();
 
   public FirebaseStaticAnalysis() {
     this(ImmutableSet.of(":tools:errorprone"), ImmutableSet.of(":tools:lint"));
@@ -32,5 +36,23 @@ public class FirebaseStaticAnalysis {
   public FirebaseStaticAnalysis(Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
     this.errorproneCheckProjects = errorproneCheckProjects;
     this.androidLintCheckProjects = androidLintCheckProjects;
+  }
+
+  /** Indicates whether Kotlin Interop Lint checks are enabled for public APIs of the library. */
+  public void disableKotlinInteropLint() {
+    if (disableKotlinInteropLint) {
+      return;
+    }
+    disableKotlinInteropLint = true;
+    for (Runnable subscription : kotlinInteropLintDisabledSubscribers) {
+      subscription.run();
+    }
+  }
+
+  void subscribeToKotlinInteropLintDisabled(Runnable subscription) {
+    this.kotlinInteropLintDisabledSubscribers.add(subscription);
+    if (disableKotlinInteropLint) {
+      subscription.run();
+    }
   }
 }

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/PublishingPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/PublishingPluginSpec.groovy
@@ -29,6 +29,12 @@ class PublishingPluginSpec extends Specification {
         plugins {
             id 'firebase-library'
         }
+        firebaseLibrary {
+          staticAnalysis {
+            errorproneCheckProjects = []
+            androidLintCheckProjects []
+          }
+        }
         group = '${group}'
         version = '${version}'
         <% if (latestReleasedVersion) println "ext.latestReleasedVersion = $latestReleasedVersion" %>

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/PublishingPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/PublishingPluginSpec.groovy
@@ -32,7 +32,7 @@ class PublishingPluginSpec extends Specification {
         firebaseLibrary {
           staticAnalysis {
             errorproneCheckProjects = []
-            androidLintCheckProjects []
+            androidLintCheckProjects = []
           }
         }
         group = '${group}'

--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -20,6 +20,7 @@ plugins {
 firebaseLibrary {
     testLab.enabled = false
     publishSources = true
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 // TODO(issue/568): Remove this once legacy logic is removed from Remote Config.

--- a/firebase-common/data-collection-tests/data-collection-tests.gradle
+++ b/firebase-common/data-collection-tests/data-collection-tests.gradle
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 // Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/firebase-common/data-collection-tests/data-collection-tests.gradle
+++ b/firebase-common/data-collection-tests/data-collection-tests.gradle
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 // Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -19,6 +19,7 @@ plugins {
 firebaseLibrary {
     testLab.enabled = true
     publishSources = true
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {

--- a/firebase-config/firebase-config.gradle
+++ b/firebase-config/firebase-config.gradle
@@ -22,6 +22,7 @@ plugins {
 firebaseLibrary {
     testLab.enabled = true
     publishSources = true
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 protobuf {

--- a/firebase-database/firebase-database.gradle
+++ b/firebase-database/firebase-database.gradle
@@ -19,6 +19,7 @@ plugins {
 firebaseLibrary {
     testLab.enabled = true
     publishSources = true
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -19,6 +19,7 @@ plugins {
 firebaseLibrary {
     publishJavadoc = false
     publishSources = true
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -20,6 +20,7 @@ plugins {
 firebaseLibrary {
     testLab.enabled = true
     publishSources = true
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 protobuf {

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -19,6 +19,7 @@ plugins {
 firebaseLibrary {
     testLab.enabled = true
     publishSources = true
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -21,6 +21,7 @@ firebaseLibrary {
     testLab.enabled = true
     publishJavadoc = true
     publishSources = true
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=8g
 
 org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=8g
 

--- a/protolite-well-known-types/protolite-well-known-types.gradle
+++ b/protolite-well-known-types/protolite-well-known-types.gradle
@@ -17,6 +17,10 @@ plugins {
     id 'com.google.protobuf'
 }
 
+firebaseLibrary {
+    staticAnalysis.disableKotlinInteropLint()
+}
+
 
 protobuf {
     protoc {

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -127,19 +127,6 @@ configure(subprojects) {
     }
 
     apply plugin: "org.jlleitschuh.gradle.ktlint"
-
-    // Adds firebase custom errorprone checks to the annotation processor classpath.
-    configurations.whenObjectAdded {
-        if (it.name == 'annotationProcessor' && project != project(':tools:errorprone')) {
-            dependencies {
-                annotationProcessor project(':tools:errorprone')
-            }
-        } else if (it.name == 'lintChecks' && project != project(':tools:lint')) {
-            dependencies {
-                lintChecks project(':tools:lint')
-            }
-        }
-    }
 }
 
 

--- a/tools/lint/lint.gradle
+++ b/tools/lint/lint.gradle
@@ -16,7 +16,7 @@ plugins {
   id 'org.jetbrains.kotlin.jvm'
 }
 
-def lintVersion = '26.3.2'
+def lintVersion = '26.4.1'
 
 dependencies {
   compileOnly "com.android.tools.lint:lint-api:$lintVersion"

--- a/tools/lint/src/main/kotlin/CheckRegistry.kt
+++ b/tools/lint/src/main/kotlin/CheckRegistry.kt
@@ -1,0 +1,35 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.lint.checks
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
+import com.android.tools.lint.detector.api.Issue
+
+class CheckRegistry : IssueRegistry() {
+    override val issues: List<Issue>
+        get() = listOf(
+                ManifestElementHasNoExportedAttributeDetector.EXPORTED_MISSING_ISSUE,
+                KotlinInteropDetector.KOTLIN_PROPERTY,
+                KotlinInteropDetector.LAMBDA_LAST,
+                KotlinInteropDetector.NO_HARD_KOTLIN_KEYWORDS,
+                KotlinInteropDetector.PLATFORM_NULLNESS
+        )
+
+    override val api: Int
+        get() = CURRENT_API
+    override val minApi: Int
+        get() = 2
+}

--- a/tools/lint/src/main/kotlin/KotlinInteropDetector.kt
+++ b/tools/lint/src/main/kotlin/KotlinInteropDetector.kt
@@ -1,0 +1,723 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.lint.checks
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Location
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.isKotlin
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiCompiledElement
+import com.intellij.psi.PsiDocCommentOwner
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaDocumentedElement
+import com.intellij.psi.PsiKeyword
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.PsiPrimitiveType
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypeParameter
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.uast.UAnonymousClass
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UDeclaration
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UField
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UParameter
+import org.jetbrains.uast.UVariable
+import org.jetbrains.uast.getContainingUClass
+import org.jetbrains.uast.getContainingUMethod
+import org.jetbrains.uast.getParentOfType
+
+class KotlinInteropDetector : Detector(), SourceCodeScanner {
+    companion object Issues {
+        private val IMPLEMENTATION = Implementation(
+                KotlinInteropDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+        )
+
+        const val IGNORE_DEPRECATED = false
+
+        @JvmField
+        val NO_HARD_KOTLIN_KEYWORDS = Issue.create(
+                id = "FirebaseNoHardKeywords",
+                briefDescription = "No Hard Kotlin Keywords",
+
+                explanation = """
+            Do not use Kotlin’s hard keywords as the name of methods or fields.
+            These require the use of backticks to escape when calling from Kotlin.
+            Soft keywords, modifier keywords, and special identifiers are allowed.
+
+            For example, Mockito’s `when` function requires backticks when used from Kotlin:
+
+                val callable = Mockito.mock(Callable::class.java)
+                Mockito.\`when\`(callable.call()).thenReturn(/* … */)
+            """,
+                category = Category.INTEROPERABILITY_KOTLIN,
+                priority = 1,
+                severity = Severity.ERROR,
+                implementation = IMPLEMENTATION
+        )
+
+        @JvmField
+        val LAMBDA_LAST = Issue.create(
+                id = "FirebaseLambdaLast",
+                briefDescription = "Lambda Parameters Last",
+
+                explanation = """
+            To improve calling this code from Kotlin,
+            parameter types eligible for SAM conversion should be last.
+            """,
+                category = Category.INTEROPERABILITY_KOTLIN,
+                priority = 1,
+                severity = Severity.ERROR,
+                implementation = IMPLEMENTATION
+        )
+
+        @JvmField
+        val PLATFORM_NULLNESS = Issue.create(
+                id = "FirebaseUnknownNullness",
+                briefDescription = "Unknown nullness",
+
+                explanation = """
+            To improve referencing this code from Kotlin, consider adding
+            explicit nullness information here with either `@NonNull` or `@Nullable`.
+            """,
+                category = Category.INTEROPERABILITY_KOTLIN,
+                priority = 1,
+                severity = Severity.ERROR,
+                implementation = IMPLEMENTATION
+        )
+
+        @JvmField
+        val KOTLIN_PROPERTY = Issue.create(
+                id = "FirebaseKotlinPropertyAccess",
+                briefDescription = "Kotlin Property Access",
+
+                explanation = """
+            For a method to be represented as a property in Kotlin, strict “bean”-style prefixing must be used.
+
+            Accessor methods require a ‘get’ prefix or for boolean-returning methods an ‘is’ prefix can be used.
+            """,
+                category = Category.INTEROPERABILITY_KOTLIN,
+                priority = 1,
+                severity = Severity.ERROR,
+                implementation = IMPLEMENTATION
+        )
+
+        private fun isKotlinHardKeyword(keyword: String): Boolean {
+            // From https://github.com/JetBrains/kotlin/blob/master/core/descriptors/src/org/jetbrains/kotlin/renderer/KeywordStringsGenerated.java
+            when (keyword) {
+                "as",
+                "break",
+                "class",
+                "continue",
+                "do",
+                "else",
+                "false",
+                "for",
+                "fun",
+                "if",
+                "in",
+                "interface",
+                "is",
+                "null",
+                "object",
+                "package",
+                "return",
+                "super",
+                "this",
+                "throw",
+                "true",
+                "try",
+                "typealias",
+                "typeof",
+                "val",
+                "var",
+                "when",
+                "while"
+                -> return true
+            }
+
+            return false
+        }
+    }
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>>? {
+        return listOf(UMethod::class.java, UField::class.java)
+    }
+
+    override fun createUastHandler(context: JavaContext): UElementHandler? {
+        // using deprecated psi field here instead of sourcePsi because the IDE
+        // still uses older version of UAST
+        if (isKotlin(context.uastFile?.sourcePsi)) {
+            // These checks apply only to Java code
+            return null
+        }
+        return JavaVisitor(context)
+    }
+
+    class JavaVisitor(private val context: JavaContext) : UElementHandler() {
+        private val checkForKeywords = true
+        private val checkNullness = true
+        private val checkLambdaLast = true
+        private val checkPropertyAccess = true
+
+        override fun visitMethod(node: UMethod) {
+            if (isPublicApi(node)) {
+                val methodName = node.name
+
+                if (checkForKeywords) {
+                    ensureNonKeyword(methodName, node, "method")
+                }
+
+                if (checkPropertyAccess && isLikelySetter(methodName, node)) {
+                    ensureValidProperty(node, methodName)
+                }
+
+                if (checkLambdaLast) {
+                    ensureLambdaLastParameter(node)
+                }
+
+                if (checkNullness) {
+                    val type = node.returnType
+                    if (type != null) { // not a constructor
+                        ensureNullnessKnown(node, type)
+                    }
+                    for (parameter in node.uastParameters) {
+                        ensureNullnessKnown(parameter, parameter.type)
+                    }
+                }
+            }
+        }
+
+        override fun visitField(node: UField) {
+            if (isPublicApi(node)) {
+                if (checkForKeywords) {
+                    ensureNonKeyword(node.name, node, "field")
+                }
+                if (checkNullness) {
+                    ensureNullnessKnown(node, node.type)
+                }
+            }
+        }
+
+        private fun isLikelySetter(
+            methodName: String,
+            node: UMethod
+        ): Boolean {
+            return methodName.startsWith("set") && methodName.length > 3 &&
+                    Character.isUpperCase(methodName[3]) &&
+                    node.uastParameters.size == 1 &&
+                    context.evaluator.isPublic(node) &&
+                    !context.evaluator.isStatic(node)
+        }
+
+        private fun isPublicApi(node: UDeclaration): Boolean {
+            if (!isJavaPublic(node)) {
+                return false
+            }
+            if (node is PsiJavaDocumentedElement) {
+                node.docComment?.findTagByName("hide")?.let {
+                    return false
+                }
+            }
+
+            if (node is PsiMember) {
+                var curNode = node.containingClass
+                while (curNode != null) {
+                    curNode.docComment?.findTagByName("hide")?.let {
+                        return false
+                    }
+                    curNode = curNode.containingClass
+                }
+            }
+
+            val psiPackage: PsiPackage = context.evaluator.getPackage(node as PsiElement)!!
+            psiPackage.getFiles(GlobalSearchScope.projectScope(psiPackage.project)).find {
+                it.name == "package-info.java"
+            }?.let {
+                if (it.viewProvider.contents.toString().matches(Regex(".*/\\*\\*.*@hide.*\\*/.*\n\\s*package.*", RegexOption.DOT_MATCHES_ALL))) {
+                    return false
+                }
+            }
+
+            return true
+        }
+
+        private fun isJavaPublic(node: UDeclaration): Boolean {
+            val evaluator = context.evaluator
+            if (evaluator.isPublic(node) || evaluator.isProtected(node)) {
+                val cls = node.getParentOfType<UClass>(UClass::class.java) ?: return true
+                return evaluator.isPublic(cls) && cls !is UAnonymousClass
+            }
+
+            return false
+        }
+
+        private fun ensureValidProperty(setter: UMethod, methodName: String) {
+            val cls = setter.getContainingUClass() ?: return
+            val propertySuffix = methodName.substring(3)
+            val propertyName = propertySuffix.decapitalize()
+            val getterName1 = "get$propertySuffix"
+            val getterName2 = "is$propertySuffix"
+            val badGetterName = "has$propertySuffix"
+            var getter: PsiMethod? = null
+            var badGetter: UMethod? = null
+            cls.methods.forEach {
+                if (it.parameters.isEmpty()) {
+                    val name = it.name
+                    if (name == getterName1 || name == getterName2) {
+                        getter = it
+                    } else if ((name == badGetterName || name == propertyName ||
+                                    name.endsWith(propertySuffix)) &&
+                            context.evaluator.isPublic(it) &&
+                            !it.isConstructor &&
+                            it.returnType == setter.uastParameters.firstOrNull()?.type
+                    ) {
+                        badGetter = it
+                    }
+                }
+            }
+
+            if (getter == null) {
+                // Look for inherited methods
+                cls.superClass?.let { superClass ->
+                    for (inherited in superClass.findMethodsByName(getterName1, true)) {
+                        if (inherited.parameterList.parametersCount == 0) {
+                            getter = inherited
+                            break
+                        }
+                    }
+                    if (getter == null) {
+                        for (inherited in superClass.findMethodsByName(getterName2, true)) {
+                            if (inherited.parameterList.parametersCount == 0) {
+                                getter = inherited
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (getter != null && getter !is PsiCompiledElement) {
+                @Suppress("NAME_SHADOWING") // compiler gets confused about getter nullness
+                val getter: PsiMethod = getter!!
+
+                // enforce public and not static
+                if (!context.evaluator.isPublic(getter)) {
+                    val message = "This getter should be public such that `$propertyName` can " +
+                            "be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+                    val location = context.getNameLocation(getter)
+                    context.report(KOTLIN_PROPERTY, getter, location, message)
+                    return
+                }
+
+                if (context.evaluator.isStatic(getter)) {
+                    var staticElement: PsiElement? = null
+                    val modifierList = getter.modifierList
+                    // Try to find the static modifier itself
+                    if (modifierList.hasExplicitModifier(PsiModifier.STATIC)) {
+                        var child: PsiElement? = modifierList.firstChild
+                        while (child != null) {
+                            if (child is PsiKeyword && PsiKeyword.STATIC == child.text) {
+                                staticElement = child
+                                break
+                            }
+                            child = child.nextSibling
+                        }
+                    }
+                    val location = if (staticElement != null) {
+                        context.getLocation(staticElement)
+                    } else {
+                        context.getNameLocation(getter)
+                    }
+                    val message =
+                            "This getter should not be static such that `$propertyName` can " +
+                                    "be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+                    context.report(
+                            KOTLIN_PROPERTY,
+                            location.source as? PsiElement ?: setter, location, message
+                    )
+                    return
+                }
+
+                val setterParameterType = setter.uastParameters.first().type
+                if (setterParameterType != getter.returnType &&
+                        !hasSetter(cls, getter.returnType, setter.name) &&
+                        !isTypeVariableReference(setterParameterType)
+                ) {
+                    val message =
+                            "The getter return type (`${getter.returnType?.presentableText}`) and setter parameter type (`${setterParameterType.presentableText}`) getter and setter methods for property `$propertyName` should have exactly the same type to allow " +
+                                    "be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+                    val location = getPropertyLocation(getter, setter)
+                    context.report(
+                            KOTLIN_PROPERTY,
+                            location.source as? PsiElement ?: setter, location, message
+                    )
+                    return
+                }
+
+                // Make sure that if the getter is inherited, it has the same return type
+                for (superMethod in getter.findSuperMethods()) {
+                    if (superMethod.containingClass?.isInterface != true) {
+                        val superReturnType = superMethod.returnType ?: return
+                        val getterType = getter.returnType
+                        if (superReturnType != getterType) {
+                            val message =
+                                    "The getter return type (`${getterType?.presentableText}`)" +
+                                            " is not the same as the setter return type " +
+                                            "(`${superReturnType.presentableText}`); they should have " +
+                                            "exactly the same type to allow " +
+                                            "`${propertySuffix.decapitalize()}` " +
+                                            "be accessed as a property from Kotlin; see " +
+                                            "https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+                            val location = getPropertyLocation(getter, setter)
+                            context.report(
+                                    KOTLIN_PROPERTY,
+                                    location.source as? PsiElement ?: setter, location, message
+                            )
+                            return
+                        }
+                    }
+                }
+            } else if (badGetter != null &&
+                    // Don't complain about overrides; we can't rename those
+                    !badGetter!!.findSuperMethods().any() &&
+                    // Don't complain if the matched bad getter method already has its own
+                    // match
+                    run {
+                        val matchingName =
+                                "set${badGetter!!.name.removePrefix("is").removePrefix("get").removePrefix("has")}"
+
+                        methodName == matchingName || cls.methods.none { it.name == matchingName }
+                    }
+            ) {
+                val name1 = badGetter!!.name
+                if (name1.startsWith("is") && methodName.startsWith("setIs") &&
+                        name1[2].isUpperCase()
+                ) {
+                    val newProperty = name1[2].toLowerCase() + name1.substring(3)
+                    val message =
+                            "This method should be called `set${newProperty.capitalize()}` such " +
+                                    "that (along with the `$name1` getter) Kotlin code can access it " +
+                                    "as a property (`$newProperty`); see " +
+                                    "https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+                    val location = context.getNameLocation(setter)
+                    context.report(KOTLIN_PROPERTY, setter, location, message)
+                    return
+                }
+
+                val location = context.getNameLocation(badGetter!!)
+                val message =
+                        "This method should be called `get$propertySuffix` such that `$propertyName` can " +
+                                "be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+                context.report(KOTLIN_PROPERTY, badGetter, location, message)
+            }
+        }
+
+        private fun isTypeVariableReference(type: PsiType): Boolean {
+            if (type is PsiClassType) {
+                val cls = type.resolve() ?: return false
+                return cls is PsiTypeParameter
+            } else {
+                return false
+            }
+        }
+
+        /** Returns true if the given class has a (possibly inherited) setter of the given type */
+        private fun hasSetter(cls: UClass, type: PsiType?, setterName: String): Boolean {
+            for (method in cls.findMethodsByName(setterName, true)) {
+                val parameterList = method.parameterList
+                val parameters = parameterList.parameters
+                if (parameters.size == 1 && parameters[0].type == type) {
+                    return true
+                }
+            }
+
+            return false
+        }
+
+        private fun getPropertyLocation(
+            location1: PsiMethod,
+            location2: PsiMethod
+        ): Location {
+            val primary: PsiMethod
+            val secondary: PsiMethod
+
+            if (location1 is PsiCompiledElement) {
+                primary = location2
+                secondary = location1
+            } else {
+                primary = location1
+                secondary = location2
+            }
+
+            return context.getNameLocation(primary).withSecondary(
+                    context.getNameLocation(secondary),
+                    "${if (secondary.name.startsWith("set")) "Setter" else "Getter"} here"
+            )
+        }
+
+        private fun ensureNullnessKnown(
+            node: UDeclaration,
+            type: PsiType
+        ) {
+            if (type is PsiPrimitiveType) {
+                return
+            }
+            if (node is UField &&
+                    node.modifierList?.hasModifierProperty(PsiModifier.FINAL) == true) {
+                return
+            }
+            for (annotation in node.annotations) {
+                val name = annotation.qualifiedName ?: continue
+
+                if (isNullableAnnotation(name)) {
+                    if (isToStringMethod(node)) {
+                        val location = context.getLocation(annotation)
+                        val message = "Unexpected `@Nullable`: `toString` should never return null"
+                        context.report(PLATFORM_NULLNESS, node as UElement, location, message)
+                    }
+                    return
+                }
+
+                if (isNonNullAnnotation(name)) {
+                    if (isEqualsParameter(node)) {
+                        val location = context.getLocation(annotation)
+                        val message =
+                                "Unexpected @NonNull: The `equals` contract allows the parameter to be null"
+                        context.report(PLATFORM_NULLNESS, node as UElement, location, message)
+                    }
+                    return
+                }
+            }
+
+            // Known nullability: don't complain
+            if (isEqualsParameter(node) || isToStringMethod(node)) {
+                return
+            }
+
+            // Annotation members cannot be null
+            if (node is UMethod) {
+                node.getContainingUClass()?.let {
+                    if (it.isAnnotationType) {
+                        return
+                    }
+                }
+            }
+
+            // Skip deprecated members?
+            if (IGNORE_DEPRECATED) {
+                val deprecatedNode =
+                        if (node is UParameter) {
+                            node.uastParent
+                        } else {
+                            node
+                        }
+                if ((deprecatedNode?.sourcePsi as? PsiDocCommentOwner)?.isDeprecated == true) {
+                    return
+                }
+                var curr = deprecatedNode
+                while (curr != null) {
+                    curr = curr.getContainingUClass() ?: break
+                    if ((curr.sourcePsi as? PsiDocCommentOwner)?.isDeprecated == true) {
+                        return
+                    }
+                }
+            }
+
+            val location: Location =
+                    when (node) {
+                        is UVariable -> // UParameter, UField
+                            context.getLocation(node.typeReference ?: return)
+                        is UMethod -> context.getLocation(node.returnTypeElement ?: return)
+                        else -> return
+                    }
+            val replaceLocation = if (node is UParameter) {
+                location
+            } else if (node is UMethod && node.modifierList != null) {
+                // Place the insertion point at the modifiers such that we don't
+                // insert the annotation for example after the "public" keyword.
+                // We also don't want to place it on the method range itself since
+                // that would place it before the method comments.
+                context.getLocation(node.modifierList)
+            } else if (node is UField && node.modifierList != null) {
+                // Ditto for fields
+                context.getLocation(node.modifierList!!)
+            } else {
+                return
+            }
+            val message = "Unknown nullability; explicitly declare as `@Nullable` or `@NonNull`" +
+                    " to improve Kotlin interoperability; see " +
+                    "https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+            val fix = LintFix.create().alternatives(
+                    LintFix.create()
+                            .replace()
+                            .name("Annotate @NonNull")
+                            .range(replaceLocation)
+                            .beginning()
+                            .shortenNames()
+                            .reformat(true)
+                            .with("$nonNullAnnotation ")
+                            .build(),
+                    LintFix.create()
+                            .replace()
+                            .name("Annotate @Nullable")
+                            .range(replaceLocation)
+                            .beginning()
+                            .shortenNames()
+                            .reformat(true)
+                            .with("$nullableAnnotation ")
+                            .build()
+            )
+            context.report(PLATFORM_NULLNESS, node as UElement, location, message, fix)
+        }
+
+        private fun isEqualsParameter(node: UDeclaration): Boolean {
+            if (node is UParameter) {
+                val method = node.getContainingUMethod() ?: return false
+                if (method.name == "equals" && method.uastParameters.size == 1) {
+                    return true
+                }
+            }
+
+            return false
+        }
+
+        private fun isToStringMethod(node: UDeclaration): Boolean {
+            if (node is UMethod) {
+                val method = node
+                if (method.name == "toString" && method.uastParameters.isEmpty()) {
+                    return true
+                }
+            }
+
+            return false
+        }
+
+        private var nonNullAnnotation: String = "@androidx.annotation.NonNull"
+        private var nullableAnnotation: String? = "@androidx.annotation.Nullable"
+
+        private fun isNullableAnnotation(qualifiedName: String): Boolean {
+            return qualifiedName.endsWith("Nullable")
+        }
+
+        private fun isNonNullAnnotation(qualifiedName: String): Boolean {
+            return qualifiedName.endsWith("NonNull") ||
+                    qualifiedName.endsWith("NotNull") ||
+                    qualifiedName.endsWith("Nonnull")
+        }
+
+        private fun ensureNonKeyword(name: String, node: UDeclaration, typeLabel: String) {
+            if (isKotlinHardKeyword(name)) {
+                // See if this method is overriding some other method; in that case
+                // we don't have a choice here.
+                if (node is UMethod && context.evaluator.isOverride(node)) {
+                    return
+                }
+                val message =
+                        "Avoid $typeLabel names that are Kotlin hard keywords (\"$name\"); see " +
+                                "https://android.github.io/kotlin-guides/interop.html#no-hard-keywords"
+                context.report(
+                        NO_HARD_KOTLIN_KEYWORDS,
+                        node as UElement,
+                        context.getNameLocation(node as UElement),
+                        message
+                )
+            }
+        }
+
+        private fun ensureLambdaLastParameter(method: UMethod) {
+            val parameters = method.uastParameters
+            if (parameters.size > 1) {
+                // Make sure that SAM-compatible parameters are last
+                val lastIndex = parameters.size - 1
+                if (!isFunctionalInterface(parameters[lastIndex].type)) {
+                    for (i in lastIndex - 1 downTo 0) {
+                        val parameter = parameters[i]
+                        if (isFunctionalInterface(parameter.type)) {
+                            val message =
+                                    "Functional interface parameters (such as parameter ${i + 1}, \"${parameter.name}\", in ${
+                                    method.containingClass?.qualifiedName}.${method.name
+                                    }) should be last to improve Kotlin interoperability; see " +
+                                            "https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+                            context.report(
+                                    LAMBDA_LAST,
+                                    method,
+                                    context.getLocation(parameters[lastIndex] as UElement),
+                                    message
+                            )
+                            break
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun isFunctionalInterface(type: PsiType): Boolean {
+            if (type !is PsiClassType) {
+                return false
+            }
+
+            val cls = type.resolve() ?: return false
+            if (!cls.isInterface) {
+                return false
+            }
+
+            var abstractCount = 0
+            for (method in cls.methods) {
+                if (method.modifierList.hasModifierProperty(PsiModifier.ABSTRACT)) {
+                    abstractCount++
+                }
+            }
+
+            if (abstractCount != 1) {
+                // Try a little harder; we don't want to count methods that are overrides
+                if (abstractCount > 1) {
+                    abstractCount = 0
+                    for (method in cls.methods) {
+                        if (method.modifierList.hasModifierProperty(PsiModifier.ABSTRACT) &&
+                                !context.evaluator.isOverride(method, true)
+                        ) {
+                            abstractCount++
+                        }
+                    }
+                }
+
+                if (abstractCount != 1) {
+                    return false
+                }
+            }
+
+            if (cls.superClass?.isInterface == true) {
+                return false
+            }
+
+            return true
+        }
+    }
+}

--- a/tools/lint/src/main/kotlin/ManifestElementHasNoExportedAttributeDetector.kt
+++ b/tools/lint/src/main/kotlin/ManifestElementHasNoExportedAttributeDetector.kt
@@ -15,8 +15,6 @@
 package com.google.firebase.lint.checks
 
 import com.android.SdkConstants
-import com.android.tools.lint.client.api.IssueRegistry
-import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Implementation
@@ -27,35 +25,27 @@ import com.android.tools.lint.detector.api.XmlContext
 import com.android.tools.lint.detector.api.XmlScanner
 import org.w3c.dom.Element
 
-class CheckRegistry : IssueRegistry() {
-    override val issues: List<Issue>
-        get() = listOf(EXPORTED_MISSING_ISSUE)
-
-    override val api: Int
-        get() = CURRENT_API
-    override val minApi: Int
-        get() = 2
-}
-
-internal val EXPORTED_MISSING_ISSUE: Issue = Issue.create(
-        "ManifestElementHasNoExportedAttribute",
-        "`android:exported` attribute missing on element",
-        "Leaving this attribute out may unintentionally lead to an exported component, please " +
-                "specify the value explicitly.",
-        Category.SECURITY,
-        1,
-        Severity.ERROR,
-        Implementation(ManifestElementHasNoExportedAttributeDetector::class.java, Scope.MANIFEST_SCOPE))
-
-enum class Component(val xmlName: String) {
-    ACTIVITY("activity"),
-    ACTIVITY_ALIAS("activity-alias"),
-    PROVIDER("provider"),
-    RECEIVER("receiver"),
-    SERVICE("service"),
-}
-
 class ManifestElementHasNoExportedAttributeDetector : Detector(), XmlScanner {
+
+    enum class Component(val xmlName: String) {
+        ACTIVITY("activity"),
+        ACTIVITY_ALIAS("activity-alias"),
+        PROVIDER("provider"),
+        RECEIVER("receiver"),
+        SERVICE("service"),
+    }
+
+    companion object {
+        internal val EXPORTED_MISSING_ISSUE: Issue = Issue.create(
+                "ManifestElementHasNoExportedAttribute",
+                "`android:exported` attribute missing on element",
+                "Leaving this attribute out may unintentionally lead to an exported component, please " +
+                        "specify the value explicitly.",
+                Category.SECURITY,
+                1,
+                Severity.ERROR,
+                Implementation(ManifestElementHasNoExportedAttributeDetector::class.java, Scope.MANIFEST_SCOPE))
+    }
 
     override fun getApplicableElements(): Collection<String>? = Component.values().map { it.xmlName }
 

--- a/tools/lint/src/test/kotlin/ManifestTests.kt
+++ b/tools/lint/src/test/kotlin/ManifestTests.kt
@@ -19,6 +19,7 @@ import com.android.tools.lint.checks.infrastructure.TestLintResult
 import com.android.tools.lint.checks.infrastructure.TestResultChecker
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
+import com.google.firebase.lint.checks.ManifestElementHasNoExportedAttributeDetector.Component
 import java.lang.AssertionError
 
 internal fun manifestWith(cmp: Component, exported: Boolean? = null): String {
@@ -76,5 +77,5 @@ class Test : LintDetectorTest() {
 
     override fun getDetector(): Detector = ManifestElementHasNoExportedAttributeDetector()
 
-    override fun getIssues(): MutableList<Issue> = mutableListOf(EXPORTED_MISSING_ISSUE)
+    override fun getIssues(): MutableList<Issue> = mutableListOf(ManifestElementHasNoExportedAttributeDetector.EXPORTED_MISSING_ISSUE)
 }

--- a/transport/transport-api/transport-api.gradle
+++ b/transport/transport-api/transport-api.gradle
@@ -16,7 +16,10 @@ plugins {
     id 'firebase-library'
 }
 
-firebaseLibrary.publishJavadoc = false
+firebaseLibrary{
+    publishJavadoc = false
+    staticAnalysis.disableKotlinInteropLint()
+}
 
 android {
     compileSdkVersion 28

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -17,7 +17,10 @@ plugins {
     id 'com.google.protobuf'
 }
 
-firebaseLibrary.publishJavadoc = false
+firebaseLibrary{
+    publishJavadoc = false
+    staticAnalysis.disableKotlinInteropLint()
+}
 
 protobuf {
     // Configure the protoc executable

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -32,6 +32,7 @@ firebaseLibrary {
         device 'model=hero2lte,version=23' // Galaxy S7
         device 'model=htc_m8,version=19' // HTC One (M8)
     }
+    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {


### PR DESCRIPTION
The checks are copied from the official lint checks, and modified to
only check public Firebase APIs, e.g. those that don't have @hide
javadoc tag in either of the following:

* The javadoc of the symbol
* The javadoc of the host class
* The javadoc of containing package-info.java