### PR TITLE
Add Index-Free query engine

### DIFF
--- a/firebase-database-collection/src/main/java/com/google/firebase/database/collection/ImmutableSortedMap.java
+++ b/firebase-database-collection/src/main/java/com/google/firebase/database/collection/ImmutableSortedMap.java
@@ -58,10 +58,10 @@ public abstract class ImmutableSortedMap<K, V> implements Iterable<Map.Entry<K, 
 
   public ImmutableSortedMap<K, V> insertAll(ImmutableSortedMap<K, V> source) {
     ImmutableSortedMap<K, V> result = this;
-    for (Map.Entry<K, V> entry: source) {
+    for (Map.Entry<K, V> entry : source) {
       result = result.insert(entry.getKey(), entry.getValue());
     }
-    return  result;
+    return result;
   }
 
   @Override

--- a/firebase-database-collection/src/main/java/com/google/firebase/database/collection/ImmutableSortedMap.java
+++ b/firebase-database-collection/src/main/java/com/google/firebase/database/collection/ImmutableSortedMap.java
@@ -56,6 +56,14 @@ public abstract class ImmutableSortedMap<K, V> implements Iterable<Map.Entry<K, 
 
   public abstract Comparator<K> getComparator();
 
+  public ImmutableSortedMap<K, V> insertAll(ImmutableSortedMap<K, V> source) {
+    ImmutableSortedMap<K, V> result = this;
+    for (Map.Entry<K, V> entry: source) {
+      result = result.insert(entry.getKey(), entry.getValue());
+    }
+    return  result;
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public boolean equals(Object o) {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/remote/RemoteStoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/remote/RemoteStoreTest.java
@@ -24,6 +24,7 @@ import com.google.firebase.firestore.core.OnlineState;
 import com.google.firebase.firestore.local.LocalStore;
 import com.google.firebase.firestore.local.MemoryPersistence;
 import com.google.firebase.firestore.local.Persistence;
+import com.google.firebase.firestore.local.SimpleQueryEngine;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.mutation.MutationBatchResult;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
@@ -72,9 +73,10 @@ public class RemoteStoreTest {
         };
 
     FakeConnectivityMonitor connectivityMonitor = new FakeConnectivityMonitor();
+    SimpleQueryEngine queryEngine = new SimpleQueryEngine();
     Persistence persistence = MemoryPersistence.createEagerGcMemoryPersistence();
     persistence.start();
-    LocalStore localStore = new LocalStore(persistence, User.UNAUTHENTICATED);
+    LocalStore localStore = new LocalStore(persistence, queryEngine, User.UNAUTHENTICATED);
     RemoteStore remoteStore =
         new RemoteStore(callback, localStore, datastore, testQueue, connectivityMonitor);
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -37,7 +37,9 @@ import com.google.firebase.firestore.local.LruDelegate;
 import com.google.firebase.firestore.local.LruGarbageCollector;
 import com.google.firebase.firestore.local.MemoryPersistence;
 import com.google.firebase.firestore.local.Persistence;
+import com.google.firebase.firestore.local.QueryEngine;
 import com.google.firebase.firestore.local.SQLitePersistence;
+import com.google.firebase.firestore.local.SimpleQueryEngine;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
@@ -263,7 +265,9 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
     }
 
     persistence.start();
-    localStore = new LocalStore(persistence, user);
+    // TODO(index-free): Use IndexFreeQueryEngine/IndexedQueryEngine as appropriate.
+    QueryEngine queryEngine = new SimpleQueryEngine();
+    localStore = new LocalStore(persistence, queryEngine, user);
     if (gc != null) {
       lruScheduler = gc.newScheduler(asyncQueue, localStore);
       lruScheduler.start();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
@@ -126,8 +126,7 @@ public final class Query {
         && startAt == null
         && endAt == null
         && (getExplicitOrderBy().isEmpty()
-            || (getExplicitOrderBy().size() == 1
-                && getFirstOrderByField().isKeyField()));
+            || (getExplicitOrderBy().size() == 1 && getFirstOrderByField().isKeyField()));
   }
 
   /** The filters on the documents returned by the query. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
@@ -117,6 +117,13 @@ public final class Query {
     return collectionGroup != null;
   }
 
+  /**
+   * Returns true if this query does not specify any query constraints that could remove results.
+   */
+  public boolean matchesAllDocuments() {
+    return filters.isEmpty() && limit == NO_LIMIT && startAt == null && endAt == null;
+  }
+
   /** The filters on the documents returned by the query. */
   public List<Filter> getFilters() {
     return filters;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
@@ -121,7 +121,11 @@ public final class Query {
    * Returns true if this query does not specify any query constraints that could remove results.
    */
   public boolean matchesAllDocuments() {
-    return filters.isEmpty() && limit == NO_LIMIT && startAt == null && endAt == null;
+    return filters.isEmpty()
+        && getExplicitOrderBy().isEmpty()
+        && limit == NO_LIMIT
+        && startAt == null
+        && endAt == null;
   }
 
   /** The filters on the documents returned by the query. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
@@ -122,10 +122,12 @@ public final class Query {
    */
   public boolean matchesAllDocuments() {
     return filters.isEmpty()
-        && getExplicitOrderBy().isEmpty()
         && limit == NO_LIMIT
         && startAt == null
-        && endAt == null;
+        && endAt == null
+        && (getExplicitOrderBy().isEmpty()
+            || (getExplicitOrderBy().size() == 1
+                && getFirstOrderByField().isKeyField()));
   }
 
   /** The filters on the documents returned by the query. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -193,9 +193,10 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
   private ViewSnapshot initializeViewAndComputeSnapshot(QueryData queryData) {
     Query query = queryData.getQuery();
 
-    ImmutableSortedMap<DocumentKey, Document> docs = localStore.executeQuery(query);
     ImmutableSortedSet<DocumentKey> remoteKeys =
         localStore.getRemoteDocumentKeys(queryData.getTargetId());
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        localStore.executeQuery(query, queryData, remoteKeys);
 
     View view = new View(query, remoteKeys);
     View.DocumentChanges viewDocChanges = view.computeDocChanges(docs);
@@ -557,7 +558,8 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
         // against the local store to make sure we didn't lose any good docs that had been past the
         // limit.
         ImmutableSortedMap<DocumentKey, Document> docs =
-            localStore.executeQuery(queryView.getQuery());
+            localStore.executeQuery(
+                queryView.getQuery(), /* queryData= */ null, DocumentKey.emptyKeySet());
         viewDocChanges = view.computeDocChanges(docs, viewDocChanges);
       }
       TargetChange targetChange =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexFreeQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexFreeQueryEngine.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore.local;
 
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import androidx.annotation.Nullable;
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.Query;
@@ -25,7 +26,6 @@ import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
 import com.google.firebase.firestore.model.SnapshotVersion;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * A query engine that takes advantage of the target document mapping in the QueryCache. The

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexFreeQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexFreeQueryEngine.java
@@ -1,0 +1,151 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.local;
+
+import static com.google.firebase.firestore.util.Assert.hardAssert;
+
+import com.google.firebase.database.collection.ImmutableSortedMap;
+import com.google.firebase.database.collection.ImmutableSortedSet;
+import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.model.Document;
+import com.google.firebase.firestore.model.DocumentCollections;
+import com.google.firebase.firestore.model.DocumentKey;
+import com.google.firebase.firestore.model.MaybeDocument;
+import com.google.firebase.firestore.model.SnapshotVersion;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * A query engine that takes advantage of the target document mapping in the QueryCache. The
+ * IndexFreeQueryEngine optimizes query execution by only reading the documents previously matched a
+ * query plus any documents that were edited after the query was last listened to.
+ *
+ * <p>There are some cases where Index-Free queries are not guaranteed to produce to the same
+ * results as full collection scans. In these case, the IndexFreeQueryEngine falls back to a full
+ * query processing. These cases are:
+ *
+ * <ol>
+ *   <li>Limit queries where a document that matched the query previously no longer matches the
+ *       query. In this case, we have to scan all local documents since a document that was sent to
+ *       us as part of a different query result may now fall into the limit.
+ *   <li>Limit queries that include edits that occurred after the last remote snapshot (both
+ *       latency-compensated or committed). Even if an edited document continues to match the query,
+ *       an edit may cause a document to sort below another document that is in the local cache.
+ *   <li>Queries where the last snapshot contained Limbo documents. Even though a Limbo document is
+ *       not part of the backend result set, we need to include Limbo documents in local views to
+ *       ensure consistency between different Query views. If there exists a previous query snapshot
+ *       that contained no limbo documents, we can instead use the older snapshot version for
+ *       Index-Free processing.
+ * </ol>
+ */
+public class IndexFreeQueryEngine implements QueryEngine {
+  private LocalDocumentsView localDocumentsView;
+
+  @Override
+  public void setLocalDocumentsView(LocalDocumentsView localDocuments) {
+    this.localDocumentsView = localDocuments;
+  }
+
+  @Override
+  public ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(
+      Query query, @Nullable QueryData queryData, ImmutableSortedSet<DocumentKey> remoteKeys) {
+    hardAssert(localDocumentsView != null, "setLocalDocumentsView() not called");
+
+    // Queries that match all document don't benefit from using IndexFreeQueries. It is more
+    // efficient to scan all documents in a collection, rather than to perform individual lookups.
+    if (query.matchesAllDocuments()) {
+      return executeFullCollectionScan(query);
+    }
+
+    // Queries that have never seen a snapshot without limbo free documents should also be run as a
+    // full collection scan.
+    if (queryData == null
+        || queryData.getLastLimboFreeSnapshotVersion().equals(SnapshotVersion.NONE)) {
+      return executeFullCollectionScan(query);
+    }
+
+    ImmutableSortedMap<DocumentKey, Document> result =
+        executeIndexFreeQuery(query, queryData, remoteKeys);
+
+    return result != null ? result : executeFullCollectionScan(query);
+  }
+
+  /**
+   * Attempts index-free query execution. Returns the set of query results on success, otherwise
+   * returns null.
+   */
+  private @Nullable ImmutableSortedMap<DocumentKey, Document> executeIndexFreeQuery(
+      Query query, QueryData queryData, ImmutableSortedSet<DocumentKey> remoteKeys) {
+    // Fetch the documents that matched the query at the last snapshot.
+    ImmutableSortedMap<DocumentKey, MaybeDocument> previousResults =
+        localDocumentsView.getDocuments(remoteKeys);
+
+    // Limit queries are not eligible for index-free query execution if any part of the result was
+    // modified
+    // after we received the last query snapshot. This makes sure that we re-populate the view with
+    // older documents that may sort before the modified document.
+    if (query.hasLimit()
+        && containsUpdatesSinceSnapshotVersion(previousResults, queryData.getSnapshotVersion())) {
+      return null;
+    }
+
+    ImmutableSortedMap<DocumentKey, Document> results = DocumentCollections.emptyDocumentMap();
+
+    // Re-apply the query filter since previously matching documents do not necessarily still
+    // match the query.
+    for (Map.Entry<DocumentKey, MaybeDocument> entry : previousResults) {
+      MaybeDocument maybeDoc = entry.getValue();
+      if (maybeDoc instanceof Document && query.matches((Document) maybeDoc)) {
+        Document doc = (Document) maybeDoc;
+        results = results.insert(entry.getKey(), doc);
+      } else if (query.hasLimit()) {
+        // Limit queries with documents that no longer match need to be re-filled from cache.
+        return null;
+      }
+    }
+
+    // Retrieve all results for documents that were updated since the last limbo-document free
+    // remote snapshot.
+    ImmutableSortedMap<DocumentKey, Document> updatedResults =
+        localDocumentsView.getDocumentsMatchingQuery(
+            query, queryData.getLastLimboFreeSnapshotVersion());
+
+    results = results.insertAll(updatedResults);
+
+    return results;
+  }
+
+  @Override
+  public void handleDocumentChange(MaybeDocument oldDocument, MaybeDocument newDocument) {
+    // No indexes to update.
+  }
+
+  private boolean containsUpdatesSinceSnapshotVersion(
+      ImmutableSortedMap<DocumentKey, MaybeDocument> previousResults,
+      SnapshotVersion sinceSnapshotVersion) {
+    for (Map.Entry<DocumentKey, MaybeDocument> doc : previousResults) {
+      if (doc.getValue().hasPendingWrites()
+          || doc.getValue().getVersion().compareTo(sinceSnapshotVersion) > 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private ImmutableSortedMap<DocumentKey, Document> executeFullCollectionScan(Query query) {
+    return localDocumentsView.getDocumentsMatchingQuery(query, SnapshotVersion.NONE);
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexFreeQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexFreeQueryEngine.java
@@ -93,9 +93,8 @@ public class IndexFreeQueryEngine implements QueryEngine {
         localDocumentsView.getDocuments(remoteKeys);
 
     // Limit queries are not eligible for index-free query execution if any part of the result was
-    // modified
-    // after we received the last query snapshot. This makes sure that we re-populate the view with
-    // older documents that may sort before the modified document.
+    // modified after we received the last query snapshot. This makes sure that we re-populate the
+    // view with older documents that may sort before the modified document.
     if (query.hasLimit()
         && containsUpdatesSinceSnapshotVersion(previousResults, queryData.getSnapshotVersion())) {
       return null;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexedQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexedQueryEngine.java
@@ -19,6 +19,7 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.database.collection.ImmutableSortedMap;
+import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.FieldFilter;
 import com.google.firebase.firestore.core.Filter;
 import com.google.firebase.firestore.core.Filter.Operator;
@@ -88,17 +89,23 @@ public class IndexedQueryEngine implements QueryEngine {
   private static final List<Class> lowCardinalityTypes =
       Arrays.asList(BooleanValue.class, ArrayValue.class, ObjectValue.class);
 
-  private final LocalDocumentsView localDocuments;
   private final SQLiteCollectionIndex collectionIndex;
+  private LocalDocumentsView localDocuments;
 
-  public IndexedQueryEngine(
-      LocalDocumentsView localDocuments, SQLiteCollectionIndex collectionIndex) {
-    this.localDocuments = localDocuments;
+  public IndexedQueryEngine(SQLiteCollectionIndex collectionIndex) {
     this.collectionIndex = collectionIndex;
   }
 
   @Override
-  public ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(Query query) {
+  public void setLocalDocumentsView(LocalDocumentsView localDocuments) {
+    this.localDocuments = localDocuments;
+  }
+
+  @Override
+  public ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(
+      Query query, @Nullable QueryData queryData, ImmutableSortedSet<DocumentKey> remoteKeys) {
+    hardAssert(localDocuments != null, "setLocalDocumentsView() not called");
+
     return query.isDocumentQuery()
         ? localDocuments.getDocumentsMatchingQuery(query, SnapshotVersion.NONE)
         : performCollectionQuery(query);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -40,7 +40,7 @@ import java.util.Map;
  * mutations in the MutationQueue to the RemoteDocumentCache.
  */
 // TODO: Turn this into the UnifiedDocumentCache / whatever.
-final class LocalDocumentsView {
+class LocalDocumentsView {
 
   private final RemoteDocumentCache remoteDocumentCache;
   private final MutationQueue mutationQueue;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryEngine.java
@@ -14,13 +14,13 @@
 
 package com.google.firebase.firestore.local;
 
+import androidx.annotation.Nullable;
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
-import javax.annotation.Nullable;
 
 /**
  * Represents a query engine capable of performing queries over the local document cache. You must

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryEngine.java
@@ -15,16 +15,25 @@
 package com.google.firebase.firestore.local;
 
 import com.google.firebase.database.collection.ImmutableSortedMap;
+import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
+import javax.annotation.Nullable;
 
-/** Represents a query engine capable of performing queries over the local document cache. */
-interface QueryEngine {
+/**
+ * Represents a query engine capable of performing queries over the local document cache. You must
+ * call setQueryDataProvider() and setLocalDocumentsView() before using.
+ */
+public interface QueryEngine {
+
+  /** Sets the document view to query against. */
+  void setLocalDocumentsView(LocalDocumentsView localDocuments);
 
   /** Returns all local documents matching the specified query. */
-  ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(Query query);
+  ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(
+      Query query, @Nullable QueryData queryData, ImmutableSortedSet<DocumentKey> remoteKeys);
 
   /**
    * Notifies the query engine of a document change in case it would like to update indexes and the

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SimpleQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SimpleQueryEngine.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore.local;
 
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import androidx.annotation.Nullable;
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.Query;
@@ -23,7 +24,6 @@ import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
 import com.google.firebase.firestore.model.SnapshotVersion;
-import javax.annotation.Nullable;
 
 /**
  * A naive implementation of QueryEngine that just loads all the documents in the queried collection

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SimpleQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SimpleQueryEngine.java
@@ -14,12 +14,16 @@
 
 package com.google.firebase.firestore.local;
 
+import static com.google.firebase.firestore.util.Assert.hardAssert;
+
 import com.google.firebase.database.collection.ImmutableSortedMap;
+import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
 import com.google.firebase.firestore.model.SnapshotVersion;
+import javax.annotation.Nullable;
 
 /**
  * A naive implementation of QueryEngine that just loads all the documents in the queried collection
@@ -27,14 +31,18 @@ import com.google.firebase.firestore.model.SnapshotVersion;
  */
 public class SimpleQueryEngine implements QueryEngine {
 
-  private final LocalDocumentsView localDocumentsView;
+  private LocalDocumentsView localDocumentsView;
 
-  public SimpleQueryEngine(LocalDocumentsView localDocumentsView) {
-    this.localDocumentsView = localDocumentsView;
+  @Override
+  public void setLocalDocumentsView(LocalDocumentsView localDocuments) {
+    this.localDocumentsView = localDocuments;
   }
 
   @Override
-  public ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(Query query) {
+  public ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingQuery(
+      Query query, @Nullable QueryData queryData, ImmutableSortedSet<DocumentKey> remoteKeys) {
+    hardAssert(localDocumentsView != null, "setLocalDocumentsView() not called");
+
     // TODO: Once LocalDocumentsView provides a getCollectionDocuments() method, we
     // should call that here and then filter the results.
     return localDocumentsView.getDocumentsMatchingQuery(query, SnapshotVersion.NONE);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
@@ -535,10 +535,13 @@ public class QueryTest {
     Query baseQuery = Query.atPath(ResourcePath.fromString("collection"));
     assertTrue(baseQuery.matchesAllDocuments());
 
-    Query query = baseQuery.filter(filter("foo", "==", "bar"));
-    assertFalse(query.matchesAllDocuments());
+    Query query = baseQuery.orderBy(orderBy("__name__"));
+    assertTrue(query.matchesAllDocuments());
 
     query = baseQuery.orderBy(orderBy("foo"));
+    assertFalse(query.matchesAllDocuments());
+
+    query = baseQuery.filter(filter("foo", "==", "bar"));
     assertFalse(query.matchesAllDocuments());
 
     query = baseQuery.limit(1);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.testutil.ComparatorTester;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -527,5 +528,23 @@ public class QueryTest {
     assertEquals(
         asList(orderBy("foo", "desc"), orderBy("bar", "asc"), orderBy(KEY_FIELD_NAME, "asc")),
         baseQuery.orderBy(orderBy("foo", "desc")).orderBy(orderBy("bar", "asc")).getOrderBy());
+  }
+
+  @Test
+  public void testMatchesAllDocuments() {
+    Query baseQuery = Query.atPath(ResourcePath.fromString("collection"));
+    assertTrue(baseQuery.matchesAllDocuments());
+
+    Query query = baseQuery.filter(filter("foo", "==", "bar"));
+    assertFalse(query.matchesAllDocuments());
+
+    query = baseQuery.limit(1);
+    assertFalse(query.matchesAllDocuments());
+
+    query = baseQuery.startAt(new Bound(Collections.emptyList(), true));
+    assertFalse(query.matchesAllDocuments());
+
+    query = baseQuery.endAt(new Bound(Collections.emptyList(), true));
+    assertFalse(query.matchesAllDocuments());
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
@@ -538,6 +538,9 @@ public class QueryTest {
     Query query = baseQuery.filter(filter("foo", "==", "bar"));
     assertFalse(query.matchesAllDocuments());
 
+    query = baseQuery.orderBy(orderBy("foo"));
+    assertFalse(query.matchesAllDocuments());
+
     query = baseQuery.limit(1);
     assertFalse(query.matchesAllDocuments());
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexFreeQueryEngineTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexFreeQueryEngineTest.java
@@ -102,12 +102,12 @@ public class IndexFreeQueryEngineTest {
   }
 
   /** Adds the provided documents to the query target mapping. */
-  private void persistQueryMapping(Document ... docs) {
+  private void persistQueryMapping(Document... docs) {
     persistence.runTransaction(
         "persistQueryMapping",
         () -> {
-          ImmutableSortedSet<DocumentKey> remoteKeys =  DocumentKey.emptyKeySet();
-          for (Document doc: docs) {
+          ImmutableSortedSet<DocumentKey> remoteKeys = DocumentKey.emptyKeySet();
+          for (Document doc : docs) {
             remoteKeys = remoteKeys.insert(doc.getKey());
           }
           queryCache.addMatchingKeys(remoteKeys, TEST_TARGET_ID);
@@ -115,7 +115,7 @@ public class IndexFreeQueryEngineTest {
   }
 
   /** Adds the provided documents to the remote document cache. */
-  private void addDocument(Document ... docs) {
+  private void addDocument(Document... docs) {
     persistence.runTransaction(
         "addDocument",
         () -> {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexFreeQueryEngineTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexFreeQueryEngineTest.java
@@ -1,0 +1,281 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.local;
+
+import static com.google.firebase.firestore.testutil.TestUtil.doc;
+import static com.google.firebase.firestore.testutil.TestUtil.filter;
+import static com.google.firebase.firestore.testutil.TestUtil.map;
+import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
+import static com.google.firebase.firestore.testutil.TestUtil.query;
+import static com.google.firebase.firestore.testutil.TestUtil.values;
+import static com.google.firebase.firestore.testutil.TestUtil.version;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+
+import com.google.firebase.database.collection.ImmutableSortedMap;
+import com.google.firebase.database.collection.ImmutableSortedSet;
+import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.model.Document;
+import com.google.firebase.firestore.model.DocumentCollections;
+import com.google.firebase.firestore.model.DocumentKey;
+import com.google.firebase.firestore.model.MaybeDocument;
+import com.google.firebase.firestore.model.SnapshotVersion;
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class IndexFreeQueryEngineTest {
+
+  private static final int TEST_TARGET_ID = 1;
+
+  private static final Document MATCHING_DOC_A =
+      doc("coll/a", 1, map("matches", true, "order", 1), Document.DocumentState.SYNCED);
+  private static final Document NON_MATCHING_DOC_A =
+      doc("coll/a", 1, map("matches", false, "order", 1), Document.DocumentState.SYNCED);
+  private static final Document PENDING_MATCHING_DOC_A =
+      doc("coll/a", 1, map("matches", true, "order", 1), Document.DocumentState.LOCAL_MUTATIONS);
+  private static final Document UDPATED_DOC_A =
+      doc("coll/a", 11, map("matches", true, "order", 1), Document.DocumentState.SYNCED);
+  private static final Document MATCHING_DOC_B =
+      doc("coll/b", 1, map("matches", true, "order", 2), Document.DocumentState.SYNCED);
+  private static final Document NON_MATCHING_DOC_B =
+      doc("coll/b", 1, map("matches", false, "order", 2), Document.DocumentState.SYNCED);
+  private static final Document UPDATED_MATCHING_DOC_B =
+      doc("coll/b", 11, map("matches", true, "order", 2), Document.DocumentState.SYNCED);
+
+  @Mock private LocalDocumentsView localDocumentsView;
+  @Mock private QueryCache queryCache;
+  private QueryEngine queryEngine;
+
+  private final Map<DocumentKey, Document> existingQueryResults = new HashMap<>();
+  private final Map<DocumentKey, Document> updatedQueryResults = new HashMap<>();
+  private boolean expectIndexFreeExecution;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    expectIndexFreeExecution = false;
+    existingQueryResults.clear();
+    updatedQueryResults.clear();
+
+    queryEngine = new IndexFreeQueryEngine();
+    queryEngine.setLocalDocumentsView(localDocumentsView);
+
+    doAnswer(
+            getMatchingKeysForTargetIdInvocation -> {
+              int targetId = getMatchingKeysForTargetIdInvocation.getArgument(0);
+              Assert.assertEquals(TEST_TARGET_ID, targetId);
+              return existingQueryResults.keySet();
+            })
+        .when(queryCache)
+        .getMatchingKeysForTargetId(anyInt());
+
+    doAnswer(
+            getDocumentsInvocation -> {
+              Iterable<DocumentKey> keys = getDocumentsInvocation.getArgument(0);
+
+              ImmutableSortedMap<DocumentKey, MaybeDocument> docs =
+                  DocumentCollections.emptyMaybeDocumentMap();
+              for (DocumentKey key : keys) {
+                docs = docs.insert(key, existingQueryResults.get(key));
+              }
+
+              return docs;
+            })
+        .when(localDocumentsView)
+        .getDocuments(any());
+
+    doAnswer(
+            getDocumentsMatchingQueryInvocation -> {
+              Query query = getDocumentsMatchingQueryInvocation.getArgument(0);
+              SnapshotVersion snapshotVersion = getDocumentsMatchingQueryInvocation.getArgument(1);
+
+              assertEquals(
+                  "Observed query execution mode did not match expectation",
+                  expectIndexFreeExecution,
+                  !SnapshotVersion.NONE.equals(snapshotVersion));
+
+              ImmutableSortedMap<DocumentKey, MaybeDocument> matchingDocs =
+                  DocumentCollections.emptyMaybeDocumentMap();
+
+              for (Document doc : updatedQueryResults.values()) {
+                if (query.matches(doc)) {
+                  matchingDocs = matchingDocs.insert(doc.getKey(), doc);
+                }
+              }
+
+              return matchingDocs;
+            })
+        .when(localDocumentsView)
+        .getDocumentsMatchingQuery(any(), any());
+  }
+
+  /** Add a document to local cache and the remote key mapping. */
+  private void addExistingResult(Document doc) {
+    existingQueryResults.put(doc.getKey(), doc);
+  }
+
+  /** Add a document to local cache but not the remote key mapping. */
+  private void addUpdatedResult(Document doc) {
+    updatedQueryResults.put(doc.getKey(), doc);
+  }
+
+  private ImmutableSortedMap<DocumentKey, Document> runQuery(
+          Query query, QueryData queryData, boolean expectIndexFree) {
+    expectIndexFreeExecution = expectIndexFree;
+    ImmutableSortedSet<DocumentKey> remoteKeys =
+            new ImmutableSortedSet<>(
+                    new ArrayList<>(existingQueryResults.keySet()), DocumentKey.comparator());
+    return queryEngine.getDocumentsMatchingQuery(query, queryData, remoteKeys);
+  }
+
+  @Test
+  public void usesTargetMappingForInitialView() {
+    Query query = query("coll").filter(filter("matches", "==", true));
+    QueryData queryData = queryData(query, /* hasLimboFreeSnapshot= */ true);
+
+    addExistingResult(MATCHING_DOC_A);
+    addExistingResult(MATCHING_DOC_B);
+
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        runQuery(query, queryData, /* expectIndexFree= */ true);
+    assertEquals(asList(MATCHING_DOC_A, MATCHING_DOC_B), values(docs));
+  }
+
+  @Test
+  public void filtersNonMatchingInitialResults() {
+    Query query = query("coll").filter(filter("matches", "==", true));
+    QueryData queryData = queryData(query, /* hasLimboFreeSnapshot= */ true);
+
+    addExistingResult(NON_MATCHING_DOC_A);
+    addExistingResult(MATCHING_DOC_B);
+
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        runQuery(query, queryData, /* expectIndexFree= */ true);
+    assertEquals(asList(MATCHING_DOC_B), values(docs));
+  }
+
+  @Test
+  public void includesChangesSinceInitialResults() {
+    Query query = query("coll").filter(filter("matches", "==", true));
+    QueryData originalQueryData = queryData(query, /* hasLimboFreeSnapshot= */ true);
+
+    addExistingResult(MATCHING_DOC_A);
+    addExistingResult(NON_MATCHING_DOC_B);
+
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        runQuery(query, originalQueryData, /* expectIndexFree= */ true);
+    assertEquals(asList(MATCHING_DOC_A), values(docs));
+
+    addUpdatedResult(UPDATED_MATCHING_DOC_B);
+
+    docs = runQuery(query, originalQueryData, /* expectIndexFree= */ true);
+    assertEquals(asList(MATCHING_DOC_A, UPDATED_MATCHING_DOC_B), values(docs));
+  }
+
+  @Test
+  public void doesNotUseInitialResultsWithoutLimboFreeSnapshotVersion() {
+    Query query = query("coll").filter(filter("matches", "==", true));
+    QueryData queryData = queryData(query, /* hasLimboFreeSnapshot= */ false);
+
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        runQuery(query, queryData, /* expectIndexFree= */ false);
+    assertEquals(asList(), values(docs));
+  }
+
+  @Test
+  public void doesNotUseInitialResultsForUnfilteredCollectionQuery() {
+    Query query = query("coll");
+    QueryData queryData = queryData(query, /* hasLimboFreeSnapshot= */ true);
+
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        runQuery(query, queryData, /* expectIndexFree= */ false);
+    assertEquals(asList(), values(docs));
+  }
+
+  @Test
+  public void doesNotUseInitialResultsForLimitQueryWithDocumentRemoval() {
+    Query query =
+        query("coll").filter(filter("matches", "==", true)).orderBy(orderBy("order")).limit(1);
+
+    addExistingResult(NON_MATCHING_DOC_A);
+    QueryData queryData = queryData(query, /* hasLimboFreeSnapshot= */ true);
+    addUpdatedResult(MATCHING_DOC_B);
+
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        runQuery(query, queryData, /* expectIndexFree= */ false);
+    assertEquals(asList(MATCHING_DOC_B), values(docs));
+  }
+
+  @Test
+  public void doesNotUseInitialResultsForLimitQueryWithPendingWrite() {
+    Query query = query("coll").filter(filter("matches", "==", true)).limit(1);
+
+    // Add a query mapping for a document that matches, but that sorts below another document due to
+    // a pending write.
+    addExistingResult(PENDING_MATCHING_DOC_A);
+
+    QueryData queryData = queryData(query, /* hasLimboFreeSnapshot= */ true);
+
+    addUpdatedResult(MATCHING_DOC_B);
+
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        runQuery(query, queryData, /* expectIndexFree= */ false);
+    assertEquals(asList(MATCHING_DOC_B), values(docs));
+  }
+
+  @Test
+  public void doesNotUseInitialResultsForLimitQueryWithDocumentThatHasBeenUpdatedOutOfBand() {
+    Query query = query("coll").filter(filter("matches", "==", true)).limit(1);
+
+    // Add a query mapping for a document that matches, but that sorts below another document based
+    // due to an update that the SDK received after the query's snapshot was persisted.
+    addExistingResult(UDPATED_DOC_A);
+
+    QueryData queryData = queryData(query, /* hasLimboFreeSnapshot= */ true);
+
+    addUpdatedResult(MATCHING_DOC_B);
+
+    ImmutableSortedMap<DocumentKey, Document> docs =
+        runQuery(query, queryData, /* expectIndexFree= */ false);
+    assertEquals(asList(MATCHING_DOC_B), values(docs));
+  }
+
+  private QueryData queryData(Query query, boolean hasLimboFreeSnapshot) {
+    return new QueryData(
+        query,
+        TEST_TARGET_ID,
+        1,
+        QueryPurpose.LISTEN,
+        version(10),
+        hasLimboFreeSnapshot ? version(10) : SnapshotVersion.NONE,
+        ByteString.EMPTY);
+  }
+}

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexFreeQueryEngineTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexFreeQueryEngineTest.java
@@ -148,11 +148,11 @@ public class IndexFreeQueryEngineTest {
   }
 
   private ImmutableSortedMap<DocumentKey, Document> runQuery(
-          Query query, QueryData queryData, boolean expectIndexFree) {
+      Query query, QueryData queryData, boolean expectIndexFree) {
     expectIndexFreeExecution = expectIndexFree;
     ImmutableSortedSet<DocumentKey> remoteKeys =
-            new ImmutableSortedSet<>(
-                    new ArrayList<>(existingQueryResults.keySet()), DocumentKey.comparator());
+        new ImmutableSortedSet<>(
+            new ArrayList<>(existingQueryResults.keySet()), DocumentKey.comparator());
     return queryEngine.getDocumentsMatchingQuery(query, queryData, remoteKeys);
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexedQueryEngineTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexedQueryEngineTest.java
@@ -69,7 +69,7 @@ public class IndexedQueryEngineTest {
     remoteDocuments = persistence.getRemoteDocumentCache();
     LocalDocumentsView localDocuments =
         new LocalDocumentsView(remoteDocuments, mutationQueue, persistence.getIndexManager());
-    queryEngine = new IndexedQueryEngine(localDocuments, index);
+    queryEngine = new IndexedQueryEngine(index);
   }
 
   private void addDocument(Document newDoc) {
@@ -214,7 +214,8 @@ public class IndexedQueryEngineTest {
     Query query = query("coll").filter(filter("a", "==", "a"));
 
     ImmutableSortedMap<DocumentKey, Document> results =
-        queryEngine.getDocumentsMatchingQuery(query);
+        queryEngine.getDocumentsMatchingQuery(
+            query, /* queryData= */ null, DocumentKey.emptyKeySet());
 
     assertThat(results).doesNotContain(IGNORED_DOC.getKey());
     assertThat(results).contains(MATCHING_DOC.getKey());
@@ -229,7 +230,8 @@ public class IndexedQueryEngineTest {
     Query query = query("coll").filter(filter("a", "==", "a"));
 
     ImmutableSortedMap<DocumentKey, Document> results =
-        queryEngine.getDocumentsMatchingQuery(query);
+        queryEngine.getDocumentsMatchingQuery(
+            query, /* queryData= */ null, DocumentKey.emptyKeySet());
 
     assertThat(results).doesNotContain(IGNORED_DOC.getKey());
     assertThat(results).contains(MATCHING_DOC.getKey());
@@ -244,7 +246,8 @@ public class IndexedQueryEngineTest {
     Query query = query("coll").filter(filter("a", "==", "a"));
 
     ImmutableSortedMap<DocumentKey, Document> results =
-        queryEngine.getDocumentsMatchingQuery(query);
+        queryEngine.getDocumentsMatchingQuery(
+            query, /* queryData= */ null, DocumentKey.emptyKeySet());
 
     assertThat(results).doesNotContain(IGNORED_DOC.getKey());
     assertThat(results).doesNotContain(MATCHING_DOC.getKey());
@@ -262,7 +265,8 @@ public class IndexedQueryEngineTest {
     Query query = query("coll").filter(filter("a.a", "==", "a"));
 
     ImmutableSortedMap<DocumentKey, Document> results =
-        queryEngine.getDocumentsMatchingQuery(query);
+        queryEngine.getDocumentsMatchingQuery(
+            query, /* queryData= */ null, DocumentKey.emptyKeySet());
 
     assertThat(results).doesNotContain(ignoredDoc.getKey());
     assertThat(results).contains(matchingDoc.getKey());
@@ -276,7 +280,8 @@ public class IndexedQueryEngineTest {
     Query query = query("coll").orderBy(TestUtil.orderBy("a"));
 
     ImmutableSortedMap<DocumentKey, Document> results =
-        queryEngine.getDocumentsMatchingQuery(query);
+        queryEngine.getDocumentsMatchingQuery(
+            query, /* queryData= */ null, DocumentKey.emptyKeySet());
 
     assertThat(results).doesNotContain(IGNORED_DOC.getKey());
     assertThat(results).contains(MATCHING_DOC.getKey());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -1201,7 +1201,8 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testQueriesFilterDocumentsThatNoLongerMatch() {
-    // This test verifies that documents that once matched a query are post-filtered if they no longer match the query filter.
+    // This test verifies that documents that once matched a query are post-filtered if they no
+    // longer match the query filter.
     if (garbageCollectorIsEager()) {
       return;
     }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -76,7 +76,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.common.collect.Iterables;
@@ -75,6 +76,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -927,10 +929,7 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testPersistsResumeTokens() {
-    // This test only works in the absence of the EagerGarbageCollector.
-    if (garbageCollectorIsEager()) {
-      return;
-    }
+    assumeFalse(garbageCollectorIsEager());
 
     Query query = query("foo/bar");
     int targetId = allocateQuery(query);
@@ -947,10 +946,7 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testDoesNotReplaceResumeTokenWithEmptyByteString() {
-    // This test only works in the absence of the EagerGarbageCollector.
-    if (garbageCollectorIsEager()) {
-      return;
-    }
+    assumeFalse(garbageCollectorIsEager());
 
     Query query = query("foo/bar");
     int targetId = allocateQuery(query);
@@ -1005,12 +1001,10 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testHandlesSetMutationThenAckThenTransformMutationThenAckThenTransformMutation() {
-    if (garbageCollectorIsEager()) {
-      // Since this test doesn't start a listen, Eager GC removes the documents from the cache as
-      // soon as the mutation is applied. This creates a lot of special casing in this unit test but
-      // does not expand its test coverage.
-      return;
-    }
+    // Since this test doesn't start a listen, Eager GC removes the documents from the cache as
+    // soon as the mutation is applied. This creates a lot of special casing in this unit test but
+    // does not expand its test coverage.
+    assumeFalse(garbageCollectorIsEager());
 
     writeMutation(setMutation("foo/bar", map("sum", 0)));
     assertContains(doc("foo/bar", 0, map("sum", 0), Document.DocumentState.LOCAL_MUTATIONS));
@@ -1035,13 +1029,11 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testUsesTargetMappingToExecuteQueries() {
-    // This test verifies that once a target mapping has been written, only documents that match
-    // the query are read from the RemoteDocumentCache.
+    assumeFalse(garbageCollectorIsEager());
     assumeTrue(queryEngine instanceof IndexFreeQueryEngine);
 
-    if (garbageCollectorIsEager()) {
-      return;
-    }
+    // This test verifies that once a target mapping has been written, only documents that match
+    // the query are read from the RemoteDocumentCache.
 
     Query query =
         Query.atPath(ResourcePath.fromString("foo")).filter(filter("matches", "==", true));
@@ -1077,13 +1069,11 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testLastLimboFreeSnapshotIsAdvancedDuringViewProcessing() {
-    // This test verifies that the `lastLimboFreeSnapshot` version for QueryData is advanced when
-    // we compute a limbo-free free view and that the mapping is persisted when we release a query.
+    assumeFalse(garbageCollectorIsEager());
     assumeTrue(queryEngine instanceof IndexFreeQueryEngine);
 
-    if (garbageCollectorIsEager()) {
-      return;
-    }
+    // This test verifies that the `lastLimboFreeSnapshot` version for QueryData is advanced when
+    // we compute a limbo-free free view and that the mapping is persisted when we release a query.
 
     writeMutation(setMutation("foo/ignored", map("matches", false)));
     acknowledgeMutation(10);
@@ -1121,12 +1111,10 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testQueriesIncludeLocallyModifiedDocuments() {
+    assumeFalse(garbageCollectorIsEager());
+
     // This test verifies that queries that have a persisted TargetMapping include documents that
     // were modified by local edits after the target mapping was written.
-    if (garbageCollectorIsEager()) {
-      return;
-    }
-
     Query query =
         Query.atPath(ResourcePath.fromString("foo")).filter(filter("matches", "==", true));
     int targetId = allocateQuery(query);
@@ -1159,11 +1147,10 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testQueriesIncludeDocumentsFromOtherQueries() {
+    assumeFalse(garbageCollectorIsEager());
+
     // This test verifies that queries that have a persisted TargetMapping include documents that
     // were modified by other queries after the target mapping was written.
-    if (garbageCollectorIsEager()) {
-      return;
-    }
 
     Query filteredQuery =
         Query.atPath(ResourcePath.fromString("foo")).filter(filter("matches", "==", true));
@@ -1201,11 +1188,10 @@ public abstract class LocalStoreTestCase {
 
   @Test
   public void testQueriesFilterDocumentsThatNoLongerMatch() {
+    assumeFalse(garbageCollectorIsEager());
+
     // This test verifies that documents that once matched a query are post-filtered if they no
     // longer match the query filter.
-    if (garbageCollectorIsEager()) {
-      return;
-    }
 
     // Add two document results for a simple filter query
     Query filteredQuery =

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/MemoryLocalStoreTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/MemoryLocalStoreTest.java
@@ -14,17 +14,36 @@
 
 package com.google.firebase.firestore.local;
 
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(ParameterizedRobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class MemoryLocalStoreTest extends LocalStoreTestCase {
+
+  private QueryEngine queryEngine;
+
+  @ParameterizedRobolectricTestRunner.Parameters(name = "QueryEngine = {0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] {new SimpleQueryEngine()}, new Object[] {new IndexFreeQueryEngine()});
+  }
+
+  public MemoryLocalStoreTest(QueryEngine queryEngine) {
+    this.queryEngine = queryEngine;
+  }
 
   @Override
   Persistence getPersistence() {
     return PersistenceTestHelpers.createEagerGCMemoryPersistence(statsCollector);
+  }
+
+  @Override
+  QueryEngine getQueryEngine() {
+    return this.queryEngine;
   }
 
   @Override

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteLocalStoreTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteLocalStoreTest.java
@@ -14,13 +14,32 @@
 
 package com.google.firebase.firestore.local;
 
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(ParameterizedRobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class SQLiteLocalStoreTest extends LocalStoreTestCase {
+
+  private QueryEngine queryEngine;
+
+  @ParameterizedRobolectricTestRunner.Parameters(name = "QueryEngine = {0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] {new SimpleQueryEngine()}, new Object[] {new IndexFreeQueryEngine()});
+  }
+
+  public SQLiteLocalStoreTest(QueryEngine queryEngine) {
+    this.queryEngine = queryEngine;
+  }
+
+  @Override
+  QueryEngine getQueryEngine() {
+    return this.queryEngine;
+  }
 
   @Override
   Persistence getPersistence() {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/QueryEvent.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/QueryEvent.java
@@ -14,10 +14,10 @@
 
 package com.google.firebase.firestore.spec;
 
+import androidx.annotation.Nullable;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.core.ViewSnapshot;
-import javax.annotation.Nullable;
 
 /** Object that contains exactly one of either a view snapshot or an error for the given query. */
 public class QueryEvent {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -48,7 +48,9 @@ import com.google.firebase.firestore.core.SyncEngine;
 import com.google.firebase.firestore.local.LocalStore;
 import com.google.firebase.firestore.local.Persistence;
 import com.google.firebase.firestore.local.QueryData;
+import com.google.firebase.firestore.local.QueryEngine;
 import com.google.firebase.firestore.local.QueryPurpose;
+import com.google.firebase.firestore.local.SimpleQueryEngine;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
@@ -262,7 +264,9 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
    */
   private void initClient() {
     localPersistence = getPersistence(garbageCollectionEnabled);
-    LocalStore localStore = new LocalStore(localPersistence, currentUser);
+    // TODO(index-free): Update to index-free query engine when it becomes default.
+    QueryEngine queryEngine = new SimpleQueryEngine();
+    LocalStore localStore = new LocalStore(localPersistence, queryEngine, currentUser);
 
     queue = new AsyncQueue();
 

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import androidx.annotation.NonNull;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.android.gms.common.internal.Preconditions;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -395,8 +396,16 @@ public class TestUtil {
 
   public static RemoteEvent addedRemoteEvent(
       MaybeDocument doc, List<Integer> updatedInTargets, List<Integer> removedFromTargets) {
-    DocumentChange change =
-        new DocumentChange(updatedInTargets, removedFromTargets, doc.getKey(), doc);
+    return addedRemoteEvent(Collections.singletonList(doc), updatedInTargets, removedFromTargets);
+  }
+
+  public static RemoteEvent addedRemoteEvent(
+      List<MaybeDocument> docs, List<Integer> updatedInTargets, List<Integer> removedFromTargets) {
+    Preconditions.checkArgument(!docs.isEmpty(), "Cannot pass empty docs array");
+
+    ResourcePath collectionPath = docs.get(0).getKey().getPath().popLast();
+    SnapshotVersion version = docs.get(0).getVersion();
+
     WatchChangeAggregator aggregator =
         new WatchChangeAggregator(
             new WatchChangeAggregator.TargetMetadataProvider() {
@@ -407,11 +416,16 @@ public class TestUtil {
 
               @Override
               public QueryData getQueryDataForTarget(int targetId) {
-                return queryData(targetId, QueryPurpose.LISTEN, doc.getKey().toString());
+                return queryData(targetId, QueryPurpose.LISTEN, collectionPath.toString());
               }
             });
-    aggregator.handleDocumentChange(change);
-    return aggregator.createRemoteEvent(doc.getVersion());
+
+    for (MaybeDocument doc : docs) {
+      DocumentChange change =
+          new DocumentChange(updatedInTargets, removedFromTargets, doc.getKey(), doc);
+      aggregator.handleDocumentChange(change);
+    }
+    return aggregator.createRemoteEvent(version);
   }
 
   public static RemoteEvent updateRemoteEvent(

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -523,7 +523,7 @@ public class TestUtil {
   }
 
   public static LocalViewChanges viewChanges(
-      int targetId, List<String> addedKeys, List<String> removedKeys) {
+      int targetId, boolean synced, List<String> addedKeys, List<String> removedKeys) {
     ImmutableSortedSet<DocumentKey> added = DocumentKey.emptyKeySet();
     for (String keyPath : addedKeys) {
       added = added.insert(key(keyPath));
@@ -532,7 +532,7 @@ public class TestUtil {
     for (String keyPath : removedKeys) {
       removed = removed.insert(key(keyPath));
     }
-    return new LocalViewChanges(targetId, false, added, removed);
+    return new LocalViewChanges(targetId, synced, added, removed);
   }
 
   /** Creates a resume token to match the given snapshot version. */


### PR DESCRIPTION
This is the last PR with index-free logic. It, however, doesn't turn it on yet (and is still against the indexfree-master branch).

There are a fair bit of comments in the code to explain how it all works. The only other thing worth pointing out is that I updated the LocalStoreTests to run parameterized with different query engine, which changed some of the plumbing during the test setup.

I verified that the Spec tests pass with the IndexFreeQueryEngine, but also left those running against the SimpleQueryEngine to match the code in production.