### PR TITLE
Fix flaky integration tests

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -248,9 +248,7 @@ public class IntegrationTestUtil {
 
     ensureStrictMode();
 
-    AsyncQueue asyncQueue = null;
-
-    asyncQueue = new AsyncQueue();
+    AsyncQueue asyncQueue = new AsyncQueue();
 
     FirebaseFirestore firestore =
         AccessHelper.newFirebaseFirestore(

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
@@ -77,7 +77,9 @@ public class GrpcCallProvider {
             () -> {
               ManagedChannel channel = initChannel(context, databaseInfo);
               FirestoreGrpc.FirestoreStub firestoreStub =
-                  FirestoreGrpc.newStub(channel).withCallCredentials(firestoreHeaders);
+                  FirestoreGrpc.newStub(channel)
+                      .withCallCredentials(firestoreHeaders)
+                      .withExecutor(asyncQueue.getExecutor());
               callOptions = firestoreStub.getCallOptions();
               return channel;
             });

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
@@ -79,6 +79,9 @@ public class GrpcCallProvider {
               FirestoreGrpc.FirestoreStub firestoreStub =
                   FirestoreGrpc.newStub(channel)
                       .withCallCredentials(firestoreHeaders)
+                      // Ensure all callbacks are issued on the worker queue. If this call is
+                      // removed, all calls need to be audited to make sure they are executed on the
+                      // right thread.
                       .withExecutor(asyncQueue.getExecutor());
               callOptions = firestoreStub.getCallOptions();
               return channel;
@@ -116,10 +119,6 @@ public class GrpcCallProvider {
     // Ensure gRPC recovers from a dead connection. (Not typically necessary, as the OS will
     // usually notify gRPC when a connection dies. But not always. This acts as a failsafe.)
     channelBuilder.keepAliveTime(30, TimeUnit.SECONDS);
-
-    // This ensures all callbacks are issued on the worker queue. If this call is removed,
-    // all calls need to be audited to make sure they are executed on the right thread.
-    channelBuilder.executor(asyncQueue.getExecutor());
 
     // Wrap the ManagedChannelBuilder in an AndroidChannelBuilder. This allows the channel to
     // respond more gracefully to network change events (such as switching from cell to wifi).


### PR DESCRIPTION
This fixes the "Running on the wrong queue" assertion that is sometimes triggered when an integration test uses two Firestores (callees of [testCollectionWithDocs()](https://github.com/firebase/firebase-android-sdk/blob/70d4388d08ca08e608a38850716435ebe87cabed/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java#L297)).

I am not 100% certain what leads to this behavior, but the problem is that https://github.com/grpc/grpc-java/blob/f3bf250a46571db3321fc3078b55e74280bdfd87/core/src/main/java/io/grpc/internal/DelayedClientTransport.java#L294 doesn't have the executor sets and then chooses the default executor, which seemingly can be from another instance.

