### PR TITLE
Add support for /?ns= query param in Database URL

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 19.1.0
+- [feature] The SDK adds support for the Firebase Database Emulator. To connect
+  to the emulator, specify "http://<emulatorHost>/?ns=<projectId>" as your
+  Database URL (via `FirebaseDatabase.getInstance(String)`).
+  Note that if you are running the Database Emulator on "localhost" and
+  connecting from an app that is running inside an Android Emulator, the
+  emulator host will be "10.0.2.2" followed by its port.
+
 # 18.0.1
 - [changed] The SDK now reports the correct version number (via
   `FirebaseDatabase.getSdkVersion()`).

--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 19.1.0
-- [feature] The SDK added support for the Firebase Database Emulator. To
-  connect to the emulator, specify "http://<emulatorHost>/?ns=<projectId>" as
-  your Database URL (via `FirebaseDatabase.getInstance(String)`).
+- [feature] Added support for the Firebase Database Emulator. To connect to
+  the emulator, specify "http://<emulatorHost>/?ns=<projectId>" as your
+  Database URL (via `FirebaseDatabase.getInstance(String)`).
   Note that if you are running the Database Emulator on "localhost" and
   connecting from an app that is running inside an Android Emulator, the
   emulator host will be "10.0.2.2" followed by its port.

--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 19.1.0
-- [feature] The SDK adds support for the Firebase Database Emulator. To connect
-  to the emulator, specify "http://<emulatorHost>/?ns=<projectId>" as your
-  Database URL (via `FirebaseDatabase.getInstance(String)`).
+- [feature] The SDK added support for the Firebase Database Emulator. To
+  connect to the emulator, specify "http://<emulatorHost>/?ns=<projectId>" as
+  your Database URL (via `FirebaseDatabase.getInstance(String)`).
   Note that if you are running the Database Emulator on "localhost" and
   connecting from an app that is running inside an Android Emulator, the
   emulator host will be "10.0.2.2" followed by its port.

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/DataTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/DataTest.java
@@ -1087,12 +1087,7 @@ public class DataTest {
 
     String child = "" + new Random().nextInt(100000000);
     new WriteFuture(ref.child(child), "testdata").timedGet();
-
     DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.child(child));
