### PR TITLE
Add support for wildcards on the CustomClassMapper.

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,5 +1,9 @@
+# 19.2.0
+- [changed] Added support for type wildcards in GenericTypeIndicator, expanding
+  our custom class serialization to include classes with wildcard generics
+  (#792).
+
 # 19.1.1
-- [changed] Added support for type wildcards in GenericTypeIndicator (#792)
 - [fixed] Fixed a crash that occurred when we attempted to start a network
   connection during app shutdown (#672).
 

--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 19.1.1
+- [changed] Added support for type wildcards in GenericTypeIndicator (#792)
 - [fixed] Fixed a crash that occurred when we attempted to start a network
   connection during app shutdown (#672).
 
@@ -26,6 +27,6 @@
 - [internal] Removed ``@PublicApi` annotations as they are no longer enforced
   and have no semantic meaning.
 
-# 16.0.6  
+# 16.0.6
 - [fixed] Fixed an issue that could cause a NullPointerException during the
   initial handshake with the Firebase backend (#119).

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/encoding/CustomClassMapper.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/encoding/CustomClassMapper.java
@@ -177,7 +177,18 @@ public class CustomClassMapper {
     } else if (type instanceof Class) {
       return deserializeToClass(o, (Class<T>) type);
     } else if (type instanceof WildcardType) {
-      throw new DatabaseException("Generic wildcard types are not supported");
+      Type[] lowerBounds = ((WildcardType) type).getLowerBounds();
+      if (lowerBounds.length > 0) {
+        throw new DatabaseException("Generic lower-bounded wildcard types are not supported");
+      }
+
+      // Upper bounded wildcards are of the form <? extends Foo>. Multiple upper bounds are allowed
+      // but if any of the bounds are of class type, that bound must come first in this array. Note
+      // that this array always has at least one element, since the unbounded wildcard <?> always
+      // has at least an upper bound of Object.
+      Type[] upperBounds = ((WildcardType) type).getUpperBounds();
+      hardAssert(upperBounds.length > 0, "Unexpected type bounds on wildcard " + type);
+      return deserializeToType(o, upperBounds[0]);
     } else if (type instanceof GenericArrayType) {
       throw new DatabaseException(
           "Generic Arrays are not supported, please use Lists " + "instead");

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/encoding/CustomClassMapper.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/encoding/CustomClassMapper.java
@@ -187,8 +187,14 @@ public class CustomClassMapper {
       // that this array always has at least one element, since the unbounded wildcard <?> always
       // has at least an upper bound of Object.
       Type[] upperBounds = ((WildcardType) type).getUpperBounds();
-      hardAssert(upperBounds.length > 0, "Unexpected type bounds on wildcard " + type);
+      hardAssert(upperBounds.length > 0, "Wildcard type " + type + " is not upper bounded.");
       return deserializeToType(o, upperBounds[0]);
+    } else if (type instanceof TypeVariable) {
+      // As above, TypeVariables always have at least one upper bound of Object.
+      Type[] upperBounds = ((TypeVariable<?>) type).getBounds();
+      hardAssert(upperBounds.length > 0, "Wildcard type " + type + " is not upper bounded.");
+      return deserializeToType(o, upperBounds[0]);
+
     } else if (type instanceof GenericArrayType) {
       throw new DatabaseException(
           "Generic Arrays are not supported, please use Lists " + "instead");

--- a/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
@@ -1763,6 +1763,15 @@ public class MapperTest {
     assertEquals("foo", bean.value);
   }
 
+  @Test
+  public void usingWildcardInGenericTypeIndicatorIsAllowed() {
+    Map<String, String> fooMap = Collections.singletonMap("foo", "bar");
+    assertEquals(
+        fooMap,
+        CustomClassMapper.convertToCustomClass(
+            fooMap, new GenericTypeIndicator<Map<String, ? extends String>>() {}));
+  }
+
   @Test(expected = DatabaseException.class)
   public void unknownTypeParametersNotSupported() {
     deserialize("{'value': 'foo'}", new GenericTypeIndicatorSubclass<GenericBean<?>>() {});

--- a/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 
 import androidx.annotation.Keep;
 import com.google.firebase.database.core.utilities.encoding.CustomClassMapper;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -625,6 +626,22 @@ public class MapperTest {
 
     public String getValue() {
       return this.value;
+    }
+  }
+
+  private static class MultiBoundedMapBean<T extends String & Serializable> {
+    private Map<String, T> values;
+
+    public Map<String, T> getValues() {
+      return values;
+    }
+  }
+
+  private static class MultiBoundedMapHolderBean {
+    private MultiBoundedMapBean<String> map;
+
+    public MultiBoundedMapBean<String> getMap() {
+      return map;
     }
   }
 
@@ -1770,6 +1787,24 @@ public class MapperTest {
         fooMap,
         CustomClassMapper.convertToCustomClass(
             fooMap, new GenericTypeIndicator<Map<String, ? extends String>>() {}));
+  }
+
+  @Test(expected = DatabaseException.class)
+  public void usingLowerBoundWildcardsIsForbidden() {
+    Map<String, String> fooMap = Collections.singletonMap("foo", "bar");
+    CustomClassMapper.convertToCustomClass(
+        fooMap, new GenericTypeIndicator<Map<String, ? super String>>() {});
+  }
+
+  @Test
+  public void multiBoundedWildcardsUsesTheFirst() {
+    Map<String, Object> source =
+        Collections.singletonMap(
+            "map", Collections.singletonMap("values", Collections.singletonMap("foo", "bar")));
+    MultiBoundedMapHolderBean bean =
+        CustomClassMapper.convertToCustomClass(source, MultiBoundedMapHolderBean.class);
+    Map<String, String> expected = Collections.singletonMap("foo", "bar");
+    assertEquals(expected, bean.map.values);
   }
 
   @Test(expected = DatabaseException.class)


### PR DESCRIPTION
CustomClassMapper can now handle GenericTypeIndicators with wildcards, instead of strictly requiring the type specified.