### PR TITLE
Fix issue with UTF8 strings in RC SDK 19.0.0

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -48,8 +48,10 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigServerException;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler.FetchResponse;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -178,7 +180,7 @@ public class ConfigFetchHttpClient {
       byte[] requestBody =
           createFetchRequestBody(instanceId, instanceIdToken, analyticsUserProperties)
               .toString()
-              .getBytes();
+              .getBytes("utf-8");
       setFetchRequestBody(urlConnection, requestBody);
 
       urlConnection.connect();
@@ -321,10 +323,10 @@ public class ConfigFetchHttpClient {
 
   private JSONObject getFetchResponseBody(URLConnection urlConnection)
       throws IOException, JSONException {
-    InputStream in = new BufferedInputStream(urlConnection.getInputStream());
+    BufferedReader br = new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), "utf-8"));
     StringBuilder responseStringBuilder = new StringBuilder();
     int current = 0;
-    while ((current = in.read()) != -1) {
+    while ((current = br.read()) != -1) {
       responseStringBuilder.append((char) current);
     }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -46,11 +46,9 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfigClientException;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigException;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigServerException;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler.FetchResponse;
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -323,7 +321,8 @@ public class ConfigFetchHttpClient {
 
   private JSONObject getFetchResponseBody(URLConnection urlConnection)
       throws IOException, JSONException {
-    BufferedReader br = new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), "utf-8"));
+    BufferedReader br =
+        new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), "utf-8"));
     StringBuilder responseStringBuilder = new StringBuilder();
     int current = 0;
     while ((current = br.read()) != -1) {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -103,7 +103,12 @@ public class ConfigFetchHttpClientTest {
     hasChangeResponseBody =
         new JSONObject()
             .put(STATE, "UPDATE")
-            .put(ENTRIES, new JSONObject().put("key_1", "value_1").put("key2", "value_2").put("key_emoji","\uD83C\uDDFA\uD83C\uDDF3"))
+            .put(
+                ENTRIES,
+                new JSONObject()
+                    .put("key_1", "value_1")
+                    .put("key2", "value_2")
+                    .put("key_emoji", "\uD83C\uDDFA\uD83C\uDDF3"))
             .put(
                 EXPERIMENT_DESCRIPTIONS,
                 new JSONArray()

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -103,7 +103,7 @@ public class ConfigFetchHttpClientTest {
     hasChangeResponseBody =
         new JSONObject()
             .put(STATE, "UPDATE")
-            .put(ENTRIES, new JSONObject().put("key_1", "value_1").put("key2", "value_2"))
+            .put(ENTRIES, new JSONObject().put("key_1", "value_1").put("key2", "value_2").put("key_emoji","\uD83C\uDDFA\uD83C\uDDF3"))
             .put(
                 EXPERIMENT_DESCRIPTIONS,
                 new JSONArray()


### PR DESCRIPTION
UTF-8 characters are not being parsed correctly on fetches from the backend. Explicitly specifying the Character set resolves this issue.

Unit tests added as well to prevent a recurrence of this issue.