### PR TITLE
Avoid double-counting key sizes in memory LRU GC

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -136,25 +136,9 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
     return new DocumentIterable();
   }
 
-  /**
-   * Returns an estimate of the number of bytes used to store the given document key in memory. This
-   * is only an estimate and includes the size of the segments of the path, but not any object
-   * overhead or path separators.
-   */
-  private static long getKeySize(DocumentKey key) {
-    ResourcePath path = key.getPath();
-    long count = 0;
-    for (int i = 0; i < path.length(); i++) {
-      // Strings in java are utf-16, each character is two bytes in memory
-      count += path.getSegment(i).length() * 2;
-    }
-    return count;
-  }
-
   long getByteSize(LocalSerializer serializer) {
     long count = 0;
     for (MaybeDocument doc : new DocumentIterable()) {
-      count += getKeySize(doc.getKey());
       count += serializer.encodeMaybeDocument(doc).getSerializedSize();
     }
     return count;


### PR DESCRIPTION
Ports the fix from firebase/firebase-ios-sdk#3752.