### PR TITLE
Remove overrideChannelBuilder

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -19,7 +19,6 @@ import static com.google.firebase.firestore.util.Util.autoId;
 import static org.junit.Assert.assertNull;
 
 import android.content.Context;
-import android.net.SSLCertificateSocketFactory;
 import android.os.StrictMode;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
@@ -40,12 +39,10 @@ import com.google.firebase.firestore.auth.EmptyCredentialsProvider;
 import com.google.firebase.firestore.core.DatabaseInfo;
 import com.google.firebase.firestore.local.Persistence;
 import com.google.firebase.firestore.model.DatabaseId;
-import com.google.firebase.firestore.remote.GrpcCallProvider;
 import com.google.firebase.firestore.testutil.provider.FirestoreProvider;
 import com.google.firebase.firestore.util.AsyncQueue;
 import com.google.firebase.firestore.util.Logger;
 import com.google.firebase.firestore.util.Logger.Level;
-import io.grpc.okhttp.OkHttpChannelBuilder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -117,25 +114,7 @@ public class IntegrationTestUtil {
 
     if (CONNECT_TO_EMULATOR) {
       settings.setHost(String.format("%s:%d", EMULATOR_HOST, EMULATOR_PORT));
-
-      // The `sslEnabled` flag in DatabaseInfo currently does not in fact disable all SSL checks.
-      // Instead, we manually disable the SSL certificate check and the hostname verification for
-      // connections to the emulator.
-      // TODO(mrschmidt): Update the client to respect the `sslEnabled` flag and remove these
-      // channel overrides.
-      OkHttpChannelBuilder channelBuilder =
-          new OkHttpChannelBuilder(EMULATOR_HOST, EMULATOR_PORT) {
-            @Override
-            protected String checkAuthority(String authority) {
-              return authority;
-            }
-          };
-      channelBuilder.hostnameVerifier((hostname, session) -> true);
-      SSLCertificateSocketFactory insecureFactory =
-          (SSLCertificateSocketFactory) SSLCertificateSocketFactory.getInsecure(0, null);
-      channelBuilder.sslSocketFactory(insecureFactory);
-      channelBuilder.usePlaintext();
-      GrpcCallProvider.overrideChannelBuilder(() -> channelBuilder);
+      settings.setSslEnabled(false);
     } else {
       settings.setHost(provider.firestoreHost());
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
@@ -15,7 +15,6 @@
 package com.google.firebase.firestore.remote;
 
 import android.content.Context;
-import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.security.ProviderInstaller;
@@ -25,7 +24,6 @@ import com.google.firebase.firestore.core.DatabaseInfo;
 import com.google.firebase.firestore.util.AsyncQueue;
 import com.google.firebase.firestore.util.Executors;
 import com.google.firebase.firestore.util.Logger;
-import com.google.firebase.firestore.util.Supplier;
 import com.google.firestore.v1.FirestoreGrpc;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
@@ -43,25 +41,10 @@ public class GrpcCallProvider {
 
   private static final String LOG_TAG = "GrpcCallProvider";
 
-  private static Supplier<ManagedChannelBuilder<?>> overrideChannelBuilderSupplier;
-
   private final Task<ManagedChannel> channelTask;
   private final AsyncQueue asyncQueue;
 
   private CallOptions callOptions;
-
-  /**
-   * Helper function to globally override the channel that RPCs use. Useful for testing when you
-   * want to bypass SSL certificate checking.
-   *
-   * @param channelBuilderSupplier The supplier for a channel builder that is used to create gRPC
-   *     channels.
-   */
-  @VisibleForTesting
-  public static void overrideChannelBuilder(
-      Supplier<ManagedChannelBuilder<?>> channelBuilderSupplier) {
-    overrideChannelBuilderSupplier = channelBuilderSupplier;
-  }
 
   GrpcCallProvider(
       AsyncQueue asyncQueue,
@@ -105,16 +88,12 @@ public class GrpcCallProvider {
       Logger.warn(LOG_TAG, "Failed to update ssl context: %s", e);
     }
 
-    ManagedChannelBuilder<?> channelBuilder;
-    if (overrideChannelBuilderSupplier != null) {
-      channelBuilder = overrideChannelBuilderSupplier.get();
-    } else {
-      channelBuilder = ManagedChannelBuilder.forTarget(databaseInfo.getHost());
-      if (!databaseInfo.isSslEnabled()) {
-        // Note that the boolean flag does *NOT* switch the wire format from Protobuf to Plaintext.
-        // It merely turns off SSL encryption.
-        channelBuilder.usePlaintext();
-      }
+    ManagedChannelBuilder<?> channelBuilder =
+        ManagedChannelBuilder.forTarget(databaseInfo.getHost());
+    if (!databaseInfo.isSslEnabled()) {
+      // Note that the boolean flag does *NOT* switch the wire format from Protobuf to Plaintext.
+      // It merely turns off SSL encryption.
+      channelBuilder.usePlaintext();
     }
 
     // Ensure gRPC recovers from a dead connection. (Not typically necessary, as the OS will


### PR DESCRIPTION
We no longer need the overrideChannelBuilder to connect to the emulator. 