### PR TITLE
Implement AAR size measurement.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/aarsize/AarSizeJsonBuilder.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/aarsize/AarSizeJsonBuilder.groovy
@@ -1,0 +1,68 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.google.firebase.gradle.plugins.measurement.aarsize
+
+/** A helper class that generates the AAR size measurement JSON report. */
+class AarSizeJsonBuilder {
+
+    private static final String PULL_REQUEST_TABLE = "AndroidPullRequests"
+    private static final String PULL_REQUEST_COLUMN = "pull_request_id"
+    private static final String AAR_SIZE_TABLE = "AndroidAarSizes"
+    private static final String SDK_COLUMN = "sdk_id"
+    private static final String AAR_SIZE_COLUMN = "aar_size"
+
+    // This comes in as a String and goes out as a String, so we might as well keep it a String
+    private final String pullRequestNumber
+    private final List<Tuple2<Integer, Integer>> sdkAarSizes
+
+    AarSizeJsonBuilder(pullRequestNumber) {
+        this.pullRequestNumber = pullRequestNumber
+        this.sdkAarSizes = []
+    }
+
+    def addAarSize(sdkId, size) {
+        sdkAarSizes.add(new Tuple2(sdkId, size))
+    }
+
+    def toJsonString() {
+        if (sdkAarSizes.isEmpty()) {
+            throw new IllegalStateException("Empty - No sizes were added")
+        }
+
+        def sizes = sdkAarSizes.collect {
+            "[$pullRequestNumber, $it.first, $it.second]"
+        }.join(", ")
+
+        def json = """
+            {
+                tables: [
+                    {
+                        table_name: "$PULL_REQUEST_TABLE",
+                        column_names: ["$PULL_REQUEST_COLUMN"],
+                        replace_measurements: [[$pullRequestNumber]],
+                    },
+                    {
+                        table_name: "$AAR_SIZE_TABLE",
+                        column_names: ["$PULL_REQUEST_COLUMN", "$SDK_COLUMN", "$AAR_SIZE_COLUMN"],
+                        replace_measurements: [$sizes],
+                    },
+                ],
+            }
+        """
+
+        return json
+    }
+}

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/aarsize/AarSizeTableBuilder.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/aarsize/AarSizeTableBuilder.groovy
@@ -1,0 +1,41 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.google.firebase.gradle.plugins.measurement.aarsize
+
+/** A helper class that generates the human-readable, AAR size measurement table. */
+class AarSizeTableBuilder {
+
+    private final List<Tuple> sdkAarSizes = []
+
+    def addAarSize(projectName, size) {
+        sdkAarSizes.add(new Tuple(projectName, size))
+    }
+
+    def toTableString() {
+        if (sdkAarSizes.isEmpty()) {
+          throw new IllegalStateException("Rempty - No sizes added")
+        }
+
+        def table = "|----------------        AAR Sizes        --------------|\n"
+        table +=    "|---------    project    ---------|--  size in bytes  --|\n"
+
+        table += sdkAarSizes.collect {
+            sprintf("|%-33s|%,21d|", it.get(0), it.get(1))
+        }.join("\n")
+
+        return table
+    }
+}

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/aarsize/GenerateMeasurementsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/aarsize/GenerateMeasurementsTask.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.tasks.TaskAction
  * Generates size measurements after building the release aar's.
  *
  * <p>This task can run in two modes. The first mode, enabled when running the task with the
