### PR TITLE
Fix getActiveContexts to return unique contexts.

### DIFF
--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation project(':transport:transport-api')
     implementation project(':transport:transport-runtime')
     implementation 'com.google.protobuf:protobuf-lite:3.0.1'
+    implementation 'androidx.annotation:annotation:1.1.0'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
 
@@ -90,6 +91,5 @@ dependencies {
     testImplementation 'junit:junit:4.13-beta-2'
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    implementation 'androidx.annotation:annotation:1.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -289,16 +289,17 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
         db ->
             tryWithCursor(
                 db.rawQuery(
-                    "SELECT t.backend_name, t.priority, t.extras FROM transport_contexts AS t, events AS e WHERE e.context_id = t._id",
+                    "SELECT distinct t._id, t.backend_name, t.priority, t.extras "
+                        + "FROM transport_contexts AS t, events AS e WHERE e.context_id = t._id",
                     new String[] {}),
                 cursor -> {
                   List<TransportContext> results = new ArrayList<>();
                   while (cursor.moveToNext()) {
                     results.add(
                         TransportContext.builder()
-                            .setBackendName(cursor.getString(0))
-                            .setPriority(cursor.getInt(1))
-                            .setExtras(maybeBase64Decode(cursor.getString(2)))
+                            .setBackendName(cursor.getString(1))
+                            .setPriority(cursor.getInt(2))
+                            .setExtras(maybeBase64Decode(cursor.getString(3)))
                             .build());
                   }
                   return results;

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
@@ -306,6 +306,8 @@ public class SQLiteEventStoreTest {
             .build();
 
     store.persist(ctx1, EVENT);
+    store.persist(ctx1, EVENT);
+    store.persist(ctx2, EVENT);
     store.persist(ctx2, EVENT);
 
     assertThat(store.loadActiveContexts()).containsExactly(ctx1, ctx2);


### PR DESCRIPTION
Instead returning the same context multiple times that is equal to the
number of pending events for that context.