### PR TITLE
Fix Remote Config Strict Mode Violation that might be caused by Android okhttp implementation

### DIFF
--- a/firebase-config/bandwagoner/src/main/java/com/googletest/firebase/remoteconfig/bandwagoner/MainApplication.java
+++ b/firebase-config/bandwagoner/src/main/java/com/googletest/firebase/remoteconfig/bandwagoner/MainApplication.java
@@ -17,6 +17,7 @@
 package com.googletest.firebase.remoteconfig.bandwagoner;
 
 import android.app.Application;
+import android.os.StrictMode;
 import com.google.firebase.FirebaseApp;
 
 /**
@@ -27,7 +28,25 @@ import com.google.firebase.FirebaseApp;
 public class MainApplication extends Application {
   @Override
   public void onCreate() {
+    enableStrictMode();
     super.onCreate();
     FirebaseApp.initializeApp(this);
+  }
+
+  private static void enableStrictMode() {
+    StrictMode.setThreadPolicy(
+        new StrictMode.ThreadPolicy.Builder()
+            .detectDiskReads()
+            .detectDiskWrites()
+            .detectNetwork()
+            .penaltyLog()
+            .build());
+    StrictMode.setVmPolicy(
+        new StrictMode.VmPolicy.Builder()
+            .detectLeakedSqlLiteObjects()
+            .detectLeakedClosableObjects()
+            .penaltyLog()
+            .penaltyDeath()
+            .build());
   }
 }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -195,6 +195,11 @@ public class ConfigFetchHttpClient {
           "The client had an error while calling the backend!", e);
     } finally {
       urlConnection.disconnect();
+      // Explicitly close the input stream due to a bug in the Android okhttp implementation.
+      try {
+        urlConnection.getInputStream().close();
+      } catch (IOException e) {
+      }
     }
 
     if (!backendHasUpdates(fetchResponse)) {


### PR DESCRIPTION
1. Fix Strict Mode Violation
2. Explicitly turn strict mode on in Firebase Remote Config's Android test app.

We received a user report of [Strict Mode](https://developer.android.com/reference/android/os/StrictMode) issues with the Remote Config SDK since 19.0.0.

The stacktrace (see below) is very similar to a known issue that was fixed in the [OkHttp repo](https://github.com/square/okhttp/pull/24/files). My assumption is that Android's okhttp implementation hasn't picked up this fix yet.

To ensure we catch similar issues early on in the future, this PR also turns on Strict Mode in Remote Config's test app.

```
Caused by: java.lang.Throwable: Explicit termination method 'end' not called
    at dalvik.system.CloseGuard.open(CloseGuard.java:221)
    at java.util.zip.Inflater.<init>(Inflater.java:114)
    at com.android.okhttp.okio.GzipSource.<init>(GzipSource.java:62)
    at com.android.okhttp.internal.http.HttpEngine.unzip(HttpEngine.java:473)
    at com.android.okhttp.internal.http.HttpEngine.readResponse(HttpEngine.java:648)
    at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:471)
    at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:407)
    at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:538)
    at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getResponseCode(DelegatingHttpsURLConnection.java:105)
    at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:26)
    at com.google.firebase.remoteconfig.internal.ConfigFetchHttpClient.fetch(com.google.firebase:firebase-config@@19.0.0:186)
    at com.google.firebase.remoteconfig.internal.ConfigFetchHandler.fetchFromBackend(com.google.firebase:firebase-config@@19.0.0:278)
    at com.google.firebase.remoteconfig.internal.ConfigFetchHandler.fetchFromBackendAndCacheResponse(com.google.firebase:firebase-config@@19.0.0:251)
    at com.google.firebase.remoteconfig.internal.ConfigFetchHandler.fetchIfCacheExpiredAndNotThrottled(com.google.firebase:firebase-config@@19.0.0:191)
    at com.google.firebase.remoteconfig.internal.ConfigFetchHandler.lambda$fetch$0(com.google.firebase:firebase-config@@19.0.0:160)
    at com.google.firebase.remoteconfig.internal.ConfigFetchHandler$$Lambda$1.then(Unknown Source:4)
    at com.google.android.gms.tasks.zzf.run(Unknown Source:2)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
```