- * {@code pull_request} flag set, is a dependency of {@linkUploadMeasurementsTask} and generates
+ * {@code pull_request} flag set, is a dependency of {@link UploadMeasurementsTask} and generates
  * a JSON file with measurement information. The second mode, enabled when running the task without
  * flags, outputs a table to standard out with more human-readable information. See the README for
  * more details.

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/aarsize/GenerateMeasurementsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/aarsize/GenerateMeasurementsTask.groovy
@@ -1,0 +1,120 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.google.firebase.gradle.plugins.measurement.aarsize
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Generates size measurements after building the release aar's.
+ *
+ * <p>This task can run in two modes. The first mode, enabled when running the task with the
+ * {@code pull_request} flag set, is a dependency of {@linkUploadMeasurementsTask} and generates
+ * a JSON file with measurement information. The second mode, enabled when running the task without
+ * flags, outputs a table to standard out with more human-readable information. See the README for
+ * more details.
+ *
+ * <p>This task has two properties, a required ignore SDK map file, as input, and the optional
+ * report file, as output. The map is used to ignore SDKs that shouldn't be included in the report.
+ * The report path is where the output should be stored. These properties are not used when the task
+ * is run in the second, human-friendly mode. However, they are still required to be specified.
+ */
+public class GenerateMeasurementsTask extends DefaultTask {
+
+    /**
+     * The file storing the SDKs to ignore.
+     *
+     * <p>This may be any type recognized by Gradle as a file. The format of the file's contents is
+     * a list of SDK subproject names, one per line.
+     *
+     * <p>For example:
+     * <pre>{@code
+     * firebase-database-collection
+     * protolite-well-known-types
+     *}</pre>
+     */
+    @InputFile
+    File sdkIgnoreFile
+
+    /**
+     * The file for storing the report.
+     *
+     * <p>This may be any type recognized by Gradle as a file. The contents, if any, will be
+     * overwritten by the new report.
+     */
+    @OutputFile
+    @Optional
+    File reportFile
+
+    @Override
+    Task configure(Closure closure) {
+        outputs.upToDateWhen { false }
+        dependsOn "assemble"
+        return super.configure(closure)
+    }
+
+    @TaskAction
+    def generate() {
+        def subprojects = [:]
+        def ignore_subprojects = sdkIgnoreFile.readLines()
+         project.rootProject.subprojects.collect { Project it ->
+            if (ignore_subprojects.contains(it.name)) {
+                return
+            }
+            def aars = it.fileTree('build') {
+                include '**/*release.aar'
+            }
+            if (aars.size() > 1) {
+                def msg = "${it.name} produced more than one AAR"
+                throw new IllegalStateException(msg)
+            }
+            aars.each { File f ->
+                subprojects[it.name] = f.length()
+            }
+        }
+        if (project.hasProperty("pull_request")) {
+            def pullRequestNumber = project.properties["pull_request"]
+            generateJson(pullRequestNumber, subprojects)
+        } else {
+            generateTable(subprojects)
+        }
+    }
+
+    private def generateJson(pullRequestNumber, subprojects) {
+        def builder = new AarSizeJsonBuilder(pullRequestNumber)
+        subprojects.each { name, aarSize ->
+            builder.addAarSize(name, aarSize)
+        }
+
+        reportFile.withWriter {
+            it.write(builder.toJsonString())
+        }
+    }
+
+    private def generateTable(subprojects) {
+        def builder = new AarSizeTableBuilder()
+        subprojects.each { name, aarSize ->
+            builder.addAarSize(name, aarSize)
+        }
+
+        project.logger.quiet(builder.toTableString())
+    }
+}

--- a/tools/measurement/apksize/apksize.gradle
+++ b/tools/measurement/apksize/apksize.gradle
@@ -25,7 +25,7 @@ apply from: "src/config/config.gradle"
 apply from: "src/database/database.gradle"
 apply from: "src/firestore/firestore.gradle"
 apply from: "src/functions/functions.gradle"
