### PR TITLE
Fix timeouts in Functions.

### DIFF
--- a/firebase-functions/src/main/java/com/google/firebase/functions/HttpsCallOptions.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/HttpsCallOptions.java
@@ -50,6 +50,10 @@ class HttpsCallOptions {
 
   /** Creates a new OkHttpClient with these options applied to it. */
   OkHttpClient apply(OkHttpClient client) {
-    return client.newBuilder().callTimeout(timeout, timeoutUnits).build();
+    return client
+        .newBuilder()
+        .callTimeout(timeout, timeoutUnits)
+        .readTimeout(timeout, timeoutUnits)
+        .build();
   }
 }


### PR DESCRIPTION
This commit resolves #604 by setting both the read and call timeouts.
The connect and write timeouts are left at their default values of 10
seconds.