### PR TITLE
Expose operation counts from Persistence layer

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryMutationQueue.java
@@ -156,7 +156,7 @@ final class MemoryMutationQueue implements MutationQueue {
           .addToCollectionParentIndex(mutation.getKey().getPath().popLast());
     }
 
-    statsCollector.recordRowsWritten(MemoryMutationQueue.TAG, 1);
+    statsCollector.recordRowsWritten(STATS_TAG, 1);
 
     return batch;
   }
@@ -164,7 +164,7 @@ final class MemoryMutationQueue implements MutationQueue {
   @Nullable
   @Override
   public MutationBatch lookupMutationBatch(int batchId) {
-    statsCollector.recordRowsRead(MemoryMutationQueue.TAG, 1);
+    statsCollector.recordRowsRead(STATS_TAG, 1);
 
     int index = indexOfBatchId(batchId);
     if (index < 0 || index >= queue.size()) {
@@ -209,7 +209,7 @@ final class MemoryMutationQueue implements MutationQueue {
       result.add(batch);
     }
 
-    statsCollector.recordRowsRead(MemoryMutationQueue.TAG, result.size());
+    statsCollector.recordRowsRead(STATS_TAG, result.size());
 
     return result;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryMutationQueue.java
@@ -69,9 +69,11 @@ final class MemoryMutationQueue implements MutationQueue {
   private ByteString lastStreamToken;
 
   private final MemoryPersistence persistence;
+  private final StatsCollector statsCollector;
 
-  MemoryMutationQueue(MemoryPersistence persistence) {
+  MemoryMutationQueue(MemoryPersistence persistence, StatsCollector statsCollector) {
     this.persistence = persistence;
+    this.statsCollector = statsCollector;
     queue = new ArrayList<>();
 
     batchesByDocumentKey = new ImmutableSortedSet<>(emptyList(), DocumentReference.BY_KEY);
@@ -154,12 +156,16 @@ final class MemoryMutationQueue implements MutationQueue {
           .addToCollectionParentIndex(mutation.getKey().getPath().popLast());
     }
 
+    statsCollector.recordRowsWritten(MemoryMutationQueue.TAG, 1);
+
     return batch;
   }
 
   @Nullable
   @Override
   public MutationBatch lookupMutationBatch(int batchId) {
+    statsCollector.recordRowsRead(MemoryMutationQueue.TAG, 1);
+
     int index = indexOfBatchId(batchId);
     if (index < 0 || index >= queue.size()) {
       return null;
@@ -202,6 +208,8 @@ final class MemoryMutationQueue implements MutationQueue {
       hardAssert(batch != null, "Batches in the index must exist in the main table");
       result.add(batch);
     }
+
+    statsCollector.recordRowsRead(MemoryMutationQueue.TAG, result.size());
 
     return result;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryPersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryPersistence.java
@@ -35,30 +35,38 @@ public final class MemoryPersistence extends Persistence {
   private final MemoryIndexManager indexManager;
   private final MemoryQueryCache queryCache;
   private final MemoryRemoteDocumentCache remoteDocumentCache;
+  private final StatsCollector statsCollector;
   private ReferenceDelegate referenceDelegate;
 
   private boolean started;
 
   public static MemoryPersistence createEagerGcMemoryPersistence() {
-    MemoryPersistence persistence = new MemoryPersistence();
+    return createEagerGcMemoryPersistence(StatsCollector.newNoOpStatsCollector());
+  }
+
+  public static MemoryPersistence createEagerGcMemoryPersistence(StatsCollector statsCollector) {
+    MemoryPersistence persistence = new MemoryPersistence(statsCollector);
     persistence.setReferenceDelegate(new MemoryEagerReferenceDelegate(persistence));
     return persistence;
   }
 
   public static MemoryPersistence createLruGcMemoryPersistence(
-      LruGarbageCollector.Params params, LocalSerializer serializer) {
-    MemoryPersistence persistence = new MemoryPersistence();
+      LruGarbageCollector.Params params,
+      StatsCollector statsCollector,
+      LocalSerializer serializer) {
+    MemoryPersistence persistence = new MemoryPersistence(statsCollector);
     persistence.setReferenceDelegate(
         new MemoryLruReferenceDelegate(persistence, params, serializer));
     return persistence;
   }
 
   /** Use static helpers to instantiate */
-  private MemoryPersistence() {
+  private MemoryPersistence(StatsCollector statsCollector) {
+    this.statsCollector = statsCollector;
     mutationQueues = new HashMap<>();
     indexManager = new MemoryIndexManager();
     queryCache = new MemoryQueryCache(this);
-    remoteDocumentCache = new MemoryRemoteDocumentCache(this);
+    remoteDocumentCache = new MemoryRemoteDocumentCache(this, statsCollector);
   }
 
   @Override
@@ -93,7 +101,7 @@ public final class MemoryPersistence extends Persistence {
   MutationQueue getMutationQueue(User user) {
     MemoryMutationQueue queue = mutationQueues.get(user);
     if (queue == null) {
-      queue = new MemoryMutationQueue(this);
+      queue = new MemoryMutationQueue(this, statsCollector);
       mutationQueues.put(user, queue);
     }
     return queue;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryPersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryPersistence.java
@@ -41,7 +41,7 @@ public final class MemoryPersistence extends Persistence {
   private boolean started;
 
   public static MemoryPersistence createEagerGcMemoryPersistence() {
-    return createEagerGcMemoryPersistence(StatsCollector.newNoOpStatsCollector());
+    return createEagerGcMemoryPersistence(StatsCollector.NO_OP_STATS_COLLECTOR);
   }
 
   public static MemoryPersistence createEagerGcMemoryPersistence(StatsCollector statsCollector) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -53,14 +53,14 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
 
   @Override
   public void remove(DocumentKey key) {
-    statsCollector.recordRowsDeleted(RemoteDocumentCache.TAG, 1);
+    statsCollector.recordRowsDeleted(STATS_TAG, 1);
     docs = docs.remove(key);
   }
 
   @Nullable
   @Override
   public MaybeDocument get(DocumentKey key) {
-    statsCollector.recordRowsRead(RemoteDocumentCache.TAG, 1);
+    statsCollector.recordRowsRead(STATS_TAG, 1);
     return docs.get(key);
   }
 
@@ -74,7 +74,7 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
       result.put(key, get(key));
     }
 
-    statsCollector.recordRowsRead(RemoteDocumentCache.TAG, result.size());
+    statsCollector.recordRowsRead(STATS_TAG, result.size());
     return result;
   }
 
@@ -95,12 +95,13 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
 
     while (iterator.hasNext()) {
       Map.Entry<DocumentKey, MaybeDocument> entry = iterator.next();
+
+      ++rowsRead;
+
       DocumentKey key = entry.getKey();
       if (!queryPath.isPrefixOf(key.getPath())) {
         break;
       }
-
-      ++rowsRead;
 
       MaybeDocument maybeDoc = entry.getValue();
       if (!(maybeDoc instanceof Document)) {
@@ -113,7 +114,7 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
       }
     }
 
-    statsCollector.recordRowsRead(RemoteDocumentCache.TAG, rowsRead);
+    statsCollector.recordRowsRead(STATS_TAG, rowsRead);
 
     return result;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 /** A queue of mutations to apply to the remote store. */
 interface MutationQueue {
   /** The tag used by the StatsCollector. */
-  String TAG = "Mutations";
+  String STATS_TAG = "mutations";
 
   /**
    * Starts the mutation queue, performing any initial reads that might be required to establish

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
@@ -25,6 +25,9 @@ import javax.annotation.Nullable;
 
 /** A queue of mutations to apply to the remote store. */
 interface MutationQueue {
+  /** The tag used by the StatsCollector. */
+  String TAG = "Mutations";
+
   /**
    * Starts the mutation queue, performing any initial reads that might be required to establish
    * invariants, etc.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
@@ -31,7 +31,8 @@ import javax.annotation.Nullable;
  */
 interface RemoteDocumentCache {
   /** The tag used by the StatsCollector. */
-  String TAG = "RemoteDocuments";
+  String STATS_TAG = "remote_documents";
+
   /**
    * Adds or replaces an entry in the cache.
    *

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
@@ -30,6 +30,8 @@ import javax.annotation.Nullable;
  * instances (indicating that the document is known to not exist).
  */
 interface RemoteDocumentCache {
+  /** The tag used by the StatsCollector. */
+  String TAG = "RemoteDocuments";
   /**
    * Adds or replaces an entry in the cache.
    *

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -145,8 +145,6 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
         .binding(prefixPath, prefixSuccessorPath)
         .forEach(
             row -> {
-              ++rowsRead[0];
-
               // TODO: Actually implement a single-collection query
               //
               // The query is actually returning any path that starts with the query path prefix
@@ -158,6 +156,8 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
               if (path.length() != immediateChildrenPathLength) {
                 return;
               }
+
+              ++rowsRead[0];
 
               byte[] rawDocument = row.getBlob(1);
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/StatsCollector.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/StatsCollector.java
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.local;
+
+/**
+ * Collects the operation count from the persistence layer. Implementing classes can expose this
+ * information to measure the efficiency of persistence operations.
+ *
+ * <p>The only consumer of the operation counts is currently the LocalStoreTestCase (via {@link
+ * com.google.firebase.firestore.local.AccumulatingStatsCollector}). If you are not interested in
+ * the stats, you can use `newNoOpStatsCollector()` to return an empty stats collector.
+ */
+abstract class StatsCollector {
+  /** A stats collector that discards all operation counts. */
+  static class NoOpStatsCollector extends StatsCollector {
+    @Override
+    void recordRowsRead(String tag, int count) {}
+
+    @Override
+    void recordRowsDeleted(String tag, int count) {}
+
+    @Override
+    void recordRowsWritten(String tag, int count) {}
+  }
+
+  static NoOpStatsCollector newNoOpStatsCollector() {
+    return new NoOpStatsCollector();
+  }
+
+  /** Records the number of rows read for the given tag. */
+  abstract void recordRowsRead(String tag, int count);
+
+  /** Records the number of rows deleted for the given tag. */
+  abstract void recordRowsDeleted(String tag, int count);
+
+  /** Records the number of rows written for the given tag. */
+  abstract void recordRowsWritten(String tag, int count);
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/StatsCollector.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/StatsCollector.java
@@ -15,36 +15,22 @@
 package com.google.firebase.firestore.local;
 
 /**
- * Collects the operation count from the persistence layer. Implementing classes can expose this
+ * Collects the operation count from the persistence layer. Implementing subclasses can expose this
  * information to measure the efficiency of persistence operations.
  *
- * <p>The only consumer of the operation counts is currently the LocalStoreTestCase (via {@link
+ * <p>The only consumer of operation counts is currently the LocalStoreTestCase (via {@link
  * com.google.firebase.firestore.local.AccumulatingStatsCollector}). If you are not interested in
- * the stats, you can use `newNoOpStatsCollector()` to return an empty stats collector.
+ * the stats, you can use `NO_OP_STATS_COLLECTOR` for the default empty stats collector.
  */
-abstract class StatsCollector {
-  /** A stats collector that discards all operation counts. */
-  static class NoOpStatsCollector extends StatsCollector {
-    @Override
-    void recordRowsRead(String tag, int count) {}
-
-    @Override
-    void recordRowsDeleted(String tag, int count) {}
-
-    @Override
-    void recordRowsWritten(String tag, int count) {}
-  }
-
-  static NoOpStatsCollector newNoOpStatsCollector() {
-    return new NoOpStatsCollector();
-  }
+class StatsCollector {
+  static final StatsCollector NO_OP_STATS_COLLECTOR = new StatsCollector();
 
   /** Records the number of rows read for the given tag. */
-  abstract void recordRowsRead(String tag, int count);
+  void recordRowsRead(String tag, int count) {}
 
   /** Records the number of rows deleted for the given tag. */
-  abstract void recordRowsDeleted(String tag, int count);
+  void recordRowsDeleted(String tag, int count) {}
 
   /** Records the number of rows written for the given tag. */
-  abstract void recordRowsWritten(String tag, int count);
+  void recordRowsWritten(String tag, int count) {}
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/AccumulatingStatsCollector.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/AccumulatingStatsCollector.java
@@ -1,0 +1,66 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.local;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/* A test-only collector of operation counts from the persistence layer. */
+class AccumulatingStatsCollector extends StatsCollector {
+
+  private final Map<String, Integer> rowsRead = new HashMap<>();
+  private final Map<String, Integer> rowsDeleted = new HashMap<>();
+  private final Map<String, Integer> rowsWritten = new HashMap<>();
+
+  @Override
+  void recordRowsRead(String tag, int count) {
+    Integer currentValue = rowsRead.get(tag);
+    rowsRead.put(tag, currentValue != null ? currentValue + count : count);
+  }
+
+  @Override
+  void recordRowsDeleted(String tag, int count) {
+    Integer currentValue = rowsDeleted.get(tag);
+    rowsDeleted.put(tag, currentValue != null ? currentValue + count : count);
+  }
+
+  @Override
+  void recordRowsWritten(String tag, int count) {
+    Integer currentValue = rowsWritten.get(tag);
+    rowsWritten.put(tag, currentValue != null ? currentValue + count : count);
+  }
+
+  /** Reset all operation counts */
+  void reset() {
+    rowsRead.clear();
+    rowsDeleted.clear();
+    rowsWritten.clear();
+  }
+
+  /** Returns the number of rows read for the given tag since the last call to `reset()`. */
+  int getRowsRead(String tag) {
+    return rowsRead.containsKey(tag) ? rowsRead.get(tag) : 0;
+  }
+
+  /** Returns the number of rows written for the given tag since the last call to `reset()`. */
+  int getRowsWritten(String tag) {
+    return rowsWritten.containsKey(tag) ? rowsWritten.get(tag) : 0;
+  }
+
+  /** Returns the number of rows deleted for the given tag since the last call to `reset()`. */
+  int getRowsDeleted(String tag) {
+    return rowsDeleted.containsKey(tag) ? rowsDeleted.get(tag) : 0;
+  }
+}

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -884,11 +884,6 @@ public abstract class LocalStoreTestCase {
             doc("foo/baz", 10, map("a", "b")),
             doc("foo/bonk", 0, map("a", "b"), Document.DocumentState.LOCAL_MUTATIONS)),
         values(docs));
-
-    // Assert that we read two documents from the remote document cache and one from the mutation
-    // queue.
-    assertRemoteDocumentsRead(2);
-    assertMutationsRead(1);
   }
 
   @Test

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -221,7 +221,7 @@ public abstract class LocalStoreTestCase {
    * `resetPersistenceStats()`.
    */
   private void assertMutationsRead(int expected) {
-    assertEquals(expected, statsCollector.getRowsRead(MutationQueue.TAG));
+    assertEquals(expected, statsCollector.getRowsRead(MutationQueue.STATS_TAG));
   }
 
   /**
@@ -229,7 +229,7 @@ public abstract class LocalStoreTestCase {
    * call to `resetPersistenceStats()`.
    */
   private void assertRemoteDocumentsRead(int expected) {
-    assertEquals(expected, statsCollector.getRowsRead(RemoteDocumentCache.TAG));
+    assertEquals(expected, statsCollector.getRowsRead(RemoteDocumentCache.STATS_TAG));
   }
 
   /** Resets the count of rows read by MutationQueue and the RemoteDocumentCache. */
@@ -872,10 +872,6 @@ public abstract class LocalStoreTestCase {
     Query query = Query.atPath(ResourcePath.fromString("foo"));
     allocateQuery(query);
     assertTargetId(2);
-
-    localStore.executeQuery(query);
-    assertRemoteDocumentsRead(0);
-    assertMutationsRead(0);
 
     applyRemoteEvent(updateRemoteEvent(doc("foo/baz", 10, map("a", "b")), asList(2), emptyList()));
     applyRemoteEvent(updateRemoteEvent(doc("foo/bar", 20, map("a", "b")), asList(2), emptyList()));

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -877,8 +877,6 @@ public abstract class LocalStoreTestCase {
     applyRemoteEvent(updateRemoteEvent(doc("foo/bar", 20, map("a", "b")), asList(2), emptyList()));
     writeMutation(setMutation("foo/bonk", map("a", "b")));
 
-    resetPersistenceStats();
-
     ImmutableSortedMap<DocumentKey, Document> docs = localStore.executeQuery(query);
     assertEquals(
         asList(
@@ -889,6 +887,23 @@ public abstract class LocalStoreTestCase {
 
     // Assert that we read two documents from the remote document cache and one from the mutation
     // queue.
+    assertRemoteDocumentsRead(2);
+    assertMutationsRead(1);
+  }
+
+  @Test
+  public void testReadsAllDocumentsForCollectionQueries() {
+    Query query = Query.atPath(ResourcePath.fromString("foo"));
+    allocateQuery(query);
+
+    applyRemoteEvent(updateRemoteEvent(doc("foo/baz", 10, map()), asList(2), emptyList()));
+    applyRemoteEvent(updateRemoteEvent(doc("foo/bar", 20, map()), asList(2), emptyList()));
+    writeMutation(setMutation("foo/bonk", map()));
+
+    resetPersistenceStats();
+
+    localStore.executeQuery(query);
+
     assertRemoteDocumentsRead(2);
     assertMutationsRead(1);
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/MemoryLocalStoreTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/MemoryLocalStoreTest.java
@@ -24,7 +24,7 @@ public class MemoryLocalStoreTest extends LocalStoreTestCase {
 
   @Override
   Persistence getPersistence() {
-    return PersistenceTestHelpers.createEagerGCMemoryPersistence();
+    return PersistenceTestHelpers.createEagerGCMemoryPersistence(statsCollector);
   }
 
   @Override

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/PersistenceTestHelpers.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/PersistenceTestHelpers.java
@@ -30,7 +30,7 @@ public final class PersistenceTestHelpers {
 
   public static SQLitePersistence createSQLitePersistence(String name) {
     return openSQLitePersistence(
-        name, StatsCollector.newNoOpStatsCollector(), LruGarbageCollector.Params.Default());
+        name, StatsCollector.NO_OP_STATS_COLLECTOR, LruGarbageCollector.Params.Default());
   }
   /**
    * Creates and starts a new SQLitePersistence instance for testing.
@@ -41,9 +41,9 @@ public final class PersistenceTestHelpers {
     return createSQLitePersistence(LruGarbageCollector.Params.Default());
   }
 
-  public static SQLitePersistence createSQLitePersistence(StatsCollector statsProvider) {
+  public static SQLitePersistence createSQLitePersistence(StatsCollector statsCollector) {
     return openSQLitePersistence(
-        nextSQLiteDatabaseName(), statsProvider, LruGarbageCollector.Params.Default());
+        nextSQLiteDatabaseName(), statsCollector, LruGarbageCollector.Params.Default());
   }
 
   public static SQLitePersistence createSQLitePersistence(LruGarbageCollector.Params params) {
@@ -51,13 +51,13 @@ public final class PersistenceTestHelpers {
     // cases, but sometimes (particularly the spec tests) we create multiple databases per test
     // case and each should be fresh. A unique name is sufficient to keep these separate.
     return openSQLitePersistence(
-        nextSQLiteDatabaseName(), StatsCollector.newNoOpStatsCollector(), params);
+        nextSQLiteDatabaseName(), StatsCollector.NO_OP_STATS_COLLECTOR, params);
   }
 
   /** Creates and starts a new MemoryPersistence instance for testing. */
   public static MemoryPersistence createEagerGCMemoryPersistence() {
     MemoryPersistence persistence =
-        MemoryPersistence.createEagerGcMemoryPersistence(StatsCollector.newNoOpStatsCollector());
+        MemoryPersistence.createEagerGcMemoryPersistence(StatsCollector.NO_OP_STATS_COLLECTOR);
     persistence.start();
     return persistence;
   }
@@ -78,18 +78,18 @@ public final class PersistenceTestHelpers {
     LocalSerializer serializer = new LocalSerializer(new RemoteSerializer(databaseId));
     MemoryPersistence persistence =
         MemoryPersistence.createLruGcMemoryPersistence(
-            params, StatsCollector.newNoOpStatsCollector(), serializer);
+            params, StatsCollector.NO_OP_STATS_COLLECTOR, serializer);
     persistence.start();
     return persistence;
   }
 
   private static SQLitePersistence openSQLitePersistence(
-      String name, StatsCollector statsProvider, LruGarbageCollector.Params params) {
+      String name, StatsCollector statsCollector, LruGarbageCollector.Params params) {
     DatabaseId databaseId = DatabaseId.forProject("projectId");
     LocalSerializer serializer = new LocalSerializer(new RemoteSerializer(databaseId));
     Context context = ApplicationProvider.getApplicationContext();
     SQLitePersistence persistence =
-        new SQLitePersistence(context, name, databaseId, serializer, statsProvider, params);
+        new SQLitePersistence(context, name, databaseId, serializer, statsCollector, params);
     persistence.start();
     return persistence;
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteLocalStoreTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteLocalStoreTest.java
@@ -24,7 +24,7 @@ public class SQLiteLocalStoreTest extends LocalStoreTestCase {
 
   @Override
   Persistence getPersistence() {
-    return PersistenceTestHelpers.createSQLitePersistence();
+    return PersistenceTestHelpers.createSQLitePersistence(statsCollector);
   }
 
   @Override

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteQueryCacheTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteQueryCacheTest.java
@@ -39,7 +39,7 @@ public final class SQLiteQueryCacheTest extends QueryCacheTestCase {
   public void testMetadataPersistedAcrossRestarts() {
     String name = "test-queryCache-restarts";
 
-    SQLitePersistence db1 = PersistenceTestHelpers.openSQLitePersistence(name);
+    SQLitePersistence db1 = PersistenceTestHelpers.createSQLitePersistence(name);
     QueryCache queryCache1 = db1.getQueryCache();
     assertEquals(0, queryCache1.getHighestListenSequenceNumber());
 
@@ -59,7 +59,7 @@ public final class SQLiteQueryCacheTest extends QueryCacheTestCase {
 
     db1.shutdown();
 
-    SQLitePersistence db2 = PersistenceTestHelpers.openSQLitePersistence(name);
+    SQLitePersistence db2 = PersistenceTestHelpers.createSQLitePersistence(name);
     db2.runTransaction(
         "verify sequence number",
         () -> {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SQLiteSpecTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SQLiteSpecTest.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.firestore.spec;
 
-import com.google.firebase.firestore.local.LruGarbageCollector;
 import com.google.firebase.firestore.local.Persistence;
 import com.google.firebase.firestore.local.PersistenceTestHelpers;
 import java.util.Set;
@@ -44,8 +43,7 @@ public class SQLiteSpecTest extends SpecTestCase {
 
   @Override
   Persistence getPersistence(boolean garbageCollectionEnabled) {
-    return PersistenceTestHelpers.openSQLitePersistence(
-        databaseName, LruGarbageCollector.Params.Default());
+    return PersistenceTestHelpers.createSQLitePersistence(databaseName);
   }
 
   @Override


### PR DESCRIPTION
This PR adds a pretty-bare bones way to export document read counts from the RemoteDocumentCache and the MutationQueue. I will use this in more thorough tests once we start optimizing our query execution.

The different ways to construct the Persistence layer are getting a little out of hand. I think a good follow up would be to add Builders for some of the classes here and address the overload overload.