### PR TITLE
Increase Remote Config's default timeout.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -60,7 +60,7 @@ public class RemoteConfigComponent {
   /** Name of the file where defaults configs are stored. */
   public static final String DEFAULTS_FILE_NAME = "defaults";
   /** Timeout for the call to the Firebase Remote Config servers in second. */
-  public static final long NETWORK_CONNECTION_TIMEOUT_IN_SECONDS = 5;
+  public static final long NETWORK_CONNECTION_TIMEOUT_IN_SECONDS = 30;
 
   private static final String FIREBASE_REMOTE_CONFIG_FILE_NAME_PREFIX = "frc";
   private static final String PREFERENCES_FILE_NAME = "settings";

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -60,7 +60,7 @@ public class RemoteConfigComponent {
   /** Name of the file where defaults configs are stored. */
   public static final String DEFAULTS_FILE_NAME = "defaults";
   /** Timeout for the call to the Firebase Remote Config servers in second. */
-  public static final long NETWORK_CONNECTION_TIMEOUT_IN_SECONDS = 30;
+  public static final long NETWORK_CONNECTION_TIMEOUT_IN_SECONDS = 60;
 
   private static final String FIREBASE_REMOTE_CONFIG_FILE_NAME_PREFIX = "frc";
   private static final String PREFERENCES_FILE_NAME = "settings";


### PR DESCRIPTION
The default timeout of 5 seconds is way too short. The network is not
guaranteed to be in a good state, and this may cause apps to crash
unexpectedly. This is the source of some flakiness in tests as well.

This change increases the timeout to 30 seconds. Updates are infrequent
and run in the background, so this should not be a problem.

Edit: The timeout is now changed to 60 seconds to match the iOS implementation.