### PR TITLE
Index-free: Use different SQL for non-index free queries

### DIFF
--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -424,11 +424,17 @@ public class SQLiteSchemaTest {
 
     SQLiteRemoteDocumentCache remoteDocumentCache = createRemoteDocumentCache();
     ImmutableSortedMap<DocumentKey, com.google.firebase.firestore.model.Document> results =
-        remoteDocumentCache.getAllDocumentsMatchingQuery(query("coll"), version(2));
+        remoteDocumentCache.getAllDocumentsMatchingQuery(query("coll"), version(0));
 
-    // Verify that queries return the documents that existed prior to the index-free migration, as
-    // well as any documents with a newer read time than the one passed in.
-    assertResultsContain(results, "coll/existing", "coll/new");
+    // Verify that queries with SnapshotVersion.NONE return all results, regardless of whether the
+    // read time has been set.
+    assertResultsContain(results, "coll/existing", "coll/old", "coll/current", "coll/new");
+
+    results = remoteDocumentCache.getAllDocumentsMatchingQuery(query("coll"), version(2));
+
+    // Queries that filter by read time only return documents that were written after the index-free
+    // migration.
+    assertResultsContain(results, "coll/new");
   }
 
   private SQLiteRemoteDocumentCache createRemoteDocumentCache() {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -423,17 +423,16 @@ public class SQLiteSchemaTest {
         new Object[] {encode(path("coll/new")), 0, 3000, createDummyDocument("coll/new")});
 
     SQLiteRemoteDocumentCache remoteDocumentCache = createRemoteDocumentCache();
-    ImmutableSortedMap<DocumentKey, com.google.firebase.firestore.model.Document> results =
-        remoteDocumentCache.getAllDocumentsMatchingQuery(query("coll"), version(0));
 
     // Verify that queries with SnapshotVersion.NONE return all results, regardless of whether the
     // read time has been set.
+    ImmutableSortedMap<DocumentKey, com.google.firebase.firestore.model.Document> results =
+        remoteDocumentCache.getAllDocumentsMatchingQuery(query("coll"), version(0));
     assertResultsContain(results, "coll/existing", "coll/old", "coll/current", "coll/new");
-
-    results = remoteDocumentCache.getAllDocumentsMatchingQuery(query("coll"), version(2));
 
     // Queries that filter by read time only return documents that were written after the index-free
     // migration.
+    results = remoteDocumentCache.getAllDocumentsMatchingQuery(query("coll"), version(2));
     assertResultsContain(results, "coll/new");
   }
 


### PR DESCRIPTION
I blame this one on @mikelehen 

The basic thought process behind is that we don't need to backfill any read times. When a user upgrades, none of the QueryData will have a lastLimboFreeSnapshot version set. Once we have a lastLimboFreeSnapshot, we know that the target mapping can be relied upon. Any changes since the target mapping will have a read time.

Thoughts? Fears?
