### PR TITLE
Add missing deprecation annotation to synchronous setDefaults method

### DIFF
--- a/firebase-config/api.txt
+++ b/firebase-config/api.txt
@@ -23,7 +23,7 @@ package com.google.firebase.remoteconfig {
     method @Deprecated public void setConfigSettings(@NonNull com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings);
     method @NonNull public Task<Void> setConfigSettingsAsync(@NonNull com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings);
     method @Deprecated public void setDefaults(@NonNull Map<String,Object>);
-    method public void setDefaults(int);
+    method @Deprecated public void setDefaults(int);
     method @NonNull public Task<Void> setDefaultsAsync(@NonNull Map<String,Object>);
     method @NonNull public Task<Void> setDefaultsAsync(int);
     field public static final boolean DEFAULT_VALUE_FOR_BOOLEAN = false;

--- a/firebase-config/gradle.properties
+++ b/firebase-config/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=18.0.1
+version=18.0.2
 latestReleasedVersion=18.0.0
 android.enableUnitTestBinaryResources=true
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -582,7 +582,9 @@ public class FirebaseRemoteConfig {
    *
    * @param resourceId Id for the XML resource, which should be in your application's {@code
    *     res/xml} folder.
+   * @deprecated Use {@link #setDefaultsAsync} instead.
    */
+  @Deprecated
   public void setDefaults(@XmlRes int resourceId) {
     Map<String, String> xmlDefaults = DefaultsXmlParser.getDefaultsFromXml(context, resourceId);
     setDefaultsWithStringsMap(xmlDefaults);


### PR DESCRIPTION
Synchronous setDefaults methods should be marked as deprecated, there are two of them and [one](https://github.com/firebase/firebase-android-sdk/blob/master/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java#L543) is already marked as deprecated. This PR adds the deprecated annotation to the other one.