### PR TITLE
Index-Free (4/6): Filter document queries by read time

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexedQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexedQueryEngine.java
@@ -29,6 +29,7 @@ import com.google.firebase.firestore.model.DocumentCollections;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.model.MaybeDocument;
+import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firebase.firestore.model.value.ArrayValue;
 import com.google.firebase.firestore.model.value.BooleanValue;
 import com.google.firebase.firestore.model.value.DoubleValue;
@@ -99,7 +100,7 @@ public class IndexedQueryEngine implements QueryEngine {
   @Override
   public ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(Query query) {
     return query.isDocumentQuery()
-        ? localDocuments.getDocumentsMatchingQuery(query)
+        ? localDocuments.getDocumentsMatchingQuery(query, SnapshotVersion.NONE)
         : performCollectionQuery(query);
   }
 
@@ -118,7 +119,7 @@ public class IndexedQueryEngine implements QueryEngine {
           "If there are any filters, we should be able to use an index.");
       // TODO: Call overlay.getCollectionDocuments(query.getPath()) and filter the
       // results (there may still be startAt/endAt bounds that apply).
-      filteredResults = localDocuments.getDocumentsMatchingQuery(query);
+      filteredResults = localDocuments.getDocumentsMatchingQuery(query, SnapshotVersion.NONE);
     }
 
     return filteredResults;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -135,18 +135,18 @@ final class LocalDocumentsView {
    * Performs a query against the local view of all documents.
    *
    * @param query The query to match documents against.
-   * @param sinceUpdateTime If not set to SnapshotVersion.MIN, return only documents that have been
-   *     modified since this snapshot version (exclusive).
+   * @param sinceReadTime If not set to SnapshotVersion.MIN, return only documents that have been
+   *     read since this snapshot version (exclusive).
    */
   ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(
-      Query query, SnapshotVersion sinceUpdateTime) {
+      Query query, SnapshotVersion sinceReadTime) {
     ResourcePath path = query.getPath();
     if (query.isDocumentQuery()) {
       return getDocumentsMatchingDocumentQuery(path);
     } else if (query.isCollectionGroupQuery()) {
-      return getDocumentsMatchingCollectionGroupQuery(query, sinceUpdateTime);
+      return getDocumentsMatchingCollectionGroupQuery(query, sinceReadTime);
     } else {
-      return getDocumentsMatchingCollectionQuery(query, sinceUpdateTime);
+      return getDocumentsMatchingCollectionQuery(query, sinceReadTime);
     }
   }
 
@@ -163,7 +163,7 @@ final class LocalDocumentsView {
   }
 
   private ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingCollectionGroupQuery(
-      Query query, SnapshotVersion sinceUpdateTime) {
+      Query query, SnapshotVersion sinceReadTime) {
     hardAssert(
         query.getPath().isEmpty(),
         "Currently we only support collection group queries at the root.");
@@ -176,7 +176,7 @@ final class LocalDocumentsView {
     for (ResourcePath parent : parents) {
       Query collectionQuery = query.asCollectionQueryAtPath(parent.append(collectionId));
       ImmutableSortedMap<DocumentKey, Document> collectionResults =
-          getDocumentsMatchingCollectionQuery(collectionQuery, sinceUpdateTime);
+          getDocumentsMatchingCollectionQuery(collectionQuery, sinceReadTime);
       for (Map.Entry<DocumentKey, Document> docEntry : collectionResults) {
         results = results.insert(docEntry.getKey(), docEntry.getValue());
       }
@@ -186,9 +186,9 @@ final class LocalDocumentsView {
 
   /** Queries the remote documents and overlays mutations. */
   private ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingCollectionQuery(
-      Query query, SnapshotVersion sinceUpdateTime) {
+      Query query, SnapshotVersion sinceReadTime) {
     ImmutableSortedMap<DocumentKey, Document> results =
-        remoteDocumentCache.getAllDocumentsMatchingQuery(query, sinceUpdateTime);
+        remoteDocumentCache.getAllDocumentsMatchingQuery(query, sinceReadTime);
 
     List<MutationBatch> matchingBatches = mutationQueue.getAllMutationBatchesAffectingQuery(query);
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -82,7 +82,8 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
   }
 
   @Override
-  public ImmutableSortedMap<DocumentKey, Document> getAllDocumentsMatchingQuery(Query query) {
+  public ImmutableSortedMap<DocumentKey, Document> getAllDocumentsMatchingQuery(
+      Query query, SnapshotVersion sinceUpdateTime) {
     hardAssert(
         !query.isCollectionGroupQuery(),
         "CollectionGroup queries should be handled in LocalDocumentsView");
@@ -109,6 +110,11 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
 
       MaybeDocument maybeDoc = entry.getValue().first;
       if (!(maybeDoc instanceof Document)) {
+        continue;
+      }
+
+      SnapshotVersion readTime = entry.getValue().second;
+      if (readTime.compareTo(sinceUpdateTime) <= 0) {
         continue;
       }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
@@ -75,10 +75,10 @@ interface RemoteDocumentCache {
    * <p>Cached NoDocument entries have no bearing on query results.
    *
    * @param query The query to match documents against.
-   * @param sinceUpdateTime If not set to SnapshotVersion.MIN, return only documents that have been
-   *     modified since this snapshot version (exclusive).
+   * @param sinceReadTime If not set to SnapshotVersion.MIN, return only documents that have been
+   *     read since this snapshot version (exclusive).
    * @return The set of matching documents.
    */
   ImmutableSortedMap<DocumentKey, Document> getAllDocumentsMatchingQuery(
-      Query query, SnapshotVersion sinceUpdateTime);
+      Query query, SnapshotVersion sinceReadTime);
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
@@ -75,7 +75,10 @@ interface RemoteDocumentCache {
    * <p>Cached NoDocument entries have no bearing on query results.
    *
    * @param query The query to match documents against.
+   * @param sinceUpdateTime If not set to SnapshotVersion.MIN, return only documents that have been
+   *     modified since this snapshot version (exclusive).
    * @return The set of matching documents.
    */
-  ImmutableSortedMap<DocumentKey, Document> getAllDocumentsMatchingQuery(Query query);
+  ImmutableSortedMap<DocumentKey, Document> getAllDocumentsMatchingQuery(
+      Query query, SnapshotVersion sinceUpdateTime);
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -77,7 +77,7 @@ public final class SQLitePersistence extends Persistence {
     }
   }
 
-  private final OpenHelper opener;
+  private final SQLiteOpenHelper opener;
   private final LocalSerializer serializer;
   private final StatsCollector statsCollector;
   private final SQLiteQueryCache queryCache;
@@ -125,8 +125,19 @@ public final class SQLitePersistence extends Persistence {
       LocalSerializer serializer,
       StatsCollector statsCollector,
       LruGarbageCollector.Params params) {
-    String databaseName = databaseName(persistenceKey, databaseId);
-    this.opener = new OpenHelper(context, databaseName);
+    this(
+        serializer,
+        statsCollector,
+        params,
+        new OpenHelper(context, databaseName(persistenceKey, databaseId)));
+  }
+
+  public SQLitePersistence(
+      LocalSerializer serializer,
+      StatsCollector statsCollector,
+      LruGarbageCollector.Params params,
+      SQLiteOpenHelper openHelper) {
+    this.opener = openHelper;
     this.serializer = serializer;
     this.statsCollector = statsCollector;
     this.queryCache = new SQLiteQueryCache(this, this.serializer);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -52,6 +52,10 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
 
   @Override
   public void add(MaybeDocument maybeDocument, SnapshotVersion readTime) {
+    hardAssert(
+        !readTime.equals(SnapshotVersion.NONE),
+        "Cannot add document to the RemoteDocumentCache with a read time of zero");
+
     String path = pathForKey(maybeDocument.getKey());
     Timestamp timestamp = readTime.getTimestamp();
     MessageLite message = serializer.encodeMaybeDocument(maybeDocument);
@@ -132,7 +136,7 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
 
   @Override
   public ImmutableSortedMap<DocumentKey, Document> getAllDocumentsMatchingQuery(
-      Query query, SnapshotVersion sinceUpdateTime) {
+      Query query, SnapshotVersion sinceReadTime) {
     hardAssert(
         !query.isCollectionGroupQuery(),
         "CollectionGroup queries should be handled in LocalDocumentsView");
@@ -143,7 +147,7 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
 
     String prefixPath = EncodedPath.encode(prefix);
     String prefixSuccessorPath = EncodedPath.prefixSuccessor(prefixPath);
-    Timestamp updateTime = sinceUpdateTime.getTimestamp();
+    Timestamp updateTime = sinceReadTime.getTimestamp();
 
     BackgroundQueue backgroundQueue = new BackgroundQueue();
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -147,7 +147,7 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
 
     String prefixPath = EncodedPath.encode(prefix);
     String prefixSuccessorPath = EncodedPath.prefixSuccessor(prefixPath);
-    Timestamp updateTime = sinceReadTime.getTimestamp();
+    Timestamp readTime = sinceReadTime.getTimestamp();
 
     BackgroundQueue backgroundQueue = new BackgroundQueue();
 
@@ -163,9 +163,9 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
             .binding(
                 prefixPath,
                 prefixSuccessorPath,
-                updateTime.getSeconds(),
-                updateTime.getSeconds(),
-                updateTime.getNanoseconds())
+                readTime.getSeconds(),
+                readTime.getSeconds(),
+                readTime.getNanoseconds())
             .forEach(
                 row -> {
                   // TODO: Actually implement a single-collection query

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -46,9 +46,9 @@ class SQLiteSchema {
    * The version of the schema. Increase this by one for each migration added to runMigrations
    * below.
    *
-   * <p>TODO(index-free): The migration to schema version 9 doesn't backfill `update_time` as this
+   * <p>TODO(index-free): The migration to schema version 9 doesn't backfill `read_time` as this
    * requires rewriting the RemoteDocumentCache. For index-free queries to efficiently handle
-   * existing documents, we still need to populate update_time for all existing entries, drop the
+   * existing documents, we still need to populate read_time for all existing entries, drop the
    * RemoteDocumentCache or ask users to invoke `clearPersistence()` manually. If we decide to
    * backfill or drop the contents of the RemoteDocumentCache, we need to perform an additional
    * schema migration.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SimpleQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SimpleQueryEngine.java
@@ -19,6 +19,7 @@ import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
+import com.google.firebase.firestore.model.SnapshotVersion;
 
 /**
  * A naive implementation of QueryEngine that just loads all the documents in the queried collection
@@ -36,7 +37,7 @@ public class SimpleQueryEngine implements QueryEngine {
   public ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(Query query) {
     // TODO: Once LocalDocumentsView provides a getCollectionDocuments() method, we
     // should call that here and then filter the results.
-    return localDocumentsView.getDocumentsMatchingQuery(query);
+    return localDocumentsView.getDocumentsMatchingQuery(query, SnapshotVersion.NONE);
   }
 
   @Override

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -727,12 +727,12 @@ public abstract class LocalStoreTestCase {
     Query query = Query.atPath(ResourcePath.fromString("foo"));
     int targetId = allocateQuery(query);
     applyRemoteEvent(
-        updateRemoteEvent(doc("foo/bar", 0, map("foo", "old")), asList(targetId), emptyList()));
+        updateRemoteEvent(doc("foo/bar", 1, map("foo", "old")), asList(targetId), emptyList()));
     writeMutation(patchMutation("foo/bar", map("foo", "bar")));
     releaseQuery(query);
     writeMutation(setMutation("foo/bah", map("foo", "bah")));
     writeMutation(deleteMutation("foo/baz"));
-    assertContains(doc("foo/bar", 0, map("foo", "bar"), Document.DocumentState.LOCAL_MUTATIONS));
+    assertContains(doc("foo/bar", 1, map("foo", "bar"), Document.DocumentState.LOCAL_MUTATIONS));
     assertContains(doc("foo/bah", 0, map("foo", "bah"), Document.DocumentState.LOCAL_MUTATIONS));
     assertContains(deletedDoc("foo/baz", 0));
 
@@ -761,13 +761,13 @@ public abstract class LocalStoreTestCase {
     Query query = Query.atPath(ResourcePath.fromString("foo"));
     int targetId = allocateQuery(query);
     applyRemoteEvent(
-        updateRemoteEvent(doc("foo/bar", 0, map("foo", "old")), asList(targetId), emptyList()));
+        updateRemoteEvent(doc("foo/bar", 1, map("foo", "old")), asList(targetId), emptyList()));
     writeMutation(patchMutation("foo/bar", map("foo", "bar")));
     // Release the query so that our target count goes back to 0 and we are considered up-to-date.
     releaseQuery(query);
     writeMutation(setMutation("foo/bah", map("foo", "bah")));
     writeMutation(deleteMutation("foo/baz"));
-    assertContains(doc("foo/bar", 0, map("foo", "bar"), Document.DocumentState.LOCAL_MUTATIONS));
+    assertContains(doc("foo/bar", 1, map("foo", "bar"), Document.DocumentState.LOCAL_MUTATIONS));
     assertContains(doc("foo/bah", 0, map("foo", "bah"), Document.DocumentState.LOCAL_MUTATIONS));
     assertContains(deletedDoc("foo/baz", 0));
 


### PR DESCRIPTION
This is the fourth of six PRs for "index-free" queries.

This PR adds the ability to `getAllDocumentsMatchingQuery()` to skip documents older than a given update time. This allows us to only scan for documents that have been modified since the Query's Target Mapping has been persisted.