### PR TITLE
Re-add tools:targetApi to firebase-common AndroidManifest.

### DIFF
--- a/firebase-common/lint-baseline.xml
+++ b/firebase-common/lint-baseline.xml
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <issues format="5" by="lint 3.4.1" client="gradle" variant="all" version="3.4.1">
-  <!-- TODO: remove when bazel support tools:targetApi -->
-    <issue
-        id="UnusedAttribute"
-        message="Attribute `directBootAware` is only used in API level 24 and higher (current min is 14)"
-        errorLine1="        android:directBootAware=&quot;true&quot; android:exported=&quot;false&quot;/>"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/AndroidManifest.xml"
-            line="11"
-            column="9"/>
-    </issue>
 
 </issues>

--- a/firebase-common/src/main/AndroidManifest.xml
+++ b/firebase-common/src/main/AndroidManifest.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.firebase">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
   <!--<uses-sdk android:minSdkVersion="14"/>-->
   <application>
 
     <service android:name="com.google.firebase.components.ComponentDiscoveryService"
-        android:directBootAware="true" android:exported="false"/>
+        android:directBootAware="true" android:exported="false"
+        tools:targetApi="n" />
 
     <provider
         android:name="com.google.firebase.provider.FirebaseInitProvider"


### PR DESCRIPTION
This attr had to be removed in https://github.com/firebase/firebase-android-sdk/pull/728 because a bug in the tooling that has been fixed now.