### PR TITLE
Migrate apk size table to metrics database.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeJsonBuilder.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeJsonBuilder.groovy
@@ -18,9 +18,9 @@ package com.google.firebase.gradle.plugins.measurement.apksize
 /** A helper class that generates the APK size measurement JSON report. */
 class ApkSizeJsonBuilder {
 
-    private static final String PULL_REQUEST_TABLE = "PullRequests"
+    private static final String PULL_REQUEST_TABLE = "AndroidPullRequests"
     private static final String PULL_REQUEST_COLUMN = "pull_request_id"
-    private static final String APK_SIZE_TABLE = "ApkSizes"
+    private static final String APK_SIZE_TABLE = "AndroidApkSizes"
     private static final String SDK_COLUMN = "sdk_id"
     private static final String APK_SIZE_COLUMN = "apk_size"
 

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeJsonBuilderTest.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeJsonBuilderTest.groovy
@@ -41,7 +41,7 @@ public class ApkSizeJsonBuilderTest {
     def prColumns = prTable.getJSONArray("column_names")
     def prMeasurements = prTable.getJSONArray("replace_measurements")
 
-    assertEquals("Bad table name", "PullRequests", prTable.getString("table_name"))
+    assertEquals("Bad table name", "AndroidPullRequests", prTable.getString("table_name"))
     assertEquals("Bad column name", "pull_request_id", prColumns.getString(0))
     assertEquals("Bad pull request number", 117, prMeasurements.getJSONArray(0).getInt(0))
     assertEquals("Too many columns", 1, prColumns.length())
@@ -59,7 +59,7 @@ public class ApkSizeJsonBuilderTest {
     def asColumns = asTable.getJSONArray("column_names")
     def asMeasurements = asTable.getJSONArray("replace_measurements")
 
-    assertEquals("Bad table name", "ApkSizes", asTable.getString("table_name"))
+    assertEquals("Bad table name", "AndroidApkSizes", asTable.getString("table_name"))
     assertEquals("Bad column name", "pull_request_id", asColumns.getString(0))
     assertEquals("Bad column name", "sdk_id", asColumns.getString(1))
     assertEquals("Bad column name", "apk_size", asColumns.getString(2))
@@ -84,7 +84,7 @@ public class ApkSizeJsonBuilderTest {
     def asMeasurements = asTable.getJSONArray("replace_measurements")
 
     // The table itself.
-    assertEquals("Bad table name", "ApkSizes", asTable.getString("table_name"))
+    assertEquals("Bad table name", "AndroidApkSizes", asTable.getString("table_name"))
     assertEquals("Bad column name", "pull_request_id", asColumns.getString(0))
     assertEquals("Bad column name", "sdk_id", asColumns.getString(1))
     assertEquals("Bad column name", "apk_size", asColumns.getString(2))


### PR DESCRIPTION
This PR is part of the effort of migrating apk size measurement database to the same one used by ios/android project health metrics.

New tables have been created with a different name (with the prefix of "Android"). This change accommodates to the table name change on the database server side. The PR that switches the database to upload is [here](https://team-review.git.corp.google.com/c/firebase-android-core/test-infra/+/537770). These two PRs will need to be submitted together.

Records in the old database/table will later be migrated to the new database/table manually.