### PR TITLE
[Smoke-tests] Switch artifact set names.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/SmokeTestsPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/SmokeTestsPlugin.groovy
@@ -64,8 +64,8 @@ class SmokeTestsPlugin implements Plugin<Project> {
         allArtifacts.each { all.put(it) }
 
         def json = new JSONObject()
-        json.put("all", all)
-        json.put("changed", changed)
+        json.put("headGit", all)
+        json.put("default", changed)
 
         def path = project.buildDir.toPath()
         path.resolve("m2repository/changed-artifacts.json").write(json.toString())


### PR DESCRIPTION
This change replaces the names of the artifact sets produced by the `assembleAllForSmokeTests` task. This is to better integrate with the upcoming changes to the smoke test runner.