### PR TITLE
Retrying transactions with backoff

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [changed] Transactions now perform exponential backoff before retrying.
+  This means transactions on highly contended documents are more likely to
+  succeed.
 
 # 21.0.0
 - [changed] Transactions are now more flexible. Some sequences of operations

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -546,6 +546,7 @@ public class TransactionTest {
   @Test
   public void testReadingADocTwiceWithDifferentVersions() {
     FirebaseFirestore firestore = testFirestore();
+    firestore.removeTransactionBackoffs();
     DocumentReference doc = firestore.collection("counters").document();
     waitFor(doc.set(map("count", 15.0)));
     AtomicInteger counter = new AtomicInteger(0);

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -313,6 +313,7 @@ public class TransactionTest {
     AtomicInteger started = new AtomicInteger(0);
 
     FirebaseFirestore firestore = testFirestore();
+    firestore.removeTransactionBackoffs();
     DocumentReference doc = firestore.collection("counters").document();
     waitFor(doc.set(map("count", 5.0)));
 
@@ -378,6 +379,7 @@ public class TransactionTest {
     AtomicInteger counter = new AtomicInteger(0);
 
     FirebaseFirestore firestore = testFirestore();
+    firestore.removeTransactionBackoffs();
     DocumentReference doc = firestore.collection("counters").document();
     waitFor(doc.set(map("count", 5.0, "other", "yes")));
 
@@ -472,6 +474,7 @@ public class TransactionTest {
     AtomicInteger started = new AtomicInteger(0);
 
     FirebaseFirestore firestore = testFirestore();
+    firestore.removeTransactionBackoffs();
     DocumentReference doc = firestore.collection("counters").document();
     waitFor(doc.set(new POJO(5.0, "no", "clean")));
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -30,6 +30,7 @@ import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.FirebaseFirestoreException.Code;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
+import com.google.firebase.firestore.util.AsyncQueue.TimerId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -313,7 +314,7 @@ public class TransactionTest {
     AtomicInteger started = new AtomicInteger(0);
 
     FirebaseFirestore firestore = testFirestore();
-    firestore.removeTransactionBackoffs();
+    firestore.getAsyncQueue().skipDelaysForTimerId(TimerId.RETRY_TRANSACTION);
     DocumentReference doc = firestore.collection("counters").document();
     waitFor(doc.set(map("count", 5.0)));
 
@@ -379,7 +380,7 @@ public class TransactionTest {
     AtomicInteger counter = new AtomicInteger(0);
 
     FirebaseFirestore firestore = testFirestore();
-    firestore.removeTransactionBackoffs();
+    firestore.getAsyncQueue().skipDelaysForTimerId(TimerId.RETRY_TRANSACTION);
     DocumentReference doc = firestore.collection("counters").document();
     waitFor(doc.set(map("count", 5.0, "other", "yes")));
 
@@ -474,7 +475,7 @@ public class TransactionTest {
     AtomicInteger started = new AtomicInteger(0);
 
     FirebaseFirestore firestore = testFirestore();
-    firestore.removeTransactionBackoffs();
+    firestore.getAsyncQueue().skipDelaysForTimerId(TimerId.RETRY_TRANSACTION);
     DocumentReference doc = firestore.collection("counters").document();
     waitFor(doc.set(new POJO(5.0, "no", "clean")));
 
@@ -549,7 +550,7 @@ public class TransactionTest {
   @Test
   public void testReadingADocTwiceWithDifferentVersions() {
     FirebaseFirestore firestore = testFirestore();
-    firestore.removeTransactionBackoffs();
+    firestore.getAsyncQueue().skipDelaysForTimerId(TimerId.RETRY_TRANSACTION);
     DocumentReference doc = firestore.collection("counters").document();
     waitFor(doc.set(map("count", 15.0)));
     AtomicInteger counter = new AtomicInteger(0);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -71,8 +71,6 @@ public class FirebaseFirestore {
   private FirebaseFirestoreSettings settings;
   private volatile FirestoreClient client;
 
-  private boolean skipTransactionBackoffs = false;
-
   @NonNull
   public static FirebaseFirestore getInstance() {
     FirebaseApp app = FirebaseApp.getInstance();
@@ -281,7 +279,7 @@ public class FirebaseFirestore {
                     updateFunction.apply(
                         new Transaction(internalTransaction, FirebaseFirestore.this)));
 
-    return client.transaction(wrappedUpdateFunction, 5, skipTransactionBackoffs);
+    return client.transaction(wrappedUpdateFunction, 5);
   }
 
   /**
@@ -385,12 +383,6 @@ public class FirebaseFirestore {
   @VisibleForTesting
   AsyncQueue getAsyncQueue() {
     return asyncQueue;
-  }
-
-  /** For tests: Skip all transaction backoffs to make integration tests complete faster. */
-  @VisibleForTesting
-  void removeTransactionBackoffs() {
-    this.skipTransactionBackoffs = true;
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -387,9 +387,7 @@ public class FirebaseFirestore {
     return asyncQueue;
   }
 
-  /**
-   * For tests: Skip all transaction backoffs to make integration tests complete faster.
-   */
+  /** For tests: Skip all transaction backoffs to make integration tests complete faster. */
   @VisibleForTesting
   void removeTransactionBackoffs() {
     this.skipTransactionBackoffs = true;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -71,6 +71,8 @@ public class FirebaseFirestore {
   private FirebaseFirestoreSettings settings;
   private volatile FirestoreClient client;
 
+  private boolean skipTransactionBackoffs = false;
+
   @NonNull
   public static FirebaseFirestore getInstance() {
     FirebaseApp app = FirebaseApp.getInstance();
@@ -279,7 +281,7 @@ public class FirebaseFirestore {
                     updateFunction.apply(
                         new Transaction(internalTransaction, FirebaseFirestore.this)));
 
-    return client.transaction(wrappedUpdateFunction, 5);
+    return client.transaction(wrappedUpdateFunction, 5, skipTransactionBackoffs);
   }
 
   /**
@@ -383,6 +385,14 @@ public class FirebaseFirestore {
   @VisibleForTesting
   AsyncQueue getAsyncQueue() {
     return asyncQueue;
+  }
+
+  /**
+   * For tests: Skip all transaction backoffs to make integration tests complete faster.
+   */
+  @VisibleForTesting
+  void removeTransactionBackoffs() {
+    this.skipTransactionBackoffs = true;
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -51,8 +51,6 @@ import com.google.firebase.firestore.remote.RemoteEvent;
 import com.google.firebase.firestore.remote.RemoteSerializer;
 import com.google.firebase.firestore.remote.RemoteStore;
 import com.google.firebase.firestore.util.AsyncQueue;
-import com.google.firebase.firestore.util.AsyncQueue.TimerId;
-import com.google.firebase.firestore.util.ExponentialBackoff;
 import com.google.firebase.firestore.util.Logger;
 import io.grpc.Status;
 import java.util.Collections;
@@ -219,20 +217,10 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
 
   /** Tries to execute the transaction in updateFunction up to retries times. */
   public <TResult> Task<TResult> transaction(
-      Function<Transaction, Task<TResult>> updateFunction,
-      int retries,
-      boolean skippedTransactionBackoffs) {
+      Function<Transaction, Task<TResult>> updateFunction, int retries) {
     this.verifyNotShutdown();
-    ExponentialBackoff backoff;
-    if (skippedTransactionBackoffs) {
-      backoff = new ExponentialBackoff(asyncQueue, TimerId.RETRY_TRANSACTION, 1, 2, 10);
-    } else {
-      backoff = new ExponentialBackoff(asyncQueue, AsyncQueue.TimerId.RETRY_TRANSACTION);
-    }
-    final TaskCompletionSource<TResult> txTaskSource = new TaskCompletionSource<>();
-    asyncQueue.enqueueAndForget(
-        () -> syncEngine.transaction(asyncQueue, backoff, txTaskSource, updateFunction, retries));
-    return txTaskSource.getTask();
+    return AsyncQueue.callTask(
+        asyncQueue.getExecutor(), () -> syncEngine.transaction(asyncQueue, updateFunction));
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -250,8 +250,8 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
    * updateFunction, the client can read and write values using the supplied transaction object.
    * After the updateFunction, all changes will be committed. If a retryable error occurs (ex: some
    * other client has changed any of the data referenced), then the updateFunction will be called
-   * again after a backoff. If the updateFunction still fails after the given number of retires,
-   * then the transaction will be rejected.
+   * again after a backoff. If the updateFunction still fails after all retries, then the
+   * transaction will be rejected.
    *
    * <p>The transaction object passed to the updateFunction contains methods for accessing documents
    * and collections. Unlike other datastore access, data accessed with the transaction will not

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -262,11 +262,7 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
    */
   public <TResult> Task<TResult> transaction(
       AsyncQueue asyncQueue, Function<Transaction, Task<TResult>> updateFunction) {
-    TransactionRunner<TResult> runner =
-        new TransactionRunner<>(asyncQueue, remoteStore, updateFunction, 5);
-
-    runner.runTransaction();
-    return runner.getTask();
+    return new TransactionRunner<TResult>(asyncQueue, remoteStore, updateFunction).run();
   }
 
   /** Called by FirestoreClient to notify us of a new remote event. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -23,7 +23,6 @@ import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
-import com.google.android.gms.tasks.Tasks;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.firebase.database.collection.ImmutableSortedMap;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -267,7 +267,7 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
   public <TResult> void transaction(
       AsyncQueue asyncQueue,
       ExponentialBackoff backoff,
-      TaskCompletionSource<TResult> txTaskSource,
+      TaskCompletionSource<TResult> taskSource,
       Function<Transaction, Task<TResult>> updateFunction,
       int retries) {
     hardAssert(retries >= 0, "Got negative number of retries for transaction.");
@@ -285,9 +285,9 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
                       if (!userTask.isSuccessful()) {
                         if (retries > 0 && isRetryableTransactionError(userTask.getException())) {
                           transaction(
-                              asyncQueue, backoff, txTaskSource, updateFunction, retries - 1);
+                              asyncQueue, backoff, taskSource, updateFunction, retries - 1);
                         } else {
-                          txTaskSource.setException(userTask.getException());
+                          taskSource.setException(userTask.getException());
                         }
                       } else {
                         transaction
@@ -298,17 +298,17 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
                                   @Override
                                   public void onComplete(@NonNull Task<Void> commitTask) {
                                     if (commitTask.isSuccessful()) {
-                                      txTaskSource.setResult(userTask.getResult());
+                                      taskSource.setResult(userTask.getResult());
                                     } else if (retries > 0
                                         && isRetryableTransactionError(commitTask.getException())) {
                                       transaction(
                                           asyncQueue,
                                           backoff,
-                                          txTaskSource,
+                                          taskSource,
                                           updateFunction,
                                           retries - 1);
                                     } else {
-                                      txTaskSource.setException(commitTask.getException());
+                                      taskSource.setException(commitTask.getException());
                                     }
                                   }
                                 });

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -284,8 +284,7 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
                     public void onComplete(@NonNull Task<TResult> userTask) {
                       if (!userTask.isSuccessful()) {
                         if (retries > 0 && isRetryableTransactionError(userTask.getException())) {
-                          transaction(
-                              asyncQueue, backoff, taskSource, updateFunction, retries - 1);
+                          transaction(asyncQueue, backoff, taskSource, updateFunction, retries - 1);
                         } else {
                           taskSource.setException(userTask.getException());
                         }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TransactionRunner.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TransactionRunner.java
@@ -25,9 +25,7 @@ import com.google.firebase.firestore.util.AsyncQueue;
 import com.google.firebase.firestore.util.AsyncQueue.TimerId;
 import com.google.firebase.firestore.util.ExponentialBackoff;
 
-/**
- * TransactionRunner encapsulates the logic needed to run and retry transactions with backoff.
- */
+/** TransactionRunner encapsulates the logic needed to run and retry transactions with backoff. */
 public class TransactionRunner<TResult> {
   private static final int RETRY_COUNT = 5;
   private AsyncQueue asyncQueue;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TransactionRunner.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TransactionRunner.java
@@ -1,0 +1,119 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.core;
+
+import static com.google.firebase.firestore.util.Assert.hardAssert;
+
+import androidx.annotation.NonNull;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.common.base.Function;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.remote.Datastore;
+import com.google.firebase.firestore.remote.RemoteStore;
+import com.google.firebase.firestore.util.AsyncQueue;
+import com.google.firebase.firestore.util.AsyncQueue.TimerId;
+import com.google.firebase.firestore.util.ExponentialBackoff;
+
+/**
+ * TransactionRunner encapsulates the logic needed to run and retry transactions so that the caller
+ * does not have to manage the backoff and retry count through recursive calls.
+ */
+public class TransactionRunner<TResult> {
+  private AsyncQueue asyncQueue;
+  private RemoteStore remoteStore;
+  private Function<Transaction, Task<TResult>> updateFunction;
+  private int retries;
+
+  private ExponentialBackoff backoff;
+  private TaskCompletionSource<TResult> taskSource = new TaskCompletionSource<>();
+
+  public TransactionRunner(
+      AsyncQueue asyncQueue,
+      RemoteStore remoteStore,
+      Function<Transaction, Task<TResult>> updateFunction,
+      int retries) {
+    hardAssert(retries >= 0, "Got negative number of retries for transaction.");
+
+    this.asyncQueue = asyncQueue;
+    this.remoteStore = remoteStore;
+    this.updateFunction = updateFunction;
+    this.retries = retries;
+
+    backoff = new ExponentialBackoff(asyncQueue, TimerId.RETRY_TRANSACTION);
+  }
+
+  /** Runs the transaction and sets the result in taskSource. */
+  public void runTransaction() {
+    backoff.backoffAndRun(
+        () -> {
+          final Transaction transaction = remoteStore.createTransaction();
+          updateFunction
+              .apply(transaction)
+              .addOnCompleteListener(
+                  asyncQueue.getExecutor(),
+                  new OnCompleteListener<TResult>() {
+                    @Override
+                    public void onComplete(@NonNull Task<TResult> userTask) {
+                      if (!userTask.isSuccessful()) {
+                        if (retries > 0 && isRetryableTransactionError(userTask.getException())) {
+                          retries -= 1;
+                          runTransaction();
+                        } else {
+                          taskSource.setException(userTask.getException());
+                        }
+                      } else {
+                        transaction
+                            .commit()
+                            .addOnCompleteListener(
+                                asyncQueue.getExecutor(),
+                                new OnCompleteListener<Void>() {
+                                  @Override
+                                  public void onComplete(@NonNull Task<Void> commitTask) {
+                                    if (commitTask.isSuccessful()) {
+                                      taskSource.setResult(userTask.getResult());
+                                    } else if (retries > 0
+                                        && isRetryableTransactionError(commitTask.getException())) {
+                                      retries -= 1;
+                                      runTransaction();
+                                    } else {
+                                      taskSource.setException(commitTask.getException());
+                                    }
+                                  }
+                                });
+                      }
+                    }
+                  });
+        });
+  }
+
+  /** Returns the result of the transaction after it has been run. */
+  public Task<TResult> getTask() {
+    return taskSource.getTask();
+  }
+
+  private static boolean isRetryableTransactionError(Exception e) {
+    if (e instanceof FirebaseFirestoreException) {
+      // In transactions, the backend will fail outdated reads with FAILED_PRECONDITION and
+      // non-matching document versions with ABORTED. These errors should be retried.
+      FirebaseFirestoreException.Code code = ((FirebaseFirestoreException) e).getCode();
+      return code == FirebaseFirestoreException.Code.ABORTED
+          || code == FirebaseFirestoreException.Code.FAILED_PRECONDITION
+          || !Datastore.isPermanentError(((FirebaseFirestoreException) e).getCode());
+    }
+    return false;
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TransactionRunner.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TransactionRunner.java
@@ -26,7 +26,7 @@ import com.google.firebase.firestore.util.AsyncQueue.TimerId;
 import com.google.firebase.firestore.util.ExponentialBackoff;
 
 /**
- * TransactionRunner encapsulates the logic needed to run and retry transactions without backoff.
+ * TransactionRunner encapsulates the logic needed to run and retry transactions with backoff.
  */
 public class TransactionRunner<TResult> {
   private static final int RETRY_COUNT = 5;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -69,7 +69,9 @@ public class AsyncQueue {
      */
     ONLINE_STATE_TIMEOUT,
     /** A timer used to periodically attempt LRU Garbage collection */
-    GARBAGE_COLLECTION
+    GARBAGE_COLLECTION,
+    /** A timer used to retry transactions */
+    RETRY_TRANSACTION
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -383,6 +383,7 @@ public class AsyncQueue {
   // theoretical removal speed, except this list will always be small so ArrayList is fine.
   private final ArrayList<DelayedTask> delayedTasks;
 
+  // List of TimerIds to fast-forward delays for.
   private final ArrayList<TimerId> timerIdsToSkip = new ArrayList<>();
 
   public AsyncQueue() {
@@ -481,6 +482,7 @@ public class AsyncQueue {
     DelayedTask delayedTask = createAndScheduleDelayedTask(timerId, delayMs, task);
     delayedTasks.add(delayedTask);
 
+    // Fast-forward delays for timerIds that have been overridden.
     for (TimerId timerIdToSkip : timerIdsToSkip) {
       if (delayedTask.timerId == timerIdToSkip) {
         delayedTask.skipDelay();
@@ -489,6 +491,12 @@ public class AsyncQueue {
     return delayedTask;
   }
 
+  /**
+   * For Tests: Skip all delays for a timer id.
+   *
+   * @param timerId The timerId to skip delays for.
+   */
+  @VisibleForTesting
   public void skipDelaysForTimerId(TimerId timerId) {
     timerIdsToSkip.add(timerId);
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -473,13 +473,6 @@ public class AsyncQueue {
    * @return A DelayedTask instance that can be used for cancellation.
    */
   public DelayedTask enqueueAfterDelay(TimerId timerId, long delayMs, Runnable task) {
-    // While not necessarily harmful, we currently don't expect to have multiple tasks with the same
-    // timer id in the queue, so defensively reject them.
-    hardAssert(
-        !containsDelayedTask(timerId),
-        "Attempted to schedule multiple operations with timer id %s.",
-        timerId);
-
     DelayedTask delayedTask = createAndScheduleDelayedTask(timerId, delayMs, task);
     delayedTasks.add(delayedTask);
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/AsyncQueue.java
@@ -483,16 +483,14 @@ public class AsyncQueue {
     delayedTasks.add(delayedTask);
 
     // Fast-forward delays for timerIds that have been overridden.
-    for (TimerId timerIdToSkip : timerIdsToSkip) {
-      if (delayedTask.timerId == timerIdToSkip) {
-        delayedTask.skipDelay();
-      }
+    if (timerIdsToSkip.contains(delayedTask.timerId)) {
+      delayedTask.skipDelay();
     }
     return delayedTask;
   }
 
   /**
-   * For Tests: Skip all delays for a timer id.
+   * For Tests: Skip all subsequent delays for a timer id.
    *
    * @param timerId The timerId to skip delays for.
    */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/ExponentialBackoff.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/ExponentialBackoff.java
@@ -20,6 +20,18 @@ import java.util.Date;
 
 /** Helper to implement exponential backoff. */
 public class ExponentialBackoff {
+
+  /**
+   * Initial backoff time in milliseconds after an error. Set to 1s according to
+   * https://cloud.google.com/apis/design/errors.
+   */
+  public static final long DEFAULT_BACKOFF_INITIAL_DELAY_MS = 1000;
+
+  public static final double DEFAULT_BACKOFF_FACTOR = 1.5;
+
+  /** Maximum backoff time in milliseconds */
+  public static final long DEFAULT_BACKOFF_MAX_DELAY_MS = 60 * 1000;
+
   private final AsyncQueue queue;
   private final TimerId timerId;
   private final long initialDelayMs;
@@ -59,6 +71,17 @@ public class ExponentialBackoff {
     this.initialDelayMs = initialDelayMs;
     this.backoffFactor = backoffFactor;
     this.maxDelayMs = maxDelayMs;
+    this.lastAttemptTime = new Date().getTime();
+
+    reset();
+  }
+
+  public ExponentialBackoff(AsyncQueue queue, AsyncQueue.TimerId timerId) {
+    this.queue = queue;
+    this.timerId = timerId;
+    this.initialDelayMs = DEFAULT_BACKOFF_INITIAL_DELAY_MS;
+    this.backoffFactor = DEFAULT_BACKOFF_FACTOR;
+    this.maxDelayMs = DEFAULT_BACKOFF_MAX_DELAY_MS;
     this.lastAttemptTime = new Date().getTime();
 
     reset();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/ExponentialBackoff.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/ExponentialBackoff.java
@@ -77,14 +77,12 @@ public class ExponentialBackoff {
   }
 
   public ExponentialBackoff(AsyncQueue queue, AsyncQueue.TimerId timerId) {
-    this.queue = queue;
-    this.timerId = timerId;
-    this.initialDelayMs = DEFAULT_BACKOFF_INITIAL_DELAY_MS;
-    this.backoffFactor = DEFAULT_BACKOFF_FACTOR;
-    this.maxDelayMs = DEFAULT_BACKOFF_MAX_DELAY_MS;
-    this.lastAttemptTime = new Date().getTime();
-
-    reset();
+    this(
+        queue,
+        timerId,
+        DEFAULT_BACKOFF_INITIAL_DELAY_MS,
+        DEFAULT_BACKOFF_FACTOR,
+        DEFAULT_BACKOFF_MAX_DELAY_MS);
   }
 
   /**


### PR DESCRIPTION
Good call on recommending that I try and implement Android first before merging web. This has a been a painful, but educational experience.

A couple things about Android:
- The recursive method seemed like the only viable option here, since we cannot await backoffs in the same thread as the one calling it (something that I realized after a bit too much struggling). That being said, I still think the web approach is cleaner and more readable compared to Android. How do you feel about keeping the implementations different? I'm also not sure how I would port the whole `TaskCompletionSource` strategy used by Android for recursion over to web.
- The `skipDelaysForTimerIds` approach of web doesn't port over to Android b/c it relies on `runDelayedTasksUntil`, which blocks until the delay is completed. This means that we must call delays from outside the AsyncQueue, or else it deadlocks. Overriding the backoff is the only other approach that works aside from calling a `runDelayedTasksUntil` on a 10ms interval on a separate thread. Thoughts on this approach?