### PR TITLE
javadoc fixups

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -277,7 +277,7 @@ public class ValidationTest {
   @Test
   public void batchWritesRequireCorrectDocumentReferences() {
     DocumentReference badRef = testAlternateFirestore().document("foo/bar");
-    String reason = "Provided document reference is from a different Firestore instance.";
+    String reason = "Provided document reference is from a different Cloud Firestore instance.";
     Map<String, Object> data = map("foo", 1);
     WriteBatch batch = testFirestore().batch();
     expectError(() -> batch.set(badRef, data), reason);
@@ -288,7 +288,7 @@ public class ValidationTest {
   @Test
   public void transactionsRequireCorrectDocumentReferences() {
     DocumentReference badRef = testAlternateFirestore().document("foo/bar");
-    String reason = "Provided document reference is from a different Firestore instance.";
+    String reason = "Provided document reference is from a different Cloud Firestore instance.";
     Map<String, Object> data = map("foo", 1);
     waitFor(
         testFirestore()

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Blob.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Blob.java
@@ -23,7 +23,7 @@ import com.google.firebase.annotations.PublicApi;
 import com.google.firebase.firestore.util.Util;
 import com.google.protobuf.ByteString;
 
-/** Immutable class representing an array of bytes in Firestore. */
+/** Immutable class representing an array of bytes in Cloud Firestore. */
 @PublicApi
 public class Blob implements Comparable<Blob> {
   private final ByteString bytes;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Blob.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Blob.java
@@ -33,10 +33,11 @@ public class Blob implements Comparable<Blob> {
   }
 
   /**
-   * Creates a new Blob instance from the provided bytes. Will make a copy of the bytes passed in.
+   * Creates a new {@code Blob} instance from the provided bytes. Will make a copy of the bytes
+   * passed in.
    *
-   * @param bytes The bytes to use for this Blob instance.
-   * @return The new Blob instance
+   * @param bytes The bytes to use for this {@code Blob} instance.
+   * @return The new {@code Blob} instance
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
@@ -26,8 +26,8 @@ import com.google.firebase.firestore.util.Util;
 import javax.annotation.Nullable;
 
 /**
- * A CollectionReference can be used for adding documents, getting document references, and querying
- * for documents (using the methods inherited from Query).
+ * A {@code CollectionReference} can be used for adding documents, getting document references, and
+ * querying for documents (using the methods inherited from {@link Query}).
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
@@ -56,10 +56,10 @@ public class CollectionReference extends Query {
   }
 
   /**
-   * Gets a DocumentReference to the document that contains this collection. Only subcollections are
-   * contained in a document. For root collections, returns null.
+   * Gets a {@link DocumentReference} to the document that contains this collection. Only
+   * subcollections are contained in a document. For root collections, returns null.
    *
-   * @return The DocumentReference that contains this collection or null if this is a root
+   * @return The {@link DocumentReference} that contains this collection or null if this is a root
    *     collection.
    */
   @Nullable
@@ -86,10 +86,10 @@ public class CollectionReference extends Query {
   }
 
   /**
-   * Returns a DocumentReference pointing to a new document with an auto-generated ID within this
-   * collection.
+   * Returns a {@link DocumentReference} pointing to a new document with an auto-generated ID within
+   * this collection.
    *
-   * @return A DocumentReference pointing to a new document with an auto-generated ID.
+   * @return A {@link DocumentReference} pointing to a new document with an auto-generated ID.
    */
   @NonNull
   @PublicApi
@@ -98,11 +98,11 @@ public class CollectionReference extends Query {
   }
 
   /**
-   * Gets a DocumentReference instance that refers to the document at the specified path within this
-   * collection.
+   * Gets a {@link DocumentReference} instance that refers to the document at the specified path
+   * within this collection.
    *
    * @param documentPath A slash-separated relative path to a document.
-   * @return The DocumentReference instance.
+   * @return The {@link DocumentReference} instance.
    */
   @NonNull
   @PublicApi
@@ -118,7 +118,8 @@ public class CollectionReference extends Query {
    *
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
-   * @return A Task that will be resolved with the DocumentReference of the newly created document.
+   * @return A Task that will be resolved with the {@link DocumentReference} of the newly created
+   *     document.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
@@ -59,8 +59,8 @@ public class CollectionReference extends Query {
    * Gets a {@code DocumentReference} to the document that contains this collection. Only
    * subcollections are contained in a document. For root collections, returns {@code null}.
    *
-   * @return The {@code DocumentReference} that contains this collection or {@code null} if this is a root
-   *     collection.
+   * @return The {@code DocumentReference} that contains this collection or {@code null} if this is
+   *     a root collection.
    */
   @Nullable
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
@@ -57,9 +57,9 @@ public class CollectionReference extends Query {
 
   /**
    * Gets a {@code DocumentReference} to the document that contains this collection. Only
-   * subcollections are contained in a document. For root collections, returns null.
+   * subcollections are contained in a document. For root collections, returns {@code null}.
    *
-   * @return The {@code DocumentReference} that contains this collection or null if this is a root
+   * @return The {@code DocumentReference} that contains this collection or {@code null} if this is a root
    *     collection.
    */
   @Nullable

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 
 /**
  * A {@code CollectionReference} can be used for adding documents, getting document references, and
- * querying for documents (using the methods inherited from {@link Query}).
+ * querying for documents (using the methods inherited from {@code Query}).
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
@@ -56,10 +56,10 @@ public class CollectionReference extends Query {
   }
 
   /**
-   * Gets a {@link DocumentReference} to the document that contains this collection. Only
+   * Gets a {@code DocumentReference} to the document that contains this collection. Only
    * subcollections are contained in a document. For root collections, returns null.
    *
-   * @return The {@link DocumentReference} that contains this collection or null if this is a root
+   * @return The {@code DocumentReference} that contains this collection or null if this is a root
    *     collection.
    */
   @Nullable
@@ -86,10 +86,10 @@ public class CollectionReference extends Query {
   }
 
   /**
-   * Returns a {@link DocumentReference} pointing to a new document with an auto-generated ID within
+   * Returns a {@code DocumentReference} pointing to a new document with an auto-generated ID within
    * this collection.
    *
-   * @return A {@link DocumentReference} pointing to a new document with an auto-generated ID.
+   * @return A {@code DocumentReference} pointing to a new document with an auto-generated ID.
    */
   @NonNull
   @PublicApi
@@ -98,11 +98,11 @@ public class CollectionReference extends Query {
   }
 
   /**
-   * Gets a {@link DocumentReference} instance that refers to the document at the specified path
+   * Gets a {@code DocumentReference} instance that refers to the document at the specified path
    * within this collection.
    *
    * @param documentPath A slash-separated relative path to a document.
-   * @return The {@link DocumentReference} instance.
+   * @return The {@code DocumentReference} instance.
    */
   @NonNull
   @PublicApi
@@ -118,7 +118,7 @@ public class CollectionReference extends Query {
    *
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
-   * @return A Task that will be resolved with the {@link DocumentReference} of the newly created
+   * @return A Task that will be resolved with the {@code DocumentReference} of the newly created
    *     document.
    */
   @NonNull

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/CollectionReference.java
@@ -29,9 +29,9 @@ import javax.annotation.Nullable;
  * A CollectionReference can be used for adding documents, getting document references, and querying
  * for documents (using the methods inherited from Query).
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class CollectionReference extends Query {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
@@ -31,9 +31,9 @@ import javax.annotation.Nullable;
  * A DocumentChange represents a change to the documents matching a query. It contains the document
  * affected and a the type of change that occurred (added, modified, or removed).
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class DocumentChange {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
@@ -112,8 +112,8 @@ public class DocumentChange {
 
   /**
    * The index of the changed document in the result set immediately prior to this {@code
-   * DocumentChange} (assuming that all prior {@code DocumentChange} objects have been
-   * applied). Returns -1 for 'added' events.
+   * DocumentChange} (assuming that all prior {@code DocumentChange} objects have been applied).
+   * Returns -1 for 'added' events.
    */
   @PublicApi
   public int getOldIndex() {
@@ -122,8 +122,8 @@ public class DocumentChange {
 
   /**
    * The index of the changed document in the result set immediately after this {@code
-   * DocumentChange} (assuming that all prior {@code DocumentChange} objects and the current
-   * {@code DocumentChange} object have been applied). Returns -1 for 'removed' events.
+   * DocumentChange} (assuming that all prior {@code DocumentChange} objects and the current {@code
+   * DocumentChange} object have been applied). Returns -1 for 'removed' events.
    */
   @PublicApi
   public int getNewIndex() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
@@ -112,7 +112,7 @@ public class DocumentChange {
 
   /**
    * The index of the changed document in the result set immediately prior to this {@code
-   * DocumentChange} (i.e. supposing that all prior {@code DocumentChange} objects have been
+   * DocumentChange} (assuming that all prior {@code DocumentChange} objects have been
    * applied). Returns -1 for 'added' events.
    */
   @PublicApi
@@ -122,7 +122,7 @@ public class DocumentChange {
 
   /**
    * The index of the changed document in the result set immediately after this {@code
-   * DocumentChange} (i.e. supposing that all prior {@code DocumentChange} objects and the current
+   * DocumentChange} (assuming that all prior {@code DocumentChange} objects and the current
    * {@code DocumentChange} object have been applied). Returns -1 for 'removed' events.
    */
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
@@ -130,7 +130,7 @@ public class DocumentChange {
     return newIndex;
   }
 
-  /** Creates the list of {@code DocumentChange}s from a {@link ViewSnapshot}. */
+  /** Creates the list of {@code DocumentChange}s from a {@code ViewSnapshot}. */
   static List<DocumentChange> changesFromSnapshot(
       FirebaseFirestore firestore, MetadataChanges metadataChanges, ViewSnapshot snapshot) {
     List<DocumentChange> documentChanges = new ArrayList<>();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
@@ -28,8 +28,8 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * A DocumentChange represents a change to the documents matching a query. It contains the document
- * affected and a the type of change that occurred (added, modified, or removed).
+ * A {@code DocumentChange} represents a change to the documents matching a query. It contains the
+ * document affected and a the type of change that occurred (added, modified, or removed).
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
@@ -97,11 +97,12 @@ public class DocumentChange {
   }
 
   /**
-   * Returns the newly added or modified document if this DocumentChange is for an updated document.
-   * Returns the deleted document if this document change represents a removal.
+   * Returns the newly added or modified document if this {@code DocumentChange} is for an updated
+   * document.  Returns the deleted document if this document change represents a removal.
    *
-   * @return A snapshot of the new data (for Type.ADDED or Type.MODIFIED) or the removed data (for
-   *     Type.REMOVED).
+   * @return A snapshot of the new data (for {@link DocumentChange.Type#ADDED} or
+   *     {@link DocumentChange.Type#MODIFIED}) or the removed data (for
+   *     {@link DocumentChange.Type.REMOVED}).
    */
   @NonNull
   @PublicApi
@@ -110,9 +111,9 @@ public class DocumentChange {
   }
 
   /**
-   * The index of the changed document in the result set immediately prior to this DocumentChange
-   * (i.e. supposing that all prior DocumentChange objects have been applied). Returns -1 for
-   * 'added' events.
+   * The index of the changed document in the result set immediately prior to this
+   * {@code DocumentChange} (i.e. supposing that all prior {@code DocumentChange} objects have been
+   * applied). Returns -1 for 'added' events.
    */
   @PublicApi
   public int getOldIndex() {
@@ -120,16 +121,16 @@ public class DocumentChange {
   }
 
   /**
-   * The index of the changed document in the result set immediately after this DocumentChange (i.e.
-   * supposing that all prior DocumentChange objects and the current DocumentChange object have been
-   * applied). Returns -1 for 'removed' events.
+   * The index of the changed document in the result set immediately after this {@code
+   * DocumentChange} (i.e. supposing that all prior {@code DocumentChange} objects and the current
+   * {@code DocumentChange} object have been applied). Returns -1 for 'removed' events.
    */
   @PublicApi
   public int getNewIndex() {
     return newIndex;
   }
 
-  /** Creates the list of DocumentChanges from a ViewSnapshot. */
+  /** Creates the list of {@code DocumentChange}s from a {@link ViewSnapshot}. */
   static List<DocumentChange> changesFromSnapshot(
       FirebaseFirestore firestore, MetadataChanges metadataChanges, ViewSnapshot snapshot) {
     List<DocumentChange> documentChanges = new ArrayList<>();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
@@ -130,7 +130,7 @@ public class DocumentChange {
     return newIndex;
   }
 
-  /** Creates the list of {@code DocumentChange}s from a {@code ViewSnapshot}. */
+  /** Creates the list of document changes from a {@code ViewSnapshot}. */
   static List<DocumentChange> changesFromSnapshot(
       FirebaseFirestore firestore, MetadataChanges metadataChanges, ViewSnapshot snapshot) {
     List<DocumentChange> documentChanges = new ArrayList<>();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentChange.java
@@ -98,11 +98,11 @@ public class DocumentChange {
 
   /**
    * Returns the newly added or modified document if this {@code DocumentChange} is for an updated
-   * document.  Returns the deleted document if this document change represents a removal.
+   * document. Returns the deleted document if this document change represents a removal.
    *
-   * @return A snapshot of the new data (for {@link DocumentChange.Type#ADDED} or
-   *     {@link DocumentChange.Type#MODIFIED}) or the removed data (for
-   *     {@link DocumentChange.Type.REMOVED}).
+   * @return A snapshot of the new data (for {@link DocumentChange.Type#ADDED} or {@link
+   *     DocumentChange.Type#MODIFIED}) or the removed data (for {@link
+   *     DocumentChange.Type.REMOVED}).
    */
   @NonNull
   @PublicApi
@@ -111,8 +111,8 @@ public class DocumentChange {
   }
 
   /**
-   * The index of the changed document in the result set immediately prior to this
-   * {@code DocumentChange} (i.e. supposing that all prior {@code DocumentChange} objects have been
+   * The index of the changed document in the result set immediately prior to this {@code
+   * DocumentChange} (i.e. supposing that all prior {@code DocumentChange} objects have been
    * applied). Returns -1 for 'added' events.
    */
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentId.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentId.java
@@ -32,16 +32,16 @@ import java.lang.annotation.Target;
  *   <li>This annotation is applied to a property that is not writable (for example, a Java Bean
  *       getter without a backing field).
  *   <li>This annotation is applied to a property with a name that conflicts with a read document
- *       field. For example, if a POJO has a field `firstName` annotated by @DocumentId, and there
- *       is a property from the document named `firstName` as well, an exception is thrown when you
- *       try to read the document into the POJO via {@link DocumentSnapshot#toObject} or {@link
- *       DocumentReference#get}.
+ *       field. For example, if a POJO has a field `firstName` annotated by {@code @DocumentId}, and
+ *       there is a property from the document named `firstName` as well, an exception is thrown
+ *       when you try to read the document into the POJO via {@link DocumentSnapshot#toObject} or
+ *       {@link DocumentReference#get}.
  *   <li>
  * </ul>
  *
  * <p>When using a POJO to write to a document (via {@link DocumentReference#set} or @{@link
- * WriteBatch#set}), the property annotated by @DocumentId is ignored, which allows writing the POJO
- * back to any document, even if it's not the origin of the POJO.
+ * WriteBatch#set}), the property annotated by {@code @DocumentId} is ignored, which allows writing
+ * the POJO back to any document, even if it's not the origin of the POJO.
  */
 @PublicApi
 @Retention(RetentionPolicy.RUNTIME)

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -481,7 +481,7 @@ public class DocumentReference {
   /**
    * Internal helper method to create add a snapshot listener.
    *
-   * <p>Will be Activity scoped if the activity parameter is non-null.
+   * <p>Will be Activity scoped if the activity parameter is non-{@code null}.
    *
    * @param userExecutor The executor to use to call the listener.
    * @param options The options to use for this listen.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -263,8 +263,8 @@ public class DocumentReference {
   /**
    * Reads the document referenced by this {@code DocumentReference}.
    *
-   * @return A Task that will be resolved with the contents of the Document at this
-   *     {@code DocumentReference}.
+   * @return A Task that will be resolved with the contents of the Document at this {@code
+   *     DocumentReference}.
    */
   @NonNull
   @PublicApi
@@ -280,8 +280,8 @@ public class DocumentReference {
    * cannot be reached. This behavior can be altered via the {@link Source} parameter.
    *
    * @param source A value to configure the get behavior.
-   * @return A Task that will be resolved with the contents of the Document at this
-   *     {@code DocumentReference}.
+   * @return A Task that will be resolved with the contents of the Document at this {@code
+   *     DocumentReference}.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -48,10 +48,10 @@ import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 /**
- * A DocumentReference refers to a document location in a Cloud Firestore database and can be used
- * to write, read, or listen to the location. There may or may not exist a document at the
- * referenced location. A DocumentReference can also be used to create a CollectionReference to a
- * subcollection.
+ * A {@code DocumentReference} refers to a document location in a Cloud Firestore database and can
+ * be used to write, read, or listen to the location. There may or may not exist a document at the
+ * referenced location. A {@code DocumentReference} can also be used to create a {@link
+ * CollectionReference} to a subcollection.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
@@ -103,9 +103,9 @@ public class DocumentReference {
   }
 
   /**
-   * Gets a CollectionReference to the collection that contains this document.
+   * Gets a {@link CollectionReference} to the collection that contains this document.
    *
-   * @return The CollectionReference that contains this document.
+   * @return The {@link CollectionReference} that contains this document.
    */
   @NonNull
   @PublicApi
@@ -126,11 +126,11 @@ public class DocumentReference {
   }
 
   /**
-   * Gets a CollectionReference instance that refers to the subcollection at the specified path
-   * relative to this document.
+   * Gets a {@link CollectionReference} instance that refers to the subcollection at the specified
+   * path relative to this document.
    *
    * @param collectionPath A slash-separated relative path to a subcollection.
-   * @return The CollectionReference instance.
+   * @return The {@link CollectionReference} instance.
    */
   @NonNull
   @PublicApi
@@ -141,8 +141,8 @@ public class DocumentReference {
   }
 
   /**
-   * Overwrites the document referred to by this DocumentReference. If the document does not yet
-   * exist, it will be created. If a document already exists, it will be overwritten.
+   * Overwrites the document referred to by this {@code DocumentReference}. If the document does not
+   * yet exist, it will be created. If a document already exists, it will be overwritten.
    *
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
@@ -155,9 +155,9 @@ public class DocumentReference {
   }
 
   /**
-   * Writes to the document referred to by this DocumentReference. If the document does not yet
-   * exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged into
-   * an existing document.
+   * Writes to the document referred to by this {@code DocumentReference}. If the document does not
+   * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
+   * into an existing document.
    *
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
@@ -180,8 +180,8 @@ public class DocumentReference {
   }
 
   /**
-   * Updates fields in the document referred to by this DocumentReference. If no document exists
-   * yet, the update will fail.
+   * Updates fields in the document referred to by this {@code DocumentReference}. If no document
+   * exists yet, the update will fail.
    *
    * @param data A map of field / value pairs to update. Fields can contain dots to reference nested
    *     fields within the document.
@@ -195,8 +195,8 @@ public class DocumentReference {
   }
 
   /**
-   * Updates fields in the document referred to by this DocumentReference. If no document exists
-   * yet, the update will fail.
+   * Updates fields in the document referred to by this {@code DocumentReference}. If no document
+   * exists yet, the update will fail.
    *
    * @param field The first field to update. Fields can contain dots to reference a nested field
    *     within the document.
@@ -218,8 +218,8 @@ public class DocumentReference {
   }
 
   /**
-   * Updates fields in the document referred to by this DocumentReference. If no document exists
-   * yet, the update will fail.
+   * Updates fields in the document referred to by this {@code DocumentReference}. If no document
+   * exists yet, the update will fail.
    *
    * @param fieldPath The first field to update.
    * @param value The first value
@@ -247,7 +247,7 @@ public class DocumentReference {
   }
 
   /**
-   * Deletes the document referred to by this DocumentReference.
+   * Deletes the document referred to by this {@code DocumentReference}.
    *
    * @return A Task that will be resolved when the delete completes.
    */
@@ -261,10 +261,10 @@ public class DocumentReference {
   }
 
   /**
-   * Reads the document referenced by this DocumentReference.
+   * Reads the document referenced by this {@code DocumentReference}.
    *
    * @return A Task that will be resolved with the contents of the Document at this
-   *     DocumentReference.
+   *     {@code DocumentReference}.
    */
   @NonNull
   @PublicApi
@@ -273,7 +273,7 @@ public class DocumentReference {
   }
 
   /**
-   * Reads the document referenced by this DocumentReference.
+   * Reads the document referenced by this {@code DocumentReference}.
    *
    * <p>By default, {@code get()} attempts to provide up-to-date data when possible by waiting for
    * data from the server, but it may return cached data or fail if you are offline and the server
@@ -281,7 +281,7 @@ public class DocumentReference {
    *
    * @param source A value to configure the get behavior.
    * @return A Task that will be resolved with the contents of the Document at this
-   *     DocumentReference.
+   *     {@code DocumentReference}.
    */
   @NonNull
   @PublicApi
@@ -372,7 +372,7 @@ public class DocumentReference {
   }
 
   /**
-   * Starts listening to the document referenced by this DocumentReference.
+   * Starts listening to the document referenced by this {@code DocumentReference}.
    *
    * @param listener The event listener that will be called with the snapshots.
    * @return A registration object that can be used to remove the listener.
@@ -385,7 +385,7 @@ public class DocumentReference {
   }
 
   /**
-   * Starts listening to the document referenced by this DocumentReference.
+   * Starts listening to the document referenced by this {@code DocumentReference}.
    *
    * @param executor The executor to use to call the listener.
    * @param listener The event listener that will be called with the snapshots.
@@ -399,8 +399,8 @@ public class DocumentReference {
   }
 
   /**
-   * Starts listening to the document referenced by this DocumentReference using an Activity-scoped
-   * listener.
+   * Starts listening to the document referenced by this {@code DocumentReference} using an
+   * Activity-scoped listener.
    *
    * <p>The listener will be automatically removed during {@link Activity#onStop}.
    *
@@ -416,7 +416,8 @@ public class DocumentReference {
   }
 
   /**
-   * Starts listening to the document referenced by this DocumentReference with the given options.
+   * Starts listening to the document referenced by this {@code DocumentReference} with the given
+   * options.
    *
    * @param metadataChanges Indicates whether metadata-only changes (i.e. only {@code
    *     DocumentSnapshot.getMetadata()} changed) should trigger snapshot events.
@@ -431,7 +432,8 @@ public class DocumentReference {
   }
 
   /**
-   * Starts listening to the document referenced by this DocumentReference with the given options.
+   * Starts listening to the document referenced by this {@code DocumentReference} with the given
+   * options.
    *
    * @param executor The executor to use to call the listener.
    * @param metadataChanges Indicates whether metadata-only changes (i.e. only {@code
@@ -452,8 +454,8 @@ public class DocumentReference {
   }
 
   /**
-   * Starts listening to the document referenced by this DocumentReference with the given options
-   * using an Activity-scoped listener.
+   * Starts listening to the document referenced by this {@code DocumentReference} with the given
+   * options using an Activity-scoped listener.
    *
    * <p>The listener will be automatically removed during {@link Activity#onStop}.
    *

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -103,9 +103,9 @@ public class DocumentReference {
   }
 
   /**
-   * Gets a {@link CollectionReference} to the collection that contains this document.
+   * Gets a {@code CollectionReference} to the collection that contains this document.
    *
-   * @return The {@link CollectionReference} that contains this document.
+   * @return The {@code CollectionReference} that contains this document.
    */
   @NonNull
   @PublicApi
@@ -126,11 +126,11 @@ public class DocumentReference {
   }
 
   /**
-   * Gets a {@link CollectionReference} instance that refers to the subcollection at the specified
+   * Gets a {@code CollectionReference} instance that refers to the subcollection at the specified
    * path relative to this document.
    *
    * @param collectionPath A slash-separated relative path to a subcollection.
-   * @return The {@link CollectionReference} instance.
+   * @return The {@code CollectionReference} instance.
    */
   @NonNull
   @PublicApi
@@ -156,7 +156,7 @@ public class DocumentReference {
 
   /**
    * Writes to the document referred to by this {@code DocumentReference}. If the document does not
-   * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
+   * yet exist, it will be created. If you pass {@code SetOptions}, the provided data can be merged
    * into an existing document.
    *
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
@@ -277,7 +277,7 @@ public class DocumentReference {
    *
    * <p>By default, {@code get()} attempts to provide up-to-date data when possible by waiting for
    * data from the server, but it may return cached data or fail if you are offline and the server
-   * cannot be reached. This behavior can be altered via the {@link Source} parameter.
+   * cannot be reached. This behavior can be altered via the {@code Source} parameter.
    *
    * @param source A value to configure the get behavior.
    * @return A Task that will be resolved with the contents of the Document at this {@code

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentReference.java
@@ -48,14 +48,14 @@ import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 /**
- * A DocumentReference refers to a document location in a Firestore database and can be used to
- * write, read, or listen to the location. There may or may not exist a document at the referenced
- * location. A DocumentReference can also be used to create a CollectionReference to a
+ * A DocumentReference refers to a document location in a Cloud Firestore database and can be used
+ * to write, read, or listen to the location. There may or may not exist a document at the
+ * referenced location. A DocumentReference can also be used to create a CollectionReference to a
  * subcollection.
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class DocumentReference {
@@ -89,7 +89,7 @@ public class DocumentReference {
     return key;
   }
 
-  /** Gets the Firestore instance associated with this document reference. */
+  /** Gets the Cloud Firestore instance associated with this document reference. */
   @NonNull
   @PublicApi
   public FirebaseFirestore getFirestore() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -150,8 +150,8 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the fields of the document as a Map or {@code null} if the document doesn't exist. Field values
-   * will be converted to their native Java representation.
+   * Returns the fields of the document as a Map or {@code null} if the document doesn't exist.
+   * Field values will be converted to their native Java representation.
    *
    * @return The fields of the document as a Map or {@code null} if the document doesn't exist.
    */
@@ -162,8 +162,8 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the fields of the document as a Map or {@code null} if the document doesn't exist. Field values
-   * will be converted to their native Java representation.
+   * Returns the fields of the document as a Map or {@code null} if the document doesn't exist.
+   * Field values will be converted to their native Java representation.
    *
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
@@ -184,11 +184,12 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the contents of the document converted to a POJO or {@code null} if the document doesn't exist.
+   * Returns the contents of the document converted to a POJO or {@code null} if the document
+   * doesn't exist.
    *
    * @param valueType The Java class to create
-   * @return The contents of the document in an object of type T or {@code null} if the document doesn't
-   *     exist.
+   * @return The contents of the document in an object of type T or {@code null} if the document
+   *     doesn't exist.
    */
   @Nullable
   @PublicApi
@@ -197,13 +198,14 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the contents of the document converted to a POJO or {@code null} if the document doesn't exist.
+   * Returns the contents of the document converted to a POJO or {@code null} if the document
+   * doesn't exist.
    *
    * @param valueType The Java class to create
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
-   * @return The contents of the document in an object of type T or {@code null} if the document doesn't
-   *     exist.
+   * @return The contents of the document in an object of type T or {@code null} if the document
+   *     doesn't exist.
    */
   @Nullable
   @PublicApi
@@ -305,8 +307,8 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document doesn't
-   * exist.
+   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document
+   * doesn't exist.
    *
    * @param field The path to the field
    * @param valueType The Java class to convert the field value to.
@@ -319,8 +321,8 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document doesn't
-   * exist.
+   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document
+   * doesn't exist.
    *
    * @param field The path to the field
    * @param valueType The Java class to convert the field value to.
@@ -338,8 +340,8 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document doesn't
-   * exist.
+   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document
+   * doesn't exist.
    *
    * @param fieldPath The path to the field
    * @param valueType The Java class to convert the field value to.
@@ -352,8 +354,8 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document doesn't
-   * exist.
+   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document
+   * doesn't exist.
    *
    * @param fieldPath The path to the field
    * @param valueType The Java class to convert the field value to.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
  * The data can be extracted with the {@link #getData()} or {@link #get()} methods.
  *
  * <p>If the {@code DocumentSnapshot} points to a non-existing document, {@link #getData()} and its
- * corresponding methods will return null. You can always explicitly check for a document's
+ * corresponding methods will return {@code null}. You can always explicitly check for a document's
  * existence by calling {@link #exists()}.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
@@ -59,7 +59,7 @@ public class DocumentSnapshot {
   @PublicApi
   public enum ServerTimestampBehavior {
     /**
-     * Return 'null' for {@link com.google.firebase.firestore.FieldValue#serverTimestamp
+     * Return {@code null} for {@link com.google.firebase.firestore.FieldValue#serverTimestamp
      * ServerTimestamps} that have not yet been set to their final value.
      */
     NONE,
@@ -97,7 +97,7 @@ public class DocumentSnapshot {
 
   private final DocumentKey key;
 
-  /** Is null if the document doesn't exist */
+  /** Is {@code null} if the document doesn't exist */
   private final @Nullable Document doc;
 
   private final SnapshotMetadata metadata;
@@ -150,10 +150,10 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the fields of the document as a Map or null if the document doesn't exist. Field values
+   * Returns the fields of the document as a Map or {@code null} if the document doesn't exist. Field values
    * will be converted to their native Java representation.
    *
-   * @return The fields of the document as a Map or null if the document doesn't exist.
+   * @return The fields of the document as a Map or {@code null} if the document doesn't exist.
    */
   @Nullable
   @PublicApi
@@ -162,12 +162,12 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the fields of the document as a Map or null if the document doesn't exist. Field values
+   * Returns the fields of the document as a Map or {@code null} if the document doesn't exist. Field values
    * will be converted to their native Java representation.
    *
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
-   * @return The fields of the document as a Map or null if the document doesn't exist.
+   * @return The fields of the document as a Map or {@code null} if the document doesn't exist.
    */
   @Nullable
   @PublicApi
@@ -184,10 +184,10 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the contents of the document converted to a POJO or null if the document doesn't exist.
+   * Returns the contents of the document converted to a POJO or {@code null} if the document doesn't exist.
    *
    * @param valueType The Java class to create
-   * @return The contents of the document in an object of type T or null if the document doesn't
+   * @return The contents of the document in an object of type T or {@code null} if the document doesn't
    *     exist.
    */
   @Nullable
@@ -197,12 +197,12 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the contents of the document converted to a POJO or null if the document doesn't exist.
+   * Returns the contents of the document converted to a POJO or {@code null} if the document doesn't exist.
    *
    * @param valueType The Java class to create
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
-   * @return The contents of the document in an object of type T or null if the document doesn't
+   * @return The contents of the document in an object of type T or {@code null} if the document doesn't
    *     exist.
    */
   @Nullable
@@ -244,10 +244,10 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field or null if the field doesn't exist.
+   * Returns the value at the field or {@code null} if the field doesn't exist.
    *
    * @param field The path to the field
-   * @return The value at the given field or null.
+   * @return The value at the given field or {@code null}.
    */
   @Nullable
   @PublicApi
@@ -256,12 +256,12 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field or null if the field doesn't exist.
+   * Returns the value at the field or {@code null} if the field doesn't exist.
    *
    * @param field The path to the field
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
-   * @return The value at the given field or null.
+   * @return The value at the given field or {@code null}.
    */
   @Nullable
   @PublicApi
@@ -271,10 +271,10 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field or null if the field or document doesn't exist.
+   * Returns the value at the field or {@code null} if the field or document doesn't exist.
    *
    * @param fieldPath The path to the field
-   * @return The value at the given field or null.
+   * @return The value at the given field or {@code null}.
    */
   @Nullable
   @PublicApi
@@ -283,12 +283,12 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field or null if the field or document doesn't exist.
+   * Returns the value at the field or {@code null} if the field or document doesn't exist.
    *
    * @param fieldPath The path to the field
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
-   * @return The value at the given field or null.
+   * @return The value at the given field or {@code null}.
    */
   @Nullable
   @PublicApi
@@ -305,12 +305,12 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
+   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document doesn't
    * exist.
    *
    * @param field The path to the field
    * @param valueType The Java class to convert the field value to.
-   * @return The value at the given field or null.
+   * @return The value at the given field or {@code null}.
    */
   @Nullable
   @PublicApi
@@ -319,14 +319,14 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
+   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document doesn't
    * exist.
    *
    * @param field The path to the field
    * @param valueType The Java class to convert the field value to.
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
-   * @return The value at the given field or null.
+   * @return The value at the given field or {@code null}.
    */
   @Nullable
   @PublicApi
@@ -338,12 +338,12 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
+   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document doesn't
    * exist.
    *
    * @param fieldPath The path to the field
    * @param valueType The Java class to convert the field value to.
-   * @return The value at the given field or null.
+   * @return The value at the given field or {@code null}.
    */
   @Nullable
   @PublicApi
@@ -352,14 +352,14 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value at the field, converted to a POJO, or null if the field or document doesn't
+   * Returns the value at the field, converted to a POJO, or {@code null} if the field or document doesn't
    * exist.
    *
    * @param fieldPath The path to the field
    * @param valueType The Java class to convert the field value to.
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
-   * @return The value at the given field or null.
+   * @return The value at the given field or {@code null}.
    */
   @Nullable
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -39,11 +39,11 @@ import javax.annotation.Nullable;
 
 /**
  * A {@code DocumentSnapshot} contains data read from a document in your Cloud Firestore database.
- * The data can be extracted with the getData() or get() methods.
+ * The data can be extracted with the {@link #getData()} or {@link #get()} methods.
  *
- * <p>If the {@code DocumentSnapshot} points to a non-existing document, getData() and its
+ * <p>If the {@code DocumentSnapshot} points to a non-existing document, {@link #getData()} and its
  * corresponding methods will return null. You can always explicitly check for a document's
- * existence by calling exists().
+ * existence by calling {@link #exists()}.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -38,16 +38,16 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * A DocumentSnapshot contains data read from a document in your Firestore database. The data can be
- * extracted with the getData() or get() methods.
+ * A DocumentSnapshot contains data read from a document in your Cloud Firestore database. The data
+ * can be extracted with the getData() or get() methods.
  *
  * <p>If the DocumentSnapshot points to a non-existing document, getData() and its corresponding
  * methods will return null. You can always explicitly check for a document's existence by calling
  * exists().
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class DocumentSnapshot {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -468,7 +468,7 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value of the field as a {@link com.google.firebase.Timestamp}.
+   * Returns the value of the field as a {@code com.google.firebase.Timestamp}.
    *
    * <p>This method ignores the global setting {@link
    * FirebaseFirestoreSettings#areTimestampsInSnapshotsEnabled}.
@@ -484,7 +484,7 @@ public class DocumentSnapshot {
   }
 
   /**
-   * Returns the value of the field as a {@link com.google.firebase.Timestamp}.
+   * Returns the value of the field as a {@code com.google.firebase.Timestamp}.
    *
    * <p>This method ignores the global setting {@link
    * FirebaseFirestoreSettings#areTimestampsInSnapshotsEnabled}.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentSnapshot.java
@@ -38,12 +38,12 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * A DocumentSnapshot contains data read from a document in your Cloud Firestore database. The data
- * can be extracted with the getData() or get() methods.
+ * A {@code DocumentSnapshot} contains data read from a document in your Cloud Firestore database.
+ * The data can be extracted with the getData() or get() methods.
  *
- * <p>If the DocumentSnapshot points to a non-existing document, getData() and its corresponding
- * methods will return null. You can always explicitly check for a document's existence by calling
- * exists().
+ * <p>If the {@code DocumentSnapshot} points to a non-existing document, getData() and its
+ * corresponding methods will return null. You can always explicitly check for a document's
+ * existence by calling exists().
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/EventListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/EventListener.java
@@ -22,8 +22,8 @@ import javax.annotation.Nullable;
 public interface EventListener<T> {
 
   /**
-   * onEvent will be called with the new value or the error if an error occurred. It's guaranteed
-   * that exactly one of value or error will be non-null.
+   * {@code onEvent} will be called with the new value or the error if an error occurred. It's
+   * guaranteed that exactly one of value or error will be non-null.
    *
    * @param value The value of the event. null if there was an error.
    * @param error The error if there was error. null otherwise.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/EventListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/EventListener.java
@@ -23,10 +23,10 @@ public interface EventListener<T> {
 
   /**
    * {@code onEvent} will be called with the new value or the error if an error occurred. It's
-   * guaranteed that exactly one of value or error will be non-null.
+   * guaranteed that exactly one of value or error will be non-{@code null}.
    *
-   * @param value The value of the event. null if there was an error.
-   * @param error The error if there was error. null otherwise.
+   * @param value The value of the event. {@code null} if there was an error.
+   * @param error The error if there was error. {@code null} otherwise.
    */
   @PublicApi
   void onEvent(@Nullable T value, @Nullable FirebaseFirestoreException error);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Exclude.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Exclude.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Marks a field as excluded from the Database. */
+/** Marks a field as excluded from the database instance. */
 @PublicApi
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldPath.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldPath.java
@@ -48,8 +48,8 @@ public final class FieldPath {
   }
 
   /**
-   * Creates a FieldPath from the provided field names. If more than one field name is provided, the
-   * path will point to a nested field in a document.
+   * Creates a {@code FieldPath} from the provided field names. If more than one field name is
+   * provided, the path will point to a nested field in a document.
    *
    * @param fieldNames A list of field names.
    * @return A {@code FieldPath} that points to a field location in a document.
@@ -71,8 +71,8 @@ public final class FieldPath {
       new FieldPath(com.google.firebase.firestore.model.FieldPath.KEY_PATH);
 
   /**
-   * Returns A special sentinel FieldPath to refer to the ID of a document. It can be used in
-   * queries to sort or filter by the document ID.
+   * Returns A special sentinel {@code FieldPath} to refer to the ID of a document. It can be used
+   * in queries to sort or filter by the document ID.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldValue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldValue.java
@@ -26,12 +26,12 @@ public abstract class FieldValue {
   FieldValue() {}
 
   /**
-   * Returns the method name (e.g. "FieldValue.delete") that was used to create this FieldValue
-   * instance, for use in error messages, etc.
+   * Returns the method name (e.g. "FieldValue.delete") that was used to create this {@code
+   * FieldValue} instance, for use in error messages, etc.
    */
   abstract String getMethodName();
 
-  /* FieldValue class for field deletes. */
+  /* {@code FieldValue} class for field deletes. */
   static class DeleteFieldValue extends FieldValue {
     @Override
     String getMethodName() {
@@ -39,7 +39,7 @@ public abstract class FieldValue {
     }
   }
 
-  /* FieldValue class for server timestamps. */
+  /* {@code FieldValue} class for server timestamps. */
   static class ServerTimestampFieldValue extends FieldValue {
     @Override
     String getMethodName() {
@@ -47,7 +47,7 @@ public abstract class FieldValue {
     }
   }
 
-  /* FieldValue class for arrayUnion() transforms. */
+  /* {@code FieldValue} class for arrayUnion() transforms. */
   static class ArrayUnionFieldValue extends FieldValue {
     private final List<Object> elements;
 
@@ -65,7 +65,7 @@ public abstract class FieldValue {
     }
   }
 
-  /* FieldValue class for arrayRemove() transforms. */
+  /* {@code FieldValue} class for arrayRemove() transforms. */
   static class ArrayRemoveFieldValue extends FieldValue {
     private final List<Object> elements;
 
@@ -83,7 +83,7 @@ public abstract class FieldValue {
     }
   }
 
-  /* FieldValue class for increment() transforms. */
+  /* {@code FieldValue} class for increment() transforms. */
   static class NumericIncrementFieldValue extends FieldValue {
     private final Number operand;
 
@@ -130,7 +130,7 @@ public abstract class FieldValue {
    * specified elements.
    *
    * @param elements The elements to union into the array.
-   * @return The FieldValue sentinel for use in a call to set() or update().
+   * @return The {@code FieldValue} sentinel for use in a call to set() or update().
    */
   @NonNull
   @PublicApi
@@ -145,7 +145,7 @@ public abstract class FieldValue {
    * already an array it will be overwritten with an empty array.
    *
    * @param elements The elements to remove from the array.
-   * @return The FieldValue sentinel for use in a call to set() or update().
+   * @return The {@code FieldValue} sentinel for use in a call to set() or update().
    */
   @NonNull
   @PublicApi
@@ -164,7 +164,7 @@ public abstract class FieldValue {
    * <p>If the current field is not an integer or double, or if the field does not yet exist, the
    * transformation will set the field to the given value.
    *
-   * @return The FieldValue sentinel for use in a call to set() or update().
+   * @return The {@code FieldValue} sentinel for use in a call to set() or update().
    */
   @NonNull
   @PublicApi
@@ -180,7 +180,7 @@ public abstract class FieldValue {
    * interpreted as doubles and all arithmetic will follow IEEE 754 semantics. Otherwise, the
    * transformation will set the field to the given value.
    *
-   * @return The FieldValue sentinel for use in a call to set() or update().
+   * @return The {@code FieldValue} sentinel for use in a call to set() or update().
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldValue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldValue.java
@@ -29,7 +29,7 @@ public abstract class FieldValue {
   FieldValue() {}
 
   /**
-   * Returns the method name (e.g. "FieldValue.delete") that was used to create this {@code
+   * Returns the method name (for example, "FieldValue.delete") that was used to create this {@code
    * FieldValue} instance, for use in error messages, etc.
    */
   abstract String getMethodName();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldValue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FieldValue.java
@@ -19,7 +19,10 @@ import com.google.firebase.annotations.PublicApi;
 import java.util.Arrays;
 import java.util.List;
 
-/** Sentinel values that can be used when writing document fields with set() or update(). */
+/**
+ * Sentinel values that can be used when writing document fields with {@code set()} or {@code
+ * update()}.
+ */
 @PublicApi
 public abstract class FieldValue {
 
@@ -47,7 +50,7 @@ public abstract class FieldValue {
     }
   }
 
-  /* {@code FieldValue} class for arrayUnion() transforms. */
+  /* {@code FieldValue} class for {@link #arrayUnion()} transforms. */
   static class ArrayUnionFieldValue extends FieldValue {
     private final List<Object> elements;
 
@@ -65,7 +68,7 @@ public abstract class FieldValue {
     }
   }
 
-  /* {@code FieldValue} class for arrayRemove() transforms. */
+  /* {@code FieldValue} class for {@link #arrayRemove()} transforms. */
   static class ArrayRemoveFieldValue extends FieldValue {
     private final List<Object> elements;
 
@@ -83,7 +86,7 @@ public abstract class FieldValue {
     }
   }
 
-  /* {@code FieldValue} class for increment() transforms. */
+  /* {@code FieldValue} class for {@link #increment()} transforms. */
   static class NumericIncrementFieldValue extends FieldValue {
     private final Number operand;
 
@@ -105,7 +108,7 @@ public abstract class FieldValue {
   private static final ServerTimestampFieldValue SERVER_TIMESTAMP_INSTANCE =
       new ServerTimestampFieldValue();
 
-  /** Returns a sentinel for use with update() to mark a field for deletion. */
+  /** Returns a sentinel for use with {@code update()} to mark a field for deletion. */
   @NonNull
   @PublicApi
   public static FieldValue delete() {
@@ -113,8 +116,8 @@ public abstract class FieldValue {
   }
 
   /**
-   * Returns a sentinel for use with set() or update() to include a server-generated timestamp in
-   * the written data.
+   * Returns a sentinel for use with {@code set()} or {@code update()} to include a server-generated
+   * timestamp in the written data.
    */
   @NonNull
   @PublicApi
@@ -123,14 +126,14 @@ public abstract class FieldValue {
   }
 
   /**
-   * Returns a special value that can be used with set() or update() that tells the server to union
-   * the given elements with any array value that already exists on the server. Each specified
-   * element that doesn't already exist in the array will be added to the end. If the field being
-   * modified is not already an array it will be overwritten with an array containing exactly the
-   * specified elements.
+   * Returns a special value that can be used with {@code set()} or {@code update()} that tells the
+   * server to union the given elements with any array value that already exists on the server. Each
+   * specified element that doesn't already exist in the array will be added to the end. If the
+   * field being modified is not already an array it will be overwritten with an array containing
+   * exactly the specified elements.
    *
    * @param elements The elements to union into the array.
-   * @return The {@code FieldValue} sentinel for use in a call to set() or update().
+   * @return The {@code FieldValue} sentinel for use in a call to {@code set()} or {@code update()}.
    */
   @NonNull
   @PublicApi
@@ -139,13 +142,13 @@ public abstract class FieldValue {
   }
 
   /**
-   * Returns a special value that can be used with set() or update() that tells the server to remove
-   * the given elements from any array value that already exists on the server. All instances of
-   * each element specified will be removed from the array. If the field being modified is not
-   * already an array it will be overwritten with an empty array.
+   * Returns a special value that can be used with {@code set()} or {@code update()} that tells the
+   * server to remove the given elements from any array value that already exists on the server. All
+   * instances of each element specified will be removed from the array. If the field being modified
+   * is not already an array it will be overwritten with an empty array.
    *
    * @param elements The elements to remove from the array.
-   * @return The {@code FieldValue} sentinel for use in a call to set() or update().
+   * @return The {@code FieldValue} sentinel for use in a call to {@code set()} or {@code update()}.
    */
   @NonNull
   @PublicApi
@@ -154,8 +157,8 @@ public abstract class FieldValue {
   }
 
   /**
-   * Returns a special value that can be used with set() or update() that tells the server to
-   * increment the field's current value by the given value.
+   * Returns a special value that can be used with {@code set()} or {@code update()} that tells the
+   * server to increment the field's current value by the given value.
    *
    * <p>If the current field value is an integer, possible integer overflows are resolved to
    * Long.MAX_VALUE or Long.MIN_VALUE. If the current field value is a double, both values will be
@@ -164,7 +167,7 @@ public abstract class FieldValue {
    * <p>If the current field is not an integer or double, or if the field does not yet exist, the
    * transformation will set the field to the given value.
    *
-   * @return The {@code FieldValue} sentinel for use in a call to set() or update().
+   * @return The {@code FieldValue} sentinel for use in a call to {@code set()} or {@code update()}.
    */
   @NonNull
   @PublicApi
@@ -173,14 +176,14 @@ public abstract class FieldValue {
   }
 
   /**
-   * Returns a special value that can be used with set() or update() that tells the server to
-   * increment the field's current value by the given value.
+   * Returns a special value that can be used with {@code set()} or {@code update()} that tells the
+   * server to increment the field's current value by the given value.
    *
    * <p>If the current value is an integer or a double, both the current and the given value will be
    * interpreted as doubles and all arithmetic will follow IEEE 754 semantics. Otherwise, the
    * transformation will set the field to the given value.
    *
-   * @return The {@code FieldValue} sentinel for use in a call to set() or update().
+   * @return The {@code FieldValue} sentinel for use in a call to {@code set()} or {@code update()}.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -366,7 +366,7 @@ public class FirebaseFirestore {
    * combination with {@link #clearPersistence} to ensure that all local state is destroyed between
    * test runs.
    *
-   * @return A <code>Task</code> that is resolved when the instance has been successfully shut down.
+   * @return A {@code Task} that is resolved when the instance has been successfully shut down.
    */
   @VisibleForTesting
   // TODO(b/135755126): Make this public and remove @VisibleForTesting
@@ -420,8 +420,8 @@ public class FirebaseFirestore {
    * <p>Must be called while the {@code FirebaseFirestore} instance is not started (after the app is
    * shutdown or when the app is first initialized). On startup, this method must be called before
    * other methods (other than {@link #setFirestoreSettings()}). If the {@code FirebaseFirestore}
-   * instance is still running, the <code>Task</code> will fail with an error code of <code>
-   *  FAILED_PRECONDITION</code>.
+   * instance is still running, the {@code Task} will fail with an error code of {@code
+   * FAILED_PRECONDITION}.
    *
    * <p>Note: {@code clearPersistence()} is primarily intended to help write reliable tests that use
    * Cloud Firestore. It uses an efficient mechanism for dropping existing data but does not attempt
@@ -429,8 +429,8 @@ public class FirebaseFirestore {
    * sensitive to the disclosure of cached data in between user sessions, we strongly recommend not
    * enabling persistence at all.
    *
-   * @return A <code>Task</code> that is resolved when the persistent storage is cleared. Otherwise,
-   *     the <code>Task</code> is rejected with an error.
+   * @return A {@code Task} that is resolved when the persistent storage is cleared. Otherwise, the
+   *     {@code Task} is rejected with an error.
    */
   @PublicApi
   public Task<Void> clearPersistence() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -267,8 +267,9 @@ public class FirebaseFirestore {
    * be retried. If it fails to commit after 5 attempts, the transaction will fail.
    *
    * <p>The maximum number of writes allowed in a single transaction is 500, but note that each
-   * usage of FieldValue.serverTimestamp(), FieldValue.arrayUnion(), FieldValue.arrayRemove(), or
-   * FieldValue.increment() inside a transaction counts as an additional write.
+   * usage of {@link FieldValue#serverTimestamp()}, {@link FieldValue#arrayUnion()}, {@link
+   * FieldValue#arrayRemove()}, or {@link FieldValue#increment()} inside a transaction counts as an
+   * additional write.
    *
    * @param updateFunction The function to execute within the transaction context.
    * @param executor The executor to run the transaction callback on.
@@ -314,8 +315,9 @@ public class FirebaseFirestore {
    * Creates a write batch, used for performing multiple writes as a single atomic operation.
    *
    * <p>The maximum number of writes allowed in a single batch is 500, but note that each usage of
-   * FieldValue.serverTimestamp(), FieldValue.arrayUnion(), FieldValue.arrayRemove(), or
-   * FieldValue.increment() inside a transaction counts as an additional write.
+   * {@link FieldValue#serverTimestamp()}, {@link FieldValue#arrayUnion()}, {@link
+   * FieldValue#arrayRemove()}, or {@link FieldValue#increment()} inside a transaction counts as an
+   * additional write.
    *
    * @return The created WriteBatch object.
    */
@@ -361,7 +363,7 @@ public class FirebaseFirestore {
    * the server will not be resolved. The next time you start this instance, it will resume
    * attempting to send these writes to the server.
    *
-   * <p>Note: Under normal circumstances, calling <code>shutdown()</code> is not required. This
+   * <p>Note: Under normal circumstances, calling {@code shutdown()} is not required. This
    * method is useful only when you want to force this instance to release all of its resources or
    * in combination with {@link #clearPersistence} to ensure that all local state is destroyed
    * between test runs.
@@ -381,7 +383,7 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Re-enables network usage for this instance after a prior call to disableNetwork().
+   * Re-enables network usage for this instance after a prior call to {@link #disableNetwork()}.
    *
    * @return A Task that will be completed once networking is enabled.
    */
@@ -393,8 +395,8 @@ public class FirebaseFirestore {
 
   /**
    * Disables network access for this instance. While the network is disabled, any snapshot
-   * listeners or get() calls will return results from cache, and any write operations will be
-   * queued until network usage is re-enabled via a call to enableNetwork().
+   * listeners or {@code get()} calls will return results from cache, and any write operations will
+   * be queued until network usage is re-enabled via a call to {@link #enableNetwork()}.
    *
    * @return A Task that will be completed once networking is disabled.
    */
@@ -419,15 +421,15 @@ public class FirebaseFirestore {
    *
    * <p>Must be called while the {@code FirebaseFirestore} instance is not started (after the app is
    * shutdown or when the app is first initialized). On startup, this method must be called before
-   * other methods (other than <code>setFirestoreSettings()</code>). If the {@code
+   * other methods (other than {@link #setFirestoreSettings()}). If the {@code
    * FirebaseFirestore} instance is still running, the <code>Task</code> will fail with an error
    * code of <code> FAILED_PRECONDITION</code>.
    *
-   * <p>Note: <code>clearPersistence()</code> is primarily intended to help write reliable tests
-   * that use Cloud Firestore. It uses an efficient mechanism for dropping existing data but does
-   * not attempt to securely overwrite or otherwise make cached data unrecoverable. For applications
-   * that are sensitive to the disclosure of cached data in between user sessions, we strongly
-   * recommend not enabling persistence at all.
+   * <p>Note: {@code clearPersistence()} is primarily intended to help write reliable tests that use
+   * Cloud Firestore. It uses an efficient mechanism for dropping existing data but does not attempt
+   * to securely overwrite or otherwise make cached data unrecoverable. For applications that are
+   * sensitive to the disclosure of cached data in between user sessions, we strongly recommend not
+   * enabling persistence at all.
    *
    * @return A <code>Task</code> that is resolved when the persistent storage is cleared. Otherwise,
    *     the <code>Task</code> is rejected with an error.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -155,7 +155,7 @@ public class FirebaseFirestore {
     settings = new FirebaseFirestoreSettings.Builder().build();
   }
 
-  /** Returns the settings used by this FirebaseFirestore object. */
+  /** Returns the settings used by this {@code FirebaseFirestore} object. */
   @NonNull
   @PublicApi
   public FirebaseFirestoreSettings getFirestoreSettings() {
@@ -163,8 +163,8 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Sets any custom settings used to configure this FirebaseFirestore object. This method can only
-   * be called before calling any other methods on this object.
+   * Sets any custom settings used to configure this {@code FirebaseFirestore} object. This method
+   * can only be called before calling any other methods on this object.
    */
   @PublicApi
   public void setFirestoreSettings(@NonNull FirebaseFirestoreSettings settings) {
@@ -200,9 +200,7 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Returns the FirebaseApp instance to which this FirebaseFirestore belongs.
-   *
-   * @return The FirebaseApp instance to which this FirebaseFirestore belongs.
+   * Returns the FirebaseApp instance to which this {@code FirebaseFirestore} belongs.
    */
   @NonNull
   @PublicApi
@@ -211,11 +209,11 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Gets a CollectionReference instance that refers to the collection at the specified path within
-   * the database.
+   * Gets a {@link CollectionReference} instance that refers to the collection at the specified path
+   * within the database.
    *
    * @param collectionPath A slash-separated path to a collection.
-   * @return The CollectionReference instance.
+   * @return The {@link CollectionReference} instance.
    */
   @NonNull
   @PublicApi
@@ -351,13 +349,13 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Shuts down this FirebaseFirestore instance.
+   * Shuts down this {@code FirebaseFirestore} instance.
    *
    * <p>After shutdown only the {@link #clearPersistence()} method may be used. Any other method
    * will throw an {@link IllegalStateException}.
    *
-   * <p>To restart after shutdown, simply create a new instance of FirebaseFirestore with {@link
-   * #getInstance()} or {@link #getInstance(FirebaseApp)}.
+   * <p>To restart after shutdown, simply create a new instance of {@code FirebaseFirestore} with
+   * {@link #getInstance()} or {@link #getInstance(FirebaseApp)}.
    *
    * <p>Shutdown does not cancel any pending writes and any tasks that are awaiting a response from
    * the server will not be resolved. The next time you start this instance, it will resume
@@ -419,11 +417,11 @@ public class FirebaseFirestore {
   /**
    * Clears the persistent storage, including pending writes and cached documents.
    *
-   * <p>Must be called while the FirebaseFirestore instance is not started (after the app is
+   * <p>Must be called while the {@code FirebaseFirestore} instance is not started (after the app is
    * shutdown or when the app is first initialized). On startup, this method must be called before
-   * other methods (other than <code>setFirestoreSettings()</code>). If the FirebaseFirestore
-   * instance is still running, the <code>Task</code> will fail with an error code of <code>
-   * FAILED_PRECONDITION</code>.
+   * other methods (other than <code>setFirestoreSettings()</code>). If the {@code
+   * FirebaseFirestore} instance is still running, the <code>Task</code> will fail with an error
+   * code of <code> FAILED_PRECONDITION</code>.
    *
    * <p>Note: <code>clearPersistence()</code> is primarily intended to help write reliable tests
    * that use Cloud Firestore. It uses an efficient mechanism for dropping existing data but does
@@ -466,7 +464,10 @@ public class FirebaseFirestore {
     return dataConverter;
   }
 
-  /** Helper to validate a DocumentReference. Used by WriteBatch and Transaction. */
+  /**
+   * Helper to validate a {@link DocumentReference}. Used by {@link WriteBatch} and {@link
+   * Transaction}.
+   */
   void validateReference(DocumentReference docRef) {
     checkNotNull(docRef, "Provided DocumentReference must not be null.");
     if (docRef.getFirestore() != this) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -42,18 +42,18 @@ import com.google.firebase.firestore.util.Logger.Level;
 import java.util.concurrent.Executor;
 
 /**
- * Represents a Firestore Database and is the entry point for all Firestore operations
+ * Represents a Cloud Firestore database and is the entry point for all Cloud Firestore operations.
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class FirebaseFirestore {
 
   /** Provides a registry management interface for {@code FirebaseFirestore} instances. */
   public interface InstanceRegistry {
-    /** Removes the Firestore instance with given name from registry. */
+    /** Removes the Cloud Firestore instance with given name from registry. */
     void remove(@NonNull String databaseId);
   }
 
@@ -406,7 +406,7 @@ public class FirebaseFirestore {
     return client.disableNetwork();
   }
 
-  /** Globally enables / disables Firestore logging for the SDK. */
+  /** Globally enables / disables Cloud Firestore logging for the SDK. */
   @PublicApi
   public static void setLoggingEnabled(boolean loggingEnabled) {
     if (loggingEnabled) {
@@ -471,7 +471,7 @@ public class FirebaseFirestore {
     checkNotNull(docRef, "Provided DocumentReference must not be null.");
     if (docRef.getFirestore() != this) {
       throw new IllegalArgumentException(
-          "Provided document reference is from a different Firestore instance.");
+          "Provided document reference is from a different Cloud Firestore instance.");
     }
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -199,9 +199,7 @@ public class FirebaseFirestore {
     }
   }
 
-  /**
-   * Returns the FirebaseApp instance to which this {@code FirebaseFirestore} belongs.
-   */
+  /** Returns the FirebaseApp instance to which this {@code FirebaseFirestore} belongs. */
   @NonNull
   @PublicApi
   public FirebaseApp getApp() {
@@ -363,10 +361,10 @@ public class FirebaseFirestore {
    * the server will not be resolved. The next time you start this instance, it will resume
    * attempting to send these writes to the server.
    *
-   * <p>Note: Under normal circumstances, calling {@code shutdown()} is not required. This
-   * method is useful only when you want to force this instance to release all of its resources or
-   * in combination with {@link #clearPersistence} to ensure that all local state is destroyed
-   * between test runs.
+   * <p>Note: Under normal circumstances, calling {@code shutdown()} is not required. This method is
+   * useful only when you want to force this instance to release all of its resources or in
+   * combination with {@link #clearPersistence} to ensure that all local state is destroyed between
+   * test runs.
    *
    * @return A <code>Task</code> that is resolved when the instance has been successfully shut down.
    */
@@ -421,9 +419,9 @@ public class FirebaseFirestore {
    *
    * <p>Must be called while the {@code FirebaseFirestore} instance is not started (after the app is
    * shutdown or when the app is first initialized). On startup, this method must be called before
-   * other methods (other than {@link #setFirestoreSettings()}). If the {@code
-   * FirebaseFirestore} instance is still running, the <code>Task</code> will fail with an error
-   * code of <code> FAILED_PRECONDITION</code>.
+   * other methods (other than {@link #setFirestoreSettings()}). If the {@code FirebaseFirestore}
+   * instance is still running, the <code>Task</code> will fail with an error code of <code>
+   *  FAILED_PRECONDITION</code>.
    *
    * <p>Note: {@code clearPersistence()} is primarily intended to help write reliable tests that use
    * Cloud Firestore. It uses an efficient mechanism for dropping existing data but does not attempt

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -207,11 +207,11 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Gets a {@link CollectionReference} instance that refers to the collection at the specified path
+   * Gets a {@code CollectionReference} instance that refers to the collection at the specified path
    * within the database.
    *
    * @param collectionPath A slash-separated path to a collection.
-   * @return The {@link CollectionReference} instance.
+   * @return The {@code CollectionReference} instance.
    */
   @NonNull
   @PublicApi
@@ -237,8 +237,8 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Creates and returns a new @link{Query} that includes all documents in the database that are
-   * contained in a collection or subcollection with the given @code{collectionId}.
+   * Creates and returns a new {@code Query} that includes all documents in the database that are
+   * contained in a collection or subcollection with the given {@code collectionId}.
    *
    * @param collectionId Identifies the collections to query over. Every collection or subcollection
    *     with this ID as the last segment of its path will be included. Cannot contain a slash.
@@ -465,7 +465,7 @@ public class FirebaseFirestore {
   }
 
   /**
-   * Helper to validate a {@link DocumentReference}. Used by {@link WriteBatch} and {@link
+   * Helper to validate a {@code DocumentReference}. Used by {@link WriteBatch} and {@link
    * Transaction}.
    */
   void validateReference(DocumentReference docRef) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreException.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreException.java
@@ -32,8 +32,8 @@ public class FirebaseFirestoreException extends FirebaseException {
   @PublicApi
   public enum Code {
     /**
-     * The operation completed successfully. FirebaseFirestoreException will never have a status of
-     * OK.
+     * The operation completed successfully. {@code FirebaseFirestoreException} will never have a
+     * status of {@code OK}.
      */
     OK(0),
 
@@ -44,9 +44,9 @@ public class FirebaseFirestoreException extends FirebaseException {
     UNKNOWN(2),
 
     /**
-     * Client specified an invalid argument. Note that this differs from FAILED_PRECONDITION.
-     * INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the
-     * system (e.g., an invalid field name).
+     * Client specified an invalid argument. Note that this differs from {@link
+     * #FAILED_PRECONDITION}. {@code INVALID_ARGUMENT} indicates arguments that are problematic
+     * regardless of the state of the system (e.g., an invalid field name).
      */
     INVALID_ARGUMENT(3),
 
@@ -167,7 +167,7 @@ public class FirebaseFirestoreException extends FirebaseException {
   /**
    * Gets the error code for the Cloud Firestore operation that failed.
    *
-   * @return the code for the FirebaseFirestoreException
+   * @return the code for the {@code FirebaseFirestoreException}.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreException.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreException.java
@@ -22,12 +22,12 @@ import com.google.firebase.FirebaseException;
 import com.google.firebase.annotations.PublicApi;
 import com.google.firebase.firestore.util.Assert;
 
-/** A class of exceptions thrown by Firestore */
+/** A class of exceptions thrown by Cloud Firestore. */
 @PublicApi
 public class FirebaseFirestoreException extends FirebaseException {
   /**
-   * The set of Firestore status codes. The codes are the same at the ones exposed by gRPC here:
-   * https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+   * The set of Cloud Firestore status codes. The codes are the same at the ones exposed by gRPC
+   * here: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
    */
   @PublicApi
   public enum Code {
@@ -165,7 +165,7 @@ public class FirebaseFirestoreException extends FirebaseException {
   }
 
   /**
-   * Gets the error code for the Firestore operation that failed.
+   * Gets the error code for the Cloud Firestore operation that failed.
    *
    * @return the code for the FirebaseFirestoreException
    */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
@@ -35,7 +35,7 @@ public final class FirebaseFirestoreSettings {
   private static final String DEFAULT_HOST = "firestore.googleapis.com";
   private static final boolean DEFAULT_TIMESTAMPS_IN_SNAPSHOTS_ENABLED = true;
 
-  /** A Builder for creating {@link FirebaseFirestoreSettings}. */
+  /** A Builder for creating {@code FirebaseFirestoreSettings}. */
   @PublicApi
   public static final class Builder {
     private String host;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
@@ -21,7 +21,7 @@ import androidx.annotation.Nullable;
 import com.google.common.base.MoreObjects;
 import com.google.firebase.annotations.PublicApi;
 
-/** Settings used to configure a FirebaseFirestore instance. */
+/** Settings used to configure a {@link FirebaseFirestore} instance. */
 @PublicApi
 public final class FirebaseFirestoreSettings {
   /**
@@ -44,7 +44,7 @@ public final class FirebaseFirestoreSettings {
     private boolean timestampsInSnapshotsEnabled;
     private long cacheSizeBytes;
 
-    /** Constructs a new FirebaseFirestoreSettings Builder object. */
+    /** Constructs a new {@code FirebaseFirestoreSettings} Builder object. */
     @PublicApi
     public Builder() {
       host = DEFAULT_HOST;
@@ -55,8 +55,8 @@ public final class FirebaseFirestoreSettings {
     }
 
     /**
-     * Constructs a new FirebaseFirestoreSettings Builder based on an existing
-     * FirebaseFirestoreSettings object.
+     * Constructs a new {@code FirebaseFirestoreSettings} Builder based on an existing {@code
+     * FirebaseFirestoreSettings} object.
      */
     @PublicApi
     public Builder(@NonNull FirebaseFirestoreSettings settings) {
@@ -172,7 +172,7 @@ public final class FirebaseFirestoreSettings {
   private final boolean timestampsInSnapshotsEnabled;
   private final long cacheSizeBytes;
 
-  /** Constructs a FirebaseFirestoreSettings object based on the values in the Builder. */
+  /** Constructs a {@code FirebaseFirestoreSettings} object based on the values in the Builder. */
   private FirebaseFirestoreSettings(Builder builder) {
     host = builder.host;
     sslEnabled = builder.sslEnabled;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
@@ -68,7 +68,7 @@ public final class FirebaseFirestoreSettings {
     }
 
     /**
-     * Sets the host of the Firestore backend.
+     * Sets the host of the Cloud Firestore backend.
      *
      * @param host The host string
      * @return A settings object with the host set.
@@ -110,12 +110,12 @@ public final class FirebaseFirestoreSettings {
      * fields in {@link DocumentSnapshot DocumentSnapshots}. This is now enabled by default and
      * should not be disabled.
      *
-     * <p>Previously, Firestore returned timestamp fields as {@link java.util.Date} but {@link
+     * <p>Previously, Cloud Firestore returned timestamp fields as {@link java.util.Date} but {@link
      * java.util.Date} only supports millisecond precision, which leads to truncation and causes
      * unexpected behavior when using a timestamp from a snapshot as a part of a subsequent query.
      *
-     * <p>So now Firestore returns {@link com.google.firebase.Timestamp Timestamp} values instead of
-     * {@link java.util.Date}, avoiding this kind of problem.
+     * <p>So now Cloud Firestore returns {@link com.google.firebase.Timestamp Timestamp} values
+     * instead of {@link java.util.Date}, avoiding this kind of problem.
      *
      * <p>To opt into the old behavior of returning {@link java.util.Date Dates}, you can
      * temporarily set {@link FirebaseFirestoreSettings#areTimestampsInSnapshotsEnabled} to false.
@@ -135,9 +135,9 @@ public final class FirebaseFirestoreSettings {
 
     /**
      * Sets an approximate cache size threshold for the on-disk data. If the cache grows beyond this
-     * size, Firestore will start removing data that hasn't been recently used. The size is not a
-     * guarantee that the cache will stay below that size, only that if the cache exceeds the given
-     * size, cleanup will be attempted.
+     * size, Cloud Firestore will start removing data that hasn't been recently used. The size is
+     * not a guarantee that the cache will stay below that size, only that if the cache exceeds the
+     * given size, cleanup will be attempted.
      *
      * <p>By default, collection is enabled with a cache size of 100 MB. The minimum value is 1 MB.
      *
@@ -219,7 +219,7 @@ public final class FirebaseFirestoreSettings {
         .toString();
   }
 
-  /** Returns the host of the Firestore backend. */
+  /** Returns the host of the Cloud Firestore backend. */
   @NonNull
   @PublicApi
   public String getHost() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreMultiDbComponent.java
@@ -24,7 +24,7 @@ import com.google.firebase.auth.internal.InternalAuthProvider;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Multi-resource container for Firestore. */
+/** Multi-resource container for Cloud Firestore. */
 class FirestoreMultiDbComponent
     implements FirebaseAppLifecycleListener, FirebaseFirestore.InstanceRegistry {
 
@@ -48,7 +48,7 @@ class FirestoreMultiDbComponent
     this.app.addLifecycleEventListener(this);
   }
 
-  /** Provides instances of Firestore for given database IDs. */
+  /** Provides instances of Cloud Firestore for given database IDs. */
   @NonNull
   synchronized FirebaseFirestore get(@NonNull String databaseId) {
     FirebaseFirestore firestore = instances.get(databaseId);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/GeoPoint.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/GeoPoint.java
@@ -19,17 +19,17 @@ import androidx.annotation.Nullable;
 import com.google.firebase.annotations.PublicApi;
 import com.google.firebase.firestore.util.Util;
 
-/** Immutable class representing a GeoPoint in Cloud Firestore */
+/** Immutable class representing a {@code GeoPoint} in Cloud Firestore */
 @PublicApi
 public class GeoPoint implements Comparable<GeoPoint> {
   private final double latitude;
   private final double longitude;
 
   /**
-   * Construct a new GeoPoint using the provided latitude and longitude values.
+   * Construct a new {@code GeoPoint} using the provided latitude and longitude values.
    *
-   * @param latitude The latitude of this GeoPoint in the range [-90, 90].
-   * @param longitude The longitude of this GeoPoint in the range [-180, 180].
+   * @param latitude The latitude of this {@code GeoPoint} in the range [-90, 90].
+   * @param longitude The longitude of this {@code GeoPoint} in the range [-180, 180].
    */
   @PublicApi
   public GeoPoint(double latitude, double longitude) {
@@ -43,13 +43,13 @@ public class GeoPoint implements Comparable<GeoPoint> {
     this.longitude = longitude;
   }
 
-  /** @return The latitude value of this GeoPoint. */
+  /** @return The latitude value of this {@code GeoPoint}. */
   @PublicApi
   public double getLatitude() {
     return latitude;
   }
 
-  /** @return The longitude value of this GeoPoint. */
+  /** @return The longitude value of this {@code GeoPoint}. */
   @PublicApi
   public double getLongitude() {
     return longitude;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/GeoPoint.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/GeoPoint.java
@@ -19,7 +19,7 @@ import androidx.annotation.Nullable;
 import com.google.firebase.annotations.PublicApi;
 import com.google.firebase.firestore.util.Util;
 
-/** Immutable class representing a GeoPoint in Firestore */
+/** Immutable class representing a GeoPoint in Cloud Firestore */
 @PublicApi
 public class GeoPoint implements Comparable<GeoPoint> {
   private final double latitude;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/ListenerRegistration.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/ListenerRegistration.java
@@ -21,7 +21,7 @@ import com.google.firebase.annotations.PublicApi;
 public interface ListenerRegistration {
 
   /**
-   * Removes the listener being tracked by this ListenerRegistration. After the initial call,
+   * Removes the listener being tracked by this {@code ListenerRegistration}. After the initial call,
    * subsequent calls have no effect.
    */
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/ListenerRegistration.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/ListenerRegistration.java
@@ -21,8 +21,8 @@ import com.google.firebase.annotations.PublicApi;
 public interface ListenerRegistration {
 
   /**
-   * Removes the listener being tracked by this {@code ListenerRegistration}. After the initial call,
-   * subsequent calls have no effect.
+   * Removes the listener being tracked by this {@code ListenerRegistration}. After the initial
+   * call, subsequent calls have no effect.
    */
   @PublicApi
   void remove();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/ListenerRegistration.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/ListenerRegistration.java
@@ -16,7 +16,7 @@ package com.google.firebase.firestore;
 
 import com.google.firebase.annotations.PublicApi;
 
-/** Represents a listener that can be removed by calling remove(). */
+/** Represents a listener that can be removed by calling {@link #remove()}. */
 @PublicApi
 public interface ListenerRegistration {
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/MetadataChanges.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/MetadataChanges.java
@@ -17,7 +17,7 @@ package com.google.firebase.firestore;
 import com.google.firebase.annotations.PublicApi;
 
 /**
- * Indicates whether metadata-only changes (i.e.&nbsp;only {@code DocumentSnapshot.getMetadata()} or
+ * Indicates whether metadata-only changes (that is, only {@code DocumentSnapshot.getMetadata()} or
  * {@code Query.getMetadata()} changed) should trigger snapshot events.
  */
 @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/MetadataChanges.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/MetadataChanges.java
@@ -17,7 +17,7 @@ package com.google.firebase.firestore;
 import com.google.firebase.annotations.PublicApi;
 
 /**
- * Indicates whether metadata-only changes (i.e. only {@code DocumentSnapshot.getMetadata()} or
+ * Indicates whether metadata-only changes (i.e.&nbsp;only {@code DocumentSnapshot.getMetadata()} or
  * {@code Query.getMetadata()} changed) should trigger snapshot events.
  */
 @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -855,9 +855,9 @@ public class Query {
   /**
    * Executes the query and returns the results as a {@link QuerySnapshot}.
    *
-   * <p>By default, get() attempts to provide up-to-date data when possible by waiting for data from
-   * the server, but it may return cached data or fail if you are offline and the server cannot be
-   * reached. This behavior can be altered via the {@link Source} parameter.
+   * <p>By default, {@code get()} attempts to provide up-to-date data when possible by waiting for
+   * data from the server, but it may return cached data or fail if you are offline and the server
+   * cannot be reached. This behavior can be altered via the {@link Source} parameter.
    *
    * @param source A value to configure the get behavior.
    * @return A Task that will be resolved with the results of the {@code Query}.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -231,8 +231,8 @@ public class Query {
    * specified field, the value must be an array, and that the array must contain the provided
    * value.
    *
-   * <p>A Query can have only one whereArrayContains() filter and it cannot be combined with
-   * whereArrayContainsAny().
+   * <p>A {@code Query} can have only one {@code whereArrayContains()} filter and it cannot be
+   * combined with {@code whereArrayContainsAny()}.
    *
    * @param field The name of the field containing an array to search.
    * @param value The value that must be contained in the array
@@ -249,8 +249,8 @@ public class Query {
    * specified field, the value must be an array, and that the array must contain the provided
    * value.
    *
-   * <p>A Query can have only one whereArrayContains() filter and it cannot be combined with
-   * whereArrayContainsAny().
+   * <p>A {@code Query} can have only one {@code whereArrayContains()} filter and it cannot be
+   * combined with {@code whereArrayContainsAny()}.
    *
    * @param fieldPath The path of the field containing an array to search.
    * @param value The value that must be contained in the array
@@ -267,8 +267,8 @@ public class Query {
    * specified field, the value must be an array, and that the array must contain at least one value
    * from the provided array.
    *
-   * <p>A Query can have only one whereArrayContainsAny() filter and it cannot be combined with
-   * whereArrayContains() or whereIn().
+   * <p>A {@code Query} can have only one {@code whereArrayContainsAny()} filter and it cannot
+   * be combined with {@code whereArrayContains()} or {@code whereIn()}.
    *
    * @param field The name of the field containing an array to search.
    * @param value The array that contains the values to match.
@@ -285,8 +285,8 @@ public class Query {
    * specified field, the value must be an array, and that the array must contain at least one value
    * from the provided array.
    *
-   * <p>A Query can have only one whereArrayContainsAny() filter and it cannot be combined with
-   * whereArrayContains() or whereIn().
+   * <p>A {@code Query} can have only one {@code whereArrayContainsAny()} filter and it cannot
+   * be combined with {@code whereArrayContains()} or {@code whereIn()}.
    *
    * @param fieldPath The path of the field containing an array to search.
    * @param value The array that contains the values to match.
@@ -302,8 +302,8 @@ public class Query {
    * Creates and returns a new Query with the additional filter that documents must contain the
    * specified field and the value must equal one of the values from the provided array.
    *
-   * <p>A Query can have only one whereIn() filter, and it cannot be combined with
-   * whereArrayContainsAny().
+   * <p>A {@code Query} can have only one {@code whereIn()} filter, and it cannot be combined
+   * with {@code whereArrayContainsAny()}.
    *
    * @param field The name of the field to search.
    * @param value The array that contains the values to match.
@@ -319,8 +319,8 @@ public class Query {
    * Creates and returns a new Query with the additional filter that documents must contain the
    * specified field and the value must equal one of the values from the provided array.
    *
-   * <p>A Query can have only one whereIn() filter, and it cannot be combined with
-   * whereArrayContainsAny().
+   * <p>A {@code Query} can have only one {@code whereIn()} filter, and it cannot be combined
+   * with {@code whereArrayContainsAny()}.
    *
    * @param fieldPath The path of the field to search.
    * @param value The array that contains the values to match.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -53,8 +53,8 @@ import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
 /**
- * A Query which you can read or listen to. You can also construct refined Query objects by adding
- * filters and ordering.
+ * A {@code Query} which you can read or listen to. You can also construct refined {@code Query}
+ * objects by adding filters and ordering.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
@@ -86,12 +86,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be equal to the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be equal to the specified value.
    *
    * @param field The name of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -100,12 +100,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be equal to the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be equal to the specified value.
    *
    * @param fieldPath The path of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -114,12 +114,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain the
    * specified field and the value should be less than the specified value.
    *
    * @param field The name of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -128,12 +128,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be less than the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be less than the specified value.
    *
    * @param fieldPath The path of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -142,12 +142,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be less than or equal to the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be less than or equal to the specified value.
    *
    * @param field The name of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -156,12 +156,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be less than or equal to the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be less than or equal to the specified value.
    *
    * @param fieldPath The path of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -170,12 +170,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be greater than the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be greater than the specified value.
    *
    * @param field The name of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -184,12 +184,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be greater than the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be greater than the specified value.
    *
    * @param fieldPath The path of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -198,12 +198,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be greater than or equal to the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be greater than or equal to the specified value.
    *
    * @param field The name of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -213,12 +213,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should be greater than or equal to the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be greater than or equal to the specified value.
    *
    * @param fieldPath The path of the field to compare
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -227,8 +227,8 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field, the value must be an array, and that the array must contain the provided
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field, the value must be an array, and that the array must contain the provided
    * value.
    *
    * <p>A {@code Query} can have only one {@code whereArrayContains()} filter and it cannot be
@@ -236,7 +236,7 @@ public class Query {
    *
    * @param field The name of the field containing an array to search.
    * @param value The value that must be contained in the array
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -245,8 +245,8 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field, the value must be an array, and that the array must contain the provided
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field, the value must be an array, and that the array must contain the provided
    * value.
    *
    * <p>A {@code Query} can have only one {@code whereArrayContains()} filter and it cannot be
@@ -254,7 +254,7 @@ public class Query {
    *
    * @param fieldPath The path of the field containing an array to search.
    * @param value The value that must be contained in the array
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -263,16 +263,16 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field, the value must be an array, and that the array must contain at least one value
-   * from the provided array.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field, the value must be an array, and that the array must contain at least one
+   * value from the provided array.
    *
    * <p>A {@code Query} can have only one {@code whereArrayContainsAny()} filter and it cannot
    * be combined with {@code whereArrayContains()} or {@code whereIn()}.
    *
    * @param field The name of the field containing an array to search.
    * @param value The array that contains the values to match.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   // TODO(in-queries): Expose to public once backend is ready.
   @NonNull
@@ -281,16 +281,16 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field, the value must be an array, and that the array must contain at least one value
-   * from the provided array.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field, the value must be an array, and that the array must contain at least one
+   * value from the provided array.
    *
    * <p>A {@code Query} can have only one {@code whereArrayContainsAny()} filter and it cannot
    * be combined with {@code whereArrayContains()} or {@code whereIn()}.
    *
    * @param fieldPath The path of the field containing an array to search.
    * @param value The array that contains the values to match.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   // TODO(in-queries): Expose to public once backend is ready.
   @NonNull
@@ -299,15 +299,15 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value must equal one of the values from the provided array.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value must equal one of the values from the provided array.
    *
    * <p>A {@code Query} can have only one {@code whereIn()} filter, and it cannot be combined
    * with {@code whereArrayContainsAny()}.
    *
    * @param field The name of the field to search.
    * @param value The array that contains the values to match.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   // TODO(in-queries): Expose to public once backend is ready.
   @NonNull
@@ -316,15 +316,15 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value must equal one of the values from the provided array.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value must equal one of the values from the provided array.
    *
    * <p>A {@code Query} can have only one {@code whereIn()} filter, and it cannot be combined
    * with {@code whereArrayContainsAny()}.
    *
    * @param fieldPath The path of the field to search.
    * @param value The array that contains the values to match.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   // TODO(in-queries): Expose to public once backend is ready.
   @NonNull
@@ -333,13 +333,13 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query with the additional filter that documents must contain the
-   * specified field and the value should satisfy the relation constraint provided.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should satisfy the relation constraint provided.
    *
    * @param fieldPath The field to compare
    * @param op The operator
    * @param value The value for comparison
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   private Query whereHelper(@NonNull FieldPath fieldPath, Operator op, Object value) {
     checkNotNull(fieldPath, "Provided field path must not be null.");
@@ -520,10 +520,10 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that's additionally sorted by the specified field.
+   * Creates and returns a new {@code Query} that's additionally sorted by the specified field.
    *
    * @param field The field to sort by.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -532,10 +532,10 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that's additionally sorted by the specified field.
+   * Creates and returns a new {@code Query} that's additionally sorted by the specified field.
    *
    * @param fieldPath The field to sort by.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -545,12 +545,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that's additionally sorted by the specified field, optionally
+   * Creates and returns a new {@code Query} that's additionally sorted by the specified field, optionally
    * in descending order instead of ascending.
    *
    * @param field The field to sort by.
    * @param direction The direction to sort.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -559,12 +559,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that's additionally sorted by the specified field, optionally
+   * Creates and returns a new {@code Query} that's additionally sorted by the specified field, optionally
    * in descending order instead of ascending.
    *
    * @param fieldPath The field to sort by.
    * @param direction The direction to sort.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -596,11 +596,11 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that's additionally limited to only return up to the specified
-   * number of documents.
+   * Creates and returns a new {@code Query} that's additionally limited to only return up to the
+   * specified number of documents.
    *
    * @param limit The maximum number of items to return.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -613,12 +613,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that starts at the provided document (inclusive). The starting
-   * position is relative to the order of the query. The document must contain all of the fields
-   * provided in the orderBy of this query.
+   * Creates and returns a new {@code Query} that starts at the provided document (inclusive). The
+   * starting position is relative to the order of the query. The document must contain all of the
+   * fields provided in the orderBy of this query.
    *
    * @param snapshot The snapshot of the document to start at.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -628,11 +628,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that starts at the provided fields relative to the order of the
-   * query. The order of the field values must match the order of the order by clauses of the query.
+   * Creates and returns a new {@code Query} that starts at the provided fields relative to the
+   * order of the query. The order of the field values must match the order of the order by clauses
+   * of the query.
    *
    * @param fieldValues The field values to start this query at, in order of the query's order by.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -642,12 +643,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that starts after the provided document (exclusive). The
-   * starting position is relative to the order of the query. The document must contain all of the
-   * fields provided in the orderBy of this query.
+   * Creates and returns a new {@code Query} that starts after the provided document (exclusive).
+   * The starting position is relative to the order of the query. The document must contain all of
+   * the fields provided in the orderBy of this query.
    *
    * @param snapshot The snapshot of the document to start after.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -657,13 +658,13 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that starts after the provided fields relative to the order of
-   * the query. The order of the field values must match the order of the order by clauses of the
-   * query.
+   * Creates and returns a new {@code Query} that starts after the provided fields relative to the
+   * order of the query. The order of the field values must match the order of the order by clauses
+   * of the query.
    *
    * @param fieldValues The field values to start this query after, in order of the query's order
    *     by.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -673,12 +674,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that ends before the provided document (exclusive). The end
-   * position is relative to the order of the query. The document must contain all of the fields
+   * Creates and returns a new {@code Query} that ends before the provided document (exclusive). The
+   * end position is relative to the order of the query. The document must contain all of the fields
    * provided in the orderBy of this query.
    *
    * @param snapshot The snapshot of the document to end before.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -688,12 +689,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that ends before the provided fields relative to the order of
-   * the query. The order of the field values must match the order of the order by clauses of the
-   * query.
+   * Creates and returns a new {@code Query} that ends before the provided fields relative to the
+   * order of the query. The order of the field values must match the order of the order by clauses
+   * of the query.
    *
    * @param fieldValues The field values to end this query before, in order of the query's order by.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -703,12 +704,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that ends at the provided document (inclusive). The end
+   * Creates and returns a new {@code Query} that ends at the provided document (inclusive). The end
    * position is relative to the order of the query. The document must contain all of the fields
    * provided in the orderBy of this query.
    *
    * @param snapshot The snapshot of the document to end at.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -718,11 +719,12 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new Query that ends at the provided fields relative to the order of the
-   * query. The order of the field values must match the order of the order by clauses of the query.
+   * Creates and returns a new {@code Query} that ends at the provided fields relative to the order
+   * of the query. The order of the field values must match the order of the order by clauses of the
+   * query.
    *
    * @param fieldValues The field values to end this query at, in order of the query's order by.
-   * @return The created Query.
+   * @return The created {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -840,9 +842,9 @@ public class Query {
   }
 
   /**
-   * Executes the query and returns the results as a QuerySnapshot.
+   * Executes the query and returns the results as a {@link QuerySnapshot}.
    *
-   * @return A Task that will be resolved with the results of the Query.
+   * @return A Task that will be resolved with the results of the {@code Query}.
    */
   @NonNull
   @PublicApi
@@ -851,14 +853,14 @@ public class Query {
   }
 
   /**
-   * Executes the query and returns the results as a QuerySnapshot.
+   * Executes the query and returns the results as a {@link QuerySnapshot}.
    *
    * <p>By default, get() attempts to provide up-to-date data when possible by waiting for data from
    * the server, but it may return cached data or fail if you are offline and the server cannot be
    * reached. This behavior can be altered via the {@link Source} parameter.
    *
    * @param source A value to configure the get behavior.
-   * @return A Task that will be resolved with the results of the Query.
+   * @return A Task that will be resolved with the results of the {@code Query}.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -114,8 +114,8 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new {@code Query} with the additional filter that documents must contain the
-   * specified field and the value should be less than the specified value.
+   * Creates and returns a new {@code Query} with the additional filter that documents must contain
+   * the specified field and the value should be less than the specified value.
    *
    * @param field The name of the field to compare
    * @param value The value for comparison
@@ -267,8 +267,8 @@ public class Query {
    * the specified field, the value must be an array, and that the array must contain at least one
    * value from the provided array.
    *
-   * <p>A {@code Query} can have only one {@code whereArrayContainsAny()} filter and it cannot
-   * be combined with {@code whereArrayContains()} or {@code whereIn()}.
+   * <p>A {@code Query} can have only one {@code whereArrayContainsAny()} filter and it cannot be
+   * combined with {@code whereArrayContains()} or {@code whereIn()}.
    *
    * @param field The name of the field containing an array to search.
    * @param value The array that contains the values to match.
@@ -285,8 +285,8 @@ public class Query {
    * the specified field, the value must be an array, and that the array must contain at least one
    * value from the provided array.
    *
-   * <p>A {@code Query} can have only one {@code whereArrayContainsAny()} filter and it cannot
-   * be combined with {@code whereArrayContains()} or {@code whereIn()}.
+   * <p>A {@code Query} can have only one {@code whereArrayContainsAny()} filter and it cannot be
+   * combined with {@code whereArrayContains()} or {@code whereIn()}.
    *
    * @param fieldPath The path of the field containing an array to search.
    * @param value The array that contains the values to match.
@@ -302,8 +302,8 @@ public class Query {
    * Creates and returns a new {@code Query} with the additional filter that documents must contain
    * the specified field and the value must equal one of the values from the provided array.
    *
-   * <p>A {@code Query} can have only one {@code whereIn()} filter, and it cannot be combined
-   * with {@code whereArrayContainsAny()}.
+   * <p>A {@code Query} can have only one {@code whereIn()} filter, and it cannot be combined with
+   * {@code whereArrayContainsAny()}.
    *
    * @param field The name of the field to search.
    * @param value The array that contains the values to match.
@@ -319,8 +319,8 @@ public class Query {
    * Creates and returns a new {@code Query} with the additional filter that documents must contain
    * the specified field and the value must equal one of the values from the provided array.
    *
-   * <p>A {@code Query} can have only one {@code whereIn()} filter, and it cannot be combined
-   * with {@code whereArrayContainsAny()}.
+   * <p>A {@code Query} can have only one {@code whereIn()} filter, and it cannot be combined with
+   * {@code whereArrayContainsAny()}.
    *
    * @param fieldPath The path of the field to search.
    * @param value The array that contains the values to match.
@@ -545,8 +545,8 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new {@code Query} that's additionally sorted by the specified field, optionally
-   * in descending order instead of ascending.
+   * Creates and returns a new {@code Query} that's additionally sorted by the specified field,
+   * optionally in descending order instead of ascending.
    *
    * @param field The field to sort by.
    * @param direction The direction to sort.
@@ -559,8 +559,8 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new {@code Query} that's additionally sorted by the specified field, optionally
-   * in descending order instead of ascending.
+   * Creates and returns a new {@code Query} that's additionally sorted by the specified field,
+   * optionally in descending order instead of ascending.
    *
    * @param fieldPath The field to sort by.
    * @param direction The direction to sort.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -1036,7 +1036,7 @@ public class Query {
   /**
    * Internal helper method to create add a snapshot listener.
    *
-   * <p>Will be Activity scoped if the activity parameter is non-null.
+   * <p>Will be Activity scoped if the activity parameter is non-{@code null}.
    *
    * @param executor The executor to use to call the listener.
    * @param options The options to use for this listen.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -842,7 +842,7 @@ public class Query {
   }
 
   /**
-   * Executes the query and returns the results as a {@link QuerySnapshot}.
+   * Executes the query and returns the results as a {@code QuerySnapshot}.
    *
    * @return A Task that will be resolved with the results of the {@code Query}.
    */
@@ -853,11 +853,11 @@ public class Query {
   }
 
   /**
-   * Executes the query and returns the results as a {@link QuerySnapshot}.
+   * Executes the query and returns the results as a {@code QuerySnapshot}.
    *
    * <p>By default, {@code get()} attempts to provide up-to-date data when possible by waiting for
    * data from the server, but it may return cached data or fail if you are offline and the server
-   * cannot be reached. This behavior can be altered via the {@link Source} parameter.
+   * cannot be reached. This behavior can be altered via the {@code Source} parameter.
    *
    * @param source A value to configure the get behavior.
    * @return A Task that will be resolved with the results of the {@code Query}.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -56,9 +56,9 @@ import javax.annotation.Nullable;
  * A Query which you can read or listen to. You can also construct refined Query objects by adding
  * filters and ordering.
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class Query {
@@ -78,7 +78,7 @@ public class Query {
     this.firestore = checkNotNull(firestore);
   }
 
-  /** Gets the Firestore instance associated with this query. */
+  /** Gets the Cloud Firestore instance associated with this query. */
   @NonNull
   @PublicApi
   public FirebaseFirestore getFirestore() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/QueryDocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/QueryDocumentSnapshot.java
@@ -25,12 +25,12 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * A QueryDocumentSnapshot contains data read from a document in your Cloud Firestore database as
- * part of a query. The document is guaranteed to exist and its data can be extracted using the
- * getData() or get() methods.
+ * A {@code QueryDocumentSnapshot} contains data read from a document in your Cloud Firestore
+ * database as part of a query. The document is guaranteed to exist and its data can be extracted
+ * using the getData() or get() methods.
  *
- * <p>QueryDocumentSnapshot offers the same API surface as {@link DocumentSnapshot}. Since query
- * results contain only existing documents, the exists() method will always return true and
+ * <p>{@code QueryDocumentSnapshot} offers the same API surface as {@link DocumentSnapshot}. Since
+ * query results contain only existing documents, the exists() method will always return true and
  * getData() will never be null.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/QueryDocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/QueryDocumentSnapshot.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  *
  * <p>{@code QueryDocumentSnapshot} offers the same API surface as {@link DocumentSnapshot}. Since
  * query results contain only existing documents, the {@link #exists()} method will always return
- * true and {@link #getData()} will never be null.
+ * true and {@link #getData()} will never be {@code null}.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
@@ -75,7 +75,7 @@ public class QueryDocumentSnapshot extends DocumentSnapshot {
    *
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet
    *     been set to their final value.
-   * @return The fields of the document as a Map or null if the document doesn't exist.
+   * @return The fields of the document as a Map or {@code null} if the document doesn't exist.
    */
   @NonNull
   @Override

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/QueryDocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/QueryDocumentSnapshot.java
@@ -25,17 +25,17 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * A QueryDocumentSnapshot contains data read from a document in your Firestore database as part of
- * a query. The document is guaranteed to exist and its data can be extracted using the getData() or
- * get() methods.
+ * A QueryDocumentSnapshot contains data read from a document in your Cloud Firestore database as
+ * part of a query. The document is guaranteed to exist and its data can be extracted using the
+ * getData() or get() methods.
  *
  * <p>QueryDocumentSnapshot offers the same API surface as {@link DocumentSnapshot}. Since query
  * results contain only existing documents, the exists() method will always return true and
  * getData() will never be null.
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class QueryDocumentSnapshot extends DocumentSnapshot {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/QueryDocumentSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/QueryDocumentSnapshot.java
@@ -27,11 +27,11 @@ import javax.annotation.Nullable;
 /**
  * A {@code QueryDocumentSnapshot} contains data read from a document in your Cloud Firestore
  * database as part of a query. The document is guaranteed to exist and its data can be extracted
- * using the getData() or get() methods.
+ * using the {@link #getData()} or {@link #get()} methods.
  *
  * <p>{@code QueryDocumentSnapshot} offers the same API surface as {@link DocumentSnapshot}. Since
- * query results contain only existing documents, the exists() method will always return true and
- * getData() will never be null.
+ * query results contain only existing documents, the {@link #exists()} method will always return
+ * true and {@link #getData()} will never be null.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/QuerySnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/QuerySnapshot.java
@@ -27,8 +27,8 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * A QuerySnapshot contains the results of a query. It can contain zero or more DocumentSnapshot
- * objects.
+ * A {@code QuerySnapshot} contains the results of a query. It can contain zero or more {@link
+ * DocumentSnapshot} objects.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
@@ -132,7 +132,7 @@ public class QuerySnapshot implements Iterable<QueryDocumentSnapshot> {
   }
 
   /**
-   * Returns the documents in this QuerySnapshot as a List in order of the query.
+   * Returns the documents in this {@code QuerySnapshot} as a List in order of the query.
    *
    * @return The list of documents.
    */
@@ -146,13 +146,13 @@ public class QuerySnapshot implements Iterable<QueryDocumentSnapshot> {
     return res;
   }
 
-  /** Returns true if there are no documents in the QuerySnapshot. */
+  /** Returns true if there are no documents in the {@code QuerySnapshot}. */
   @PublicApi
   public boolean isEmpty() {
     return snapshot.getDocuments().isEmpty();
   }
 
-  /** Returns the number of documents in the QuerySnapshot. */
+  /** Returns the number of documents in the {@code QuerySnapshot}. */
   @PublicApi
   public int size() {
     return snapshot.getDocuments().size();
@@ -166,8 +166,8 @@ public class QuerySnapshot implements Iterable<QueryDocumentSnapshot> {
   }
 
   /**
-   * Returns the contents of the documents in the QuerySnapshot, converted to the provided class, as
-   * a list.
+   * Returns the contents of the documents in the {@code QuerySnapshot}, converted to the provided
+   * class, as a list.
    *
    * @param clazz The POJO type used to convert the documents in the list.
    */
@@ -178,8 +178,8 @@ public class QuerySnapshot implements Iterable<QueryDocumentSnapshot> {
   }
 
   /**
-   * Returns the contents of the documents in the QuerySnapshot, converted to the provided class, as
-   * a list.
+   * Returns the contents of the documents in the {@code QuerySnapshot}, converted to the provided
+   * class, as a list.
    *
    * @param clazz The POJO type used to convert the documents in the list.
    * @param serverTimestampBehavior Configures the behavior for server timestamps that have not yet

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/QuerySnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/QuerySnapshot.java
@@ -30,9 +30,9 @@ import javax.annotation.Nullable;
  * A QuerySnapshot contains the results of a query. It can contain zero or more DocumentSnapshot
  * objects.
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class QuerySnapshot implements Iterable<QueryDocumentSnapshot> {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/ServerTimestamp.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/ServerTimestamp.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation used to mark a timestamp field to be populated with a server timestamp. If a POJO
- * being written contains null for a @ServerTimestamp-annotated field, it will be replaced with a
+ * being written contains {@code null} for a @ServerTimestamp-annotated field, it will be replaced with a
  * server-generated timestamp.
  */
 @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/ServerTimestamp.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/ServerTimestamp.java
@@ -22,8 +22,8 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation used to mark a timestamp field to be populated with a server timestamp. If a POJO
- * being written contains {@code null} for a @ServerTimestamp-annotated field, it will be replaced with a
- * server-generated timestamp.
+ * being written contains {@code null} for a @ServerTimestamp-annotated field, it will be replaced
+ * with a server-generated timestamp.
  */
 @PublicApi
 @Retention(RetentionPolicy.RUNTIME)

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/SetOptions.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/SetOptions.java
@@ -26,10 +26,11 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * An options object that configures the behavior of set() calls. By providing one of the SetOptions
- * objects returned by {@link #merge}, {@link #mergeFields} and {@link #mergeFieldPaths}, the set()
- * calls in {@link DocumentReference}, {@link WriteBatch} and {@link Transaction} can be configured
- * to perform granular merges instead of overwriting the target documents in their entirety.
+ * An options object that configures the behavior of {@code set()} calls. By providing one of the
+ * SetOptions objects returned by {@link #merge}, {@link #mergeFields} and {@link #mergeFieldPaths},
+ * the {@code set()} calls in {@link DocumentReference}, {@link WriteBatch} and {@link Transaction}
+ * can be configured to perform granular merges instead of overwriting the target documents in their
+ * entirety.
  */
 @PublicApi
 public final class SetOptions {
@@ -59,8 +60,8 @@ public final class SetOptions {
   }
 
   /**
-   * Changes the behavior of set() calls to only replace the values specified in its data argument.
-   * Fields omitted from the set() call will remain untouched.
+   * Changes the behavior of {@code set()} calls to only replace the values specified in its data
+   * argument. Fields omitted from the {@code set()} call will remain untouched.
    */
   @NonNull
   @PublicApi
@@ -69,11 +70,11 @@ public final class SetOptions {
   }
 
   /**
-   * Changes the behavior of set() calls to only replace the fields under fieldPaths. Any field that
-   * is not specified in fieldPaths is ignored and remains untouched.
+   * Changes the behavior of {@code set()} calls to only replace the fields under fieldPaths. Any
+   * field that is not specified in fieldPaths is ignored and remains untouched.
    *
-   * <p>It is an error to pass a {@code SetOptions} object to a set() call that is missing a value
-   * for any of the fields specified here.
+   * <p>It is an error to pass a {@code SetOptions} object to a {@code set()} call that is missing a
+   * value for any of the fields specified here.
    *
    * @param fields The list of fields to merge. Fields can contain dots to reference nested fields
    *     within the document.
@@ -91,11 +92,11 @@ public final class SetOptions {
   }
 
   /**
-   * Changes the behavior of set() calls to only replace the fields under fieldPaths. Any field that
-   * is not specified in fieldPaths is ignored and remains untouched.
+   * Changes the behavior of {@code set()} calls to only replace the fields under fieldPaths. Any
+   * field that is not specified in fieldPaths is ignored and remains untouched.
    *
-   * <p>It is an error to pass a {@code SetOptions} object to a set() call that is missing a value
-   * for any of the fields specified here.
+   * <p>It is an error to pass a {@code SetOptions} object to a {@code set()} call that is missing a
+   * value for any of the fields specified here.
    *
    * @param fields The list of fields to merge. Fields can contain dots to reference nested fields
    *     within the document.
@@ -113,11 +114,11 @@ public final class SetOptions {
   }
 
   /**
-   * Changes the behavior of set() calls to only replace the fields under fieldPaths. Any field that
-   * is not specified in fieldPaths is ignored and remains untouched.
+   * Changes the behavior of {@code set()} calls to only replace the fields under fieldPaths. Any
+   * field that is not specified in fieldPaths is ignored and remains untouched.
    *
-   * <p>It is an error to pass a {@code SetOptions} object to a set() call that is missing a value
-   * for any of the fields specified here in its to data argument.
+   * <p>It is an error to pass a {@code SetOptions} object to a {@code set()} call that is missing a
+   * value for any of the fields specified here in its to data argument.
    *
    * @param fields The list of fields to merge.
    */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/SetOptions.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/SetOptions.java
@@ -72,8 +72,8 @@ public final class SetOptions {
    * Changes the behavior of set() calls to only replace the fields under fieldPaths. Any field that
    * is not specified in fieldPaths is ignored and remains untouched.
    *
-   * <p>It is an error to pass a SetOptions object to a set() call that is missing a value for any
-   * of the fields specified here.
+   * <p>It is an error to pass a {@code SetOptions} object to a set() call that is missing a value
+   * for any of the fields specified here.
    *
    * @param fields The list of fields to merge. Fields can contain dots to reference nested fields
    *     within the document.
@@ -94,8 +94,8 @@ public final class SetOptions {
    * Changes the behavior of set() calls to only replace the fields under fieldPaths. Any field that
    * is not specified in fieldPaths is ignored and remains untouched.
    *
-   * <p>It is an error to pass a SetOptions object to a set() call that is missing a value for any
-   * of the fields specified here.
+   * <p>It is an error to pass a {@code SetOptions} object to a set() call that is missing a value
+   * for any of the fields specified here.
    *
    * @param fields The list of fields to merge. Fields can contain dots to reference nested fields
    *     within the document.
@@ -116,8 +116,8 @@ public final class SetOptions {
    * Changes the behavior of set() calls to only replace the fields under fieldPaths. Any field that
    * is not specified in fieldPaths is ignored and remains untouched.
    *
-   * <p>It is an error to pass a SetOptions object to a set() call that is missing a value for any
-   * of the fields specified here in its to data argument.
+   * <p>It is an error to pass a {@code SetOptions} object to a set() call that is missing a value
+   * for any of the fields specified here in its to data argument.
    *
    * @param fields The list of fields to merge.
    */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/SnapshotMetadata.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/SnapshotMetadata.java
@@ -20,9 +20,9 @@ import javax.annotation.Nullable;
 /**
  * Metadata about a snapshot, describing the state of the snapshot.
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class SnapshotMetadata {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/SnapshotMetadata.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/SnapshotMetadata.java
@@ -35,7 +35,7 @@ public class SnapshotMetadata {
   }
 
   /**
-   * @return true if the snapshot contains the result of local writes (e.g. {@code set()} or {@code
+   * @return true if the snapshot contains the result of local writes (for example, {@code set()} or {@code
    *     update()} calls) that have not yet been committed to the backend. If your listener has
    *     opted into metadata updates (via {@link MetadataChanges#INCLUDE}) you will receive another
    *     snapshot with {@code hasPendingWrites()} equal to false once the writes have been committed

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/SnapshotMetadata.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/SnapshotMetadata.java
@@ -35,11 +35,11 @@ public class SnapshotMetadata {
   }
 
   /**
-   * @return true if the snapshot contains the result of local writes (for example, {@code set()} or {@code
-   *     update()} calls) that have not yet been committed to the backend. If your listener has
-   *     opted into metadata updates (via {@link MetadataChanges#INCLUDE}) you will receive another
-   *     snapshot with {@code hasPendingWrites()} equal to false once the writes have been committed
-   *     to the backend.
+   * @return true if the snapshot contains the result of local writes (for example, {@code set()} or
+   *     {@code update()} calls) that have not yet been committed to the backend. If your listener
+   *     has opted into metadata updates (via {@link MetadataChanges#INCLUDE}) you will receive
+   *     another snapshot with {@code hasPendingWrites()} equal to false once the writes have been
+   *     committed to the backend.
    */
   @PublicApi
   public boolean hasPendingWrites() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/SnapshotMetadata.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/SnapshotMetadata.java
@@ -35,10 +35,11 @@ public class SnapshotMetadata {
   }
 
   /**
-   * @return true if the snapshot contains the result of local writes (e.g. set() or update() calls)
-   *     that have not yet been committed to the backend. If your listener has opted into metadata
-   *     updates (via `MetadataChanges.INCLUDE`) you will receive another snapshot with
-   *     `hasPendingWrites()` equal to false once the writes have been committed to the backend.
+   * @return true if the snapshot contains the result of local writes (e.g. {@code set()} or {@code
+   *     update()} calls) that have not yet been committed to the backend. If your listener has
+   *     opted into metadata updates (via {@link MetadataChanges#INCLUDE}) you will receive another
+   *     snapshot with {@code hasPendingWrites()} equal to false once the writes have been committed
+   *     to the backend.
    */
   @PublicApi
   public boolean hasPendingWrites() {
@@ -47,9 +48,9 @@ public class SnapshotMetadata {
 
   /**
    * @return true if the snapshot was created from cached data rather than guaranteed up-to-date
-   *     server data. If your listener has opted into metadata updates (via
-   *     `MetadataChanges.INCLUDE`) you will receive another snapshot with `isFomCache()` equal to
-   *     false once the client has received up-to-date data from the backend.
+   *     server data. If your listener has opted into metadata updates (via {@link
+   *     MetadataChanges#INCLUDE}) you will receive another snapshot with {@code isFromCache()}
+   *     equal to false once the client has received up-to-date data from the backend.
    */
   @PublicApi
   public boolean isFromCache() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Source.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Source.java
@@ -18,9 +18,9 @@ import com.google.firebase.annotations.PublicApi;
 
 /**
  * Configures the behavior of {@code get()} calls on {@link DocumentReference} and {@link Query}. By
- * providing a Source value, these methods can be configured to fetch results only from the server,
- * only from the local cache, or attempt to fetch results from the server and fall back to the cache
- * (which is the default).
+ * providing a {@code Source} value, these methods can be configured to fetch results only from the
+ * server, only from the local cache, or attempt to fetch results from the server and fall back to
+ * the cache (which is the default).
  */
 @PublicApi
 public enum Source {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Source.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Source.java
@@ -25,23 +25,23 @@ import com.google.firebase.annotations.PublicApi;
 @PublicApi
 public enum Source {
   /**
-   * Causes Firestore to try to retrieve an up-to-date (server-retrieved) snapshot, but fall back to
-   * returning cached data if the server can't be reached.
+   * Causes Cloud Firestore to try to retrieve an up-to-date (server-retrieved) snapshot, but fall
+   * back to returning cached data if the server can't be reached.
    */
   DEFAULT,
 
   /**
-   * Causes Firestore to avoid the cache, generating an error if the server cannot be reached. Note
-   * that the cache will still be updated if the server request succeeds. Also note that
+   * Causes Cloud Firestore to avoid the cache, generating an error if the server cannot be reached.
+   * Note that the cache will still be updated if the server request succeeds. Also note that
    * latency-compensation still takes effect, so any pending write operations will be visible in the
    * returned data (merged into the server-provided data).
    */
   SERVER,
 
   /**
-   * Causes Firestore to immediately return a value from the cache, ignoring the server completely
-   * (implying that the returned value may be stale with respect to the value on the server). If
-   * there is no data in the cache to satisfy the {@code get()} call, {@link
+   * Causes Cloud Firestore to immediately return a value from the cache, ignoring the server
+   * completely (implying that the returned value may be stale with respect to the value on the
+   * server). If there is no data in the cache to satisfy the {@code get()} call, {@link
    * DocumentReference#get()} will return an error and {@link Query#get()} will return an empty
    * {@link QuerySnapshot} with no documents.
    */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
@@ -191,8 +191,8 @@ public class Transaction {
    * Reads the document referenced by the provided {@link DocumentReference}
    *
    * @param documentRef The {@link DocumentReference} to read.
-   * @return A Task that will be resolved with the contents of the Document at this
-   *     {@link DocumentReference}.
+   * @return A Task that will be resolved with the contents of the Document at this {@link
+   *     DocumentReference}.
    */
   private Task<DocumentSnapshot> getAsync(DocumentReference documentRef) {
     return transaction

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
@@ -35,8 +35,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 /**
- * A Transaction is passed to a Function to provide the methods to read and write data within the
- * transaction context.
+ * A {@code Transaction} is passed to a Function to provide the methods to read and write data
+ * within the transaction context.
  *
  * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
@@ -56,13 +56,13 @@ public class Transaction {
   }
 
   /**
-   * Overwrites the document referred to by the provided DocumentReference. If the document does not
-   * yet exist, it will be created. If a document already exists, it will be overwritten.
+   * Overwrites the document referred to by the provided {@link DocumentReference}. If the document
+   * does not yet exist, it will be created. If a document already exists, it will be overwritten.
    *
-   * @param documentRef The DocumentReference to overwrite.
+   * @param documentRef The {@link DocumentReference} to overwrite.
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
-   * @return This Transaction instance. Used for chaining method calls.
+   * @return This {@code Transaction} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -75,11 +75,11 @@ public class Transaction {
    * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
    * into an existing document.
    *
-   * @param documentRef The DocumentReference to overwrite.
+   * @param documentRef The {@link DocumentReference} to overwrite.
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
    * @param options An object to configure the set behavior.
-   * @return This Transaction instance. Used for chaining method calls.
+   * @return This {@code Transaction} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -97,13 +97,13 @@ public class Transaction {
   }
 
   /**
-   * Updates fields in the document referred to by the provided DocumentReference. If no document
-   * exists yet, the update will fail.
+   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * document exists yet, the update will fail.
    *
-   * @param documentRef The DocumentReference to update.
+   * @param documentRef The {@link DocumentReference} to update.
    * @param data A map of field / value pairs to update. Fields can contain dots to reference nested
    *     fields within the document.
-   * @return This Transaction instance. Used for chaining method calls.
+   * @return This {@code Transaction} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -114,15 +114,15 @@ public class Transaction {
   }
 
   /**
-   * Updates fields in the document referred to by the provided DocumentReference. If no document
-   * exists yet, the update will fail.
+   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * document exists yet, the update will fail.
    *
-   * @param documentRef The DocumentReference to update.
+   * @param documentRef The {@link DocumentReference} to update.
    * @param field The first field to update. Fields can contain dots to reference a nested field
    *     within the document.
    * @param value The first value
    * @param moreFieldsAndValues Additional field/value pairs.
-   * @return This Transaction instance. Used for chaining method calls.
+   * @return This {@code Transaction} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -141,14 +141,14 @@ public class Transaction {
   }
 
   /**
-   * Updates fields in the document referred to by the provided DocumentReference. If no document
-   * exists yet, the update will fail.
+   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * document exists yet, the update will fail.
    *
-   * @param documentRef The DocumentReference to update.
+   * @param documentRef The {@link DocumentReference} to update.
    * @param fieldPath The first field to update.
    * @param value The first value
    * @param moreFieldsAndValues Additional field/value pairs.
-   * @return This Transaction instance. Used for chaining method calls.
+   * @return This {@code Transaction} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -174,10 +174,10 @@ public class Transaction {
   }
 
   /**
-   * Deletes the document referred to by the provided DocumentReference.
+   * Deletes the document referred to by the provided {@link DocumentReference}.
    *
-   * @param documentRef The DocumentReference to delete.
-   * @return This Transaction instance. Used for chaining method calls.
+   * @param documentRef The {@link DocumentReference} to delete.
+   * @return This {@code Transaction} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -188,11 +188,11 @@ public class Transaction {
   }
 
   /**
-   * Reads the document referenced by the provided DocumentReference
+   * Reads the document referenced by the provided {@link DocumentReference}
    *
-   * @param documentRef The DocumentReference to read.
+   * @param documentRef The {@link DocumentReference} to read.
    * @return A Task that will be resolved with the contents of the Document at this
-   *     DocumentReference.
+   *     {@link DocumentReference}.
    */
   private Task<DocumentSnapshot> getAsync(DocumentReference documentRef) {
     return transaction
@@ -223,10 +223,10 @@ public class Transaction {
   }
 
   /**
-   * Reads the document referenced by this DocumentReference
+   * Reads the document referenced by this {@link DocumentReference}
    *
-   * @param documentRef The DocumentReference to read.
-   * @return The contents of the Document at this DocumentReference.
+   * @param documentRef The {@link DocumentReference} to read.
+   * @return The contents of the Document at this {@link DocumentReference}.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
@@ -38,9 +38,9 @@ import java.util.concurrent.ExecutionException;
  * A Transaction is passed to a Function to provide the methods to read and write data within the
  * transaction context.
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  *
  * @see FirebaseFirestore#runTransaction(Function)
  */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Transaction.java
@@ -56,10 +56,10 @@ public class Transaction {
   }
 
   /**
-   * Overwrites the document referred to by the provided {@link DocumentReference}. If the document
+   * Overwrites the document referred to by the provided {@code DocumentReference}. If the document
    * does not yet exist, it will be created. If a document already exists, it will be overwritten.
    *
-   * @param documentRef The {@link DocumentReference} to overwrite.
+   * @param documentRef The {@code DocumentReference} to overwrite.
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
    * @return This {@code Transaction} instance. Used for chaining method calls.
@@ -72,10 +72,10 @@ public class Transaction {
 
   /**
    * Writes to the document referred to by the provided DocumentReference. If the document does not
-   * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
+   * yet exist, it will be created. If you pass {@code SetOptions}, the provided data can be merged
    * into an existing document.
    *
-   * @param documentRef The {@link DocumentReference} to overwrite.
+   * @param documentRef The {@code DocumentReference} to overwrite.
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
    * @param options An object to configure the set behavior.
@@ -97,10 +97,10 @@ public class Transaction {
   }
 
   /**
-   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * Updates fields in the document referred to by the provided {@code DocumentReference}. If no
    * document exists yet, the update will fail.
    *
-   * @param documentRef The {@link DocumentReference} to update.
+   * @param documentRef The {@code DocumentReference} to update.
    * @param data A map of field / value pairs to update. Fields can contain dots to reference nested
    *     fields within the document.
    * @return This {@code Transaction} instance. Used for chaining method calls.
@@ -114,10 +114,10 @@ public class Transaction {
   }
 
   /**
-   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * Updates fields in the document referred to by the provided {@code DocumentReference}. If no
    * document exists yet, the update will fail.
    *
-   * @param documentRef The {@link DocumentReference} to update.
+   * @param documentRef The {@code DocumentReference} to update.
    * @param field The first field to update. Fields can contain dots to reference a nested field
    *     within the document.
    * @param value The first value
@@ -141,10 +141,10 @@ public class Transaction {
   }
 
   /**
-   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * Updates fields in the document referred to by the provided {@code DocumentReference}. If no
    * document exists yet, the update will fail.
    *
-   * @param documentRef The {@link DocumentReference} to update.
+   * @param documentRef The {@code DocumentReference} to update.
    * @param fieldPath The first field to update.
    * @param value The first value
    * @param moreFieldsAndValues Additional field/value pairs.
@@ -174,9 +174,9 @@ public class Transaction {
   }
 
   /**
-   * Deletes the document referred to by the provided {@link DocumentReference}.
+   * Deletes the document referred to by the provided {@code DocumentReference}.
    *
-   * @param documentRef The {@link DocumentReference} to delete.
+   * @param documentRef The {@code DocumentReference} to delete.
    * @return This {@code Transaction} instance. Used for chaining method calls.
    */
   @NonNull
@@ -188,10 +188,10 @@ public class Transaction {
   }
 
   /**
-   * Reads the document referenced by the provided {@link DocumentReference}
+   * Reads the document referenced by the provided {@code DocumentReference}
    *
-   * @param documentRef The {@link DocumentReference} to read.
-   * @return A Task that will be resolved with the contents of the Document at this {@link
+   * @param documentRef The {@code DocumentReference} to read.
+   * @return A Task that will be resolved with the contents of the Document at this {@code
    *     DocumentReference}.
    */
   private Task<DocumentSnapshot> getAsync(DocumentReference documentRef) {
@@ -223,10 +223,10 @@ public class Transaction {
   }
 
   /**
-   * Reads the document referenced by this {@link DocumentReference}
+   * Reads the document referenced by this {@code DocumentReference}
    *
-   * @param documentRef The {@link DocumentReference} to read.
-   * @return The contents of the Document at this {@link DocumentReference}.
+   * @param documentRef The {@code DocumentReference} to read.
+   * @return The contents of the Document at this {@code DocumentReference}.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -88,7 +88,7 @@ public final class UserDataConverter {
    * Parse document data from a {@code set()} call with {@link SetOptions#merge()} set.
    *
    * @param input A map or POJO object representing document data.
-   * @param fieldMask A {@link FieldMask} object representing the fields to be merged.
+   * @param fieldMask A {@code FieldMask} object representing the fields to be merged.
    */
   public ParsedSetData parseMergeData(Object input, @Nullable FieldMask fieldMask) {
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.MergeSet);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -74,7 +74,7 @@ public final class UserDataConverter {
   }
 
   /**
-   * Parse document data from a non-merge set() call.
+   * Parse document data from a non-merge {@code set()} call.
    *
    * @param input A map or POJO object representing document data.
    */
@@ -85,7 +85,7 @@ public final class UserDataConverter {
   }
 
   /**
-   * Parse document data from a set() call with SetOptions.merge() set.
+   * Parse document data from a {@code set()} call with {@link SetOptions#merge()} set.
    *
    * @param input A map or POJO object representing document data.
    * @param fieldMask A {@link FieldMask} object representing the fields to be merged.
@@ -111,7 +111,7 @@ public final class UserDataConverter {
     }
   }
 
-  /** Parse update data from an update() call. */
+  /** Parse update data from an {@code update()} call. */
   public ParsedUpdateData parseUpdateData(Map<String, Object> data) {
     checkNotNull(data, "Provided update data must not be null.");
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -241,7 +241,7 @@ public final class UserDataConverter {
    * @param input Data to be parsed.
    * @param context A context object representing the current path being parsed, the source of the
    *     data being parsed, etc.
-   * @return The parsed value, or null if the value was a FieldValue sentinel that should not be
+   * @return The parsed value, or {@code null} if the value was a FieldValue sentinel that should not be
    *     included in the resulting parsed data.
    */
   @Nullable
@@ -380,7 +380,7 @@ public final class UserDataConverter {
   /**
    * Helper to parse a scalar value (i.e. not a Map or List)
    *
-   * @return The parsed value, or null if the value was a FieldValue sentinel that should not be
+   * @return The parsed value, or {@code null} if the value was a FieldValue sentinel that should not be
    *     included in the resulting parsed data.
    */
   @Nullable

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -241,8 +241,8 @@ public final class UserDataConverter {
    * @param input Data to be parsed.
    * @param context A context object representing the current path being parsed, the source of the
    *     data being parsed, etc.
-   * @return The parsed value, or {@code null} if the value was a FieldValue sentinel that should not be
-   *     included in the resulting parsed data.
+   * @return The parsed value, or {@code null} if the value was a FieldValue sentinel that should
+   *     not be included in the resulting parsed data.
    */
   @Nullable
   private FieldValue parseData(Object input, ParseContext context) {
@@ -380,8 +380,8 @@ public final class UserDataConverter {
   /**
    * Helper to parse a scalar value (i.e. not a Map or List)
    *
-   * @return The parsed value, or {@code null} if the value was a FieldValue sentinel that should not be
-   *     included in the resulting parsed data.
+   * @return The parsed value, or {@code null} if the value was a FieldValue sentinel that should
+   *     not be included in the resulting parsed data.
    */
   @Nullable
   private FieldValue parseScalarValue(Object input, ParseContext context) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
@@ -55,10 +55,10 @@ public class WriteBatch {
   }
 
   /**
-   * Overwrites the document referred to by the provided {@link DocumentReference}. If the document
+   * Overwrites the document referred to by the provided {@code DocumentReference}. If the document
    * does not yet exist, it will be created. If a document already exists, it will be overwritten.
    *
-   * @param documentRef The {@link DocumentReference} to overwrite.
+   * @param documentRef The {@code DocumentReference} to overwrite.
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
    * @return This {@code WriteBatch} instance. Used for chaining method calls.
@@ -70,11 +70,11 @@ public class WriteBatch {
   }
 
   /**
-   * Writes to the document referred to by the provided {@link DocumentReference}. If the document
-   * does not yet exist, it will be created. If you pass {@link SetOptions}, the provided data can
+   * Writes to the document referred to by the provided {@code DocumentReference}. If the document
+   * does not yet exist, it will be created. If you pass {@code SetOptions}, the provided data can
    * be merged into an existing document.
    *
-   * @param documentRef The {@link DocumentReference} to overwrite.
+   * @param documentRef The {@code DocumentReference} to overwrite.
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
    * @param options An object to configure the set behavior.
@@ -97,10 +97,10 @@ public class WriteBatch {
   }
 
   /**
-   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * Updates fields in the document referred to by the provided {@code DocumentReference}. If no
    * document exists yet, the update will fail.
    *
-   * @param documentRef The {@link DocumentReference} to update.
+   * @param documentRef The {@code DocumentReference} to update.
    * @param data A map of field / value pairs to update. Fields can contain dots to reference nested
    *     fields within the document.
    * @return This {@code WriteBatch} instance. Used for chaining method calls.
@@ -114,10 +114,10 @@ public class WriteBatch {
   }
 
   /**
-   * Updates field in the document referred to by the provided {@link DocumentReference}. If no
+   * Updates field in the document referred to by the provided {@code DocumentReference}. If no
    * document exists yet, the update will fail.
    *
-   * @param documentRef The {@link DocumentReference} to update.
+   * @param documentRef The {@code DocumentReference} to update.
    * @param field The first field to update. Fields can contain dots to reference a nested field
    *     within the document.
    * @param value The first value
@@ -141,10 +141,10 @@ public class WriteBatch {
   }
 
   /**
-   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * Updates fields in the document referred to by the provided {@code DocumentReference}. If no
    * document exists yet, the update will fail.
    *
-   * @param documentRef The {@link DocumentReference} to update.
+   * @param documentRef The {@code DocumentReference} to update.
    * @param fieldPath The first field to update.
    * @param value The first value
    * @param moreFieldsAndValues Additional field/value pairs.
@@ -175,9 +175,9 @@ public class WriteBatch {
   }
 
   /**
-   * Deletes the document referred to by the provided {@link DocumentReference}.
+   * Deletes the document referred to by the provided {@code DocumentReference}.
    *
-   * @param documentRef The {@link DocumentReference} to delete.
+   * @param documentRef The {@code DocumentReference} to delete.
    * @return This {@code WriteBatch} instance. Used for chaining method calls.
    */
   @NonNull
@@ -214,7 +214,7 @@ public class WriteBatch {
   }
 
   /**
-   * An interface for providing code to be executed within a {@link WriteBatch} context.
+   * An interface for providing code to be executed within a {@code WriteBatch} context.
    *
    * @see FirebaseFirestore#runBatch(WriteBatch.Function)
    */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
@@ -40,9 +40,9 @@ import java.util.Map;
  * <p>Unlike transactions, write batches are persisted offline and therefore are preferable when you
  * don't need to condition your writes on read data.
  *
- * <p><b>Subclassing Note</b>: Firestore classes are not meant to be subclassed except for use in
- * test mocks. Subclassing is not supported in production code and new SDK releases may break code
- * that does so.
+ * <p><b>Subclassing Note</b>: Cloud Firestore classes are not meant to be subclassed except for use
+ * in test mocks. Subclassing is not supported in production code and new SDK releases may break
+ * code that does so.
  */
 @PublicApi
 public class WriteBatch {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/WriteBatch.java
@@ -55,13 +55,13 @@ public class WriteBatch {
   }
 
   /**
-   * Overwrites the document referred to by the provided DocumentReference. If the document does not
-   * yet exist, it will be created. If a document already exists, it will be overwritten.
+   * Overwrites the document referred to by the provided {@link DocumentReference}. If the document
+   * does not yet exist, it will be created. If a document already exists, it will be overwritten.
    *
-   * @param documentRef The DocumentReference to overwrite.
+   * @param documentRef The {@link DocumentReference} to overwrite.
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
-   * @return This WriteBatch instance. Used for chaining method calls.
+   * @return This {@code WriteBatch} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -70,15 +70,15 @@ public class WriteBatch {
   }
 
   /**
-   * Writes to the document referred to by the provided DocumentReference. If the document does not
-   * yet exist, it will be created. If you pass {@link SetOptions}, the provided data can be merged
-   * into an existing document.
+   * Writes to the document referred to by the provided {@link DocumentReference}. If the document
+   * does not yet exist, it will be created. If you pass {@link SetOptions}, the provided data can
+   * be merged into an existing document.
    *
-   * @param documentRef The DocumentReference to overwrite.
+   * @param documentRef The {@link DocumentReference} to overwrite.
    * @param data The data to write to the document (e.g. a Map or a POJO containing the desired
    *     document contents).
    * @param options An object to configure the set behavior.
-   * @return This WriteBatch instance. Used for chaining method calls.
+   * @return This {@code WriteBatch} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -97,13 +97,13 @@ public class WriteBatch {
   }
 
   /**
-   * Updates fields in the document referred to by the provided DocumentReference. If no document
-   * exists yet, the update will fail.
+   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * document exists yet, the update will fail.
    *
-   * @param documentRef The DocumentReference to update.
+   * @param documentRef The {@link DocumentReference} to update.
    * @param data A map of field / value pairs to update. Fields can contain dots to reference nested
    *     fields within the document.
-   * @return This WriteBatch instance. Used for chaining method calls.
+   * @return This {@code WriteBatch} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -114,15 +114,15 @@ public class WriteBatch {
   }
 
   /**
-   * Updates field in the document referred to by the provided DocumentReference. If no document
-   * exists yet, the update will fail.
+   * Updates field in the document referred to by the provided {@link DocumentReference}. If no
+   * document exists yet, the update will fail.
    *
-   * @param documentRef The DocumentReference to update.
+   * @param documentRef The {@link DocumentReference} to update.
    * @param field The first field to update. Fields can contain dots to reference a nested field
    *     within the document.
    * @param value The first value
    * @param moreFieldsAndValues Additional field/value pairs.
-   * @return This WriteBatch instance. Used for chaining method calls.
+   * @return This {@code WriteBatch} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -141,14 +141,14 @@ public class WriteBatch {
   }
 
   /**
-   * Updates fields in the document referred to by the provided DocumentReference. If no document
-   * exists yet, the update will fail.
+   * Updates fields in the document referred to by the provided {@link DocumentReference}. If no
+   * document exists yet, the update will fail.
    *
-   * @param documentRef The DocumentReference to update.
+   * @param documentRef The {@link DocumentReference} to update.
    * @param fieldPath The first field to update.
    * @param value The first value
    * @param moreFieldsAndValues Additional field/value pairs.
-   * @return This WriteBatch instance. Used for chaining method calls.
+   * @return This {@code WriteBatch} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi
@@ -175,10 +175,10 @@ public class WriteBatch {
   }
 
   /**
-   * Deletes the document referred to by the provided DocumentReference.
+   * Deletes the document referred to by the provided {@link DocumentReference}.
    *
-   * @param documentRef The DocumentReference to delete.
-   * @return This WriteBatch instance. Used for chaining method calls.
+   * @param documentRef The {@link DocumentReference} to delete.
+   * @return This {@code WriteBatch} instance. Used for chaining method calls.
    */
   @NonNull
   @PublicApi

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -350,8 +350,7 @@ public final class SQLitePersistence extends Persistence {
   }
 
   /**
-   * Execute the given non-query SQL statement. Equivalent to <code>execute(prepare(sql), args)
-   * </code>.
+   * Execute the given non-query SQL statement. Equivalent to {@code execute(prepare(sql), args)}.
    */
   void execute(String sql, Object... args) {
     // Note that unlike db.query and friends, execSQL already takes Object[] bindArgs so there's no

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -149,8 +149,8 @@ public final class SQLitePersistence extends Persistence {
               + " app. Keep in mind that multi-process Android apps execute the code in your"
               + " Application class in all processes, so you may need to avoid initializing"
               + " Cloud Firestore in your Application class. If you are intentionally using Cloud"
-              + " Firestore from multiple processes, you can only enable offline persistence (i.e. "
-              + " call setPersistenceEnabled(true)) in one of them.",
+              + " Firestore from multiple processes, you can only enable offline persistence (that"
+              + " is, call setPersistenceEnabled(true)) in one of them.",
           e);
     }
     queryCache.start();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -144,13 +144,13 @@ public final class SQLitePersistence extends Persistence {
     } catch (SQLiteDatabaseLockedException e) {
       // TODO: Use a better exception type
       throw new RuntimeException(
-          "Failed to gain exclusive lock to the Firestore client's offline persistence. This"
-              + " generally means you are using Firestore from multiple processes in your app."
-              + " Keep in mind that multi-process Android apps execute the code in your"
+          "Failed to gain exclusive lock to the Cloud Firestore client's offline persistence. This"
+              + " generally means you are using Cloud Firestore from multiple processes in your"
+              + " app. Keep in mind that multi-process Android apps execute the code in your"
               + " Application class in all processes, so you may need to avoid initializing"
-              + " Firestore in your Application class. If you are intentionally using Firestore"
-              + " from multiple processes, you can only enable offline persistence (i.e. call"
-              + " setPersistenceEnabled(true)) in one of them.",
+              + " Cloud Firestore in your Application class. If you are intentionally using Cloud"
+              + " Firestore from multiple processes, you can only enable offline persistence (i.e. "
+              + " call setPersistenceEnabled(true)) in one of them.",
           e);
     }
     queryCache.start();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
@@ -63,9 +63,9 @@ public class Datastore {
    * part of their app's dependencies.
    */
   static final String SSL_DEPENDENCY_ERROR_MESSAGE =
-      "The Firestore SDK failed to establish a secure connection. This is likely a problem with "
-          + "your app, rather than with Firestore itself. See https://bit.ly/2XFpdma for "
-          + "instructions on how to enable TLS on Android 4.x devices.";
+      "The Cloud Firestore SDK failed to establish a secure connection. This is likely a problem "
+          + "with your app, rather than with Cloud Firestore itself. See https://bit.ly/2XFpdma "
+          + "for instructions on how to enable TLS on Android 4.x devices.";
 
   /** Set of lowercase, white-listed headers for logging purposes. */
   static final Set<String> WHITE_LISTED_HEADERS =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
@@ -63,9 +63,9 @@ public class Datastore {
    * part of their app's dependencies.
    */
   static final String SSL_DEPENDENCY_ERROR_MESSAGE =
-      "The Cloud Firestore SDK failed to establish a secure connection. This is likely a problem "
-          + "with your app, rather than with Cloud Firestore itself. See https://bit.ly/2XFpdma "
-          + "for instructions on how to enable TLS on Android 4.x devices.";
+      "The Cloud Firestore client failed to establish a secure connection. This is likely a "
+          + "problem with your app, rather than with Cloud Firestore itself. See "
+          + "https://bit.ly/2XFpdma for instructions on how to enable TLS on Android 4.x devices.";
 
   /** Set of lowercase, white-listed headers for logging purposes. */
   static final Set<String> WHITE_LISTED_HEADERS =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -511,7 +511,7 @@ public class AsyncQueue {
             throw error;
           } else {
             throw new RuntimeException(
-                "Internal error in Firestore (" + BuildConfig.VERSION_NAME + ").", t);
+                "Internal error in Cloud Firestore (" + BuildConfig.VERSION_NAME + ").", t);
           }
         });
   }


### PR DESCRIPTION
Addresses the comments in http://b/137376378.

I additionally attempted to find/fix some other similar issues while I was at it. In all cases, I used automated/semi-automated methods to find/fix rather than actually auditing the files, so there's probably many more things that could be addressed.

Generally, I've used `@code` for self-references (i.e. `{@code Blob}` within Blob.java) and `@link` otherwise.) But I haven't attempted to unify this across the codebase.