### PR TITLE
Update protobuf plugin to the latest version.

### DIFF
--- a/root-project.gradle
+++ b/root-project.gradle
@@ -27,7 +27,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.7.1'
         classpath 'org.jsoup:jsoup:1.11.2'
         classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8'


### PR DESCRIPTION
Among other updates, it fixes the API variant.getJavaCompile() obsolete warning. For more info about the changes see the CHANGELOG https://github.com/google/protobuf-gradle-plugin/releases