### PR TITLE
Index-Free: Drop last limbo free snapshot version for schema v9

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -396,9 +396,9 @@ public final class LocalStore {
                 || doc.getVersion().compareTo(existingDoc.getVersion()) > 0
                 || (doc.getVersion().compareTo(existingDoc.getVersion()) == 0
                     && existingDoc.hasPendingWrites())) {
-              // TODO(index-free): Comment in this assert when we enable Index-Free queries
-              // hardAssert(!SnapshotVersion.NONE.equals(remoteEvent.getSnapshotVersion()), "Cannot
-              // add a document when the remote version is zero");
+              hardAssert(
+                  !SnapshotVersion.NONE.equals(remoteEvent.getSnapshotVersion()),
+                  "Cannot add a document when the remote version is zero");
               remoteDocuments.add(doc, remoteEvent.getSnapshotVersion());
               changedDocs.put(key, doc);
             } else {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -46,11 +46,9 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
 
   @Override
   public void add(MaybeDocument document, SnapshotVersion readTime) {
-    // TODO(index-free): This assert causes a crash for one of our customers. Re-add the assert once
-    // we have fixed the root cause and cleaned up the underlying data.
-    //    hardAssert(
-    //        !readTime.equals(SnapshotVersion.NONE),
-    //        "Cannot add document to the RemoteDocumentCache with a read time of zero");
+    hardAssert(
+        !readTime.equals(SnapshotVersion.NONE),
+        "Cannot add document to the RemoteDocumentCache with a read time of zero");
     docs = docs.insert(document.getKey(), new Pair<>(document, readTime));
 
     persistence.getIndexManager().addToCollectionParentIndex(document.getKey().getPath().popLast());

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -49,11 +49,9 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
 
   @Override
   public void add(MaybeDocument maybeDocument, SnapshotVersion readTime) {
-    // TODO(index-free): This assert causes a crash for one of our customers. Re-add the assert once
-    // we have fixed the root cause and cleaned up the underlying data.
-    //    hardAssert(
-    //        !readTime.equals(SnapshotVersion.NONE),
-    //        "Cannot add document to the RemoteDocumentCache with a read time of zero");
+    hardAssert(
+        !readTime.equals(SnapshotVersion.NONE),
+        "Cannot add document to the RemoteDocumentCache with a read time of zero");
 
     String path = pathForKey(maybeDocument.getKey());
     Timestamp timestamp = readTime.getTimestamp();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -49,7 +49,7 @@ class SQLiteSchema {
    * The version of the schema. Increase this by one for each migration added to runMigrations
    * below.
    */
-  static final int VERSION = 9;
+  static final int VERSION = 10;
 
   // Remove this constant and increment VERSION to enable indexing support
   static final int INDEXING_SUPPORT_VERSION = VERSION + 1;
@@ -131,13 +131,16 @@ class SQLiteSchema {
       createV8CollectionParentsIndex();
     }
 
-    if (fromVersion < 9 && toVersion >= 9) {
+    if ((fromVersion < 9 && toVersion >= 9) || (fromVersion < 10 && toVersion >= 10)) {
+      // Firestore v21.10 introduced an issue that led us to disable an assert that is required
+      // to ensure data integrity. While the schema did not change between version 9 and 10, we use
+      // the schema bump to version 10 to clear any affected data.
       if (!hasReadTime()) {
         addReadTime();
       } else {
         // Index-free queries rely on the fact that documents updated after a query's last limbo
         // free snapshot version are persisted with their read-time. If a customer upgrades to
-        // schema version 9, downgrades and then upgrades again, some queries may have a last limbo
+        // schema version 10, downgrades and then upgrades again, some queries may have a last limbo
         // free snapshot version despite the fact that not all updated document have an associated
         // read time.
         dropLastLimboFreeSnapshotVersion();


### PR DESCRIPTION
This PR re-adds the asserts we reverted out in v21.10.1 and drops the last limbo free Snapshot Version for any query data that has been written with v21.10.1.