### PR TITLE
Make component discovery directBootAware

### DIFF
--- a/firebase-common/src/main/AndroidManifest.xml
+++ b/firebase-common/src/main/AndroidManifest.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.firebase">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
   <!--<uses-sdk android:minSdkVersion="14"/>-->
   <application>
+
+    <service android:name="com.google.firebase.components.ComponentDiscoveryService"
+        android:directBootAware="true" android:exported="false"
+        tools:targetApi="n" />
 
     <provider
         android:name="com.google.firebase.provider.FirebaseInitProvider"


### PR DESCRIPTION
Firebase itself does not initialize in direct-boot mode and only does so
when the device is unlocked.

While this works most of the time, there are apps that initializeApp()
manually when in direct boot mode and this causes component discovery to
fail(b/138578076).

The change marks ComponentDiscoveryService as directBootAware so that
components are able to be discovered. Whether components are able to
function in direct boot mode is up to each SDK implementation and is
currently provided as best effort.