-apply from: "src/inappmessagingdisplay/inappmessaging-display.gradle"
+// apply from: "src/inappmessagingdisplay/inappmessaging-display.gradle"
 apply from: "src/storage/storage.gradle"
 
 /**
@@ -40,6 +40,15 @@ task generateApkSizeMeasurements(type: GenerateMeasurementsTask) {
 
     sdkMapFile = file("sdks.csv")
     reportFile = file("$buildDir/size-report.json")
+}
+
+task generateAarSizeMeasurements(type: com.google.firebase.gradle.plugins.measurement.aarsize.GenerateMeasurementsTask) {
+    description 'Builds release aar artifacts and calculates AAR sizes.'
+    group 'Measurements'
+
+    dependsOn (":publishAllToBuildDir")
+
+    sdkIgnoreFile = file("sdks_ignore.csv")
 }
 
 /**

--- a/tools/measurement/apksize/apksize.gradle
+++ b/tools/measurement/apksize/apksize.gradle
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import com.google.firebase.gradle.plugins.measurement.apksize.GenerateMeasurementsTask
+import com.google.firebase.gradle.plugins.measurement.aarsize.GenerateMeasurementsTask as GenerateAarMeasurementTask
 import com.google.firebase.gradle.plugins.measurement.UploadMeasurementsTask
 
 apply plugin: "com.android.application"
@@ -25,7 +26,7 @@ apply from: "src/config/config.gradle"
 apply from: "src/database/database.gradle"
 apply from: "src/firestore/firestore.gradle"
 apply from: "src/functions/functions.gradle"
-// apply from: "src/inappmessagingdisplay/inappmessaging-display.gradle"
+apply from: "src/inappmessagingdisplay/inappmessaging-display.gradle"
 apply from: "src/storage/storage.gradle"
 
 /**
@@ -42,7 +43,7 @@ task generateApkSizeMeasurements(type: GenerateMeasurementsTask) {
     reportFile = file("$buildDir/size-report.json")
 }
 
-task generateAarSizeMeasurements(type: com.google.firebase.gradle.plugins.measurement.aarsize.GenerateMeasurementsTask) {
+task generateAarSizeMeasurements(type: GenerateAarMeasurementTask) {
     description 'Builds release aar artifacts and calculates AAR sizes.'
     group 'Measurements'
 

--- a/tools/measurement/apksize/apksize.gradle
+++ b/tools/measurement/apksize/apksize.gradle
@@ -47,8 +47,6 @@ task generateAarSizeMeasurements(type: com.google.firebase.gradle.plugins.measur
     group 'Measurements'
 
     dependsOn (":publishAllToBuildDir")
-
-    sdkIgnoreFile = file("sdks_ignore.csv")
 }
 
 /**

--- a/tools/measurement/apksize/default.gradle
+++ b/tools/measurement/apksize/default.gradle
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         applicationId 'com.google.apksize'
         minSdkVersion project.targetSdkVersion
-            multiDexEnabled true
+        multiDexEnabled true
         targetSdkVersion project.targetSdkVersion
         versionCode 1
         versionName '1.0'

--- a/tools/measurement/apksize/default.gradle
+++ b/tools/measurement/apksize/default.gradle
@@ -30,7 +30,7 @@ android {
     defaultConfig {
         applicationId 'com.google.apksize'
         minSdkVersion project.targetSdkVersion
-	    multiDexEnabled true
+            multiDexEnabled true
         targetSdkVersion project.targetSdkVersion
         versionCode 1
         versionName '1.0'

--- a/tools/measurement/apksize/sdks_ignore.csv
+++ b/tools/measurement/apksize/sdks_ignore.csv
@@ -1,0 +1,5 @@
+firebase-database-collection
+protolite-well-known-types
+ktx
+transport-backend-cct
+transport-runtime

--- a/tools/measurement/apksize/sdks_ignore.csv
+++ b/tools/measurement/apksize/sdks_ignore.csv
@@ -1,5 +1,0 @@
-firebase-database-collection
-protolite-well-known-types
-ktx
-transport-backend-cct
-transport-runtime


### PR DESCRIPTION
The new task `generateAarSizeMeasurements` generates either a table or a JSON report with the size, in bytes, of the release AAR generated by each subproject. It follows the same logic, and has the same flags, as `generateApkSizeMeasurements`.