### PR TITLE
Fix ByteArray issue with setDefaults and setDefaultsAsync

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -544,7 +544,12 @@ public class FirebaseRemoteConfig {
     // Fetch values from the server are in the Map<String, String> format, so match that here.
     Map<String, String> defaultsStringMap = new HashMap<>();
     for (Map.Entry<String, Object> defaultsEntry : defaults.entrySet()) {
-      defaultsStringMap.put(defaultsEntry.getKey(), defaultsEntry.getValue().toString());
+      Object value = defaultsEntry.getValue();
+      if (value instanceof byte[]) {
+        defaultsStringMap.put(defaultsEntry.getKey(), new String((byte[]) value));
+      } else {
+        defaultsStringMap.put(defaultsEntry.getKey(), value.toString());
+      }
     }
 
     setDefaultsWithStringsMap(defaultsStringMap);
@@ -571,7 +576,12 @@ public class FirebaseRemoteConfig {
     // Fetch values from the server are in the Map<String, String> format, so match that here.
     Map<String, String> defaultsStringMap = new HashMap<>();
     for (Map.Entry<String, Object> defaultsEntry : defaults.entrySet()) {
-      defaultsStringMap.put(defaultsEntry.getKey(), defaultsEntry.getValue().toString());
+      Object value = defaultsEntry.getValue();
+      if (value instanceof byte[]) {
+        defaultsStringMap.put(defaultsEntry.getKey(), new String((byte[]) value));
+      } else {
+        defaultsStringMap.put(defaultsEntry.getKey(), value.toString());
+      }
     }
 
     return setDefaultsWithStringsMapAsync(defaultsStringMap);

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -95,7 +95,8 @@ public final class FirebaseRemoteConfigTest {
   private static final String ETAG = "ETag";
 
   // We use a HashMap so that Mocking is easier.
-  private static final HashMap<String, String> DEFAULTS_MAP = new HashMap<>();
+  private static final HashMap<String, Object> DEFAULTS_MAP = new HashMap<>();
+  private static final HashMap<String, String> DEFAULTS_STRING_MAP = new HashMap<>();
 
   @Mock private ConfigCacheClient mockFetchedCache;
   @Mock private ConfigCacheClient mockActivatedCache;
@@ -126,6 +127,12 @@ public final class FirebaseRemoteConfigTest {
     DEFAULTS_MAP.put("first_default_key", "first_default_value");
     DEFAULTS_MAP.put("second_default_key", "second_default_value");
     DEFAULTS_MAP.put("third_default_key", "third_default_value");
+    DEFAULTS_MAP.put("byte_array_default_key", "fourth_default_value".getBytes());
+
+    DEFAULTS_STRING_MAP.put("first_default_key", "first_default_value");
+    DEFAULTS_STRING_MAP.put("second_default_key", "second_default_value");
+    DEFAULTS_STRING_MAP.put("third_default_key", "third_default_value");
+    DEFAULTS_STRING_MAP.put("byte_array_default_key", "fourth_default_value");
 
     MockitoAnnotations.initMocks(this);
 
@@ -1063,7 +1070,7 @@ public final class FirebaseRemoteConfigTest {
   public void setDefaults_withMap_setsDefaults() throws Exception {
     frc.setDefaults(ImmutableMap.copyOf(DEFAULTS_MAP));
 
-    ConfigContainer defaultsContainer = newDefaultsContainer(DEFAULTS_MAP);
+    ConfigContainer defaultsContainer = newDefaultsContainer(DEFAULTS_STRING_MAP);
     ArgumentCaptor<ConfigContainer> captor = ArgumentCaptor.forClass(ConfigContainer.class);
 
     verify(mockDefaultsCache).putWithoutWaitingForDiskWrite(captor.capture());
@@ -1072,7 +1079,7 @@ public final class FirebaseRemoteConfigTest {
 
   @Test
   public void setDefaultsAsync_withMap_setsDefaults() throws Exception {
-    ConfigContainer defaultsContainer = newDefaultsContainer(DEFAULTS_MAP);
+    ConfigContainer defaultsContainer = newDefaultsContainer(DEFAULTS_STRING_MAP);
     ArgumentCaptor<ConfigContainer> captor = ArgumentCaptor.forClass(ConfigContainer.class);
     cachePutReturnsConfig(mockDefaultsCache, defaultsContainer);
 


### PR DESCRIPTION
# Issue

On Android, when one of the values passed into `setDefaults*(Map<String, Object>)` is of type `byte[]`, the code calls `toString()` on the byte array, which returns a specially-formatted string representation of the array such as `"[B@4df982e"` for the byte array `{0x06,0x00,0x00,0x06,0x07,0x03}`.

Later on, when getByteArray is called, it returns a byte array containing the string representation that was passed in (e.g. the bytes of the string `"[B@4df982e"`) rather than the bytes of the original byte array that was passed in. 



