### PR TITLE
Remove Index-Free assert

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 21.1.1
+- [fixed] Addressed a regression in 21.1.0 that caused the crash: "Cannot add
+  document to the RemoteDocumentCache with a read time of zero".
+
 # 21.1.0
 - [feature] Added a `terminate()` method to `FirebaseFirestore` which
   terminates the instance, releasing any held resources. Once it completes, you

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -268,7 +268,9 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
     }
 
     persistence.start();
-    // TODO(index-free): Use IndexFreeQueryEngine/IndexedQueryEngine as appropriate.
+    // TODO(index-free): Use IndexFreeQueryEngine/IndexedQueryEngine as appropriate. When we enable
+    // IndexFreeQueryEngine, we have to reset the "lastLimboFreeSnapshotVersion" for all persisted
+    // QueryData as we had to revert the part of the change that ensured that the data is reliable.
     QueryEngine queryEngine = new SimpleQueryEngine();
     localStore = new LocalStore(persistence, queryEngine, user);
     if (gc != null) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -48,9 +48,11 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
 
   @Override
   public void add(MaybeDocument document, SnapshotVersion readTime) {
-    hardAssert(
-        !readTime.equals(SnapshotVersion.NONE),
-        "Cannot add document to the RemoteDocumentCache with a read time of zero");
+    // TODO(index-free): This assert causes a crash for one of our customers. Re-add the assert once
+    // we have fixed the root cause and cleaned up the underlying data.
+    //    hardAssert(
+    //        !readTime.equals(SnapshotVersion.NONE),
+    //        "Cannot add document to the RemoteDocumentCache with a read time of zero");
     docs = docs.insert(document.getKey(), new Pair<>(document, readTime));
 
     persistence.getIndexManager().addToCollectionParentIndex(document.getKey().getPath().popLast());

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -52,9 +52,11 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
 
   @Override
   public void add(MaybeDocument maybeDocument, SnapshotVersion readTime) {
-    hardAssert(
-        !readTime.equals(SnapshotVersion.NONE),
-        "Cannot add document to the RemoteDocumentCache with a read time of zero");
+    // TODO(index-free): This assert causes a crash for one of our customers. Re-add the assert once
+    // we have fixed the root cause and cleaned up the underlying data.
+    //    hardAssert(
+    //        !readTime.equals(SnapshotVersion.NONE),
+    //        "Cannot add document to the RemoteDocumentCache with a read time of zero");
 
     String path = pathForKey(maybeDocument.getKey());
     Timestamp timestamp = readTime.getTimestamp();


### PR DESCRIPTION
This PR removes the assert that causes a crash for one of our customers: 

```
Caused by: java.lang.AssertionError: INTERNAL ASSERTION FAILED: Cannot add document to the RemoteDocumentCache with a read time of zero
        at com.google.firebase.firestore.g.b.a(com.google.firebase:firebase-firestore@@21.1.0:46)
        at com.google.firebase.firestore.g.b.a(com.google.firebase:firebase-firestore@@21.1.0:31)
```

This is the first step in fixing this issue. As a follow up, we have to fix the underlying root cause and clean up all affected data.