### PR TITLE
Don't crash app on WebSocket error

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 19.1.1
+- [fixed] Fixed a crash that occurred when we attempted to start a network
+  connection during app shutdown (#672).
+
 # 19.1.0
 - [feature] Added support for the Firebase Database Emulator. To connect to
   the emulator, specify "http://<emulatorHost>/?ns=<projectId>" as your

--- a/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
@@ -427,9 +427,9 @@ public class WebSocket {
       receiver.run();
     } catch (WebSocketException wse) {
       eventHandler.onError(wse);
-    } catch (IOException ioe) {
+    } catch (Throwable t) {
       eventHandler.onError(
-          new WebSocketException("error while connecting: " + ioe.getMessage(), ioe));
+          new WebSocketException("error while connecting: " + t.getMessage(), t));
     } finally {
       close();
     }

--- a/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
@@ -428,8 +428,7 @@ public class WebSocket {
     } catch (WebSocketException wse) {
       eventHandler.onError(wse);
     } catch (Throwable t) {
-      eventHandler.onError(
-          new WebSocketException("error while connecting: " + t.getMessage(), t));
+      eventHandler.onError(new WebSocketException("error while connecting: " + t.getMessage(), t));
     } finally {
       close();
     }


### PR DESCRIPTION
This seems to be the minimal fix to not crash apps when Tubesock encounters any exception.

I'm torn on whether we should port this back to https://github.com/FirebaseExtended/TubeSock since I am not 100% confident in our release pipeline over in that repo.

Fixes: https://github.com/firebase/firebase-android-sdk/issues/672