### PR TITLE
[Smoke-tests] Enable automated release workflow.

### DIFF
--- a/smoke-tests/runner.config
+++ b/smoke-tests/runner.config
@@ -29,8 +29,9 @@ firebase {
   # latestBillOfMaterials
   ## This option specifies the Bill of Materials for the latest release. This is
   ## given as a Maven id. The tests will use this information to build a test
-  ## matrix. This is mandatory.
-  latestBillOfMaterials com.google.firebase:firebase-bom:22.1.0
+  ## matrix. If the version is set to `LATEST` or `RELEASE`, the runner will find
+  ## the latest version in GMaven. This is mandatory.
+  latestBillOfMaterials com.google.firebase:firebase-bom:RELEASE
 
   # project
   ## This option specifies the path to the main Firebase project. This is


### PR DESCRIPTION
This change sets the bill of materials version to RELEASE. The runner
has been updated to fetch the latest release from GMaven when this is
set.