### PR TITLE
Remove custom DSL to disable kotlin checks.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
@@ -16,6 +16,7 @@ package com.google.firebase.gradle.plugins;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabExtension;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -39,7 +40,7 @@ public class FirebaseLibraryExtension {
   public boolean publishSources;
 
   /** Static analysis configuration. */
-  public final FirebaseStaticAnalysis staticAnalysis = new FirebaseStaticAnalysis();
+  public final FirebaseStaticAnalysis staticAnalysis;
 
   /** Firebase Test Lab configuration/ */
   public final FirebaseTestLabExtension testLab;
@@ -78,6 +79,20 @@ public class FirebaseLibraryExtension {
       artifactId.set(new DefaultProvider<>(project::getName));
       groupId.set(new DefaultProvider<>(() -> project.getGroup().toString()));
     }
+    this.staticAnalysis = initializeStaticAnalysis(project);
+  }
+
+  private FirebaseStaticAnalysis initializeStaticAnalysis(Project project) {
+    return new FirebaseStaticAnalysis(
+        projectsFromProperty(project, "firebase.checks.errorproneProjects"),
+        projectsFromProperty(project, "firebase.checks.lintProjects"));
+  }
+
+  private Set<String> projectsFromProperty(Project project, String propertyName) {
+    if (!project.hasProperty(propertyName)) {
+      return Collections.emptySet();
+    }
+    return ImmutableSet.copyOf(project.property(propertyName).toString().split(",", -1));
   }
 
   /** Configure Firebase Test Lab. */

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
@@ -17,22 +17,12 @@ package com.google.firebase.gradle.plugins;
 import com.android.build.gradle.LibraryExtension;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.firebase.gradle.plugins.ci.device.FirebaseTestServer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile;
 
-import java.util.Set;
-
 public class FirebaseLibraryPlugin implements Plugin<Project> {
-
-  private static final Set<String> KOTLIN_CHECKS =
-      ImmutableSet.of(
-          "FirebaseNoHardKeywords",
-          "FirebaseLambdaLast",
-          "FirebaseUnknownNullness",
-          "FirebaseKotlinPropertyAccess");
 
   @Override
   public void apply(Project project) {
@@ -105,11 +95,6 @@ public class FirebaseLibraryPlugin implements Plugin<Project> {
                         }
                       }
                     }));
-
-    library.staticAnalysis.subscribeToKotlinInteropLintDisabled(
-        () ->
-            android.lintOptions(
-                lintOptions -> lintOptions.disable(KOTLIN_CHECKS.toArray(new String[0]))));
 
     project.getTasks().register("firebaseLint", task -> task.dependsOn("lint"));
   }

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/PublishingPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/PublishingPluginSpec.groovy
@@ -29,12 +29,6 @@ class PublishingPluginSpec extends Specification {
         plugins {
             id 'firebase-library'
         }
-        firebaseLibrary {
-          staticAnalysis {
-            errorproneCheckProjects = []
-            androidLintCheckProjects = []
-          }
-        }
         group = '${group}'
         version = '${version}'
         <% if (latestReleasedVersion) println "ext.latestReleasedVersion = $latestReleasedVersion" %>

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -19,7 +19,6 @@ plugins {
 firebaseLibrary {
     publishJavadoc = false
     publishSources = true
-    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -19,7 +19,6 @@ plugins {
 firebaseLibrary {
     testLab.enabled = true
     publishSources = true
-    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {
@@ -34,9 +33,11 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    // TODO: b/111563140
     lintOptions {
-        abortOnError false
+        // TODO: b/111563140
+        disable "InvalidPackage"
+
+        disable "FirebaseUnknownNullness"
     }
 
     compileOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,6 @@ android.useAndroidX=true
 
 org.gradle.parallel=true
 org.gradle.caching=true
+
+firebase.checks.errorproneProjects=:tools:errorprone
+firebase.checks.lintProjects=:tools:lint

--- a/protolite-well-known-types/protolite-well-known-types.gradle
+++ b/protolite-well-known-types/protolite-well-known-types.gradle
@@ -17,10 +17,6 @@ plugins {
     id 'com.google.protobuf'
 }
 
-firebaseLibrary {
-    staticAnalysis.disableKotlinInteropLint()
-}
-
 
 protobuf {
     protoc {

--- a/transport/transport-api/src/main/java/com/google/android/datatransport/package-info.java
+++ b/transport/transport-api/src/main/java/com/google/android/datatransport/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport;

--- a/transport/transport-api/transport-api.gradle
+++ b/transport/transport-api/transport-api.gradle
@@ -18,7 +18,6 @@ plugins {
 
 firebaseLibrary{
     publishJavadoc = false
-    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/package-info.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport.cct;

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -19,7 +19,6 @@ plugins {
 
 firebaseLibrary{
     publishJavadoc = false
-    staticAnalysis.disableKotlinInteropLint()
 }
 
 protobuf {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/package-info.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport.runtime.backends;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/package-info.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport.runtime;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/package-info.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport.runtime.scheduling.jobscheduling;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/package-info.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport.runtime.scheduling;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/package-info.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport.runtime.scheduling.persistence;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/synchronization/package-info.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/synchronization/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport.runtime.synchronization;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/time/package-info.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/time/package-info.java
@@ -12,17 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.gradle.plugins;
-
-import java.util.Set;
-
-public class FirebaseStaticAnalysis {
-  public Set<String> errorproneCheckProjects;
-  public Set<String> androidLintCheckProjects;
-
-  public FirebaseStaticAnalysis(
-      Set<String> errorproneCheckProjects, Set<String> androidLintCheckProjects) {
-    this.errorproneCheckProjects = errorproneCheckProjects;
-    this.androidLintCheckProjects = androidLintCheckProjects;
-  }
-}
+/** @hide */
+package com.google.android.datatransport.runtime.time;

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -32,7 +32,6 @@ firebaseLibrary {
         device 'model=hero2lte,version=23' // Galaxy S7
         device 'model=htc_m8,version=19' // HTC One (M8)
     }
-    staticAnalysis.disableKotlinInteropLint()
 }
 
 android {


### PR DESCRIPTION
Teams can explicitly opt-out by either adding `@hide` to affected
packages or modifying `android.lintOptions`.