### PR TITLE
Fix CreationContext propagation to TransportFactories.

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/BackendRegistryModule.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/BackendRegistryModule.java
@@ -14,24 +14,11 @@
 
 package com.google.android.datatransport.runtime.backends;
 
-import android.content.Context;
-import com.google.android.datatransport.runtime.time.Clock;
-import com.google.android.datatransport.runtime.time.Monotonic;
-import com.google.android.datatransport.runtime.time.WallTime;
 import dagger.Binds;
 import dagger.Module;
-import dagger.Provides;
-import javax.inject.Singleton;
 
 @Module
 public abstract class BackendRegistryModule {
   @Binds
   abstract BackendRegistry backendRegistry(MetadataBackendRegistry registry);
-
-  @Provides
-  @Singleton
-  static CreationContext creationContext(
-      Context applicationContext, @WallTime Clock wallClock, @Monotonic Clock monotonicClock) {
-    return CreationContext.create(applicationContext, wallClock, monotonicClock);
-  }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/CreationContextFactory.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/CreationContextFactory.java
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.android.datatransport.runtime.backends;
+
+import android.content.Context;
+import com.google.android.datatransport.runtime.time.Clock;
+import com.google.android.datatransport.runtime.time.Monotonic;
+import com.google.android.datatransport.runtime.time.WallTime;
+import javax.inject.Inject;
+
+class CreationContextFactory {
+  private final Context applicationContext;
+  private final Clock wallClock;
+  private final Clock monotonicClock;
+
+  @Inject
+  CreationContextFactory(
+      Context applicationContext, @WallTime Clock wallClock, @Monotonic Clock monotonicClock) {
+    this.applicationContext = applicationContext;
+    this.wallClock = wallClock;
+    this.monotonicClock = monotonicClock;
+  }
+
+  CreationContext create(String backendName) {
+    return CreationContext.create(applicationContext, wallClock, monotonicClock, backendName);
+  }
+}


### PR DESCRIPTION
Since the `backendName` property was introduced to `CreationContext`, it
can no longer be a singleton, but rather needs to vary based on the
requested `backendName`.

Additionally the change makes BackendRegistry more testable.