### PR TITLE
Migrate org.mockito.Matchers to org.mockito.ArgumentMatchers

### DIFF
--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -86,7 +86,7 @@ dependencies {
     }
     implementation 'com.google.android.gms:play-services-basement:17.0.0'
     implementation 'com.google.protobuf:protobuf-lite:3.0.1'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.google.truth:truth:0.44'
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'androidx.test:runner:1.2.0'

--- a/firebase-common/data-collection-tests/data-collection-tests.gradle
+++ b/firebase-common/data-collection-tests/data-collection-tests.gradle
@@ -48,5 +48,5 @@ dependencies {
     testImplementation 'com.google.auto.value:auto-value-annotations:1.6.5'
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }

--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -75,14 +75,14 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
     annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation "org.mockito:mockito-core:$mockitoVersion"
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.25.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
     androidTestImplementation ('com.google.firebase:firebase-auth:17.0.0') {

--- a/firebase-common/src/test/java/com/google/firebase/components/EventBusTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/components/EventBusTest.java
@@ -15,7 +15,7 @@
 package com.google.firebase.components;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/firebase-config/firebase-config.gradle
+++ b/firebase-config/firebase-config.gradle
@@ -93,14 +93,14 @@ dependencies {
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.google.truth:truth:0.44'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.2'
     testImplementation "org.skyscreamer:jsonassert:1.5.0"
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation "org.mockito:mockito-core:$mockitoVersion"
     androidTestImplementation 'com.google.truth:truth:0.44'
 
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.25.0'

--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -53,5 +53,5 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -25,7 +25,7 @@ import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.DEFAULT_VALU
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_STATUS_THROTTLED;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.toExperimentInfoMaps;
 import static com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler.FRC_BYTE_ARRAY_ENCODING;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -20,7 +20,7 @@ import static com.google.firebase.remoteconfig.AbtExperimentHelper.createAbtExpe
 import static com.google.firebase.remoteconfig.AbtExperimentHelper.createAbtExperiments;
 import static com.google.firebase.remoteconfig.RemoteConfigComponent.DEFAULT_NAMESPACE;
 import static com.google.firebase.remoteconfig.RemoteConfigComponent.NETWORK_CONNECTION_TIMEOUT_IN_SECONDS;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/LegacyConfigsHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/LegacyConfigsHandlerTest.java
@@ -31,7 +31,7 @@ import static com.google.firebase.remoteconfig.internal.LegacyConfigsHandler.pro
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;

--- a/firebase-database/firebase-database.gradle
+++ b/firebase-database/firebase-database.gradle
@@ -94,7 +94,7 @@ dependencies {
 
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'com.firebase:firebase-token-generator:2.0.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.9.8'

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -66,7 +66,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'com.android.support.test:runner:1.0.1'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'

--- a/firebase-dynamic-links/src/test/java/com/google/firebase/dynamiclinks/PendingDynamicLinkDataTest.java
+++ b/firebase-dynamic-links/src/test/java/com/google/firebase/dynamiclinks/PendingDynamicLinkDataTest.java
@@ -20,7 +20,7 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;

--- a/firebase-dynamic-links/src/test/java/com/google/firebase/dynamiclinks/internal/FirebaseDynamicLinksImplTest.java
+++ b/firebase-dynamic-links/src/test/java/com/google/firebase/dynamiclinks/internal/FirebaseDynamicLinksImplTest.java
@@ -20,7 +20,7 @@ import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
 import android.content.Intent;

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -139,7 +139,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
@@ -147,7 +147,7 @@ dependencies {
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation "org.mockito:mockito-core:$mockitoVersion"
     androidTestImplementation 'org.mockito:mockito-android:2.25.0'
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     androidTestImplementation "androidx.annotation:annotation:1.1.0"

--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation project(':firebase-firestore')
     implementation 'androidx.annotation:annotation:1.1.0'
     testImplementation project(':firebase-database-collection')
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     testImplementation 'com.google.android.gms:play-services-tasks:16.0.1'
     testImplementation 'com.google.protobuf:protobuf-lite:3.0.1'

--- a/firebase-functions/firebase-functions.gradle
+++ b/firebase-functions/firebase-functions.gradle
@@ -68,12 +68,12 @@ dependencies {
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation "org.mockito:mockito-core:$mockitoVersion"
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.25.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'androidx.test:rules:1.2.0'

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -89,10 +89,10 @@ dependencies {
 
     testImplementation "org.robolectric:robolectric:4.2"
     testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-core:2.25.0"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "com.google.truth:truth:0.44"
 
-    androidTestImplementation "org.mockito:mockito-core:2.25.0"
+    androidTestImplementation "org.mockito:mockito-core:$mockitoVersion"
     androidTestImplementation "com.google.dexmaker:dexmaker:1.2"
     androidTestImplementation "com.linkedin.dexmaker:dexmaker-mockito:2.25.0"
     androidTestImplementation 'androidx.annotation:annotation:1.1.0'

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -135,7 +135,7 @@ dependencies {
     annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
     annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
 
-    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:runner:1.2.0'
@@ -146,7 +146,7 @@ dependencies {
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation "org.mockito:mockito-core:$mockitoVersion"
     androidTestImplementation 'org.awaitility:awaitility:3.1.0'
     androidTestImplementation 'io.grpc:grpc-testing:1.21.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.25.0'

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/FirebaseInAppMessagingTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/FirebaseInAppMessagingTest.java
@@ -21,7 +21,7 @@ import static com.google.firebase.inappmessaging.testutil.TestData.CAMPAIGN_ID_S
 import static com.google.firebase.inappmessaging.testutil.TestData.CAMPAIGN_NAME_STRING;
 import static io.reactivex.BackpressureStrategy.BUFFER;
 import static io.reactivex.schedulers.Schedulers.trampoline;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/AnalyticsEventsManagerTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/AnalyticsEventsManagerTest.java
@@ -16,8 +16,8 @@ package com.google.firebase.inappmessaging.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.inappmessaging.CommonTypesProto.Trigger.ON_FOREGROUND;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import android.util.Log;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/ApiClientTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/ApiClientTest.java
@@ -15,7 +15,7 @@
 package com.google.firebase.inappmessaging.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/CampaignCacheClientTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/CampaignCacheClientTest.java
@@ -15,7 +15,7 @@
 package com.google.firebase.inappmessaging.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DeveloperListenerManagerTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DeveloperListenerManagerTest.java
@@ -15,7 +15,7 @@
 package com.google.firebase.inappmessaging.internal;
 
 import static com.google.firebase.inappmessaging.testutil.TestData.BANNER_MESSAGE_MODEL;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImplTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImplTest.java
@@ -32,7 +32,7 @@ import static com.google.firebase.inappmessaging.testutil.TestData.TITLE_MODEL;
 import static com.google.firebase.inappmessaging.testutil.TestData.createBannerMessageCustomMetadata;
 import static io.reactivex.BackpressureStrategy.BUFFER;
 import static io.reactivex.schedulers.Schedulers.trampoline;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/ImpressionStorageClientTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/ImpressionStorageClientTest.java
@@ -15,7 +15,7 @@
 package com.google.firebase.inappmessaging.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/InAppMessageStreamManagerTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/InAppMessageStreamManagerTest.java
@@ -25,8 +25,8 @@ import static com.google.firebase.inappmessaging.testutil.TestData.ON_FOREGROUND
 import static com.google.firebase.inappmessaging.testutil.TestProtos.BANNER_MESSAGE_PROTO;
 import static io.reactivex.BackpressureStrategy.BUFFER;
 import static io.reactivex.schedulers.Schedulers.trampoline;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/MetricsLoggerClientTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/MetricsLoggerClientTest.java
@@ -23,7 +23,7 @@ import static com.google.firebase.inappmessaging.testutil.TestData.BANNER_TEST_M
 import static com.google.firebase.inappmessaging.testutil.TestData.CAMPAIGN_ID_STRING;
 import static com.google.firebase.inappmessaging.testutil.TestData.CAMPAIGN_NAME_STRING;
 import static com.google.firebase.inappmessaging.testutil.TestData.CARD_MESSAGE_WITHOUT_ACTIONS;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyObject;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/RateLimiterClientTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/RateLimiterClientTest.java
@@ -15,7 +15,7 @@
 package com.google.firebase.inappmessaging.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/SharedPreferencesUtilsTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/SharedPreferencesUtilsTest.java
@@ -15,7 +15,7 @@
 package com.google.firebase.inappmessaging.internal;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -91,7 +91,7 @@ dependencies {
     androidTestImplementation 'junit:junit:4.12'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'androidx.test:rules:1.2.0'

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -48,6 +48,7 @@ ext {
     errorproneJavacVersion = '9+181-r4173-1'
     googleTruthVersion = '0.45'
     robolectricVersion = '4.1'
+    mockitoVersion = '2.25.0'
 }
 
 apply plugin: com.google.firebase.gradle.plugins.publish.PublishingPlugin

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -69,13 +69,13 @@ dependencies {
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'org.robolectric:robolectric:4.2'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation "org.mockito:mockito-core:$mockitoVersion"
     androidTestImplementation 'org.mockito:mockito-android:2.25.0'
 
     androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.22'


### PR DESCRIPTION
The former is deprecated in favor of the latter. This matches the
internal change cl/272200869