### PR TITLE
Index-Free: Using readTime instead of updateTime

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -390,7 +390,7 @@ public final class LocalStore {
                 || doc.getVersion().equals(SnapshotVersion.NONE)
                 || (authoritativeUpdates.contains(doc.getKey()) && !existingDoc.hasPendingWrites())
                 || doc.getVersion().compareTo(existingDoc.getVersion()) >= 0) {
-              remoteDocuments.add(doc);
+              remoteDocuments.add(doc, remoteEvent.getSnapshotVersion());
               changedDocs.put(key, doc);
             } else {
               Logger.debug(
@@ -634,7 +634,7 @@ public final class LocalStore {
               batch,
               remoteDoc);
         } else {
-          remoteDocuments.add(doc);
+          remoteDocuments.add(doc, batchResult.getCommitVersion());
         }
       }
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
@@ -117,8 +117,8 @@ class MemoryLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   public int removeOrphanedDocuments(long upperBound) {
     int count = 0;
     MemoryRemoteDocumentCache cache = persistence.getRemoteDocumentCache();
-    for (Map.Entry<DocumentKey, MaybeDocument> entry : cache.getDocuments()) {
-      DocumentKey key = entry.getKey();
+    for (MaybeDocument doc : cache.getDocuments()) {
+      DocumentKey key = doc.getKey();
       if (!isPinned(key, upperBound)) {
         cache.remove(key);
         orphanedSequenceNumbers.remove(key);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -124,7 +124,7 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
   }
 
   Iterable<MaybeDocument> getDocuments() {
-    return new DocumentIterator();
+    return new DocumentIterable();
   }
 
   /**
@@ -144,15 +144,17 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
 
   long getByteSize(LocalSerializer serializer) {
     long count = 0;
-    for (MaybeDocument doc : new DocumentIterator()) {
+    for (MaybeDocument doc : new DocumentIterable()) {
       count += getKeySize(doc.getKey());
       count += serializer.encodeMaybeDocument(doc).getSerializedSize();
     }
     return count;
   }
 
-  /** An Iterator that iterates the current set of documents in the RemoteDocumentCache. */
-  private class DocumentIterator implements Iterable<MaybeDocument> {
+  /**
+   * A proxy that exposes an iterator over the current set of documents in the RemoteDocumentCache.
+   */
+  private class DocumentIterable implements Iterable<MaybeDocument> {
     @NonNull
     @Override
     public Iterator<MaybeDocument> iterator() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
@@ -20,6 +20,7 @@ import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
+import com.google.firebase.firestore.model.SnapshotVersion;
 import java.util.Map;
 
 /**
@@ -40,8 +41,9 @@ interface RemoteDocumentCache {
    * for the key, it will be replaced.
    *
    * @param maybeDocument A Document or NoDocument to put in the cache.
+   * @param readTime The time at which the document was read or committed.
    */
-  void add(MaybeDocument maybeDocument);
+  void add(MaybeDocument maybeDocument, SnapshotVersion readTime);
 
   /** Removes the cached entry for the given key (no-op if no entry exists). */
   void remove(DocumentKey documentKey);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -26,6 +26,7 @@ import com.google.firebase.firestore.model.DocumentCollections;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
 import com.google.firebase.firestore.model.ResourcePath;
+import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firebase.firestore.util.BackgroundQueue;
 import com.google.firebase.firestore.util.Executors;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -50,16 +51,16 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
   }
 
   @Override
-  public void add(MaybeDocument maybeDocument) {
+  public void add(MaybeDocument maybeDocument, SnapshotVersion readTime) {
     String path = pathForKey(maybeDocument.getKey());
-    Timestamp timestamp = maybeDocument.getVersion().getTimestamp();
+    Timestamp timestamp = readTime.getTimestamp();
     MessageLite message = serializer.encodeMaybeDocument(maybeDocument);
 
     statsCollector.recordRowsWritten(STATS_TAG, 1);
 
     db.execute(
         "INSERT OR REPLACE INTO remote_documents "
-            + "(path, update_time_seconds, update_time_nanos, contents) "
+            + "(path, read_time_seconds, read_time_nanos, contents) "
             + "VALUES (?, ?, ?, ?)",
         path,
         timestamp.getSeconds(),

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -136,7 +136,7 @@ class SQLiteSchema {
     }
 
     if (fromVersion < 9 && toVersion >= 9) {
-      addUpdateTime();
+      addReadTime();
     }
 
     /*
@@ -363,13 +363,13 @@ class SQLiteSchema {
     }
   }
 
-  private void addUpdateTime() {
-    if (!tableContainsColumn("remote_documents", "update_time_seconds")) {
+  private void addReadTime() {
+    if (!tableContainsColumn("remote_documents", "read_time_seconds")) {
       hardAssert(
-          !tableContainsColumn("remote_documents", "update_time_nanos"),
-          "Table contained update_time_seconds, but is missing update_time_nanos");
-      db.execSQL("ALTER TABLE remote_documents ADD COLUMN update_time_seconds INTEGER");
-      db.execSQL("ALTER TABLE remote_documents ADD COLUMN update_time_nanos INTEGER");
+          !tableContainsColumn("remote_documents", "read_time_nanos"),
+          "Table contained read_time_nanos, but is missing read_time_seconds");
+      db.execSQL("ALTER TABLE remote_documents ADD COLUMN read_time_seconds INTEGER");
+      db.execSQL("ALTER TABLE remote_documents ADD COLUMN read_time_nanos INTEGER");
     }
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexedQueryEngineTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexedQueryEngineTest.java
@@ -73,7 +73,8 @@ public class IndexedQueryEngineTest {
   }
 
   private void addDocument(Document newDoc) {
-    remoteDocuments.add(newDoc);
+    // Use document version as read time as the IndexedQueryEngine does not rely on read time.
+    remoteDocuments.add(newDoc, newDoc.getVersion());
     queryEngine.handleDocumentChange(
         deletedDoc(newDoc.getKey().toString(), ORIGINAL_VERSION), newDoc);
   }
@@ -85,7 +86,7 @@ public class IndexedQueryEngineTest {
   }
 
   private void updateDocument(Document oldDoc, Document newDoc) {
-    remoteDocuments.add(newDoc);
+    remoteDocuments.add(newDoc, newDoc.getVersion());
     queryEngine.handleDocumentChange(oldDoc, newDoc);
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
@@ -139,7 +139,7 @@ public abstract class LruGarbageCollectorTestCase {
 
   private Document cacheADocumentInTransaction() {
     Document doc = nextTestDocument();
-    documentCache.add(doc);
+    documentCache.add(doc, doc.getVersion());
     return doc;
   }
 
@@ -554,7 +554,7 @@ public abstract class LruGarbageCollectorTestCase {
           SnapshotVersion newVersion = version(3);
           Document doc =
               new Document(middleDocToUpdate, newVersion, Document.DocumentState.SYNCED, testValue);
-          documentCache.add(doc);
+          documentCache.add(doc, newVersion);
           updateTargetInTransaction(middleTarget);
         });
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
@@ -188,6 +188,8 @@ abstract class RemoteDocumentCacheTestCase {
     return doc;
   }
 
+  // TODO(mrschmidt): Add a test uses different update and read times and verifies that we correctly
+  // filter by read time
   private void add(MaybeDocument doc, SnapshotVersion readTime) {
     persistence.runTransaction("add entry", () -> remoteDocumentCache.add(doc, readTime));
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
@@ -21,6 +21,7 @@ import static com.google.firebase.firestore.testutil.TestUtil.key;
 import static com.google.firebase.firestore.testutil.TestUtil.map;
 import static com.google.firebase.firestore.testutil.TestUtil.path;
 import static com.google.firebase.firestore.testutil.TestUtil.values;
+import static com.google.firebase.firestore.testutil.TestUtil.version;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -32,6 +33,7 @@ import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
 import com.google.firebase.firestore.model.NoDocument;
+import com.google.firebase.firestore.model.SnapshotVersion;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -134,7 +136,7 @@ abstract class RemoteDocumentCacheTestCase {
   public void testSetAndReadDeletedDocument() {
     String path = "a/b";
     NoDocument deletedDoc = deletedDoc(path, 42);
-    add(deletedDoc);
+    add(deletedDoc, version(42));
     assertEquals(deletedDoc, get(path));
   }
 
@@ -144,7 +146,7 @@ abstract class RemoteDocumentCacheTestCase {
     Document written = addTestDocumentAtPath(path);
 
     Document newDoc = doc(path, 57, map("data", 5));
-    add(newDoc);
+    add(newDoc, version(57));
 
     assertNotEquals(written, newDoc);
     assertEquals(newDoc, get(path));
@@ -182,12 +184,12 @@ abstract class RemoteDocumentCacheTestCase {
 
   private Document addTestDocumentAtPath(String path) {
     Document doc = doc(path, 42, map("data", 2));
-    add(doc);
+    add(doc, version(42));
     return doc;
   }
 
-  private void add(MaybeDocument doc) {
-    persistence.runTransaction("add entry", () -> remoteDocumentCache.add(doc));
+  private void add(MaybeDocument doc, SnapshotVersion readTime) {
+    persistence.runTransaction("add entry", () -> remoteDocumentCache.add(doc, readTime));
   }
 
   @Nullable


### PR DESCRIPTION
This PR updates index-free queries to use readTime instead of updateTime, which allows us to pick up documents that matched a given query at the Query's snapshot version but were not part of the query's limit (see spec test: "Resumed limit queries use updated documents")