### PR TITLE
Simplify IndexFree tests

### DIFF
--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -418,13 +418,15 @@ public class TestUtil {
               }
             });
 
+    SnapshotVersion version = SnapshotVersion.NONE;
+
     for (MaybeDocument doc : docs) {
       DocumentChange change =
           new DocumentChange(updatedInTargets, removedFromTargets, doc.getKey(), doc);
       aggregator.handleDocumentChange(change);
+      version = doc.getVersion().compareTo(version) > 0 ? doc.getVersion() : version;
     }
 
-    SnapshotVersion version = docs.get(0).getVersion();
     return aggregator.createRemoteEvent(version);
   }
 


### PR DESCRIPTION
This simplifies the newly added Index-Free tests in LocalStoreTests:

- Instead of using three docs, most tests only need two.
- Removed some setup and asserts that were unrelated to the actual test.