### PR TITLE
@Hide abt public classes

### DIFF
--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -20,7 +20,6 @@ plugins {
 firebaseLibrary {
     testLab.enabled = false
     publishSources = true
-    staticAnalysis.disableKotlinInteropLint()
 }
 
 // TODO(issue/568): Remove this once legacy logic is removed from Remote Config.

--- a/firebase-abt/src/main/java/com/google/firebase/abt/component/package-info.java
+++ b/firebase-abt/src/main/java/com/google/firebase/abt/component/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * @hide
+ */
+package com.google.firebase.abt.component;

--- a/firebase-abt/src/main/java/com/google/firebase/abt/component/package-info.java
+++ b/firebase-abt/src/main/java/com/google/firebase/abt/component/package-info.java
@@ -1,8 +1,3 @@
-<<<<<<< Updated upstream
-/**
- * @hide
- */
-=======
 // Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,5 +13,4 @@
 // limitations under the License.
 
 /** @hide */
->>>>>>> Stashed changes
 package com.google.firebase.abt.component;

--- a/firebase-abt/src/main/java/com/google/firebase/abt/component/package-info.java
+++ b/firebase-abt/src/main/java/com/google/firebase/abt/component/package-info.java
@@ -1,4 +1,22 @@
+<<<<<<< Updated upstream
 /**
  * @hide
  */
+=======
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @hide */
+>>>>>>> Stashed changes
 package com.google.firebase.abt.component;

--- a/firebase-abt/src/main/java/com/google/firebase/abt/package-info.java
+++ b/firebase-abt/src/main/java/com/google/firebase/abt/package-info.java
@@ -1,4 +1,22 @@
+<<<<<<< Updated upstream
 /**
  * @hide
  */
+=======
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @hide */
+>>>>>>> Stashed changes
 package com.google.firebase.abt;

--- a/firebase-abt/src/main/java/com/google/firebase/abt/package-info.java
+++ b/firebase-abt/src/main/java/com/google/firebase/abt/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * @hide
+ */
+package com.google.firebase.abt;

--- a/firebase-abt/src/main/java/com/google/firebase/abt/package-info.java
+++ b/firebase-abt/src/main/java/com/google/firebase/abt/package-info.java
@@ -1,8 +1,3 @@
-<<<<<<< Updated upstream
-/**
- * @hide
- */
-=======
 // Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,5 +13,4 @@
 // limitations under the License.
 
 /** @hide */
->>>>>>> Stashed changes
 package com.google.firebase.abt;

--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Unreleased
+# 18.0.1
+- [changed] The SDK now reports the correct version number (via
+  `FirebaseDatabase.getSdkVersion()`).
+
+# 17.0.0
 - [changed] Added `@RestrictTo` annotations to discourage the use of APIs that
   are not public. This affects internal APIs that were previously obfuscated
   and are not mentioned in our documentation.

--- a/firebase-database/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -38,7 +38,7 @@ import com.google.firebase.database.core.utilities.Validation;
 @PublicApi
 public class FirebaseDatabase {
 
-  private static final String SDK_VERSION = "3.0.0";
+  private static final String SDK_VERSION = BuildConfig.VERSION_NAME;
 
   private final FirebaseApp app;
   private final RepoInfo repoInfo;

--- a/firebase-functions/src/main/java/com/google/firebase/functions/HttpsCallOptions.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/HttpsCallOptions.java
@@ -50,6 +50,10 @@ class HttpsCallOptions {
 
   /** Creates a new OkHttpClient with these options applied to it. */
   OkHttpClient apply(OkHttpClient client) {
-    return client.newBuilder().callTimeout(timeout, timeoutUnits).build();
+    return client
+        .newBuilder()
+        .callTimeout(timeout, timeoutUnits)
+        .readTimeout(timeout, timeoutUnits)
+        .build();
   }
 }


### PR DESCRIPTION
A/B Testing doesn't have user visible classes, so they should be  annotated with javadoc's @hide.