### PR TITLE
Index-free: Drop last limbo free snapshot if re-upgraded

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -405,7 +405,7 @@ class SQLiteSchema {
                     "UPDATE targets SET target_proto = ? WHERE target_id = ?",
                     new Object[] {targetProto.toByteArray(), targetId});
               } catch (InvalidProtocolBufferException e) {
-                fail("Failed to decode Query data for target %s", targetId);
+                throw fail("Failed to decode Query data for target %s", targetId);
               }
             });
   }


### PR DESCRIPTION
If we don't want to backfill the read time, we need to ensure that all documents written after any last limbo free snapshot version need to already have a read time. Since that is not the case if a user downgrades, we should clear all limbo free snapshot versions when the user upgrades again.