### PR TITLE
Don't persist manufactured documents

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -382,17 +382,17 @@ public final class LocalStore {
             MaybeDocument doc = entry.getValue();
             MaybeDocument existingDoc = existingDocs.get(key);
 
-            // If a document update isn't authoritative, make sure we don't apply an old document
-            // version to the remote cache.
             if (existingDoc == null
                 || (authoritativeUpdates.contains(doc.getKey()) && !existingDoc.hasPendingWrites())
                 || doc.getVersion().compareTo(existingDoc.getVersion()) >= 0) {
+              // If a document update isn't authoritative, make sure we don't apply an old document
+              // version to the remote cache.
               remoteDocuments.add(doc);
               changedDocs.put(key, doc);
+            } else if (doc instanceof NoDocument && doc.getVersion().equals(SnapshotVersion.NONE)) {
               // NoDocuments with SnapshotVersion.MIN are used in manufactured events (e.g. in the
               // case of a limbo document resolution failing). We remove these documents from cache
               // since we lost access.
-            } else if (doc instanceof NoDocument && doc.getVersion().equals(SnapshotVersion.NONE)) {
               remoteDocuments.remove(doc.getKey());
               changedDocs.put(key, doc);
             } else {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -383,14 +383,15 @@ public final class LocalStore {
             MaybeDocument existingDoc = existingDocs.get(key);
 
             // If a document update isn't authoritative, make sure we don't apply an old document
-            // version to the remote cache. We make an exception for SnapshotVersion.MIN which can
-            // happen for manufactured events (e.g. in the case of a limbo document resolution
-            // failing).
+            // version to the remote cache.
             if (existingDoc == null
                 || (authoritativeUpdates.contains(doc.getKey()) && !existingDoc.hasPendingWrites())
                 || doc.getVersion().compareTo(existingDoc.getVersion()) >= 0) {
               remoteDocuments.add(doc);
               changedDocs.put(key, doc);
+              // NoDocuments with SnapshotVersion.MIN are used in manufactured events (e.g. in the
+              // case of a limbo document resolution failing). We remove these documents from cache
+              // since we lost access.
             } else if (doc instanceof NoDocument && doc.getVersion().equals(SnapshotVersion.NONE)) {
               remoteDocuments.remove(doc.getKey());
               changedDocs.put(key, doc);


### PR DESCRIPTION
This PR makes sure we don't write documents to the RemoteDocumentCache that have a version of 0. This allows us to add an assert in the Index-Free query branch and also makes sure that we don't just persist NoDocuments because of RPC failures.