### PR TITLE
Implement firebase-database coroutine extension

### DIFF
--- a/firebase-database/ktx/ktx.gradle
+++ b/firebase-database/ktx/ktx.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(':firebase-database')
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-tasks:17.0.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.1'
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"


### PR DESCRIPTION
Doesn't support generics like List<> and Map<> unless suspended function is inlined and type is reified