### PR TITLE
Fix AlarmManagerScheduler timestamp computation.

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/SchedulingModule.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/SchedulingModule.java
@@ -21,6 +21,8 @@ import com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfo
 import com.google.android.datatransport.runtime.scheduling.jobscheduling.SchedulerConfig;
 import com.google.android.datatransport.runtime.scheduling.jobscheduling.WorkScheduler;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
+import com.google.android.datatransport.runtime.time.Clock;
+import com.google.android.datatransport.runtime.time.Monotonic;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -29,11 +31,11 @@ import dagger.Provides;
 public abstract class SchedulingModule {
   @Provides
   static WorkScheduler workScheduler(
-      Context context, EventStore eventStore, SchedulerConfig config) {
+      Context context, EventStore eventStore, SchedulerConfig config, @Monotonic Clock clock) {
     if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       return new JobInfoScheduler(context, eventStore, config);
     } else {
-      return new AlarmManagerScheduler(context, eventStore, config);
+      return new AlarmManagerScheduler(context, eventStore, clock, config);
     }
   }
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -19,7 +19,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.SystemClock;
 import android.util.Base64;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.datatransport.runtime.TransportContext;
@@ -106,7 +105,7 @@ public class AlarmManagerScheduler implements WorkScheduler {
 
     long backendTime = eventStore.getNextCallTime(transportContext);
 
-    long scheduleDelay = clock.getTime() +
+    long scheduleDelay =
         config.getScheduleDelay(transportContext.getPriority(), backendTime, attemptNumber);
 
     Logging.d(
@@ -118,6 +117,7 @@ public class AlarmManagerScheduler implements WorkScheduler {
         attemptNumber);
 
     PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
-    this.alarmManager.set(AlarmManager.ELAPSED_REALTIME, scheduleDelay, pendingIntent);
+    this.alarmManager.set(
+        AlarmManager.ELAPSED_REALTIME, clock.getTime() + scheduleDelay, pendingIntent);
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -25,7 +25,6 @@ import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.logging.Logging;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
 import com.google.android.datatransport.runtime.time.Clock;
-import com.google.android.datatransport.runtime.time.WallTimeClock;
 
 /**
  * Schedules the service {@link AlarmManagerSchedulerBroadcastReceiver} based on the backendname.
@@ -49,12 +48,12 @@ public class AlarmManagerScheduler implements WorkScheduler {
   private final Clock clock;
 
   public AlarmManagerScheduler(
-      Context applicationContext, EventStore eventStore, SchedulerConfig config) {
+      Context applicationContext, EventStore eventStore, Clock clock, SchedulerConfig config) {
     this(
         applicationContext,
         eventStore,
         (AlarmManager) applicationContext.getSystemService(Context.ALARM_SERVICE),
-        new WallTimeClock(),
+        clock,
         config);
   }
 

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerSchedulerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerSchedulerTest.java
@@ -35,7 +35,6 @@ import com.google.android.datatransport.runtime.scheduling.persistence.EventStor
 import com.google.android.datatransport.runtime.scheduling.persistence.InMemoryEventStore;
 import com.google.android.datatransport.runtime.time.Clock;
 import com.google.android.datatransport.runtime.time.TestClock;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -90,7 +89,8 @@ public class AlarmManagerSchedulerTest {
     scheduler.schedule(TRANSPORT_CONTEXT, 1);
     assertThat(scheduler.isJobServiceOn(intent)).isTrue();
     PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
-    verify(alarmManager, times(1)).set(eq(AlarmManager.ELAPSED_REALTIME), eq(INITIAL_TIMESTAMP + 999999L), any());
+    verify(alarmManager, times(1))
+        .set(eq(AlarmManager.ELAPSED_REALTIME), eq(INITIAL_TIMESTAMP + 999999L), any());
   }
 
   @Test
@@ -101,7 +101,10 @@ public class AlarmManagerSchedulerTest {
     assertThat(scheduler.isJobServiceOn(intent)).isTrue();
     PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
     verify(alarmManager, times(1))
-        .set(eq(AlarmManager.ELAPSED_REALTIME), eq(INITIAL_TIMESTAMP + THIRTY_SECONDS), any()); // 2^0*DELTA
+        .set(
+            eq(AlarmManager.ELAPSED_REALTIME),
+            eq(INITIAL_TIMESTAMP + THIRTY_SECONDS),
+            any()); // 2^0*DELTA
   }
 
   @Test
@@ -112,7 +115,10 @@ public class AlarmManagerSchedulerTest {
     scheduler.schedule(TRANSPORT_CONTEXT, 1);
     assertThat(scheduler.isJobServiceOn(intent)).isTrue();
     verify(alarmManager, times(1))
-        .set(eq(AlarmManager.ELAPSED_REALTIME), eq(INITIAL_TIMESTAMP + THIRTY_SECONDS), any()); // 2^0*DELTA
+        .set(
+            eq(AlarmManager.ELAPSED_REALTIME),
+            eq(INITIAL_TIMESTAMP + THIRTY_SECONDS),
+            any()); // 2^0*DELTA
   }
 
   @Test
@@ -157,10 +163,16 @@ public class AlarmManagerSchedulerTest {
 
     assertThat(scheduler.isJobServiceOn(intent1)).isTrue();
     verify(alarmManager, times(1))
-        .set(eq(AlarmManager.ELAPSED_REALTIME), eq(INITIAL_TIMESTAMP + THIRTY_SECONDS), any()); // 2^0*DELTA
+        .set(
+            eq(AlarmManager.ELAPSED_REALTIME),
+            eq(INITIAL_TIMESTAMP + THIRTY_SECONDS),
+            any()); // 2^0*DELTA
 
     assertThat(scheduler.isJobServiceOn(intent2)).isTrue();
     verify(alarmManager, times(1))
-        .set(eq(AlarmManager.ELAPSED_REALTIME), eq(INITIAL_TIMESTAMP + TWENTY_FOUR_HOURS), any()); // 2^0*DELTA
+        .set(
+            eq(AlarmManager.ELAPSED_REALTIME),
+            eq(INITIAL_TIMESTAMP + TWENTY_FOUR_HOURS),
+            any()); // 2^0*DELTA
   }
 }


### PR DESCRIPTION
AlarmManager expects time to be specified as milliseconds since epoch, instead of the ms since when invoked.