### PR TITLE
Remove unused parameter from LocalStore tests

### DIFF
--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -824,10 +824,13 @@ public abstract class LocalStoreTestCase {
       return;
     }
 
-    int targetID = 321;
+    int unknownTargetID = 321;
     applyRemoteEvent(
-        updateRemoteEvent(doc("foo/bar", 1, map()), emptyList(), emptyList(), asList(targetID)));
-
+        updateRemoteEvent(
+            doc("foo/bar", 1, map()),
+            /* updatedInTargets= */ asList(unknownTargetID),
+            /* removedFromTargets= */ emptyList(),
+            /* activeTargets= */ emptyList()));
     assertNotContains("foo/bar");
   }
 


### PR DESCRIPTION
This PR removes the unused `limboTargets` param and updates the test `testThrowsAwayDocumentsWithUnknownTargetIDsImmediately` to actually return `null` from `getQueryDataForTarget` for the inactive target.