### PR TITLE
Don't double escape list references

### DIFF
--- a/firebase-storage/CHANGELOG.md
+++ b/firebase-storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 19.0.2
+- [fixed] Fixed an encoding issue in `list()/listAll()` that caused us to miss
+  entries for folders that contained special characters.
+
 # 19.0.1
 - [fixed] `listAll()` now propagates the error messages if the List operation
   was denied by a Security Rule.

--- a/firebase-storage/src/androidTest/java/com/google/firebase/storage/IntegrationTest.java
+++ b/firebase-storage/src/androidTest/java/com/google/firebase/storage/IntegrationTest.java
@@ -51,6 +51,8 @@ public class IntegrationTest {
 
   private final String randomPrefix = UUID.randomUUID().toString();
 
+  private final String unicodePrefix = "prefix/\\%:😊 ";
+
   @Before
   public void before() throws ExecutionException, InterruptedException {
     if (storageClient == null) {
@@ -60,6 +62,7 @@ public class IntegrationTest {
       Tasks.await(getReference("metadata.dat").putBytes(new byte[0]));
       Tasks.await(getReference("download.dat").putBytes(new byte[LARGE_FILE_SIZE_BYTES]));
       Tasks.await(getReference("prefix/empty.dat").putBytes(new byte[0]));
+      Tasks.await(getReference(unicodePrefix + "/empty.dat").putBytes(new byte[0]));
     }
   }
 
@@ -73,6 +76,15 @@ public class IntegrationTest {
     assertThat(tempFile.exists()).isTrue();
     assertThat(tempFile.length()).isEqualTo(LARGE_FILE_SIZE_BYTES);
     assertThat(fileTask.getBytesTransferred()).isEqualTo(LARGE_FILE_SIZE_BYTES);
+  }
+
+  @Test
+  public void downloadUnicodeFile() throws ExecutionException, InterruptedException, IOException {
+    File tempFile = new File(Environment.getExternalStorageDirectory(), "empty.dat");
+
+    Tasks.await(getReference(unicodePrefix + "/empty.dat").getFile(tempFile));
+
+    assertThat(tempFile.exists()).isTrue();
   }
 
   @Test
@@ -159,6 +171,19 @@ public class IntegrationTest {
     assertThat(listResult.getItems())
         .containsExactly(getReference("metadata.dat"), getReference("download.dat"));
     assertThat(listResult.getPageToken()).isNull();
+  }
+
+  @Test
+  public void listUnicodeFiles() throws ExecutionException, InterruptedException {
+    Task<ListResult> listTask = getReference("prefix").listAll();
+    ListResult listResult = Tasks.await(listTask);
+
+    assertThat(listResult.getPrefixes()).containsExactly(getReference(unicodePrefix));
+
+    listTask = getReference(unicodePrefix).listAll();
+    listResult = Tasks.await(listTask);
+
+    assertThat(listResult.getItems()).containsExactly(getReference(unicodePrefix + "/empty.dat"));
   }
 
   @NonNull

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
@@ -59,8 +59,10 @@ class GetDownloadUrlTask implements Runnable {
 
     if (!TextUtils.isEmpty(downloadTokens)) {
       String downloadToken = downloadTokens.split(",", -1)[0];
-      String baseURL = NetworkRequest.getDefaultURL(storageRef.getStorageUri());
-      return Uri.parse(baseURL + "?alt=media&token=" + downloadToken);
+      Uri.Builder uriBuilder = NetworkRequest.getDefaultURL(storageRef.getStorageUri()).buildUpon();
+      uriBuilder.appendQueryParameter("alt", "media");
+      uriBuilder.appendQueryParameter("token", downloadToken);
+      return uriBuilder.build();
     }
 
     return null;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -345,7 +345,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
   private boolean recoverStatus(boolean withRetry) {
     NetworkRequest queryRequest =
         new ResumableUploadQueryRequest(
-            mStorageRef.getStorageUri(), mStorageRef.getApp(), mUploadUri.toString());
+            mStorageRef.getStorageUri(), mStorageRef.getApp(), mUploadUri);
 
     if (RESUMABLE_FINAL_STATUS.equals(mServerStatus)) {
       return false;
@@ -411,7 +411,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
           new ResumableUploadByteRequest(
               mStorageRef.getStorageUri(),
               mStorageRef.getApp(),
-              mUploadUri.toString(),
+              mUploadUri,
               mStreamBuffer.get(),
               mBytesUploaded.get(),
               bytesToUpload,
@@ -484,7 +484,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
     if (mUploadUri != null) {
       cancelRequest =
           new ResumableUploadCancelRequest(
-              mStorageRef.getStorageUri(), mStorageRef.getApp(), mUploadUri.toString());
+              mStorageRef.getStorageUri(), mStorageRef.getApp(), mUploadUri);
     }
 
     if (cancelRequest != null) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/Slashes.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/Slashes.java
@@ -54,18 +54,6 @@ public class Slashes {
     return s.replace("%2F", "/");
   }
 
-  /**
-   * URL Encodes slashes (only) within a string.
-   *
-   * @param s The String to change
-   * @return A modified string that replaces slashes with their escape codes.
-   */
-  @NonNull
-  public static String unSlashize(@NonNull String s) {
-    Preconditions.checkNotNull(s);
-    return s.replace("/", "%2F");
-  }
-
   @NonNull
   @SuppressWarnings("StringSplitter")
   public static String normalizeSlashes(@NonNull String uriSegment) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
@@ -40,7 +40,6 @@ public class GetNetworkRequest extends NetworkRequest {
   @Override
   @NonNull
   protected String getQueryParameters() {
-    return getPostDataString(
-        Collections.singletonList("alt"), Collections.singletonList("media"), true);
+    return getPostDataString(Collections.singletonList("alt"), Collections.singletonList("media"));
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
@@ -18,6 +18,7 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import com.google.firebase.FirebaseApp;
 import java.util.Collections;
+import java.util.Map;
 
 /** A network request that returns bytes of a gcs object. */
 public class GetNetworkRequest extends NetworkRequest {
@@ -39,7 +40,7 @@ public class GetNetworkRequest extends NetworkRequest {
 
   @Override
   @NonNull
-  protected String getQueryParameters() {
-    return getPostDataString(Collections.singletonList("alt"), Collections.singletonList("media"));
+  protected Map<String, String> getQueryParameters() {
+    return Collections.singletonMap("alt", "media");
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -79,6 +79,6 @@ public class ListNetworkRequest extends NetworkRequest {
       values.add(nextPageToken);
     }
 
-    return getPostDataString(keys, values, true);
+    return getPostDataString(keys, values);
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -19,8 +19,8 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 /** A network request that lists folder contents within gcs. */
 public class ListNetworkRequest extends NetworkRequest {
@@ -45,40 +45,35 @@ public class ListNetworkRequest extends NetworkRequest {
 
   @Override
   @NonNull
-  protected String getURL() {
-    return sNetworkRequestUrl + "/b/" + mGsUri.getAuthority() + "/o";
+  protected Uri getURL() {
+    return Uri.parse(sNetworkRequestUrl + "/b/" + mGsUri.getAuthority() + "/o");
   }
 
   @Override
   @Nullable
-  protected String getQueryParameters() {
-    List<String> keys = new ArrayList<>();
-    List<String> values = new ArrayList<>();
+  protected Map<String, String> getQueryParameters() {
+    Map<String, String> headers = new HashMap<>();
 
     String prefix = getPathWithoutBucket();
-    if (!TextUtils.isEmpty(prefix)) {
-      keys.add("prefix");
-      values.add(prefix + "/");
+    if (!prefix.isEmpty()) {
+      headers.put("prefix", prefix + "/");
     }
 
     // Firebase Storage uses file system semantics and treats slashes as separators. GCS's List API
     // does not prescribe a separator, and hence we need to provide a slash as the delimiter.
-    keys.add("delimiter");
-    values.add("/");
+    headers.put("delimiter", "/");
 
     // We don't set the `maxPageSize` for listAll() as this allows Firebase Storage to return
     // fewer items per page. This removes the need to backfill results if Firebase Storage filters
     // objects that are considered invalid (such as items with two consecutive slashes).
     if (maxPageSize != null) {
-      keys.add("maxResults");
-      values.add(Integer.toString(maxPageSize));
+      headers.put("maxResults", Integer.toString(maxPageSize));
     }
 
     if (!TextUtils.isEmpty(nextPageToken)) {
-      keys.add("pageToken");
-      values.add(nextPageToken);
+      headers.put("pageToken", nextPageToken);
     }
 
-    return getPostDataString(keys, values);
+    return headers;
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -50,7 +50,7 @@ public class ListNetworkRequest extends NetworkRequest {
   }
 
   @Override
-  @Nullable
+  @NonNull
   protected Map<String, String> getQueryParameters() {
     Map<String, String> headers = new HashMap<>();
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
@@ -28,7 +28,6 @@ import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.storage.StorageException;
-import com.google.firebase.storage.internal.Slashes;
 import com.google.firebase.storage.network.connection.HttpURLConnectionFactory;
 import com.google.firebase.storage.network.connection.HttpURLConnectionFactoryImpl;
 import java.io.BufferedOutputStream;
@@ -116,18 +115,18 @@ public abstract class NetworkRequest {
         + "/b/"
         + gsUri.getAuthority()
         + "/o/"
-        + (pathWithoutBucket != null ? Slashes.unSlashize(pathWithoutBucket) : "");
+        + (pathWithoutBucket != null ? Uri.encode(pathWithoutBucket) : "");
   }
 
   /**
-   * Returns the path of the object but excludes the bucket name
+   * Returns the decoded path of the object but excludes the bucket name
    *
    * @param gsUri the "gs://" Uri of the blob.
    * @return the path in string form.
    */
   @Nullable
   public static String getPathWithoutBucket(@NonNull Uri gsUri) {
-    String path = gsUri.getEncodedPath();
+    String path = gsUri.getPath();
     if (path != null && path.startsWith("/")) {
       // this should always be true.
       path = path.substring(1);
@@ -136,7 +135,7 @@ public abstract class NetworkRequest {
   }
 
   /**
-   * Returns the path of the object but excludes the bucket name
+   * Returns the decoded path of the object but excludes the bucket name
    *
    * @return the path in string form.
    */
@@ -506,7 +505,7 @@ public abstract class NetworkRequest {
     return resultCode >= 200 && resultCode < 300;
   }
 
-  String getPostDataString(@Nullable List<String> keys, List<String> values, boolean encode) {
+  String getPostDataString(@Nullable List<String> keys, List<String> values) {
     if (keys == null || keys.size() == 0) {
       return null;
     }
@@ -520,9 +519,9 @@ public abstract class NetworkRequest {
         result.append("&");
       }
 
-      result.append(encode ? Uri.encode(keys.get(i), "UTF-8") : keys.get(i));
+      result.append(Uri.encode(keys.get(i), "UTF-8"));
       result.append("=");
-      result.append(encode ? Uri.encode(values.get(i), "UTF-8") : values.get(i));
+      result.append(Uri.encode(values.get(i), "UTF-8"));
     }
 
     return result.toString();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
@@ -68,8 +68,8 @@ public abstract class NetworkRequest {
   private static final String CONTENT_LENGTH = "Content-Length";
   private static final String UTF_8 = "UTF-8";
 
-  @NonNull public static String sNetworkRequestUrl = "https://firebasestorage.googleapis.com/v0";
-  @NonNull public static String sUploadUrl = "https://firebasestorage.googleapis.com/v0/b/";
+  @NonNull static Uri sNetworkRequestUrl = Uri.parse("https://firebasestorage.googleapis.com/v0");
+
   // For test purposes only.
   /*package*/ static HttpURLConnectionFactory connectionFactory =
       new HttpURLConnectionFactoryImpl();
@@ -97,8 +97,7 @@ public abstract class NetworkRequest {
 
   @NonNull
   public static String getAuthority() {
-    Uri uri = Uri.parse(sNetworkRequestUrl);
-    return uri.getAuthority();
+    return sNetworkRequestUrl.getAuthority();
   }
 
   /**
@@ -107,15 +106,15 @@ public abstract class NetworkRequest {
    * @return Url for the target REST call in string form.
    */
   @NonNull
-  public static String getDefaultURL(@NonNull Uri gsUri) {
+  public static Uri getDefaultURL(@NonNull Uri gsUri) {
     Preconditions.checkNotNull(gsUri);
-
     String pathWithoutBucket = getPathWithoutBucket(gsUri);
-    return sNetworkRequestUrl
-        + "/b/"
-        + gsUri.getAuthority()
-        + "/o/"
-        + (pathWithoutBucket != null ? Uri.encode(pathWithoutBucket) : "");
+    Uri.Builder uriBuilder = sNetworkRequestUrl.buildUpon();
+    uriBuilder.appendPath("b");
+    uriBuilder.appendPath(gsUri.getAuthority());
+    uriBuilder.appendPath("o");
+    uriBuilder.appendPath(pathWithoutBucket);
+    return uriBuilder.build();
   }
 
   /**
@@ -124,14 +123,12 @@ public abstract class NetworkRequest {
    * @param gsUri the "gs://" Uri of the blob.
    * @return the path in string form.
    */
-  @Nullable
-  public static String getPathWithoutBucket(@NonNull Uri gsUri) {
+  private static String getPathWithoutBucket(@NonNull Uri gsUri) {
     String path = gsUri.getPath();
-    if (path != null && path.startsWith("/")) {
-      // this should always be true.
-      path = path.substring(1);
+    if (path == null) {
+      return "";
     }
-    return path;
+    return path.startsWith("/") ? path.substring(1) : path;
   }
 
   /**
@@ -139,8 +136,7 @@ public abstract class NetworkRequest {
    *
    * @return the path in string form.
    */
-  @Nullable
-  public String getPathWithoutBucket() {
+  String getPathWithoutBucket() {
     return getPathWithoutBucket(mGsUri);
   }
 
@@ -153,7 +149,7 @@ public abstract class NetworkRequest {
    * @return Url for the target REST call in string form.
    */
   @NonNull
-  protected String getURL() {
+  protected Uri getURL() {
     return getDefaultURL(mGsUri);
   }
 
@@ -193,7 +189,7 @@ public abstract class NetworkRequest {
    * @return query parameters in string form.
    */
   @Nullable
-  protected String getQueryParameters() {
+  protected Map<String, String> getQueryParameters() {
     return null;
   }
 
@@ -306,16 +302,18 @@ public abstract class NetworkRequest {
     HttpURLConnection conn;
     URL url;
 
-    String urlString;
-    String queryParams = getQueryParameters();
-    if (TextUtils.isEmpty(queryParams)) {
-      urlString = getURL();
-    } else {
-      urlString = getURL() + "?" + queryParams;
+    Uri connectionUri = getURL();
+
+    Map<String, String> queryParams = getQueryParameters();
+    if (queryParams != null) {
+      Uri.Builder uriBuilder = connectionUri.buildUpon();
+      for (Map.Entry<String, String> param : queryParams.entrySet()) {
+        uriBuilder.appendQueryParameter(param.getKey(), param.getValue());
+      }
+      connectionUri = uriBuilder.build();
     }
 
-    url = new URL(urlString);
-    conn = connectionFactory.createInstance(url);
+    conn = connectionFactory.createInstance(new URL(connectionUri.toString()));
     return conn;
   }
 
@@ -503,28 +501,6 @@ public abstract class NetworkRequest {
    */
   public boolean isResultSuccess() {
     return resultCode >= 200 && resultCode < 300;
-  }
-
-  String getPostDataString(@Nullable List<String> keys, List<String> values) {
-    if (keys == null || keys.size() == 0) {
-      return null;
-    }
-
-    StringBuilder result = new StringBuilder();
-    boolean first = true;
-    for (int i = 0; i < keys.size(); i++) {
-      if (first) {
-        first = false;
-      } else {
-        result.append("&");
-      }
-
-      result.append(Uri.encode(keys.get(i), "UTF-8"));
-      result.append("=");
-      result.append(Uri.encode(values.get(i), "UTF-8"));
-    }
-
-    return result.toString();
   }
 
   @Nullable

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
@@ -186,7 +186,7 @@ public abstract class NetworkRequest {
   /**
    * If overridden, returns the query parameters to send on the REST request.
    *
-   * @return query parameters in string form.
+   * @return If applicable, query params as a Map.
    */
   @Nullable
   protected Map<String, String> getQueryParameters() {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadByteRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadByteRequest.java
@@ -15,14 +15,13 @@
 package com.google.firebase.storage.network;
 
 import android.net.Uri;
-import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
 
 /** A request to upload a single chunk of a large blob. */
 public class ResumableUploadByteRequest extends ResumableNetworkRequest {
-  private final String uploadURL;
+  private final Uri uploadURL;
   private final byte[] chunk;
   private final long offset;
   private final boolean isFinal;
@@ -31,15 +30,12 @@ public class ResumableUploadByteRequest extends ResumableNetworkRequest {
   public ResumableUploadByteRequest(
       @NonNull Uri gsUri,
       @NonNull FirebaseApp app,
-      @NonNull String uploadURL,
+      @NonNull Uri uploadURL,
       @Nullable byte[] chunk,
       long offset,
       int bytesToWrite,
       boolean isFinal) {
     super(gsUri, app);
-    if (TextUtils.isEmpty(uploadURL)) {
-      super.mException = new IllegalArgumentException("uploadURL is null or empty");
-    }
     if (chunk == null && bytesToWrite != -1) {
       super.mException = new IllegalArgumentException("contentType is null or empty");
     }
@@ -71,7 +67,7 @@ public class ResumableUploadByteRequest extends ResumableNetworkRequest {
 
   @Override
   @NonNull
-  protected String getURL() {
+  protected Uri getURL() {
     return uploadURL;
   }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
@@ -15,7 +15,6 @@
 package com.google.firebase.storage.network;
 
 import android.net.Uri;
-import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.FirebaseApp;
@@ -24,15 +23,12 @@ import com.google.firebase.FirebaseApp;
 public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
   @VisibleForTesting public static boolean cancelCalled = false;
 
-  private final String uploadURL;
+  private final Uri uploadURL;
 
   public ResumableUploadCancelRequest(
-      @NonNull Uri gsUri, @NonNull FirebaseApp app, @NonNull String uploadURL) {
+      @NonNull Uri gsUri, @NonNull FirebaseApp app, @NonNull Uri uploadURL) {
     super(gsUri, app);
     cancelCalled = true;
-    if (TextUtils.isEmpty(uploadURL)) {
-      super.mException = new IllegalArgumentException("uploadURL is null or empty");
-    }
     this.uploadURL = uploadURL;
     super.setCustomHeader(PROTOCOL, "resumable");
     super.setCustomHeader(COMMAND, "cancel");
@@ -46,7 +42,7 @@ public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
 
   @NonNull
   @Override
-  protected String getURL() {
+  protected Uri getURL() {
     return uploadURL;
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
@@ -15,20 +15,16 @@
 package com.google.firebase.storage.network;
 
 import android.net.Uri;
-import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import com.google.firebase.FirebaseApp;
 
 /** Queries the current status of a resumable upload session. */
 public class ResumableUploadQueryRequest extends ResumableNetworkRequest {
-  private final String uploadURL;
+  private final Uri uploadURL;
 
   public ResumableUploadQueryRequest(
-      @NonNull Uri gsUri, @NonNull FirebaseApp app, @NonNull String uploadURL) {
+      @NonNull Uri gsUri, @NonNull FirebaseApp app, @NonNull Uri uploadURL) {
     super(gsUri, app);
-    if (TextUtils.isEmpty(uploadURL)) {
-      super.mException = new IllegalArgumentException("uploadURL is null or empty");
-    }
     this.uploadURL = uploadURL;
 
     super.setCustomHeader(PROTOCOL, "resumable");
@@ -43,7 +39,7 @@ public class ResumableUploadQueryRequest extends ResumableNetworkRequest {
 
   @NonNull
   @Override
-  protected String getURL() {
+  protected Uri getURL() {
     return uploadURL;
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
@@ -19,7 +19,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.storage.internal.Slashes;
 import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONObject;
@@ -65,10 +64,10 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
 
     String pathWithoutBucket = getPathWithoutBucket();
     keys.add("name");
-    values.add(pathWithoutBucket != null ? Slashes.unSlashize(pathWithoutBucket) : "");
+    values.add(pathWithoutBucket != null ? pathWithoutBucket : "");
     keys.add("uploadType");
     values.add("resumable");
-    return getPostDataString(keys, values, false);
+    return getPostDataString(keys, values);
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
@@ -19,8 +19,8 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import org.json.JSONObject;
 
 /** Starts a resumable upload session with GCS. */
@@ -46,8 +46,12 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
 
   @Override
   @NonNull
-  protected String getURL() {
-    return sUploadUrl + mGsUri.getAuthority() + "/o";
+  protected Uri getURL() {
+    Uri.Builder uriBuilder = sNetworkRequestUrl.buildUpon();
+    uriBuilder.appendPath("b");
+    uriBuilder.appendPath(mGsUri.getAuthority());
+    uriBuilder.appendPath("o");
+    return uriBuilder.build();
   }
 
   @Override
@@ -58,16 +62,11 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
 
   @Override
   @NonNull
-  protected String getQueryParameters() {
-    List<String> keys = new ArrayList<>();
-    List<String> values = new ArrayList<>();
-
-    String pathWithoutBucket = getPathWithoutBucket();
-    keys.add("name");
-    values.add(pathWithoutBucket != null ? pathWithoutBucket : "");
-    keys.add("uploadType");
-    values.add("resumable");
-    return getPostDataString(keys, values);
+  protected Map<String, String> getQueryParameters() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put("name", getPathWithoutBucket());
+    headers.put("uploadType", "resumable");
+    return headers;
   }
 
   @Override

--- a/firebase-storage/src/test/java/com/google/firebase/storage/UploadTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/UploadTest.java
@@ -274,7 +274,9 @@ public class UploadTest {
     System.out.println("Starting test uploadWithSpace.");
 
     MockConnectionFactory factory = NetworkLayerMock.ensureNetworkMock("uploadWithSpace", true);
-    Task<StringBuilder> task = TestUploadHelper.uploadWithSpace();
+    StorageReference storage =
+        FirebaseStorage.getInstance().getReference().child("hello world.txt");
+    Task<StringBuilder> task = TestUploadHelper.byteUpload(storage);
 
     TestUtil.await(task);
 
@@ -340,6 +342,20 @@ public class UploadTest {
 
     factory.verifyOldMock();
     TestUtil.verifyTaskStateChanges("emptyUpload", task.getResult().toString());
+  }
+
+  @Test
+  public void unicodeUpload() throws Exception {
+    System.out.println("Starting test unicodeUpload.");
+
+    MockConnectionFactory factory = NetworkLayerMock.ensureNetworkMock("uploadWithUnicode", true);
+    StorageReference storage = FirebaseStorage.getInstance().getReference().child("\\%:😊");
+    Task<StringBuilder> task = TestUploadHelper.byteUpload(storage);
+
+    TestUtil.await(task);
+
+    factory.verifyOldMock();
+    TestUtil.verifyTaskStateChanges("uploadWithUnicode", task.getResult().toString());
   }
 
   @Test

--- a/firebase-storage/src/test/resources/activitylogs/uploadWithUnicode_network.txt
+++ b/firebase-storage/src/test/resources/activitylogs/uploadWithUnicode_network.txt
@@ -1,0 +1,130 @@
+
+<new>
+Url:https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o?name=%5C%25%3A%F0%9F%98%8A&uploadType=resumable
+setRequestMethod:POST
+setRequestProperty:X-Firebase-Storage-Version,Android/[No Gmscore]
+setRequestProperty:x-firebase-gmpid,fooey
+setRequestProperty:X-Goog-Upload-Protocol,resumable
+setRequestProperty:X-Goog-Upload-Header-Content-Type,text/plain
+setRequestProperty:X-Goog-Upload-Command,start
+setRequestProperty:Content-Type,application/json
+setDoOutput:true
+setRequestProperty:Content-Length,29
+setUseCaches:false
+setDoInput:true
+getOutputStream:
+getResponseCode:200
+getHeaderFields:
+ null:[HTTP/1.1 200 OK]
+ Alt-Svc:[quic=":443"; ma=2592000; v="36,35,34"]
+ Content-Length:[0]
+ Content-Type:[text/html; charset=UTF-8]
+ Date:[Fri, 03 Mar 2017 23:00:11 GMT]
+ Server:[UploadServer]
+ X-Android-Received-Millis:[1488582013323]
+ X-Android-Response-Source:[NETWORK 200]
+ X-Android-Selected-Protocol:[http/1.1]
+ X-Android-Sent-Millis:[1488582012958]
+ X-Goog-Upload-Chunk-Granularity:[262144]
+ X-Goog-Upload-Control-URL:[https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o?name=%5C%25%3A%F0%9F%98%8A&uploadType=resumable&upload_id=AEnB2Up6a4kp5P8Xuhz1mofQpbwHFKEuLxt0X_KpCwzCwZ1N_LGtzBFm9vPpqt3eI2BDD2EDffjtzTovN6W-Cf6UHVYg9vrtGpzuU2xIV6aEtHrvBwQj8g8&upload_protocol=resumable]
+ X-Goog-Upload-Status:[active]
+ X-Goog-Upload-URL:[https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o?name=%5C%25%3A%F0%9F%98%8A&uploadType=resumable&upload_id=AEnB2Up6a4kp5P8Xuhz1mofQpbwHFKEuLxt0X_KpCwzCwZ1N_LGtzBFm9vPpqt3eI2BDD2EDffjtzTovN6W-Cf6UHVYg9vrtGpzuU2xIV6aEtHrvBwQj8g8&upload_protocol=resumable]
+ X-GUploader-UploadID:[AEnB2Up6a4kp5P8Xuhz1mofQpbwHFKEuLxt0X_KpCwzCwZ1N_LGtzBFm9vPpqt3eI2BDD2EDffjtzTovN6W-Cf6UHVYg9vrtGpzuU2xIV6aEtHrvBwQj8g8]
+getInputStream:
+disconnect:
+<new>
+Url:https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o?name=%5C%25%3A%F0%9F%98%8A&uploadType=resumable&upload_id=AEnB2Up6a4kp5P8Xuhz1mofQpbwHFKEuLxt0X_KpCwzCwZ1N_LGtzBFm9vPpqt3eI2BDD2EDffjtzTovN6W-Cf6UHVYg9vrtGpzuU2xIV6aEtHrvBwQj8g8&upload_protocol=resumable
+setRequestMethod:POST
+setRequestProperty:X-Firebase-Storage-Version,Android/[No Gmscore]
+setRequestProperty:x-firebase-gmpid,fooey
+setRequestProperty:X-Goog-Upload-Protocol,resumable
+setRequestProperty:X-Goog-Upload-Offset,0
+setRequestProperty:X-Goog-Upload-Command,upload, finalize
+setDoOutput:true
+setRequestProperty:Content-Length,17
+setUseCaches:false
+setDoInput:true
+getOutputStream:
+getResponseCode:200
+getHeaderFields:
+ null:[HTTP/1.1 200 OK]
+ Access-Control-Allow-Origin:[*]
+ Access-Control-Expose-Headers:[X-Firebase-Storage-XSRF]
+ Alt-Svc:[quic=":443"; ma=2592000; v="36,35,34"]
+ Content-Length:[568]
+ Content-Type:[application/json; charset=UTF-8]
+ Date:[Fri, 03 Mar 2017 23:00:45 GMT]
+ Server:[UploadServer]
+ X-Android-Received-Millis:[1488582047427]
+ X-Android-Response-Source:[NETWORK 200]
+ X-Android-Selected-Protocol:[http/1.1]
+ X-Android-Sent-Millis:[1488582046945]
+ X-Content-Type-Options:[nosniff]
+ X-Goog-Upload-Status:[final]
+ X-GUploader-UploadID:[AEnB2Up6a4kp5P8Xuhz1mofQpbwHFKEuLxt0X_KpCwzCwZ1N_LGtzBFm9vPpqt3eI2BDD2EDffjtzTovN6W-Cf6UHVYg9vrtGpzuU2xIV6aEtHrvBwQj8g8]
+getInputStream:ewogICJuYW1lIjogIlxcJTrwn5iKIiwKICAiYnVja2V0IjogImZvb2V5LmFwcHNwb3QuY29tIiwKICAiZ2VuZXJhdGlvbiI6ICIxNDg4NTgyMDQ1NzAwMDAwIiwKICAibWV0YWdlbmVyYXRpb24iOiAiMSIsCiAgImNvbnRlbnRUeXBlIjogInRleHQvcGxhaW4iLAogICJ0aW1lQ3JlYXRlZCI6ICIyMDE3LTAzLTAzVDIzOjAwOjQ1LjYwNFoiLAogICJ1cGRhdGVkIjogIjIwMTctMDMtMDNUMjM6MDA6NDUuNjA0WiIsCiAgInN0b3JhZ2VDbGFzcyI6ICJTVEFOREFSRCIsCiAgInNpemUiOiAiMTciLAogICJtZDVIYXNoIjogInNDSVA2ajhlcXVOZ1hrZlc0WlRFUXc9PSIsCiAgImNvbnRlbnRFbmNvZGluZyI6ICJpZGVudGl0eSIsCiAgImNvbnRlbnREaXNwb3NpdGlvbiI6ICJpbmxpbmU7IGZpbGVuYW1lKj11dGYtOCcnJTVDJTI1JTNBJUYwJTlGJTk4JThBIiwKICAiY3JjMzJjIjogIkRyOG5FQT09IiwKICAiZXRhZyI6ICJDS0NmdHFDNHU5SUNFQUU9IiwKICAiZG93bmxvYWRUb2tlbnMiOiAiNWFkNDAwZDgtYWJjYS00M2NiLTllOTYtNTBhOGMwYWQ4NTBhIgp9
+disconnect:
+<new>
+Url:https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o/%5C%25%3A%F0%9F%98%8A
+setRequestMethod:GET
+setRequestProperty:X-Firebase-Storage-Version,Android/[No Gmscore]
+setRequestProperty:x-firebase-gmpid,fooey
+setRequestProperty:Content-Length,0
+setUseCaches:false
+setDoInput:true
+getResponseCode:200
+getHeaderFields:
+ null:[HTTP/1.1 200 OK]
+ Access-Control-Allow-Origin:[*]
+ Access-Control-Expose-Headers:[X-Firebase-Storage-XSRF]
+ Alt-Svc:[quic=":443"; ma=2592000; v="36,35,34"]
+ Cache-Control:[private, max-age=0]
+ Content-Length:[568]
+ Content-Type:[application/json; charset=UTF-8]
+ Date:[Fri, 03 Mar 2017 23:01:05 GMT]
+ Expires:[Fri, 03 Mar 2017 23:01:05 GMT]
+ Server:[UploadServer]
+ X-Android-Received-Millis:[1488582066821]
+ X-Android-Response-Source:[NETWORK 200]
+ X-Android-Selected-Protocol:[http/1.1]
+ X-Android-Sent-Millis:[1488582066670]
+ X-Content-Type-Options:[nosniff]
+ X-GUploader-UploadID:[AEnB2UoXFQd6vfXyfreuXyAVKSw-dCOcYBtXIAodtgR93SydOKB4WOFOH3If0o7JNTMgcCDt14o8SgdBQw49T9V2WS2IPZ80N5TQDxvSyE_Of-MwL6e-j5c]
+getInputStream:ewogICJuYW1lIjogIlxcJTrwn5iKIiwKICAiYnVja2V0IjogImZvb2V5LmFwcHNwb3QuY29tIiwKICAiZ2VuZXJhdGlvbiI6ICIxNDg4NTgyMDQ1NzAwMDAwIiwKICAibWV0YWdlbmVyYXRpb24iOiAiMSIsCiAgImNvbnRlbnRUeXBlIjogInRleHQvcGxhaW4iLAogICJ0aW1lQ3JlYXRlZCI6ICIyMDE3LTAzLTAzVDIzOjAwOjQ1LjYwNFoiLAogICJ1cGRhdGVkIjogIjIwMTctMDMtMDNUMjM6MDA6NDUuNjA0WiIsCiAgInN0b3JhZ2VDbGFzcyI6ICJTVEFOREFSRCIsCiAgInNpemUiOiAiMTciLAogICJtZDVIYXNoIjogInNDSVA2ajhlcXVOZ1hrZlc0WlRFUXc9PSIsCiAgImNvbnRlbnRFbmNvZGluZyI6ICJpZGVudGl0eSIsCiAgImNvbnRlbnREaXNwb3NpdGlvbiI6ICJpbmxpbmU7IGZpbGVuYW1lKj11dGYtOCcnJTVDJTI1JTNBJUYwJTlGJTk4JThBIiwKICAiY3JjMzJjIjogIkRyOG5FQT09IiwKICAiZXRhZyI6ICJDS0NmdHFDNHU5SUNFQUU9IiwKICAiZG93bmxvYWRUb2tlbnMiOiAiNWFkNDAwZDgtYWJjYS00M2NiLTllOTYtNTBhOGMwYWQ4NTBhIgp9
+disconnect:
+<new>
+Url:https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o/%5C%25%3A%F0%9F%98%8A?alt=media
+setRequestMethod:GET
+setRequestProperty:X-Firebase-Storage-Version,Android/[No Gmscore]
+setRequestProperty:x-firebase-gmpid,fooey
+setRequestProperty:Content-Length,0
+setUseCaches:false
+setDoInput:true
+getResponseCode:200
+getHeaderFields:
+ null:[HTTP/1.1 200 OK]
+ Accept-Ranges:[bytes]
+ Alt-Svc:[quic=":443"; ma=2592000; v="36,35,34"]
+ Cache-Control:[private, max-age=0]
+ Content-Disposition:[inline; filename*=utf-8''%5C%25%3A%F0%9F%98%8A]
+ Content-Length:[17]
+ Content-Type:[text/plain]
+ Date:[Fri, 03 Mar 2017 23:01:09 GMT]
+ ETag:["b0220fea3f1eaae3605e47d6e194c443"]
+ Expires:[Fri, 03 Mar 2017 23:01:09 GMT]
+ Last-Modified:[Fri, 03 Mar 2017 23:00:45 GMT]
+ Server:[UploadServer]
+ X-Android-Received-Millis:[1488582071224]
+ X-Android-Response-Source:[NETWORK 200]
+ X-Android-Selected-Protocol:[http/1.1]
+ X-Android-Sent-Millis:[1488582070989]
+ x-goog-generation:[1488582045700000]
+ x-goog-hash:[crc32c=Dr8nEA==][md5=sCIP6j8equNgXkfW4ZTEQw==]
+ x-goog-meta-firebaseStorageDownloadTokens:[5ad400d8-abca-43cb-9e96-50a8c0ad850a]
+ x-goog-metageneration:[1]
+ x-goog-storage-class:[STANDARD]
+ x-goog-stored-content-encoding:[identity]
+ x-goog-stored-content-length:[17]
+ X-GUploader-UploadID:[AEnB2UoCD1g6ZTwfSeJUjf26LsatDn2wD0owCuLzsSnT5Jmc9O58XuZiIb9QTvmKjzTNQ706cNQZSzA03xcTuCOkNzEgoFHuEu4QjYzmps1RaJEi4O3sV-s]
+getInputStream:VGhpcyBpcyBhIHRlc3QhISE=
+disconnect:

--- a/firebase-storage/src/test/resources/activitylogs/uploadWithUnicode_task.txt
+++ b/firebase-storage/src/test/resources/activitylogs/uploadWithUnicode_task.txt
@@ -1,0 +1,56 @@
+
+onProgress:
+  exceptionMessage:<none>
+  targetStorageString:gs://fooey.appspot.com/%5C%25%3A%F0%9F%98%8A
+  bytesUploaded:0
+  currentState:4
+  uploadUri:<none>
+  total bytes:17
+onProgress:
+  exceptionMessage:<none>
+  targetStorageString:gs://fooey.appspot.com/%5C%25%3A%F0%9F%98%8A
+  bytesUploaded:0
+  currentState:4
+  uploadUri:<none>
+  total bytes:17
+onProgress:
+  exceptionMessage:<none>
+  targetStorageString:gs://fooey.appspot.com/%5C%25%3A%F0%9F%98%8A
+  bytesUploaded:17
+  currentState:128
+  uploadUri:https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o?name=%5C%25%3A%F0%9F%98%8A&uploadType=resumable&upload_id=AEnB2Up6a4kp5P8Xuhz1mofQpbwHFKEuLxt0X_KpCwzCwZ1N_LGtzBFm9vPpqt3eI2BDD2EDffjtzTovN6W-Cf6UHVYg9vrtGpzuU2xIV6aEtHrvBwQj8g8&upload_protocol=resumable
+  total bytes:17
+onSuccess:
+  exceptionMessage:<none>
+  targetStorageString:gs://fooey.appspot.com/%5C%25%3A%F0%9F%98%8A
+  bytesUploaded:17
+  currentState:128
+  uploadUri:https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o?name=%5C%25%3A%F0%9F%98%8A&uploadType=resumable&upload_id=AEnB2Up6a4kp5P8Xuhz1mofQpbwHFKEuLxt0X_KpCwzCwZ1N_LGtzBFm9vPpqt3eI2BDD2EDffjtzTovN6W-Cf6UHVYg9vrtGpzuU2xIV6aEtHrvBwQj8g8&upload_protocol=resumable
+  total bytes:17
+getBucket:fooey.appspot.com
+getCacheControl:
+getContentDisposition:inline; filename*=utf-8''%5C%25%3A%F0%9F%98%8A
+getContentEncoding:identity
+getContentLanguage:
+getContentType:text/plain
+getName:\%:😊
+getPath:\%:😊
+getMD5Hash:sCIP6j8equNgXkfW4ZTEQw==
+getGeneration:1488582045700000
+getMetadataGeneration:1
+getSizeBytes:17
+getReference:\%:😊
+getCreationTimeMillis:03/03/2017
+getUpdatedTimeMillis:03/03/2017
+Type:FILE
+
+onSuccessTask:
+  exceptionMessage:<none>
+  targetStorageString:gs://fooey.appspot.com/%5C%25%3A%F0%9F%98%8A
+  bytesUploaded:17
+  currentState:128
+  uploadUri:https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o?name=%5C%25%3A%F0%9F%98%8A&uploadType=resumable&upload_id=AEnB2Up6a4kp5P8Xuhz1mofQpbwHFKEuLxt0X_KpCwzCwZ1N_LGtzBFm9vPpqt3eI2BDD2EDffjtzTovN6W-Cf6UHVYg9vrtGpzuU2xIV6aEtHrvBwQj8g8&upload_protocol=resumable
+  total bytes:17
+onComplete:Success=
+true
+done.

--- a/firebase-storage/src/testUtil/java/com/google/firebase/storage/TestUploadHelper.java
+++ b/firebase-storage/src/testUtil/java/com/google/firebase/storage/TestUploadHelper.java
@@ -134,10 +134,8 @@ public class TestUploadHelper {
         });
   }
 
-  public static Task<StringBuilder> uploadWithSpace() {
+  public static Task<StringBuilder> byteUpload(StorageReference storage) {
     final StringBuilder builder = new StringBuilder();
-    StorageReference storage =
-        FirebaseStorage.getInstance().getReference().child("hello world.txt");
     String foo = "This is a test!!!";
     byte[] bytes = foo.getBytes(Charset.forName("UTF-8"));
     StorageMetadata metadata = new StorageMetadata.Builder().setContentType("text/plain").build();

--- a/firebase-storage/test-app/src/main/java/com/example/storage/MainActivity.java
+++ b/firebase-storage/test-app/src/main/java/com/example/storage/MainActivity.java
@@ -107,6 +107,7 @@ public class MainActivity extends AppCompatActivity {
 
     FirebaseApp.initializeApp(getApplicationContext());
     FirebaseAuth.getInstance().signInAnonymously();
+    FirebaseStorage storage = FirebaseStorage.getInstance();
 
     Button clickButton = findViewById(R.id.streamDownload);
     clickButton.setOnClickListener(
@@ -158,7 +159,7 @@ public class MainActivity extends AppCompatActivity {
                 "uploadWithSpace",
                 () -> {
                   try {
-                    return TestUploadHelper.uploadWithSpace();
+                    return TestUploadHelper.byteUpload(storage.getReference("hello world.txt"));
                   } catch (Exception e) {
                     e.printStackTrace();
                   }


### PR DESCRIPTION
Fixes b/139750197

This PR makes sure that we always encode query parameters and always use the decoded path if we process them further.