### PR TITLE
Update API text file

### DIFF
--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -165,10 +165,6 @@ package com.google.firebase.firestore {
     method public static void setLoggingEnabled(boolean);
   }
 
-  public static interface FirebaseFirestore.InstanceRegistry {
-    method public void remove(@NonNull String);
-  }
-
   public class FirebaseFirestoreException {
     ctor public FirebaseFirestoreException(@NonNull String, @NonNull com.google.firebase.firestore.FirebaseFirestoreException.Code);
     ctor public FirebaseFirestoreException(@NonNull String, @NonNull com.google.firebase.firestore.FirebaseFirestoreException.Code, @Nullable Throwable);


### PR DESCRIPTION
This should remove the additional messages for every Firestore PR. InstanceRegistry was never officially part of our public API.