### PR TITLE
Split orphaned document GC into batches

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 21.1.2
+- [fixed] Fixed a crash that could occur when a large number of documents were
+  removed during garbage collection of the persistence cache.
+
 # 21.1.1
 - [fixed] Addressed a regression in 21.1.0 that caused the crash: "Cannot add
   document to the RemoteDocumentCache with a read time of zero".

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
@@ -402,7 +402,7 @@ public abstract class LruGarbageCollectorTestCase {
   }
 
   @Test
-  public void testRemoveOrphanedDocumentsExistsEarlyWithNoDocuments() {
+  public void testRemoveOrphanedDocumentsWithNoDocuments() {
     int removed = garbageCollector.removeOrphanedDocuments(1000);
     assertEquals(0, removed);
   }


### PR DESCRIPTION
This applies the same fix as https://github.com/firebase/firebase-android-sdk/pull/374 to orphan document removal. I used the same batch size since both operations just read document kets.

Fixes https://github.com/firebase/firebase-android-sdk/issues/706