### PR TITLE
Change the order of checks in applyRemoteEvent()

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -384,7 +384,7 @@ public final class LocalStore {
             // rejected limbo resolutions (which fabricate NoDocuments with SnapshotVersion.NONE)
             // never add documents to cache.
             if (doc instanceof NoDocument && doc.getVersion().equals(SnapshotVersion.NONE)) {
-              // NoDocuments with SnapshotVersion.MIN are used in manufactured events. We remove
+              // NoDocuments with SnapshotVersion.NONE are used in manufactured events. We remove
               // these documents from cache since we lost access.
               remoteDocuments.remove(doc.getKey());
               changedDocs.put(key, doc);


### PR DESCRIPTION
If there is a chance that a limbo resolution fails for a document that no longer exists, we could get into a state where we write a document into the RemoteDocumentCache with a snapshot version of zero. By re-ordering the statements, we make sure this does not happen