### PR TITLE
Fixed a memory leak

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -9,6 +9,8 @@
 - [feature] Added a `waitForPendingWrites()` method to `FirebaseFirestore`
   class which allows users to wait on a promise that resolves when all
   pending writes are acknowledged by the Firestore backend.
+- [fixed] Fixed a memory leak that occurred on certain devices while reading
+  from the local database.
 
 # 21.0.0
 - [changed] Transactions are now more flexible. Some sequences of operations

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -468,10 +468,16 @@ public final class SQLitePersistence extends Persistence {
      */
     int forEach(Consumer<Cursor> consumer) {
       int rowsProcessed = 0;
-      try (Cursor cursor = startQuery()) {
+      Cursor cursor = null;
+      try {
+        cursor = startQuery();
         while (cursor.moveToNext()) {
           ++rowsProcessed;
           consumer.accept(cursor);
+        }
+      } finally {
+        if (cursor != null) {
+          cursor.close();
         }
       }
       return rowsProcessed;


### PR DESCRIPTION
... that occurred on certain devices while reading from the local
database.

try-with-resources requires API level 19, whereas firestore only
requires 14.