### PR TITLE
Ignore some proto generated files from coverage.

### DIFF
--- a/root-project.gradle
+++ b/root-project.gradle
@@ -103,7 +103,7 @@ configure(subprojects) {
     }
     task(['type': JacocoReport, 'dependsOn': 'check', 'group': 'Coverage',
           'description': 'Generates JaCoCo unit test coverage reports.'], checkCoverage) {
-        def excludes = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**Manifest*.*']
+        def excludes = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/proto/**', '**Manifest*.*']
         classDirectories = files([
             fileTree(dir: "$buildDir/intermediates/javac/release", excludes: excludes),
             fileTree(dir: "$buildDir/intermediates/javac/releaseUnitTest", excludes: excludes),


### PR DESCRIPTION
Files ignored are those class files within a "proto/" directory when generated. Generated files in other 
directories are still being counted.