-    assertEquals("testdata", snap.getValue());
-
-    DatabaseReference refWithEncoding = new DatabaseReference(encoded, ctx);
-    snap = IntegrationTestHelpers.getSnap(refWithEncoding.child(child));
     assertEquals("testdata", snap.getValue());
   }
 

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/DataTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/DataTest.java
@@ -1081,13 +1081,18 @@ public class DataTest {
         new DatabaseReference(
             IntegrationTestValues.getNamespace() + "/a%b&c@d/space: /non-ascii:ø", ctx);
     String result = ref.toString();
-    String expected =
+    String encoded =
         IntegrationTestValues.getNamespace() + "/a%25b%26c%40d/space%3A%20/non-ascii%3A%C3%B8";
-    assertEquals(expected, result);
+    assertEquals(encoded, result);
 
     String child = "" + new Random().nextInt(100000000);
     new WriteFuture(ref.child(child), "testdata").timedGet();
+
     DataSnapshot snap = IntegrationTestHelpers.getSnap(ref.child(child));
+    assertEquals("testdata", snap.getValue());
+
+    DatabaseReference refWithEncoding = new DatabaseReference(encoded, ctx);
+    snap = IntegrationTestHelpers.getSnap(refWithEncoding.child(child));
     assertEquals("testdata", snap.getValue());
   }
 

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -170,7 +170,7 @@ public class FirebaseDatabaseTest {
     config.setPersistenceCacheSizeBytes(1 * 1024 * 1024);
 
     try {
-      FirebaseDatabase db = new DatabaseReference("", config).getDatabase();
+      FirebaseDatabase db = new DatabaseReference("http://localhost", config).getDatabase();
       db.setPersistenceCacheSizeBytes(1 * 1024 * 1024);
       fail("should throw - can't modify after init");
     } catch (DatabaseException e) {

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/RealtimeTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/RealtimeTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.fail;
 import androidx.test.runner.AndroidJUnit4;
 import com.google.firebase.database.core.DatabaseConfig;
 import com.google.firebase.database.core.RepoManager;
-import com.google.firebase.database.core.utilities.ParsedUrl;
-import com.google.firebase.database.core.utilities.Utilities;
 import com.google.firebase.database.future.ReadFuture;
 import com.google.firebase.database.future.WriteFuture;
 import java.util.List;
@@ -46,21 +44,6 @@ public class RealtimeTest {
   @After
   public void tearDown() {
     IntegrationTestHelpers.failOnFirstUncaughtException();
-  }
-
-  @Test
-  public void testUrlParsing() throws DatabaseException {
-    ParsedUrl parsed = Utilities.parseUrl("http://gsoltis.fblocal.com:9000");
-    assertEquals(parsed.path.toString(), "/");
-    assertEquals(parsed.repoInfo.host, "gsoltis.fblocal.com:9000");
-    assertEquals(parsed.repoInfo.internalHost, "gsoltis.fblocal.com:9000");
-    assertEquals(parsed.repoInfo.secure, false);
-
-    parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com/foo/bar");
-    assertEquals(parsed.path.toString(), "/foo/bar");
-    assertEquals(parsed.repoInfo.host, "gsoltis.firebaseio.com");
-    assertEquals(parsed.repoInfo.internalHost, "gsoltis.firebaseio.com");
-    assertEquals(parsed.repoInfo.secure, true);
   }
 
   @Test

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/ParsedUrl.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/ParsedUrl.java
@@ -21,4 +21,15 @@ public class ParsedUrl {
 
   public RepoInfo repoInfo;
   public Path path;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ParsedUrl parsedUrl = (ParsedUrl) o;
+
+    if (!repoInfo.equals(parsedUrl.repoInfo)) return false;
+    return path.equals(parsedUrl.path);
+  }
 }

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.database.core.utilities;
 
+import android.net.Uri;
 import android.util.Base64;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
@@ -23,44 +24,16 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.core.Path;
 import com.google.firebase.database.core.RepoInfo;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.Map;
 
 public class Utilities {
   private static final char[] HEX_CHARACTERS = "0123456789abcdef".toCharArray();
 
   public static ParsedUrl parseUrl(String url) throws DatabaseException {
-    String original = url;
     try {
-      int schemeOffset = original.indexOf("//");
-      if (schemeOffset == -1) {
-        throw new URISyntaxException(original, "Invalid scheme specified");
-      }
-      int pathOffset = original.substring(schemeOffset + 2).indexOf("/");
-      if (pathOffset != -1) {
-        pathOffset += schemeOffset + 2;
-        String[] pathSegments = original.substring(pathOffset).split("/", -1);
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < pathSegments.length; ++i) {
-          if (!pathSegments[i].equals("")) {
-            builder.append("/");
-            builder.append(URLEncoder.encode(pathSegments[i], "UTF-8"));
-          }
-        }
-        original = original.substring(0, pathOffset) + builder.toString();
-      }
-
-      URI uri = new URI(original);
-      // URLEncoding a space turns it into a '+', which is different
-      // from our expected behavior. Do a manual replace to fix it.
-      String pathString = uri.getPath().replace("+", " ");
-      Validation.validateRootPathString(pathString);
-      Path path = new Path(pathString);
+      Uri uri = Uri.parse(url);
       String scheme = uri.getScheme();
 
       RepoInfo repoInfo = new RepoInfo();
@@ -70,36 +43,61 @@ public class Utilities {
       if (port != -1) {
         repoInfo.secure = scheme.equals("https");
         repoInfo.host += ":" + port;
+      } else if (repoInfo.host.equals("localhost")) {
+        repoInfo.secure = scheme.equals("https");
       } else {
         repoInfo.secure = true;
       }
-      String[] parts = repoInfo.host.split("\\.", -1);
 
-      repoInfo.namespace = parts[0].toLowerCase();
+      String namespaceParam = uri.getQueryParameter("ns");
+      String[] parts = uri.getHost().split("\\.", -1);
+      if (parts.length == 3 || namespaceParam == null) {
+        // We use the subdomain from the provided host even when a query parameter is provided to
+        // maintain backward compatibility.
+        repoInfo.namespace = parts[0].toLowerCase();
+      } else {
+        repoInfo.namespace = namespaceParam;
+      }
+
       repoInfo.internalHost = repoInfo.host;
-      ParsedUrl parsedUrl = new ParsedUrl();
-      parsedUrl.path = path;
-      parsedUrl.repoInfo = repoInfo;
-      return parsedUrl;
 
-    } catch (URISyntaxException e) {
+      String originalPathString = extractPathString(url);
+      // Instead of '+', the RTDB SDK uses spaces
+      originalPathString = originalPathString.replace("+", " ");
+      Validation.validateRootPathString(originalPathString);
+
+      ParsedUrl parsedUrl = new ParsedUrl();
+      parsedUrl.path = new Path(originalPathString);
+      parsedUrl.repoInfo = repoInfo;
+
+      return parsedUrl;
+    } catch (Exception e) {
       throw new DatabaseException("Invalid Firebase Database url specified", e);
-    } catch (UnsupportedEncodingException e) {
-      throw new DatabaseException("Failed to URLEncode the path", e);
     }
   }
 
-  public static String[] splitIntoFrames(String src, int maxFrameSize) {
-    if (src.length() <= maxFrameSize) {
-      return new String[] {src};
-    } else {
-      ArrayList<String> segs = new ArrayList<String>();
-      for (int i = 0; i < src.length(); i += maxFrameSize) {
-        int end = Math.min(i + maxFrameSize, src.length());
-        String seg = src.substring(i, end);
-        segs.add(seg);
+  /**
+   * Extracts the path string from the original URL without changing the encoding (unlike
+   * Uri.getPath()).
+   */
+  private static String extractPathString(String originalUrl) {
+    int schemeOffset = originalUrl.indexOf("//");
+    if (schemeOffset == -1) {
+      throw new DatabaseException("Firebase Database URL is missing URL scheme");
+    }
+
+    int pathOffset = originalUrl.substring(schemeOffset + 2).indexOf("/");
+    if (pathOffset != -1) {
+      pathOffset += schemeOffset + 2;
+
+      int queryOffset = originalUrl.indexOf("?");
+      if (queryOffset != -1) {
+        return originalUrl.substring(pathOffset, queryOffset);
+      } else {
+        return originalUrl.substring(pathOffset);
       }
-      return segs.toArray(new String[segs.size()]);
+    } else {
+      return "";
     }
   }
 

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
@@ -24,7 +24,6 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.core.Path;
 import com.google.firebase.database.core.RepoInfo;
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -68,7 +67,9 @@ public class Utilities {
       repoInfo.internalHost = repoInfo.host;
 
       String originalPathString = extractPathString(url);
-      originalPathString = tryUrlDecode(originalPathString, /*fallback=*/ originalPathString);
+      // URLEncoding a space turns it into a '+', which is different
+      // from our expected behavior. Do a manual replace to fix it.
+      originalPathString = originalPathString.replace("+", " ");
       Validation.validateRootPathString(originalPathString);
 
       ParsedUrl parsedUrl = new ParsedUrl();
@@ -102,15 +103,6 @@ public class Utilities {
       }
     } else {
       return "";
-    }
-  }
-
-  private static String tryUrlDecode(String url, String fallback) {
-    try {
-      return URLDecoder.decode(url, "UTF-8");
-    } catch (IllegalArgumentException | UnsupportedEncodingException e) {
-      // Manually replace "+" with space even if the decoding failed.
-      return fallback.replace("+", " ");
     }
   }
 

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
@@ -86,15 +86,14 @@ public class Utilities {
       throw new DatabaseException("Firebase Database URL is missing URL scheme");
     }
 
-    int pathOffset = originalUrl.substring(schemeOffset + 2).indexOf("/");
+    String urlWithoutScheme = originalUrl.substring(schemeOffset + 2);
+    int pathOffset = urlWithoutScheme.indexOf("/");
     if (pathOffset != -1) {
-      pathOffset += schemeOffset + 2;
-
-      int queryOffset = originalUrl.indexOf("?");
+      int queryOffset = urlWithoutScheme.indexOf("?");
       if (queryOffset != -1) {
-        return originalUrl.substring(pathOffset, queryOffset);
+        return urlWithoutScheme.substring(pathOffset + 1, queryOffset);
       } else {
-        return originalUrl.substring(pathOffset);
+        return urlWithoutScheme.substring(pathOffset + 1);
       }
     } else {
       return "";

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
@@ -24,6 +24,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.core.Path;
 import com.google.firebase.database.core.RepoInfo;
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -62,8 +63,7 @@ public class Utilities {
       repoInfo.internalHost = repoInfo.host;
 
       String originalPathString = extractPathString(url);
-      // Instead of '+', the RTDB SDK uses spaces
-      originalPathString = originalPathString.replace("+", " ");
+      originalPathString = tryUrlDecode(originalPathString, /*fallback=*/ originalPathString);
       Validation.validateRootPathString(originalPathString);
 
       ParsedUrl parsedUrl = new ParsedUrl();
@@ -72,7 +72,16 @@ public class Utilities {
 
       return parsedUrl;
     } catch (Exception e) {
-      throw new DatabaseException("Invalid Firebase Database url specified", e);
+      throw new DatabaseException("Invalid Firebase Database url specified: " + url, e);
+    }
+  }
+
+  private static String tryUrlDecode(String url, String fallback) {
+    try {
+      return URLDecoder.decode(url, "UTF-8");
+    } catch (IllegalArgumentException | UnsupportedEncodingException e) {
+      // Manually replace "+" with space even if the decoding failed.
+      return fallback.replace("+", " ");
     }
   }
 

--- a/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
@@ -1,0 +1,95 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.database.core.utilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.firebase.database.DatabaseException;
+import org.junit.Test;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@org.junit.runner.RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ParseUrlTest {
+
+  @Test
+  public void testUrlParsing() throws DatabaseException {
+    ParsedUrl parsed = Utilities.parseUrl("http://gsoltis.fblocal.com:9000");
+    assertEquals("/", parsed.path.toString());
+    assertEquals("gsoltis.fblocal.com:9000", parsed.repoInfo.host);
+    assertEquals("gsoltis.fblocal.com:9000", parsed.repoInfo.internalHost);
+
+    parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com/foo/bar");
+    assertEquals("/foo/bar", parsed.path.toString());
+    assertEquals("gsoltis.firebaseio.com", parsed.repoInfo.host);
+    assertEquals("gsoltis.firebaseio.com", parsed.repoInfo.internalHost);
+
+    parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com/foo/empty space");
+    assertEquals("/foo/empty space", parsed.path.toString());
+    assertEquals("gsoltis.firebaseio.com", parsed.repoInfo.host);
+    assertEquals("gsoltis.firebaseio.com", parsed.repoInfo.internalHost);
+
+    parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com/foo/\\;:@\uD83D\uDE00");
+    assertEquals("/foo/\\;:@\uD83D\uDE00", parsed.path.toString());
+    assertEquals("gsoltis.firebaseio.com", parsed.repoInfo.host);
+    assertEquals("gsoltis.firebaseio.com", parsed.repoInfo.internalHost);
+  }
+
+  @Test
+  public void testUrlParsingTurnsPlusIntoSpace() throws DatabaseException {
+    ParsedUrl parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com/+");
+    assertEquals("/ ", parsed.path.toString());
+  }
+
+  @Test
+  public void testUrlParsingSpecialCharacters() throws DatabaseException {
+    ParsedUrl parsed =
+        Utilities.parseUrl("http://gsoltis.firebaseio.com/a%b&c@d/space: /non-ascii:ø");
+    assertEquals("/a%b&c@d/space: /non-ascii:ø", parsed.path.toString());
+  }
+
+  @Test
+  public void testUrlParsingWithNamespace() throws DatabaseException {
+    ParsedUrl parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com/foo/bar?ns=mrschmidt");
+    assertEquals(parsed.path.toString(), "/foo/bar");
+    // The subdomain takes precedence if one is provided
+    assertEquals("gsoltis", parsed.repoInfo.namespace);
+
+    parsed = Utilities.parseUrl("http://localhost/foo/bar?ns=mrschmidt");
+    assertEquals("mrschmidt", parsed.repoInfo.namespace);
+
+    parsed = Utilities.parseUrl("http://10.0.2.2:9000/foo/bar?ns=mrschmidt");
+    assertEquals(parsed.path.toString(), "/foo/bar");
+    assertEquals("mrschmidt", parsed.repoInfo.namespace);
+  }
+
+  @Test
+  public void testUrlParsingSslDetection() throws DatabaseException {
+    // Hosts with custom ports are considered non-secure
+    ParsedUrl parsed = Utilities.parseUrl("http://gsoltis.fblocal.com:9000");
+    assertFalse(parsed.repoInfo.secure);
+
+    // Hosts with the default ports are considered secure
+    parsed = Utilities.parseUrl("http://gsoltis.firebaseio.comr");
+    assertTrue(parsed.repoInfo.secure);
+
+    // Localhost is special-cased as insecure
+    parsed = Utilities.parseUrl("http://localhost/");
+    assertFalse(parsed.repoInfo.secure);
+  }
+}

--- a/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
@@ -92,7 +92,7 @@ public class ParseUrlTest {
     assertFalse(parsed.repoInfo.secure);
 
     // Hosts with the default ports are considered secure
-    parsed = Utilities.parseUrl("http://gsoltis.firebaseio.comr");
+    parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com");
     assertTrue(parsed.repoInfo.secure);
 
     // Localhost is special-cased as insecure

--- a/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
@@ -59,8 +59,8 @@ public class ParseUrlTest {
   @Test
   public void testUrlParsingSpecialCharacters() throws DatabaseException {
     ParsedUrl parsed =
-        Utilities.parseUrl("http://gsoltis.firebaseio.com/a%b&c@d/space: /non-ascii:ø");
-    assertEquals("/a%b&c@d/space: /non-ascii:ø", parsed.path.toString());
+        Utilities.parseUrl("http://gsoltis.firebaseio.com/a%b&c@d/+space: /non-ascii:ø");
+    assertEquals("/a%b&c@d/ space: /non-ascii:ø", parsed.path.toString());
   }
 
   @Test

--- a/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
@@ -64,6 +64,13 @@ public class ParseUrlTest {
   }
 
   @Test
+  public void testUrlParsingIgnoresTrailingSlash() throws DatabaseException {
+    ParsedUrl parsed1 = Utilities.parseUrl("http://gsoltis.firebaseio.com/");
+    ParsedUrl parsed2 = Utilities.parseUrl("http://gsoltis.firebaseio.com");
+    assertEquals(parsed1, parsed2);
+  }
+
+  @Test
   public void testUrlParsingWithNamespace() throws DatabaseException {
     ParsedUrl parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com/foo/bar?ns=mrschmidt");
     assertEquals(parsed.path.toString(), "/foo/bar");

--- a/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/core/utilities/ParseUrlTest.java
@@ -72,12 +72,7 @@ public class ParseUrlTest {
 
   @Test
   public void testUrlParsingWithNamespace() throws DatabaseException {
-    ParsedUrl parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com/foo/bar?ns=mrschmidt");
-    assertEquals(parsed.path.toString(), "/foo/bar");
-    // The subdomain takes precedence if one is provided
-    assertEquals("gsoltis", parsed.repoInfo.namespace);
-
-    parsed = Utilities.parseUrl("http://localhost/foo/bar?ns=mrschmidt");
+    ParsedUrl parsed = Utilities.parseUrl("http://localhost/foo/bar?ns=mrschmidt");
     assertEquals("mrschmidt", parsed.repoInfo.namespace);
 
     parsed = Utilities.parseUrl("http://10.0.2.2:9000/foo/bar?ns=mrschmidt");
@@ -94,9 +89,5 @@ public class ParseUrlTest {
     // Hosts with the default ports are considered secure
     parsed = Utilities.parseUrl("http://gsoltis.firebaseio.com");
     assertTrue(parsed.repoInfo.secure);
-
-    // Localhost is special-cased as insecure
-    parsed = Utilities.parseUrl("http://localhost/");
-    assertFalse(parsed.repoInfo.secure);
   }
 }


### PR DESCRIPTION
We need to specify the namespace to connect to the Firestore Emulator from an Android Emulator.

With this change, a connection to the Emulator can be made by specifying a database URL such as "http://10.0.2.2:9000/?ns=foo". I ended up using Android URI parser over Java's since it has built in support for query param.

The new unit tests (some of them are old and moved from the integration test suite) pass with bold the old and the new parser.

Note that this PR drops the path segment encoding since I am no longer roundtripping through URL to get the database path.