### PR TITLE
Port over clearPersistence spec test changes

### DIFF
--- a/firebase-firestore/src/test/resources/json/persistence_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/persistence_spec_test.json
@@ -1284,18 +1284,16 @@
       },
       {
         "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "expectIsShutdown": true,
+        "stateExpect": {
+          "isShutdown": true
+        },
         "clientIndex": 1
       },
       {
         "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "expectIsShutdown": true,
+        "stateExpect": {
+          "isShutdown": true
+        },
         "clientIndex": 2
       }
     ]


### PR DESCRIPTION
I think I ported this over before, but it's being copied over when I generate the spec test json. I think it may be due to Andy's shutdown work on web.