### PR TITLE
Prepare `shutdown` to be a public api.

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AccessHelper.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AccessHelper.java
@@ -32,7 +32,7 @@ public final class AccessHelper {
       CredentialsProvider credentialsProvider,
       AsyncQueue asyncQueue,
       FirebaseApp firebaseApp,
-      FirestoreMultiDbComponent.DeregisterCommand deregisterCommand) {
+      FirebaseFirestore.InstanceRegistry instanceRegistry) {
     return new FirebaseFirestore(
         context,
         databaseId,
@@ -40,7 +40,7 @@ public final class AccessHelper {
         credentialsProvider,
         asyncQueue,
         firebaseApp,
-        deregisterCommand);
+        instanceRegistry);
   }
 
   /** Makes the shutdown method accessible. */

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AccessHelper.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AccessHelper.java
@@ -31,9 +31,16 @@ public final class AccessHelper {
       String persistenceKey,
       CredentialsProvider credentialsProvider,
       AsyncQueue asyncQueue,
-      FirebaseApp firebaseApp) {
+      FirebaseApp firebaseApp,
+      FirestoreMultiDbComponent.DeregisterCommand deregisterCommand) {
     return new FirebaseFirestore(
-        context, databaseId, persistenceKey, credentialsProvider, asyncQueue, firebaseApp);
+        context,
+        databaseId,
+        persistenceKey,
+        credentialsProvider,
+        asyncQueue,
+        firebaseApp,
+        deregisterCommand);
   }
 
   /** Makes the shutdown method accessible. */

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -1062,8 +1062,7 @@ public class FirestoreTest {
   @Test
   public void testNewOperationThrowsAfterFirestoreShutdown() {
     FirebaseFirestore instance = testFirestore();
-    final DocumentReference reference = instance.document("abc/123");
-    DocumentReference ref = reference;
+    DocumentReference reference = instance.document("abc/123");
     waitFor(reference.set(Collections.singletonMap("Field", 100)));
 
     instance.shutdown();
@@ -1079,5 +1078,22 @@ public class FirestoreTest {
     expectError(
         () -> waitFor(instance.runTransaction(transaction -> transaction.get(reference))),
         expectedMessage);
+  }
+
+  @Test
+  public void testShutdownCalledMultipleTimes() {
+    FirebaseFirestore instance = testFirestore();
+    DocumentReference reference = instance.document("abc/123");
+    waitFor(reference.set(Collections.singletonMap("Field", 100)));
+
+    instance.shutdown();
+
+    final String expectedMessage = "The client has already been shutdown";
+    expectError(() -> waitFor(reference.get()), expectedMessage);
+
+    // Calling a second time should go through and change nothing.
+    instance.shutdown();
+
+    expectError(() -> waitFor(reference.get()), expectedMessage);
   }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -1048,19 +1048,24 @@ public class FirestoreTest {
     assertNotSame(instance, newInstance);
   }
 
-  /*
   @Test
   public void testAppDeleteLeadsToFirestoreShutdown() {
     FirebaseApp app = testFirebaseApp();
     FirebaseFirestore instance = FirebaseFirestore.getInstance(app);
-    instance.document("abc/123").set(Collections.singletonMap("Field", 100));
+    waitFor(instance.document("abc/123").set(Collections.singletonMap("Field", 100)));
 
     app.delete();
 
-    try {
-      instance.document("abc/123").get();
-    } catch (Exception e) {
+    assertTrue(instance.getClient().isShutdown());
+  }
 
-    }
-  }*/
+  @Test(expected = IllegalStateException.class)
+  public void testNewOperationThrowsAfterFirestoreShutdown() {
+    FirebaseFirestore instance = testFirestore();
+    waitFor(instance.document("abc/123").set(Collections.singletonMap("Field", 100)));
+
+    instance.shutdown();
+
+    waitForException(instance.document("abc/123").get());
+  }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -264,7 +264,8 @@ public class IntegrationTestUtil {
             persistenceKey,
             new EmptyCredentialsProvider(),
             asyncQueue,
-            /*firebaseApp=*/ null);
+            /*firebaseApp=*/ null,
+            /*deregisterCommand=*/ () -> {});
     waitFor(AccessHelper.clearPersistence(firestore));
     firestore.setFirestoreSettings(settings);
     firestoreStatus.put(firestore, true);

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -25,6 +25,7 @@ import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.firestore.AccessHelper;
 import com.google.firebase.firestore.BuildConfig;
 import com.google.firebase.firestore.CollectionReference;
@@ -143,6 +144,10 @@ public class IntegrationTestUtil {
     settings.setTimestampsInSnapshotsEnabled(enabled);
 
     return settings.build();
+  }
+
+  public static FirebaseApp testFirebaseApp() {
+    return FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext());
   }
 
   /** Initializes a new Firestore instance that uses the default project. */

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -265,7 +265,7 @@ public class IntegrationTestUtil {
             new EmptyCredentialsProvider(),
             asyncQueue,
             /*firebaseApp=*/ null,
-            /*deregisterCommand=*/ () -> {});
+            /*instanceRegistry=*/ (dbId) -> {});
     waitFor(AccessHelper.clearPersistence(firestore));
     firestore.setFirestoreSettings(settings);
     firestoreStatus.put(firestore, true);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -411,7 +411,7 @@ public class FirebaseFirestore {
   @PublicApi
   public Task<Void> clearPersistence() {
     final TaskCompletionSource<Void> source = new TaskCompletionSource<>();
-    asyncQueue.enqueueAndForget(
+    asyncQueue.enqueueAndForgetEvenAfterShutdown(
         () -> {
           try {
             if (client != null && !client.isShutdown()) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -345,8 +345,29 @@ public class FirebaseFirestore {
     return client.shutdown();
   }
 
+  /**
+   * Shuts down this Firestore SDK instance.
+   *
+   * <p>IMPORTANT: If your application is designed to run with Firestore the entire life cycle, it
+   * is not recommended to call `shutdown` explicitly, the shutting down happens naturally when the
+   * application itself is shut down.
+   *
+   * <p>For applications designed to run without Firestore from some point on (typically to save
+   * resources as much as possible), you may call this method.
+   *
+   * <p>Once `shutdown` is called, trying to issue new reads/writes through this instance will
+   * result in {@link IllegalStateException}. Already requested reads/writes might stop resolving.
+   * Be sure to handle this well in your application if proceeding with Firestore shutting down is
+   * desired in your case.
+   *
+   * <p>Note that {@link #clearPersistence()} is an exception, it is designed to run when the
+   * Firestore SDK instance is shutdown.
+   *
+   * <p>To re-start a Firestore SDK instance, simply create a new instance via {@link
+   * #getInstance()} or {@link #getInstance(FirebaseApp)}.
+   */
   @VisibleForTesting
-  // TODO: Make this public
+  // TODO: Make this public and remove @VisibleForTesting
   Task<Void> shutdown() {
     return shutdown(/* fromAppDeletion */ false);
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -120,8 +120,8 @@ public class FirebaseFirestore {
     FirebaseFirestore firestore =
         new FirebaseFirestore(context, databaseId, persistenceKey, provider, queue, app);
     app.addLifecycleEventListener(
-        /* onDeleted */ (firebaseAppName, options) -> {
-          firestore.shutdown(/* fromAppDeletion */ true);
+        (firebaseAppName, options) -> {
+          firestore.shutdown(/* fromAppDeletion= */ true);
         });
     return firestore;
   }
@@ -346,30 +346,29 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Shuts down this Firestore SDK instance.
+   * Shuts down this FirebaseFirestore instance.
    *
-   * <p>IMPORTANT: If your application is designed to run with Firestore the entire life cycle, it
-   * is not recommended to call `shutdown` explicitly, the shutting down happens naturally when the
-   * application itself is shut down.
+   * <p>After shutdown only the {@link #clearPersistence()} method may be used. Any other method
+   * will throw an {@link IllegalStateException}.
    *
-   * <p>For applications designed to run without Firestore from some point on (typically to save
-   * resources as much as possible), you may call this method.
-   *
-   * <p>Once `shutdown` is called, trying to issue new reads/writes through this instance will
-   * result in {@link IllegalStateException}. Already requested reads/writes might stop resolving.
-   * Be sure to handle this well in your application if proceeding with Firestore shutting down is
-   * desired in your case.
-   *
-   * <p>Note that {@link #clearPersistence()} is an exception, it is designed to run when the
-   * Firestore SDK instance is shutdown.
-   *
-   * <p>To re-start a Firestore SDK instance, simply create a new instance via {@link
+   * <p>To restart after shutdown, simply create a new instance of FirebaseFirestore with {@link
    * #getInstance()} or {@link #getInstance(FirebaseApp)}.
+   *
+   * <p>Shutdown does not cancel any pending writes and any tasks that are awaiting a response from
+   * the server will not be resolved. The next time you start this instance, it will resume
+   * attempting to send these writes to the server.
+   *
+   * <p>Note: Under normal circumstances, calling <code>shutdown()</code> is not required. This
+   * method is useful only when you want to force this instance to release all of its resources or
+   * in combination with {@link #clearPersistence} to ensure that all local state is destroyed
+   * between test runs.
+   *
+   * @return A <code>Task</code> that is resolved when the instance has been successfully shut down.
    */
   @VisibleForTesting
-  // TODO: Make this public and remove @VisibleForTesting
+  // TODO(b/135755126): Make this public and remove @VisibleForTesting
   Task<Void> shutdown() {
-    return shutdown(/* fromAppDeletion */ false);
+    return shutdown(/* fromAppDeletion= */ false);
   }
 
   @VisibleForTesting

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
@@ -26,6 +26,11 @@ import java.util.Map;
 
 /** Multi-resource container for Firestore. */
 class FirestoreMultiDbComponent implements FirebaseAppLifecycleListener {
+
+  public interface DeregisterCommand {
+    void execute();
+  }
+
   /**
    * A static map from instance key to FirebaseFirestore instances. Instance keys are database
    * names.
@@ -51,7 +56,9 @@ class FirestoreMultiDbComponent implements FirebaseAppLifecycleListener {
   synchronized FirebaseFirestore get(@NonNull String databaseId) {
     FirebaseFirestore firestore = instances.get(databaseId);
     if (firestore == null) {
-      firestore = FirebaseFirestore.newInstance(context, app, authProvider, databaseId);
+      firestore =
+          FirebaseFirestore.newInstance(
+              context, app, authProvider, databaseId, () -> this.remove(databaseId));
       instances.put(databaseId, firestore);
     }
     return firestore;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
@@ -43,7 +43,7 @@ class FirestoreMultiDbComponent {
     this.authProvider = authProvider;
   }
 
-  /** Provides instances of Firestore for given database names. */
+  /** Provides instances of Firestore for given database IDs. */
   @NonNull
   synchronized FirebaseFirestore get(@NonNull String databaseId) {
     FirebaseFirestore firestore = instances.get(databaseId);
@@ -55,7 +55,7 @@ class FirestoreMultiDbComponent {
   }
 
   /**
-   * Remove the instance of a given database name from this component, such that if {@link
+   * Remove the instance of a given database ID from this component, such that if {@link
    * FirestoreMultiDbComponent#get(String)} is called again with the same name, a new instance of
    * {@link FirebaseFirestore} is created.
    *

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
@@ -25,11 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** Multi-resource container for Firestore. */
-class FirestoreMultiDbComponent implements FirebaseAppLifecycleListener {
-
-  public interface DeregisterCommand {
-    void execute();
-  }
+class FirestoreMultiDbComponent
+    implements FirebaseAppLifecycleListener, FirebaseFirestore.InstanceRegistry {
 
   /**
    * A static map from instance key to FirebaseFirestore instances. Instance keys are database
@@ -56,9 +53,7 @@ class FirestoreMultiDbComponent implements FirebaseAppLifecycleListener {
   synchronized FirebaseFirestore get(@NonNull String databaseId) {
     FirebaseFirestore firestore = instances.get(databaseId);
     if (firestore == null) {
-      firestore =
-          FirebaseFirestore.newInstance(
-              context, app, authProvider, databaseId, () -> this.remove(databaseId));
+      firestore = FirebaseFirestore.newInstance(context, app, authProvider, databaseId, this);
       instances.put(databaseId, firestore);
     }
     return firestore;
@@ -71,7 +66,8 @@ class FirestoreMultiDbComponent implements FirebaseAppLifecycleListener {
    *
    * <p>It is a no-op if there is no instance associated with the given database name.
    */
-  synchronized void remove(@NonNull String databaseId) {
+  @Override
+  public synchronized void remove(@NonNull String databaseId) {
     instances.remove(databaseId);
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
@@ -72,7 +72,7 @@ class FirestoreMultiDbComponent
   }
 
   @Override
-  public void onDeleted(String firebaseAppName, FirebaseOptions options) {
+  public synchronized void onDeleted(String firebaseAppName, FirebaseOptions options) {
     // Shuts down all database instances and remove them from registry map when App is deleted.
     for (Map.Entry<String, FirebaseFirestore> entry : instances.entrySet()) {
       entry.getValue().shutdownInternal();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
@@ -45,12 +45,23 @@ class FirestoreMultiDbComponent {
 
   /** Provides instances of Firestore for given database names. */
   @NonNull
-  synchronized FirebaseFirestore get(@NonNull String databaseName) {
-    FirebaseFirestore firestore = instances.get(databaseName);
+  synchronized FirebaseFirestore get(@NonNull String databaseId) {
+    FirebaseFirestore firestore = instances.get(databaseId);
     if (firestore == null) {
-      firestore = FirebaseFirestore.newInstance(context, app, authProvider, databaseName);
-      instances.put(databaseName, firestore);
+      firestore = FirebaseFirestore.newInstance(context, app, authProvider, databaseId);
+      instances.put(databaseId, firestore);
     }
     return firestore;
+  }
+
+  /**
+   * Remove the instance of a given database name from this component, such that if {@link
+   * FirestoreMultiDbComponent#get(String)} is called again with the same name, a new instance of
+   * {@link FirebaseFirestore} is created.
+   *
+   * <p>It is a no-op if there is no instance associated with the given database name.
+   */
+  synchronized void remove(@NonNull String databaseId) {
+    instances.remove(databaseId);
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -147,7 +147,7 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
         });
   }
 
-  /** Has this client been shutdown. */
+  /** Returns true if this client has been shutdown. */
   public boolean isShutdown() {
     // Technically, the asyncQueue is still running, but only accepting tasks related to shutdown
     // or supposed to be run after shutdown. It is effectively shut down to the eyes of users.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
@@ -34,6 +34,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import io.grpc.android.AndroidChannelBuilder;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /** Manages the gRPC channel and encapsulates all SSL and gRPC initialization. */
@@ -137,48 +138,53 @@ public class GrpcCallProvider {
 
   /** Shuts down the gRPC channel and the internal worker queue. */
   void shutdown() {
-    channelTask.addOnCompleteListener(
-        asyncQueue.getExecutorForShutdown(),
-        task -> {
-          ManagedChannel channel = task.getResult();
-          channel.shutdown();
-          try {
-            // TODO(rsgowman): Investigate occasional hangs in channel.shutdown().
-            //
-            // While running the integration tests, channel.shutdown() will occasionally timeout.
-            // (Typically on ~4-5 different tests, differing from one run to the next.) We should
-            // figure this out. But in the meantime, just use an exceptionally short timeout here
-            // and skip straight to shutdownNow() which works every time. (We don't support shutting
-            // down Firestore, so this should only be triggered from the test suite.)
-            if (!channel.awaitTermination(1, TimeUnit.SECONDS)) {
-              Logger.debug(
-                  FirestoreChannel.class.getSimpleName(),
-                  "Unable to gracefully shutdown the gRPC ManagedChannel. Will attempt an immediate shutdown.");
-              channel.shutdownNow();
+    ManagedChannel channel = null;
+    try {
+      channel = Tasks.await(channelTask);
+    } catch (ExecutionException | InterruptedException e) {
+      Logger.warn(
+          FirestoreChannel.class.getSimpleName(),
+          "Channel is not initialized, shutdown will just do nothing.");
+      return;
+    }
 
-              // gRPC docs claim "Although forceful, the shutdown process is still not
-              // instantaneous; isTerminated() will likely return false immediately after this
-              // method returns." Therefore, we still need to awaitTermination() again.
-              if (!channel.awaitTermination(60, TimeUnit.SECONDS)) {
-                // Something bad has happened. We could assert, but this is just resource cleanup
-                // for a resource that is likely only released at the end of the execution. So
-                // instead, we'll just log the error.
-                Logger.warn(
-                    FirestoreChannel.class.getSimpleName(),
-                    "Unable to forcefully shutdown the gRPC ManagedChannel.");
-              }
-            }
-          } catch (InterruptedException e) {
-            // (Re-)Cancel if current thread also interrupted
-            channel.shutdownNow();
+    channel.shutdown();
+    try {
+      // TODO(rsgowman): Investigate occasional hangs in channel.shutdown().
+      //
+      // While running the integration tests, channel.shutdown() will occasionally timeout.
+      // (Typically on ~4-5 different tests, differing from one run to the next.) We should
+      // figure this out. But in the meantime, just use an exceptionally short timeout here
+      // and skip straight to shutdownNow() which works every time. (We don't support shutting
+      // down Firestore, so this should only be triggered from the test suite.)
+      if (!channel.awaitTermination(1, TimeUnit.SECONDS)) {
+        Logger.debug(
+            FirestoreChannel.class.getSimpleName(),
+            "Unable to gracefully shutdown the gRPC ManagedChannel. Will attempt an immediate shutdown.");
+        channel.shutdownNow();
 
-            // Similar to above, something bad happened, but it's not worth asserting. Just log it.
-            Logger.warn(
-                FirestoreChannel.class.getSimpleName(),
-                "Interrupted while shutting down the gRPC Managed Channel");
-            // Preserve interrupt status
-            Thread.currentThread().interrupt();
-          }
-        });
+        // gRPC docs claim "Although forceful, the shutdown process is still not
+        // instantaneous; isTerminated() will likely return false immediately after this
+        // method returns." Therefore, we still need to awaitTermination() again.
+        if (!channel.awaitTermination(60, TimeUnit.SECONDS)) {
+          // Something bad has happened. We could assert, but this is just resource cleanup
+          // for a resource that is likely only released at the end of the execution. So
+          // instead, we'll just log the error.
+          Logger.warn(
+              FirestoreChannel.class.getSimpleName(),
+              "Unable to forcefully shutdown the gRPC ManagedChannel.");
+        }
+      }
+    } catch (InterruptedException e) {
+      // (Re-)Cancel if current thread also interrupted
+      channel.shutdownNow();
+
+      // Similar to above, something bad happened, but it's not worth asserting. Just log it.
+      Logger.warn(
+          FirestoreChannel.class.getSimpleName(),
+          "Interrupted while shutting down the gRPC Managed Channel");
+      // Preserve interrupt status
+      Thread.currentThread().interrupt();
+    }
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
@@ -138,7 +138,7 @@ public class GrpcCallProvider {
   /** Shuts down the gRPC channel and the internal worker queue. */
   void shutdown() {
     channelTask.addOnCompleteListener(
-        asyncQueue.getExecutor(),
+        asyncQueue.getExecutorForShutdown(),
         task -> {
           ManagedChannel channel = task.getResult();
           channel.shutdown();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -179,11 +179,11 @@ public class AsyncQueue {
    * A wrapper around a {@link ScheduledThreadPoolExecutor} class that provides:
    *
    * <ol>
-   *   <li>1. Synchronized task scheduling. This is different from function 3, which is about task
+   *   <li>Synchronized task scheduling. This is different from function 3, which is about task
    *       execution in a single thread.
-   *   <li>2. Ability to do soft-shutdown: only critical tasks related to shutting Firestore SDK
-   *       down can be executed once the shutdown process initiated.
-   *   <li>3. Single threaded execution service, no concurrent execution among the `Runnable`s
+   *   <li>Ability to do soft-shutdown: only critical tasks related to shutting Firestore SDK down
+   *       can be executed once the shutdown process initiated.
+   *   <li>Single threaded execution service, no concurrent execution among the `Runnable`s
    *       scheduled in this Executor.
    * </ol>
    */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -176,97 +176,180 @@ public class AsyncQueue {
   }
 
   /**
-   * The single thread that will be used by the executor. This is created early and managed directly
-   * so that it's possible later to make assertions about executing on the correct thread.
+   * A wrapper around a {@link ScheduledThreadPoolExecutor} class that provides:
+   *
+   * <ul>
+   *   <li>1. Synchronized task scheduling. This is different from function 3, which is about task
+   *       execution in a single thread.
+   *   <li>2. Ability to do soft-shutdown: only critical tasks related to shutting Firestore SDK
+   *       down can be executed once the shutdown process initiated.
+   *   <li>3. Single threaded execution service, no concurrent execution among the `Runnable`s
+   *       scheduled in this Executor.
+   * </ul>
    */
-  private final Thread thread;
+  private class SynchronizedShutdownAwareExecutor implements Executor {
+    /**
+     * The single threaded executor that is backing this Executor. This is also the executor used
+     * when some tasks explicitly request to run after shutdown has been initiated.
+     */
+    private final ScheduledThreadPoolExecutor internalExecutor;
 
-  /** The single threaded executor that is backing this AsyncQueue */
-  private final ScheduledThreadPoolExecutor executor;
+    /** Whether the shutdown process has initiated, once it is started, it is not revertable. */
+    private boolean isShuttingDown;
 
+    /**
+     * The single thread that will be used by the executor. This is created early and managed
+     * directly so that it's possible later to make assertions about executing on the correct
+     * thread.
+     */
+    private final Thread thread;
+
+    /** A ThreadFactory for a single, pre-created thread. */
+    private class DelayedStartFactory implements Runnable, ThreadFactory {
+      private final CountDownLatch latch = new CountDownLatch(1);
+      private Runnable delegate;
+
+      @Override
+      public void run() {
+        try {
+          latch.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        delegate.run();
+      }
+
+      @Override
+      public Thread newThread(@NonNull Runnable runnable) {
+        hardAssert(delegate == null, "Only one thread may be created in an AsyncQueue.");
+        delegate = runnable;
+        latch.countDown();
+        return thread;
+      }
+    }
+
+    SynchronizedShutdownAwareExecutor() {
+      DelayedStartFactory threadFactory = new DelayedStartFactory();
+
+      thread = Executors.defaultThreadFactory().newThread(threadFactory);
+      thread.setName("FirestoreWorker");
+      thread.setDaemon(true);
+      thread.setUncaughtExceptionHandler((crashingThread, throwable) -> panic(throwable));
+
+      internalExecutor =
+          new ScheduledThreadPoolExecutor(1, threadFactory) {
+            @Override
+            protected void afterExecute(Runnable r, Throwable t) {
+              super.afterExecute(r, t);
+              if (t == null && r instanceof Future<?>) {
+                Future<?> future = (Future<?>) r;
+                try {
+                  // Not all Futures will be done, e.g. when used with scheduledAtFixedRate
+                  if (future.isDone()) {
+                    future.get();
+                  }
+                } catch (CancellationException ce) {
+                  // Cancellation exceptions are okay, we expect them to happen sometimes
+                } catch (ExecutionException ee) {
+                  t = ee.getCause();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                }
+              }
+              if (t != null) {
+                panic(t);
+              }
+            }
+          };
+
+      // Core threads don't time out, this only takes effect when we drop the number of required
+      // core threads
+      internalExecutor.setKeepAliveTime(3, TimeUnit.SECONDS);
+
+      isShuttingDown = false;
+    }
+
+    /** Synchronized access to isShuttingDown */
+    private synchronized boolean isShuttingDown() {
+      return isShuttingDown;
+    }
+
+    /**
+     * Check if shutdown is initiated before scheduling. If it is initiated, the command will not be
+     * executed.
+     */
+    @Override
+    public synchronized void execute(Runnable command) {
+      if (!isShuttingDown) {
+        internalExecutor.execute(command);
+      }
+    }
+
+    /**
+     * Initiate the shutdown process. Once called, the only possible way to run `Runnable`s are by
+     * holding the `internalExecutor` reference.
+     */
+    private synchronized void initiateShutdown() {
+      if (!isShuttingDown) {
+        isShuttingDown = true;
+      }
+    }
+
+    /**
+     * Wraps {@link ScheduledThreadPoolExecutor#schedule(Runnable, long, TimeUnit)} and provides
+     * shutdown state check: the command will not be scheduled if the shutdown has been initiated.
+     */
+    private synchronized ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+      if (!isShuttingDown) {
+        return internalExecutor.schedule(command, delay, unit);
+      }
+      return null;
+    }
+
+    /** Wraps around {@link ScheduledThreadPoolExecutor#shutdownNow()}. */
+    private void shutdownNow() {
+      internalExecutor.shutdownNow();
+    }
+
+    /** Wraps around {@link ScheduledThreadPoolExecutor#setCorePoolSize(int)}. */
+    private void setCorePoolSize(int size) {
+      internalExecutor.setCorePoolSize(size);
+    }
+  }
+
+  /** The executor backing this AsyncQueue. */
+  private final SynchronizedShutdownAwareExecutor executor;
   // Tasks scheduled to be queued in the future. Tasks are automatically removed after they are run
   // or canceled.
   // NOTE: We disallow duplicates currently, so this could be a Set<> which might have better
   // theoretical removal speed, except this list will always be small so ArrayList is fine.
   private final ArrayList<DelayedTask> delayedTasks;
 
-  /** A ThreadFactory for a single, pre-created thread. */
-  private class DelayedStartFactory implements Runnable, ThreadFactory {
-    private final CountDownLatch latch = new CountDownLatch(1);
-    private Runnable delegate;
-
-    @Override
-    public void run() {
-      try {
-        latch.await();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-      delegate.run();
-    }
-
-    @Override
-    public Thread newThread(@NonNull Runnable runnable) {
-      hardAssert(delegate == null, "Only one thread may be created in an AsyncQueue.");
-      delegate = runnable;
-      latch.countDown();
-      return thread;
-    }
-  }
-
   public AsyncQueue() {
     delayedTasks = new ArrayList<>();
-
-    DelayedStartFactory threadFactory = new DelayedStartFactory();
-
-    thread = Executors.defaultThreadFactory().newThread(threadFactory);
-    thread.setName("FirestoreWorker");
-    thread.setDaemon(true);
-    thread.setUncaughtExceptionHandler((crashingThread, throwable) -> panic(throwable));
-
-    executor =
-        new ScheduledThreadPoolExecutor(1, threadFactory) {
-          @Override
-          protected void afterExecute(Runnable r, Throwable t) {
-            super.afterExecute(r, t);
-            if (t == null && r instanceof Future<?>) {
-              Future<?> future = (Future<?>) r;
-              try {
-                // Not all Futures will be done, e.g. when used with scheduledAtFixedRate
-                if (future.isDone()) {
-                  future.get();
-                }
-              } catch (CancellationException ce) {
-                // Cancellation exceptions are okay, we expect them to happen sometimes
-              } catch (ExecutionException ee) {
-                t = ee.getCause();
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-              }
-            }
-            if (t != null) {
-              panic(t);
-            }
-          }
-        };
-
-    // Core threads don't time out, this only takes effect when we drop the number of required
-    // core threads
-    executor.setKeepAliveTime(3, TimeUnit.SECONDS);
+    executor = new SynchronizedShutdownAwareExecutor();
   }
 
   public Executor getExecutor() {
     return executor;
   }
 
+  /**
+   * For tasks that need to run after shutdown has been initiated. The tasks should themselves be
+   * shutdown related.
+   */
+  public Executor getExecutorForShutdown() {
+    return executor.internalExecutor;
+  }
+
   /** Verifies that the current thread is the managed AsyncQueue thread. */
   public void verifyIsCurrentThread() {
     Thread current = Thread.currentThread();
-    if (thread != current) {
+    if (executor.thread != current) {
       throw fail(
           "We are running on the wrong thread. Expected to be on the AsyncQueue "
               + "thread %s/%d but was %s/%d",
-          thread.getName(), thread.getId(), current.getName(), current.getId());
+          executor.thread.getName(), executor.thread.getId(), current.getName(), current.getId());
     }
   }
 
@@ -279,6 +362,10 @@ public class AsyncQueue {
    */
   @CheckReturnValue
   public <T> Task<T> enqueue(Callable<T> task) {
+    return enqueueImpl(task, executor);
+  }
+
+  private <T> Task<T> enqueueImpl(Callable<T> task, Executor executor) {
     final TaskCompletionSource<T> completionSource = new TaskCompletionSource<>();
     try {
       executor.execute(
@@ -311,6 +398,48 @@ public class AsyncQueue {
           task.run();
           return null;
         });
+  }
+
+  /**
+   * Queue a Runnable and immediately mark the initiation of shutdown process. Tasks queued after
+   * this method is called are not run unless they explicitly request via {@link
+   * AsyncQueue#enqueueAndForgetEvenAfterShutdown(Runnable)} or {@link
+   * AsyncQueue#getExecutorForShutdown()}.
+   */
+  public Task<Void> enqueueAndInitiateShutdown(Runnable task) {
+    synchronized (executor) {
+      if (executor.isShuttingDown()) {
+        TaskCompletionSource<Void> source = new TaskCompletionSource<>();
+        source.setResult(null);
+        return source.getTask();
+      }
+      Task<Void> t =
+          enqueue(
+              () -> {
+                task.run();
+                return null;
+              });
+      executor.initiateShutdown();
+      return t;
+    }
+  }
+
+  /**
+   * Queue and run this Runnable task immediately after every other already queued task, regardless
+   * if shutdown has been initiated.
+   */
+  public void enqueueAndForgetEvenAfterShutdown(Runnable task) {
+    enqueueImpl(
+        () -> {
+          task.run();
+          return null;
+        },
+        executor.internalExecutor);
+  }
+
+  /** Has the shutdown process been initiated. */
+  public boolean isShuttingDown() {
+    return executor.isShuttingDown();
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -178,14 +178,14 @@ public class AsyncQueue {
   /**
    * A wrapper around a {@link ScheduledThreadPoolExecutor} class that provides:
    *
-   * <ul>
+   * <ol>
    *   <li>1. Synchronized task scheduling. This is different from function 3, which is about task
    *       execution in a single thread.
    *   <li>2. Ability to do soft-shutdown: only critical tasks related to shutting Firestore SDK
    *       down can be executed once the shutdown process initiated.
    *   <li>3. Single threaded execution service, no concurrent execution among the `Runnable`s
    *       scheduled in this Executor.
-   * </ul>
+   * </ol>
    */
   private class SynchronizedShutdownAwareExecutor implements Executor {
     /**

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/AsyncQueueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/AsyncQueueTest.java
@@ -126,7 +126,7 @@ public class AsyncQueueTest {
 
   @Test
   public void tasksAreScheduledWithRespectToShutdown() {
-    expectedSteps = Arrays.asList(1, 2, 4, 6);
+    expectedSteps = Arrays.asList(1, 2, 4);
     queue.enqueueAndForget(runnableForStep(1));
 
     // From this point on, `normal` tasks are not scheduled. Only those who explicitly request to
@@ -137,6 +137,5 @@ public class AsyncQueueTest {
     queue.enqueueAndForgetEvenAfterShutdown(runnableForStep(4));
 
     queue.getExecutor().execute(runnableForStep(5));
-    queue.getExecutorForShutdown().execute(runnableForStep(6));
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/AsyncQueueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/AsyncQueueTest.java
@@ -123,4 +123,20 @@ public class AsyncQueueTest {
     queue.runDelayedTasksUntil(TIMER_ID_3);
     assertEquals(Arrays.asList(1, 2, 3, 4), completedSteps);
   }
+
+  @Test
+  public void tasksAreScheduledWithRespectToShutdown() {
+    expectedSteps = Arrays.asList(1, 2, 4, 6);
+    queue.enqueueAndForget(runnableForStep(1));
+
+    // From this point on, `normal` tasks are not scheduled. Only those who explicitly request to
+    // run after shutdown initiated will run.
+    queue.enqueueAndInitiateShutdown(runnableForStep(2));
+
+    queue.enqueueAndForget(runnableForStep(3));
+    queue.enqueueAndForgetEvenAfterShutdown(runnableForStep(4));
+
+    queue.getExecutor().execute(runnableForStep(5));
+    queue.getExecutorForShutdown().execute(runnableForStep(6));
+  }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/AsyncQueueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/AsyncQueueTest.java
@@ -137,5 +137,6 @@ public class AsyncQueueTest {
     queue.enqueueAndForgetEvenAfterShutdown(runnableForStep(4));
 
     queue.getExecutor().execute(runnableForStep(5));
+    waitForExpectedSteps();
   }
 }

--- a/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
+++ b/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Matchers.enclosingMethod;
 import static com.google.errorprone.matchers.Matchers.hasAnnotation;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 import static com.google.errorprone.matchers.Matchers.isStatic;
-import static com.google.errorprone.matchers.Matchers.isVoidType;
 import static com.google.errorprone.matchers.Matchers.methodHasVisibility;
 import static com.google.errorprone.matchers.Matchers.methodInvocation;
 import static com.google.errorprone.matchers.Matchers.methodIsNamed;
@@ -98,11 +97,8 @@ public class ComponentsAppGetCheck extends BugChecker
    * </pre>
    */
   private static final Matcher<ExpressionTree> WITHIN_SHUTDOWN =
-      enclosingMethod(
-          allOf(
-              methodIsNamed("shutdown")));
-              //methodReturns(isVoidType())));
-
+      enclosingMethod(allOf(methodIsNamed("shutdown")));
+  // methodReturns(isVoidType())));
 
   /**
    * This matches methods of the forms:

--- a/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
+++ b/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
@@ -92,18 +92,6 @@ public class ComponentsAppGetCheck extends BugChecker
    *
    * <pre>{@code
    * class Foo {
-   *     void shutdown();
-   * }
-   * </pre>
-   */
-  private static final Matcher<ExpressionTree> WITHIN_SHUTDOWN =
-      enclosingMethod(allOf(methodIsNamed("shutdown")));
-
-  /**
-   * This matches methods of the forms:
-   *
-   * <pre>{@code
-   * class Foo {
    *     private static Foo getInstanceImpl(/* any number of parameters * /);
    * }
    *
@@ -126,7 +114,7 @@ public class ComponentsAppGetCheck extends BugChecker
       enclosingClass(hasAnnotation("org.junit.runner.RunWith"));
 
   private static final Matcher<ExpressionTree> ALLOWED_USAGES =
-      anyOf(WITHIN_GET_INSTANCE, WITHIN_GET_INSTANCE_IMPL, WITHIN_SHUTDOWN, WITHIN_JUNIT_TEST);
+      anyOf(WITHIN_GET_INSTANCE, WITHIN_GET_INSTANCE_IMPL, WITHIN_JUNIT_TEST);
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
+++ b/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
@@ -21,6 +21,7 @@ import static com.google.errorprone.matchers.Matchers.enclosingMethod;
 import static com.google.errorprone.matchers.Matchers.hasAnnotation;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 import static com.google.errorprone.matchers.Matchers.isStatic;
+import static com.google.errorprone.matchers.Matchers.isVoidType;
 import static com.google.errorprone.matchers.Matchers.methodHasVisibility;
 import static com.google.errorprone.matchers.Matchers.methodInvocation;
 import static com.google.errorprone.matchers.Matchers.methodIsNamed;
@@ -92,6 +93,22 @@ public class ComponentsAppGetCheck extends BugChecker
    *
    * <pre>{@code
    * class Foo {
+   *     void shutdown();
+   * }
+   * </pre>
+   */
+  private static final Matcher<ExpressionTree> WITHIN_SHUTDOWN =
+      enclosingMethod(
+          allOf(
+              methodIsNamed("shutdown")));
+              //methodReturns(isVoidType())));
+
+
+  /**
+   * This matches methods of the forms:
+   *
+   * <pre>{@code
+   * class Foo {
    *     private static Foo getInstanceImpl(/* any number of parameters * /);
    * }
    *
@@ -114,7 +131,7 @@ public class ComponentsAppGetCheck extends BugChecker
       enclosingClass(hasAnnotation("org.junit.runner.RunWith"));
 
   private static final Matcher<ExpressionTree> ALLOWED_USAGES =
-      anyOf(WITHIN_GET_INSTANCE, WITHIN_GET_INSTANCE_IMPL, WITHIN_JUNIT_TEST);
+      anyOf(WITHIN_GET_INSTANCE, WITHIN_GET_INSTANCE_IMPL, WITHIN_SHUTDOWN, WITHIN_JUNIT_TEST);
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
+++ b/tools/errorprone/src/main/java/com/google/firebase/errorprone/ComponentsAppGetCheck.java
@@ -98,7 +98,6 @@ public class ComponentsAppGetCheck extends BugChecker
    */
   private static final Matcher<ExpressionTree> WITHIN_SHUTDOWN =
       enclosingMethod(allOf(methodIsNamed("shutdown")));
-  // methodReturns(isVoidType())));
 
   /**
    * This matches methods of the forms:


### PR DESCRIPTION
1. FirebaseApp delete calls firestore shutdown.
2. Deregister firestore when shutdown is called, new instance can then be registered.
3. Synchronize AsyncQueue.Executor scheduling. Also make it stop handling most of schedule requests once it is shutdown, only tasks originated from shutdown itself and clearPersistence can proceed.