### PR TITLE
Don't double save Query Data

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -574,28 +574,8 @@ public final class LocalStore {
     persistence.runTransaction(
         "Release query",
         () -> {
-          QueryData queryData = queryCache.getQueryData(query);
+          QueryData queryData = getQueryData(query);
           hardAssert(queryData != null, "Tried to release nonexistent query: %s", query);
-
-          int targetId = queryData.getTargetId();
-          QueryData cachedQueryData = targetIds.get(targetId);
-
-          boolean needsUpdate = false;
-          if (cachedQueryData.getSnapshotVersion().compareTo(queryData.getSnapshotVersion()) > 0) {
-            // If we've been avoiding persisting the resumeToken (see shouldPersistQueryData for
-            // conditions and rationale) we need to persist the token now because there will no
-            // longer be an in-memory version to fall back on.
-            needsUpdate = true;
-          } else if (!cachedQueryData
-              .getLastLimboFreeSnapshotVersion()
-              .equals(queryData.getLastLimboFreeSnapshotVersion())) {
-            needsUpdate = true;
-          }
-
-          if (needsUpdate) {
-            queryData = cachedQueryData;
-            queryCache.updateQueryData(queryData);
-          }
 
           // References for documents sent via Watch are automatically removed when we delete a
           // query's target data from the reference delegate. Since this does not remove references
@@ -606,6 +586,8 @@ public final class LocalStore {
           for (DocumentKey key : removedReferences) {
             persistence.getReferenceDelegate().removeReference(key);
           }
+
+          // Note: This also updates the query cache
           persistence.getReferenceDelegate().removeTarget(queryData);
           targetIds.remove(queryData.getTargetId());
         });


### PR DESCRIPTION
This removes the sophisticated logic to determine whether we need to persist query data in `releaseQuery()` as LRU GC bumps the sequence number and always persists the query when the reference is removed.