### PR TITLE
Add new config file for smoke tests.

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -49,6 +49,10 @@ android {
     }
   }
 
+  if (project.hasProperty("testBuildType")) {
+    testBuildType project.getProperty("testBuildType")
+  }
+
   flavorDimensions "systemUnderTest"
 
   // TODO(allisonbm92): Switch to the default flavor.

--- a/smoke-tests/runner.config
+++ b/smoke-tests/runner.config
@@ -1,0 +1,82 @@
+core {
+  # gcloud
+  ## This option is the path to the Gcloud executable. It may be relative or
+  ## absolute. This is optional, because the default is `/usr/bin/gcloud`.
+
+  # gradle
+  ## This option is the path to the Gradle executable. It may be relative or
+  ## absolute. This is optional, because the default is `gradlew`.
+
+  # loggingDir
+  ## This option is the path to the directory to be used for logging. All logs
+  ## from the test runner and its sub-processes will be placed in this
+  ## directory. It is optional, and is configured by the `ARTIFACTS` environment
+  ## variable by default.
+}
+
+firebase {
+  # buildTask
+  ## This option specifies the Gradle task to execute to build Firebase
+  ## libraries. It is mandatory.
+  buildTask assembleAllForSmokeTests
+
+  # localMavenRepo
+  ## This option specifies the path to a local Maven repository. This repository
+  ## should contain the Firebase artifacts constructed by the build task. It is
+  ## mandatory.
+  localMavenRepo build/m2repository
+
+  # latestBillOfMaterials
+  ## This option specifies the Bill of Materials for the latest release. This is
+  ## given as a Maven id. The tests will use this information to build a test
+  ## matrix. This is mandatory.
+  latestBillOfMaterials com.google.firebase:firebase-bom:20.1.0
+
+  # project
+  ## This option specifies the path to the main Firebase project. This is
+  ## optional and defaults to the current directory.
+}
+
+smokeTest {
+  # flavors
+  ## This option specifies the Android flavors of the test to build for testing.
+  ## It may be omitted if there are no flavors.
+  flavors combined
+
+  # googleServices
+  ## This option is the path to the Google Services file. If provided, the
+  ## runner will make this available to the build. This file must be
+  ## manually placed in the smoke tests' project directory if this option
+  ## is unspecified.
+  googleServices /smoke-tests-google-services/google-services.json
+
+  # project
+  ## This option specifies the path to the smoke tests' project. It may be
+  ## relative or absolute. It is mandatory.
+  project smoke-tests
+
+  # variants
+  ## This option specifies the Android build variants to build for testing. It
+  ## is mandatory, and there must be at least one build variant.
+  variants debug, release
+}
+
+testLab {
+  # artifactsBucket
+  ## This option specifies the target GCS bucket for uploading test lab logs.
+  ## These logs are not written to core.loggingDir. This is optional, and the
+  ## public, test lab bucket will be used if nothing is provided. Note, the
+  ## artifactsDir option must also be specified for this to take effect.
+  artifactsBucket android-ci
+
+  # artifactsDir
+  ## This option specifies the directory to use within the bucket specified by
+  ## the artifactsBucket option. It is constructed by default using environment
+  ## variables.
+
+  # credentials
+  ## This option is the path to a Google credentials file. It is optional. If
+  ## provided, the runner will authenticate to Google Cloud before running any
+  ## tests on Firebase Test Lab. The default configuration is determined by the
+  ## `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+}


### PR DESCRIPTION
This change adds the new configuration, which will soon be used by the
runner. This imcreases flexibility by allowing GitHub changes to
immediately affect how the runner operates on CI.

Additionally, this change tweaks the build file to allow testing against
release builds. This will be live once the new runner is deployed.