### PR TITLE
Remove newly redundant synced flag

### DIFF
--- a/firebase-firestore/ktx/src/test/java/com/google/firebase/firestore/TestUtil.java
+++ b/firebase-firestore/ktx/src/test/java/com/google/firebase/firestore/TestUtil.java
@@ -117,7 +117,6 @@ public class TestUtil {
             documentChanges,
             isFromCache,
             mutatedKeys,
-            /* synced= */ false,
             /* didSyncStateChange= */ true,
             /* excludesMetadataChanges= */ false);
     return new QuerySnapshot(query(path), viewSnapshot, FIRESTORE);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
@@ -80,7 +80,6 @@ public class QueryListener {
               documentChanges,
               newSnapshot.isFromCache(),
               newSnapshot.getMutatedKeys(),
-              newSnapshot.isSynced(),
               newSnapshot.didSyncStateChange(),
               /* excludesMetadataChanges= */ true);
     }
@@ -159,7 +158,6 @@ public class QueryListener {
             snapshot.getDocuments(),
             snapshot.getMutatedKeys(),
             snapshot.isFromCache(),
-            snapshot.isSynced(),
             snapshot.excludesMetadataChanges());
     raisedInitialEvent = true;
     listener.onEvent(snapshot, null);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
@@ -311,7 +311,6 @@ public class View {
               viewChanges,
               fromCache,
               docChanges.mutatedKeys,
-              synced,
               syncStatedChanged,
               /* excludesMetadataChanges= */ false);
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
@@ -37,7 +37,6 @@ public class ViewSnapshot {
   private final List<DocumentViewChange> changes;
   private final boolean isFromCache;
   private final ImmutableSortedSet<DocumentKey> mutatedKeys;
-  private final boolean synced;
   private final boolean didSyncStateChange;
   private boolean excludesMetadataChanges;
 
@@ -48,7 +47,6 @@ public class ViewSnapshot {
       List<DocumentViewChange> changes,
       boolean isFromCache,
       ImmutableSortedSet<DocumentKey> mutatedKeys,
-      boolean synced,
       boolean didSyncStateChange,
       boolean excludesMetadataChanges) {
     this.query = query;
@@ -57,7 +55,6 @@ public class ViewSnapshot {
     this.changes = changes;
     this.isFromCache = isFromCache;
     this.mutatedKeys = mutatedKeys;
-    this.synced = synced;
     this.didSyncStateChange = didSyncStateChange;
     this.excludesMetadataChanges = excludesMetadataChanges;
   }
@@ -68,7 +65,6 @@ public class ViewSnapshot {
       DocumentSet documents,
       ImmutableSortedSet<DocumentKey> mutatedKeys,
       boolean fromCache,
-      boolean synced,
       boolean excludesMetadataChanges) {
     List<DocumentViewChange> viewChanges = new ArrayList<>();
     for (Document doc : documents) {
@@ -81,17 +77,12 @@ public class ViewSnapshot {
         viewChanges,
         fromCache,
         mutatedKeys,
-        synced,
         /* didSyncStateChange= */ true,
         excludesMetadataChanges);
   }
 
   public Query getQuery() {
     return query;
-  }
-
-  public boolean isSynced() {
-    return synced;
   }
 
   public DocumentSet getDocuments() {
@@ -140,9 +131,6 @@ public class ViewSnapshot {
     if (isFromCache != that.isFromCache) {
       return false;
     }
-    if (synced != that.synced) {
-      return false;
-    }
     if (didSyncStateChange != that.didSyncStateChange) {
       return false;
     }
@@ -172,7 +160,6 @@ public class ViewSnapshot {
     result = 31 * result + changes.hashCode();
     result = 31 * result + mutatedKeys.hashCode();
     result = 31 * result + (isFromCache ? 1 : 0);
-    result = 31 * result + (synced ? 1 : 0);
     result = 31 * result + (didSyncStateChange ? 1 : 0);
     result = 31 * result + (excludesMetadataChanges ? 1 : 0);
     return result;
@@ -192,8 +179,6 @@ public class ViewSnapshot {
         + isFromCache
         + ", mutatedKeys="
         + mutatedKeys.size()
-        + ", synced="
-        + synced
         + ", didSyncStateChange="
         + didSyncStateChange
         + ", excludesMetadataChanges="

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -478,7 +478,7 @@ public final class LocalStore {
             }
             localViewReferences.removeReferences(removed, targetId);
 
-            if (viewChange.isSynced()) {
+            if (!viewChange.isFromCache()) {
               QueryData queryData = targetIds.get(targetId);
               hardAssert(
                   queryData != null,

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalViewChanges.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalViewChanges.java
@@ -49,22 +49,22 @@ public final class LocalViewChanges {
       }
     }
 
-    return new LocalViewChanges(targetId, snapshot.isSynced(), addedKeys, removedKeys);
+    return new LocalViewChanges(targetId, snapshot.isFromCache(), addedKeys, removedKeys);
   }
 
   private final int targetId;
-  private final boolean synced;
+  private final boolean fromCache;
 
   private final ImmutableSortedSet<DocumentKey> added;
   private final ImmutableSortedSet<DocumentKey> removed;
 
   public LocalViewChanges(
       int targetId,
-      boolean synced,
+      boolean fromCache,
       ImmutableSortedSet<DocumentKey> added,
       ImmutableSortedSet<DocumentKey> removed) {
     this.targetId = targetId;
-    this.synced = synced;
+    this.fromCache = fromCache;
     this.added = added;
     this.removed = removed;
   }
@@ -73,8 +73,8 @@ public final class LocalViewChanges {
     return targetId;
   }
 
-  public boolean isSynced() {
-    return synced;
+  public boolean isFromCache() {
+    return fromCache;
   }
 
   public ImmutableSortedSet<DocumentKey> getAdded() {

--- a/firebase-firestore/src/roboUtil/java/com/google/firebase/firestore/TestUtil.java
+++ b/firebase-firestore/src/roboUtil/java/com/google/firebase/firestore/TestUtil.java
@@ -129,7 +129,6 @@ public class TestUtil {
             documentChanges,
             isFromCache,
             mutatedKeys,
-            /* synced= */ false,
             /* didSyncStateChange= */ true,
             /* excludesMetadataChanges= */ false);
     return new QuerySnapshot(query(path), viewSnapshot, FIRESTORE);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/QuerySnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/QuerySnapshotTest.java
@@ -125,7 +125,6 @@ public class QuerySnapshotTest {
             documentChanges,
             /*isFromCache=*/ false,
             /*mutatedKeys=*/ keySet(),
-            /*isSynced=*/ true,
             /*didSyncStateChange=*/ true,
             /* excludesMetadataChanges= */ false);
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryListenerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryListenerTest.java
@@ -108,7 +108,6 @@ public class QueryListenerTest {
             asList(change1, change4),
             snap2.isFromCache(),
             snap2.getMutatedKeys(),
-            /* synced= */ false,
             /* didSyncStateChange= */ true,
             /* excludesMetadataChanges= */ false);
     assertEquals(asList(snap2Prime), otherAccum);
@@ -266,7 +265,6 @@ public class QueryListenerTest {
             asList(),
             snap4.isFromCache(),
             snap4.getMutatedKeys(),
-            snap4.isSynced(),
             snap4.didSyncStateChange(),
             /* excludeMetadataChanges= */ true); // This test excludes document metadata changes
 
@@ -308,7 +306,6 @@ public class QueryListenerTest {
             asList(change3),
             snap2.isFromCache(),
             snap2.getMutatedKeys(),
-            snap2.isSynced(),
             snap2.didSyncStateChange(),
             /* excludesMetadataChanges= */ true);
     assertEquals(
@@ -351,7 +348,6 @@ public class QueryListenerTest {
             asList(change1, change2),
             /* isFromCache= */ false,
             snap3.getMutatedKeys(),
-            /* synced= */ true,
             /* didSyncStateChange= */ true,
             /* excludesMetadataChanges= */ true);
     assertEquals(asList(expectedSnapshot), events);
@@ -390,7 +386,6 @@ public class QueryListenerTest {
             asList(change1),
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
-            snap1.isSynced(),
             /* didSyncStateChange= */ true,
             /* excludesMetadataChanges= */ true);
     ViewSnapshot expectedSnapshot2 =
@@ -401,7 +396,6 @@ public class QueryListenerTest {
             asList(change2),
             /* isFromCache= */ true,
             snap2.getMutatedKeys(),
-            snap2.isSynced(),
             /* didSyncStateChange= */ false,
             /* excludesMetadataChanges= */ true);
     assertEquals(asList(expectedSnapshot1, expectedSnapshot2), events);
@@ -429,7 +423,6 @@ public class QueryListenerTest {
             asList(),
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
-            snap1.isSynced(),
             /* didSyncStateChange= */ true,
             /* excludesMetadataChanges= */ true);
     assertEquals(asList(expectedSnapshot), events);
@@ -456,7 +449,6 @@ public class QueryListenerTest {
             asList(),
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
-            snap1.isSynced(),
             /* didSyncStateChange= */ true,
             /* excludesMetadataChanges= */ true);
     assertEquals(asList(expectedSnapshot), events);
@@ -470,7 +462,6 @@ public class QueryListenerTest {
         snap.getChanges(),
         snap.isFromCache(),
         snap.getMutatedKeys(),
-        snap.isSynced(),
         snap.didSyncStateChange(),
         MetadataChanges.EXCLUDE.equals(metadata));
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewSnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewSnapshotTest.java
@@ -45,7 +45,6 @@ public class ViewSnapshotTest {
     List<DocumentViewChange> changes =
         Arrays.asList(DocumentViewChange.create(Type.ADDED, doc("c/foo", 1, map())));
     ImmutableSortedSet<DocumentKey> mutatedKeys = keySet(key("c/foo"));
-    boolean synced = true;
     boolean fromCache = true;
     boolean hasPendingWrites = true;
     boolean syncStateChanges = true;
@@ -59,7 +58,6 @@ public class ViewSnapshotTest {
             changes,
             fromCache,
             mutatedKeys,
-            synced,
             syncStateChanges,
             excludesMetadataChanges);
 
@@ -69,7 +67,6 @@ public class ViewSnapshotTest {
     assertEquals(changes, snapshot.getChanges());
     assertEquals(fromCache, snapshot.isFromCache());
     assertEquals(mutatedKeys, snapshot.getMutatedKeys());
-    assertEquals(synced, snapshot.isSynced());
     assertEquals(hasPendingWrites, snapshot.hasPendingWrites());
     assertEquals(syncStateChanges, snapshot.didSyncStateChange());
     assertEquals(excludesMetadataChanges, snapshot.excludesMetadataChanges());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewTest.java
@@ -302,7 +302,7 @@ public class ViewTest {
   }
 
   @Test
-  public void testViewsWithLimboDocumentsAreNotMarkedSynced() {
+  public void testViewsWithLimboDocumentsAreMarkedFromCache() {
     Query query = messageQuery();
     View view = new View(query, DocumentKey.emptyKeySet());
     Document doc1 = doc("rooms/eros/messages/0", 0, map());
@@ -311,20 +311,20 @@ public class ViewTest {
     // Doc1 is contained in the local view, but we are not yet CURRENT so it is expected that the
     // backend hasn't told us about all documents yet.
     ViewChange change = applyChanges(view, doc1);
-    assertFalse(change.getSnapshot().isSynced());
+    assertTrue(change.getSnapshot().isFromCache());
 
     // Add doc2 to generate a snapshot. Doc1 is still missing.
     View.DocumentChanges viewDocChanges = view.computeDocChanges(docUpdates(doc2));
     change =
         view.applyChanges(
             viewDocChanges, targetChange(ByteString.EMPTY, true, asList(doc2), null, null));
-    assertFalse(change.getSnapshot().isSynced()); // We are CURRENT but doc1 is in limbo.
+    assertTrue(change.getSnapshot().isFromCache()); // We are CURRENT but doc1 is in limbo.
 
     // Add doc1 to the backend's result set.
     change =
         view.applyChanges(
             viewDocChanges, targetChange(ByteString.EMPTY, true, asList(doc1), null, null));
-    assertTrue(change.getSnapshot().isSynced());
+    assertFalse(change.getSnapshot().isFromCache());
   }
 
   @Test

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -146,8 +146,8 @@ public abstract class LocalStoreTestCase {
     localStore.notifyLocalViewChanges(asList(changes));
   }
 
-  private void udpateViews(int targetId, boolean synced) {
-    notifyLocalViewChanges(viewChanges(targetId, synced, asList(), asList()));
+  private void udpateViews(int targetId, boolean fromCache) {
+    notifyLocalViewChanges(viewChanges(targetId, fromCache, asList(), asList()));
   }
 
   private void acknowledgeMutation(long documentVersion, @Nullable Object transformResult) {
@@ -311,7 +311,7 @@ public abstract class LocalStoreTestCase {
     allocateQuery(query);
 
     writeMutation(setMutation("foo/bar", map("foo", "bar")));
-    notifyLocalViewChanges(viewChanges(2, /* synced= */ false, asList("foo/bar"), emptyList()));
+    notifyLocalViewChanges(viewChanges(2, /* fromCache= */ false, asList("foo/bar"), emptyList()));
 
     assertChanged(doc("foo/bar", 0, map("foo", "bar"), Document.DocumentState.LOCAL_MUTATIONS));
     assertContains(doc("foo/bar", 0, map("foo", "bar"), Document.DocumentState.LOCAL_MUTATIONS));
@@ -832,7 +832,7 @@ public abstract class LocalStoreTestCase {
     assertContains(doc("foo/baz", 0, map("foo", "baz"), Document.DocumentState.LOCAL_MUTATIONS));
 
     notifyLocalViewChanges(
-        viewChanges(2, /* synced= */ false, asList("foo/bar", "foo/baz"), emptyList()));
+        viewChanges(2, /* fromCache= */ false, asList("foo/bar", "foo/baz"), emptyList()));
     applyRemoteEvent(updateRemoteEvent(doc("foo/bar", 1, map("foo", "bar")), none, two));
     applyRemoteEvent(updateRemoteEvent(doc("foo/baz", 2, map("foo", "baz")), two, none));
     acknowledgeMutation(2);
@@ -840,7 +840,7 @@ public abstract class LocalStoreTestCase {
     assertContains(doc("foo/baz", 2, map("foo", "baz")));
 
     notifyLocalViewChanges(
-        viewChanges(2, /* synced= */ false, emptyList(), asList("foo/bar", "foo/baz")));
+        viewChanges(2, /* fromCache= */ false, emptyList(), asList("foo/bar", "foo/baz")));
     releaseQuery(query);
 
     assertNotContains("foo/bar");
@@ -1062,7 +1062,7 @@ public abstract class LocalStoreTestCase {
             asList(targetId),
             emptyList()));
     applyRemoteEvent(noChangeEvent(targetId, 10));
-    udpateViews(targetId, /* synced= */ true);
+    udpateViews(targetId, /* fromCache= */ false);
 
     // Execute the query again, this time verifying that we only read the two documents that match
     // the query.
@@ -1101,10 +1101,10 @@ public abstract class LocalStoreTestCase {
     // Update the view, but don't mark the view synced.
     Assert.assertEquals(
         SnapshotVersion.NONE, localStore.getQueryData(query).getLastLimboFreeSnapshotVersion());
-    udpateViews(targetId, /* synced=*/ true);
+    udpateViews(targetId, /* fromCache=*/ false);
 
     // The query is marked limbo-free only when we mark the view synced.
-    udpateViews(targetId, /* synced=*/ true);
+    udpateViews(targetId, /* fromCache=*/ false);
     Assert.assertNotEquals(
         SnapshotVersion.NONE, localStore.getQueryData(query).getLastLimboFreeSnapshotVersion());
 
@@ -1134,7 +1134,7 @@ public abstract class LocalStoreTestCase {
             asList(targetId),
             emptyList()));
     applyRemoteEvent(noChangeEvent(targetId, 10));
-    udpateViews(targetId, /* synced= */ true);
+    udpateViews(targetId, /* fromCache= */ false);
 
     // Execute the query based on the RemoteEvent.
     executeQuery(query);
@@ -1171,7 +1171,7 @@ public abstract class LocalStoreTestCase {
             asList(targetId),
             emptyList()));
     applyRemoteEvent(noChangeEvent(targetId, 10));
-    udpateViews(targetId, /* synced=*/ true);
+    udpateViews(targetId, /* fromCache=*/ false);
     releaseQuery(filteredQuery);
 
     // Start another query and add more matching documents to the collection.
@@ -1213,7 +1213,7 @@ public abstract class LocalStoreTestCase {
             asList(targetId),
             emptyList()));
     applyRemoteEvent(noChangeEvent(targetId, 10));
-    udpateViews(targetId, /* synced=*/ true);
+    udpateViews(targetId, /* fromCache=*/ false);
     releaseQuery(filteredQuery);
 
     // Modify one of the documents to no longer match while the filtered query is inactive.

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -524,7 +524,7 @@ public class TestUtil {
   }
 
   public static LocalViewChanges viewChanges(
-      int targetId, boolean synced, List<String> addedKeys, List<String> removedKeys) {
+      int targetId, boolean fromCache, List<String> addedKeys, List<String> removedKeys) {
     ImmutableSortedSet<DocumentKey> added = DocumentKey.emptyKeySet();
     for (String keyPath : addedKeys) {
       added = added.insert(key(keyPath));
@@ -533,7 +533,7 @@ public class TestUtil {
     for (String keyPath : removedKeys) {
       removed = removed.insert(key(keyPath));
     }
-    return new LocalViewChanges(targetId, synced, added, removed);
+    return new LocalViewChanges(targetId, fromCache, added, removed);
   }
 
   /** Creates a resume token to match the given snapshot version. */


### PR DESCRIPTION
`synced` is always `!fromCache`, so we don't need it.