### PR TITLE
Various updates to datatransport

### DIFF
--- a/transport/transport-backend-cct/gradle.properties
+++ b/transport/transport-backend-cct/gradle.properties
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=2.0.1
-latestReleasedVersion=2.0.0
+version=2.0.2
+latestReleasedVersion=2.0.1
 firebaseSkipPreguard=false

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
@@ -19,6 +19,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
 import androidx.annotation.VisibleForTesting;
+import com.google.android.datatransport.backend.cct.BuildConfig;
 import com.google.android.datatransport.cct.proto.AndroidClientInfo;
 import com.google.android.datatransport.cct.proto.BatchedLogRequest;
 import com.google.android.datatransport.cct.proto.ClientInfo;
@@ -217,6 +218,8 @@ final class CctTransportBackend implements TransportBackend {
     connection.setDoOutput(true);
     connection.setInstanceFollowRedirects(false);
     connection.setRequestMethod("POST");
+    connection.setRequestProperty(
+        "User-Agent", String.format("datatransport/%s android/", BuildConfig.VERSION_NAME));
     connection.setRequestProperty(CONTENT_ENCODING_HEADER_KEY, GZIP_CONTENT_ENCODING);
     connection.setRequestProperty(CONTENT_TYPE_HEADER_KEY, PROTOBUF_CONTENT_TYPE);
 

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
@@ -31,6 +31,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.android.datatransport.backend.cct.BuildConfig;
 import com.google.android.datatransport.cct.ProtoMatchers.PredicateMatcher;
 import com.google.android.datatransport.cct.proto.BatchedLogRequest;
 import com.google.android.datatransport.cct.proto.LogEvent;
@@ -126,6 +127,9 @@ public class CctTransportBackendTest {
 
     verify(
         postRequestedFor(urlEqualTo("/api"))
+            .withHeader(
+                "User-Agent",
+                equalTo(String.format("datatransport/%s android/", BuildConfig.VERSION_NAME)))
             .withHeader("Content-Type", equalTo("application/x-protobuf"))
             .andMatching(batchRequestMatcher.test(batch -> batch.getLogRequestCount() == 1))
             .andMatching(

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -54,6 +54,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        versionName version
     }
     compileOptions {
         sourceCompatibility = '1.8'

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntime.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/TransportRuntime.java
@@ -36,7 +36,7 @@ import javax.inject.Singleton;
 @Singleton
 public class TransportRuntime implements TransportInternal {
 
-  private static volatile TransportRuntimeComponent INSTANCE = null;
+  private static volatile TransportRuntimeComponent instance = null;
 
   private final Clock eventClock;
   private final Clock uptimeClock;
@@ -61,12 +61,14 @@ public class TransportRuntime implements TransportInternal {
    * <p>This method must be called before {@link #getInstance()}.
    */
   public static void initialize(Context applicationContext) {
-    if (INSTANCE == null) {
+    if (instance == null) {
       synchronized (TransportRuntime.class) {
-        INSTANCE =
-            DaggerTransportRuntimeComponent.builder()
-                .setApplicationContext(applicationContext)
-                .build();
+        if (instance == null) {
+          instance =
+              DaggerTransportRuntimeComponent.builder()
+                  .setApplicationContext(applicationContext)
+                  .build();
+        }
       }
     }
     // send warning
@@ -78,7 +80,7 @@ public class TransportRuntime implements TransportInternal {
    * @throws IllegalStateException if {@link #initialize(Context)} is not called before this method.
    */
   public static TransportRuntime getInstance() {
-    TransportRuntimeComponent localRef = INSTANCE;
+    TransportRuntimeComponent localRef = instance;
     if (localRef == null) {
       throw new IllegalStateException("Not initialized!");
     }
@@ -91,14 +93,14 @@ public class TransportRuntime implements TransportInternal {
       throws Throwable {
     TransportRuntimeComponent original;
     synchronized (TransportRuntime.class) {
-      original = INSTANCE;
-      INSTANCE = component;
+      original = instance;
+      instance = component;
     }
     try {
       callable.call();
     } finally {
       synchronized (TransportRuntime.class) {
-        INSTANCE = original;
+        instance = original;
       }
     }
   }


### PR DESCRIPTION
* Fix data race in initialize().
  The issue is that we were not doing the double-checked locking properly,
  which could manifest in instantiating multiple instances of
  TransportRuntime due to concurrent calls to initialize().
* Set custom user-agent on requests to CCT.