### PR TITLE
Random code cleanup for Storage

### DIFF
--- a/firebase-storage/api.txt
+++ b/firebase-storage/api.txt
@@ -68,7 +68,6 @@ package com.google.firebase.storage {
     method @com.google.firebase.storage.StorageException.ErrorCode public int getErrorCode();
     method public int getHttpResultCode();
     method public boolean getIsRecoverableException();
-    method @NonNull public String getMessage();
     field public static final int ERROR_BUCKET_NOT_FOUND = -13011; // 0xffffcd2d
     field public static final int ERROR_CANCELED = -13040; // 0xffffcd10
     field public static final int ERROR_INVALID_CHECKSUM = -13031; // 0xffffcd19

--- a/firebase-storage/src/androidTest/java/com/google/firebase/storage/IntegrationTest.java
+++ b/firebase-storage/src/androidTest/java/com/google/firebase/storage/IntegrationTest.java
@@ -134,7 +134,7 @@ public class IntegrationTest {
 
   @Test
   public void pagedListFiles() throws ExecutionException, InterruptedException {
-    Task<ListResult> listTask = storageClient.getReference(randomPrefix).list(2);
+    Task<ListResult> listTask = getReference().list(2);
     ListResult listResult = Tasks.await(listTask);
 
     assertThat(listResult.getItems())
@@ -142,7 +142,7 @@ public class IntegrationTest {
     assertThat(listResult.getPrefixes()).isEmpty();
     assertThat(listResult.getPageToken()).isNotEmpty();
 
-    listTask = storageClient.getReference(randomPrefix).list(2, listResult.getPageToken());
+    listTask = getReference().list(2, listResult.getPageToken());
     listResult = Tasks.await(listTask);
 
     assertThat(listResult.getItems()).isEmpty();
@@ -152,13 +152,18 @@ public class IntegrationTest {
 
   @Test
   public void listAllFiles() throws ExecutionException, InterruptedException {
-    Task<ListResult> listTask = storageClient.getReference(randomPrefix).listAll();
+    Task<ListResult> listTask = getReference().listAll();
     ListResult listResult = Tasks.await(listTask);
 
     assertThat(listResult.getPrefixes()).containsExactly(getReference("prefix"));
     assertThat(listResult.getItems())
         .containsExactly(getReference("metadata.dat"), getReference("download.dat"));
     assertThat(listResult.getPageToken()).isNull();
+  }
+
+  @NonNull
+  private StorageReference getReference() {
+    return storageClient.getReference(randomPrefix);
   }
 
   @NonNull

--- a/firebase-storage/src/main/java/com/google/firebase/storage/ListResult.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/ListResult.java
@@ -89,7 +89,7 @@ public final class ListResult {
   }
 
   /**
-   * Returns a token that can be used to resume a previous {@code list()} operation. ${@code null}
+   * Returns a token that can be used to resume a previous {@code list()} operation. {@code null}
    * indicates that there are no more results.
    *
    * @return A page token if more results are available.

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageException.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageException.java
@@ -42,22 +42,22 @@ public class StorageException extends FirebaseException {
 
   private final int errorCode;
   private final int httpResultCode;
-  private String detailMessage;
   private Throwable cause;
 
   StorageException(@ErrorCode int errorCode, Throwable inner, int httpResultCode) {
-    this.detailMessage = getErrorMessageForCode(errorCode);
+    super(getErrorMessageForCode(errorCode));
+
     this.cause = inner;
     this.errorCode = errorCode;
     this.httpResultCode = httpResultCode;
     Log.e(
         TAG,
         "StorageException has occurred.\n"
-            + detailMessage
+            + getErrorMessageForCode(errorCode)
             + "\n Code: "
-            + Integer.toString(this.errorCode)
+            + this.errorCode
             + " HttpResult: "
-            + Integer.toString(this.httpResultCode));
+            + this.httpResultCode);
     if (cause != null) {
       Log.e(TAG, cause.getMessage(), cause);
     }
@@ -153,16 +153,6 @@ public class StorageException extends FirebaseException {
         return "An unknown error occurred, please check the HTTP result code and inner "
             + "exception for server response.";
     }
-  }
-
-  /**
-   * Returns the detail message which was provided when this {@code Throwable} was created. Returns
-   * {@code null} if no message was provided at creation time.
-   */
-  @NonNull
-  @Override
-  public String getMessage() {
-    return detailMessage;
   }
 
   /** Returns the cause of this {@code Throwable}, or {@code null} if there is no cause. */

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageMetadata.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageMetadata.java
@@ -16,13 +16,11 @@ package com.google.firebase.storage;
 
 import android.net.Uri;
 import android.text.TextUtils;
-import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.firebase.storage.internal.Slashes;
 import com.google.firebase.storage.internal.Util;
-import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -257,17 +255,12 @@ public class StorageMetadata {
           return null;
         }
         Uri uri;
-        try {
-          uri =
-              new Uri.Builder()
-                  .scheme("gs")
-                  .authority(bucket)
-                  .encodedPath(Slashes.preserveSlashEncode(path))
-                  .build();
-        } catch (UnsupportedEncodingException e) {
-          Log.e(TAG, "Unable to create a valid default Uri. " + bucket + path, e);
-          throw new IllegalStateException(e);
-        }
+        uri =
+            new Uri.Builder()
+                .scheme("gs")
+                .authority(bucket)
+                .encodedPath(Slashes.preserveSlashEncode(path))
+                .build();
 
         return new StorageReference(uri, mStorage);
       }
@@ -276,7 +269,7 @@ public class StorageMetadata {
   }
 
   @NonNull
-  JSONObject createJSONObject() throws JSONException {
+  JSONObject createJSONObject() {
     Map<String, Object> jsonData = new HashMap<>();
 
     if (mContentType.isUserProvided()) {
@@ -347,11 +340,11 @@ public class StorageMetadata {
       mMetadata.mGeneration = jsonObject.optString(GENERATION_KEY);
       mMetadata.mPath = jsonObject.optString(NAME_KEY);
       mMetadata.mBucket = jsonObject.optString(BUCKET_KEY);
-      mMetadata.mMetadataGeneration = (jsonObject.optString(META_GENERATION_KEY));
-      mMetadata.mCreationTime = (jsonObject.optString(TIME_CREATED_KEY));
-      mMetadata.mUpdatedTime = (jsonObject.optString(TIME_UPDATED_KEY));
-      mMetadata.mSize = (jsonObject.optLong(SIZE_KEY));
-      mMetadata.mMD5Hash = (jsonObject.optString(MD5_HASH_KEY));
+      mMetadata.mMetadataGeneration = jsonObject.optString(META_GENERATION_KEY);
+      mMetadata.mCreationTime = jsonObject.optString(TIME_CREATED_KEY);
+      mMetadata.mUpdatedTime = jsonObject.optString(TIME_UPDATED_KEY);
+      mMetadata.mSize = jsonObject.optLong(SIZE_KEY);
+      mMetadata.mMD5Hash = jsonObject.optString(MD5_HASH_KEY);
 
       if (jsonObject.has(CUSTOM_METADATA_KEY) && !jsonObject.isNull(CUSTOM_METADATA_KEY)) {
         JSONObject customMetadata = jsonObject.getJSONObject(CUSTOM_METADATA_KEY);

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageMetadata.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageMetadata.java
@@ -254,8 +254,7 @@ public class StorageMetadata {
         if (TextUtils.isEmpty(bucket) || TextUtils.isEmpty(path)) {
           return null;
         }
-        Uri uri;
-        uri =
+        Uri uri =
             new Uri.Builder()
                 .scheme("gs")
                 .authority(bucket)

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageReference.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageReference.java
@@ -33,7 +33,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -86,17 +85,8 @@ public class StorageReference implements Comparable<StorageReference> {
 
     pathString = Slashes.normalizeSlashes(pathString);
     Uri child;
-    try {
-      child =
-          mStorageUri
-              .buildUpon()
-              .appendEncodedPath(Slashes.preserveSlashEncode(pathString))
-              .build();
-    } catch (UnsupportedEncodingException e) {
-      Log.e(TAG, "Unable to create a valid default Uri. " + pathString, e);
-
-      throw new IllegalArgumentException("childName");
-    }
+    child =
+        mStorageUri.buildUpon().appendEncodedPath(Slashes.preserveSlashEncode(pathString)).build();
     return new StorageReference(child, mFirebaseStorage);
   }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageReference.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageReference.java
@@ -84,8 +84,7 @@ public class StorageReference implements Comparable<StorageReference> {
         !TextUtils.isEmpty(pathString), "childName cannot be null or empty");
 
     pathString = Slashes.normalizeSlashes(pathString);
-    Uri child;
-    child =
+    Uri child =
         mStorageUri.buildUpon().appendEncodedPath(Slashes.preserveSlashEncode(pathString)).build();
     return new StorageReference(child, mFirebaseStorage);
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
@@ -51,16 +51,9 @@ class UpdateMetadataTask implements Runnable {
   @Override
   public void run() {
     final NetworkRequest request;
-    try {
-      request =
-          new UpdateMetadataNetworkRequest(
-              mStorageRef.getStorageUri(), mStorageRef.getApp(), mNewMetadata.createJSONObject());
-    } catch (final JSONException e) {
-      Log.e(TAG, "Unable to create the request from metadata.", e);
-
-      mPendingResult.setException(StorageException.fromException(e));
-      return;
-    }
+    request =
+        new UpdateMetadataNetworkRequest(
+            mStorageRef.getStorageUri(), mStorageRef.getApp(), mNewMetadata.createJSONObject());
 
     mSender.sendWithExponentialBackoff(request);
     if (request.isResultSuccess()) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
@@ -50,8 +50,7 @@ class UpdateMetadataTask implements Runnable {
 
   @Override
   public void run() {
-    final NetworkRequest request;
-    request =
+    final NetworkRequest request =
         new UpdateMetadataNetworkRequest(
             mStorageRef.getStorageUri(), mStorageRef.getApp(), mNewMetadata.createJSONObject());
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -258,8 +258,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
     if (TextUtils.isEmpty(mimeType)) {
       mimeType = APPLICATION_OCTET_STREAM;
     }
-    NetworkRequest startRequest;
-    startRequest =
+    NetworkRequest startRequest =
         new ResumableUploadStartRequest(
             mStorageRef.getStorageUri(),
             mStorageRef.getApp(),

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -259,18 +259,12 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
       mimeType = APPLICATION_OCTET_STREAM;
     }
     NetworkRequest startRequest;
-    try {
-      startRequest =
-          new ResumableUploadStartRequest(
-              mStorageRef.getStorageUri(),
-              mStorageRef.getApp(),
-              mMetadata != null ? mMetadata.createJSONObject() : null,
-              mimeType);
-    } catch (JSONException e) {
-      Log.e(TAG, "Unable to create a network request from metadata", e);
-      mException = e;
-      return;
-    }
+    startRequest =
+        new ResumableUploadStartRequest(
+            mStorageRef.getStorageUri(),
+            mStorageRef.getApp(),
+            mMetadata != null ? mMetadata.createJSONObject() : null,
+            mimeType);
 
     if (!sendWithRetry(startRequest)) {
       return;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/Slashes.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/Slashes.java
@@ -19,7 +19,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.common.internal.Preconditions;
-import java.io.UnsupportedEncodingException;
 
 /**
  * Utility methods for Firebase Storage.
@@ -34,10 +33,9 @@ public class Slashes {
    *
    * @param s The String to convert
    * @return A partially URL encoded string where slashes are preserved.
-   * @throws UnsupportedEncodingException
    */
   @NonNull
-  public static String preserveSlashEncode(@Nullable String s) throws UnsupportedEncodingException {
+  public static String preserveSlashEncode(@Nullable String s) {
     if (TextUtils.isEmpty(s)) {
       return "";
     }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
@@ -17,7 +17,6 @@ package com.google.firebase.storage.network;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import com.google.firebase.FirebaseApp;
-import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 
 /** A network request that returns bytes of a gcs object. */
@@ -40,7 +39,7 @@ public class GetNetworkRequest extends NetworkRequest {
 
   @Override
   @NonNull
-  protected String getQueryParameters() throws UnsupportedEncodingException {
+  protected String getQueryParameters() {
     return getPostDataString(
         Collections.singletonList("alt"), Collections.singletonList("media"), true);
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -19,7 +19,6 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,7 +51,7 @@ public class ListNetworkRequest extends NetworkRequest {
 
   @Override
   @Nullable
-  protected String getQueryParameters() throws UnsupportedEncodingException {
+  protected String getQueryParameters() {
     List<String> keys = new ArrayList<>();
     List<String> values = new ArrayList<>();
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
@@ -37,11 +37,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.SocketException;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +194,7 @@ public abstract class NetworkRequest {
    * @return query parameters in string form.
    */
   @Nullable
-  protected String getQueryParameters() throws UnsupportedEncodingException {
+  protected String getQueryParameters() {
     return null;
   }
 
@@ -508,8 +506,7 @@ public abstract class NetworkRequest {
     return resultCode >= 200 && resultCode < 300;
   }
 
-  String getPostDataString(@Nullable List<String> keys, List<String> values, boolean encode)
-      throws UnsupportedEncodingException {
+  String getPostDataString(@Nullable List<String> keys, List<String> values, boolean encode) {
     if (keys == null || keys.size() == 0) {
       return null;
     }
@@ -523,9 +520,9 @@ public abstract class NetworkRequest {
         result.append("&");
       }
 
-      result.append(encode ? URLEncoder.encode(keys.get(i), "UTF-8") : keys.get(i));
+      result.append(encode ? Uri.encode(keys.get(i), "UTF-8") : keys.get(i));
       result.append("=");
-      result.append(encode ? URLEncoder.encode(values.get(i), "UTF-8") : values.get(i));
+      result.append(encode ? Uri.encode(values.get(i), "UTF-8") : values.get(i));
     }
 
     return result.toString();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
@@ -20,7 +20,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.storage.internal.Slashes;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import org.json.JSONObject;
@@ -60,7 +59,7 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
 
   @Override
   @NonNull
-  protected String getQueryParameters() throws UnsupportedEncodingException {
+  protected String getQueryParameters() {
     List<String> keys = new ArrayList<>();
     List<String> values = new ArrayList<>();
 


### PR DESCRIPTION
- Use `getReference()` helper in all Integration test.
- Use `Uri.encode()` since it doesn't throw exceptions (and follows the existing encoding of spaces to %20 everywhere)
- Remove unnecessary parenthesis
- Remove JSONException that is never thrown
- Stop using deprecated FirebaseException constructor, instead we pass in the detailed message