### PR TITLE
Better format the table generated by generateApkSizeMeasurements

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeTableBuilder.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeTableBuilder.groovy
@@ -33,7 +33,7 @@ class ApkSizeTableBuilder {
         table +=    "|---    project    ---|--  build type   --|--  size in bytes  --|\n"
 
         table += sdkSizes.collect {
-            sprintf("|%-21s|%-19s|%-21s|", it.get(0), it.get(1), it.get(2))
+            sprintf("|%-21s|%-19s|%,21d|", it.get(0), it.get(1), it.get(2))
         }.join("\n")
 
         return table

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeTableBuilderTest.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/measurement/apksize/ApkSizeTableBuilderTest.groovy
@@ -37,7 +37,7 @@ public class ApkSizeTableBuilderTest {
   @Test
   public void toTableString_withOneMeasurement() {
     def expected = HEADER +
-        "|firebase foo         |debug              |255000               |"
+        "|firebase foo         |debug              |              255,000|"
 
     def builder = new ApkSizeTableBuilder()
     builder.addApkSize("firebase foo", "debug", 255000)
@@ -48,9 +48,9 @@ public class ApkSizeTableBuilderTest {
   @Test
   public void toTableString_withThreeMeasurements() {
     def expected = HEADER +
-        "|firebase foo         |debug              |255000               |\n" +
-        "|google loo           |release            |4000                 |\n" +
-        "|Appy Snap App        |Snappy             |781000               |"
+        "|firebase foo         |debug              |              255,000|\n" +
+        "|google loo           |release            |                4,000|\n" +
+        "|Appy Snap App        |Snappy             |              781,000|"
 
     def builder = new ApkSizeTableBuilder()
     builder.addApkSize("firebase foo", "debug", 255000)


### PR DESCRIPTION
The table now shows sizes right aligned and with thousand-delimiters for easier reading.

For example

```
|--------------------        APK Sizes        ------------------|
|---    project    ---|--  build type   --|--  size in bytes  --|
|firestore            |aggressive         |              902,019|
|database             |aggressive         |              421,788|
|functions            |aggressive         |              550,057|
|inappmessagingdisplay|aggressive         |            1,714,661|
|storage              |aggressive         |              341,995|
|config               |aggressive         |              390,261|

```