### PR TITLE
feat: add builder ktx for FirebaseRemoteConfigSettings

### DIFF
--- a/docs/ktx/remote-config.md
+++ b/docs/ktx/remote-config.md
@@ -83,10 +83,4 @@ val configSettings = remoteConfigSettings {
     setFetchTimeoutInSeconds(60)
 }
 remoteConfig.setConfigSettingsAsync(configSettings)
-
-// Or alternatively
-remoteConfig.setConfigSettingsAsync {
-    setMinimumFetchIntervalInSeconds(3600)
-    setFetchTimeoutInSeconds(60)
-}
 ```

--- a/docs/ktx/remote-config.md
+++ b/docs/ktx/remote-config.md
@@ -79,8 +79,8 @@ remoteConfig.setConfigSettingsAsync(configSettings)
 **Kotlin + KTX**
 ```kotlin
 val configSettings = remoteConfigSettings {
-    setMinimumFetchIntervalInSeconds(3600)
-    setFetchTimeoutInSeconds(60)
+    minimumFetchIntervalInSeconds = 3600
+    fetchTimeoutInSeconds = 60
 }
 remoteConfig.setConfigSettingsAsync(configSettings)
 ```

--- a/docs/ktx/remote-config.md
+++ b/docs/ktx/remote-config.md
@@ -64,3 +64,23 @@ val maxCharacters = remoteConfig["max_characters"].asLong()
 
 val accessKey = remoteConfig["access_key"].asString()
 ```
+
+### Set Remote Config Settings
+
+**Kotlin**
+```kotlin
+val configSettings = FirebaseRemoteConfigSettings.Builder()
+        .setMinimumFetchIntervalInSeconds(3600)
+        .setFetchTimeoutInSeconds(60)
+        .build()
+remoteConfig.setConfigSettingsAsync(configSettings)
+```
+
+**Kotlin + KTX**
+```kotlin
+val configSettings = remoteConfigSettings {
+    setMinimumFetchIntervalInSeconds(3600)
+    setFetchTimeoutInSeconds(60)
+}
+remoteConfig.setConfigSettingsAsync(configSettings)
+```

--- a/docs/ktx/remote-config.md
+++ b/docs/ktx/remote-config.md
@@ -83,4 +83,10 @@ val configSettings = remoteConfigSettings {
     setFetchTimeoutInSeconds(60)
 }
 remoteConfig.setConfigSettingsAsync(configSettings)
+
+// Or alternatively
+remoteConfig.setConfigSettingsAsync {
+    setMinimumFetchIntervalInSeconds(3600)
+    setFetchTimeoutInSeconds(60)
+}
 ```

--- a/firebase-config/api.txt
+++ b/firebase-config/api.txt
@@ -85,6 +85,8 @@ package com.google.firebase.remoteconfig {
     method @Deprecated @NonNull public com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings.Builder setDeveloperModeEnabled(boolean);
     method @NonNull public com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings.Builder setFetchTimeoutInSeconds(long);
     method @NonNull public com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings.Builder setMinimumFetchIntervalInSeconds(long);
+    method public long getFetchTimeoutInSeconds();
+    method public long getMinimumFetchIntervalInSeconds();
   }
 
   public interface FirebaseRemoteConfigValue {

--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(':firebase-config')
     implementation project (':firebase-abt')
     implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.google.android.gms:play-services-tasks:17.0.0'
 
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'

--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -49,7 +49,6 @@ dependencies {
     implementation project(':firebase-config')
     implementation project (':firebase-abt')
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-tasks:17.0.0'
 
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'

--- a/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
+++ b/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
@@ -15,7 +15,6 @@
 package com.google.firebase.remoteconfig.ktx
 
 import androidx.annotation.Keep
-import com.google.android.gms.tasks.Task
 import com.google.firebase.FirebaseApp
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue

--- a/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
+++ b/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
@@ -15,6 +15,7 @@
 package com.google.firebase.remoteconfig.ktx
 
 import androidx.annotation.Keep
+import com.google.android.gms.tasks.Task
 import com.google.firebase.FirebaseApp
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue
@@ -41,6 +42,12 @@ fun remoteConfigSettings(init: FirebaseRemoteConfigSettings.Builder.() -> Unit) 
     val builder = FirebaseRemoteConfigSettings.Builder()
     builder.init()
     return builder.build()
+}
+
+fun FirebaseRemoteConfig.setConfigSettingsAsync(init: FirebaseRemoteConfigSettings.Builder.() -> Unit) : Task<Void> {
+    val builder = FirebaseRemoteConfigSettings.Builder()
+    builder.init()
+    return setConfigSettingsAsync(builder.build())
 }
 
 internal const val LIBRARY_NAME: String = "fire-cfg-ktx"

--- a/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
+++ b/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
@@ -23,6 +23,7 @@ import com.google.firebase.components.ComponentRegistrar
 
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.platforminfo.LibraryVersionComponent
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 
 /** Returns the [FirebaseRemoteConfig] instance of the default [FirebaseApp]. */
 val Firebase.remoteConfig: FirebaseRemoteConfig
@@ -34,6 +35,12 @@ fun Firebase.remoteConfig(app: FirebaseApp): FirebaseRemoteConfig = FirebaseRemo
 /** See [FirebaseRemoteConfig#getValue] */
 operator fun FirebaseRemoteConfig.get(key: String): FirebaseRemoteConfigValue {
     return this.getValue(key)
+}
+
+fun remoteConfigSettings(init: FirebaseRemoteConfigSettings.Builder.() -> Unit) : FirebaseRemoteConfigSettings {
+    val builder = FirebaseRemoteConfigSettings.Builder()
+    builder.init()
+    return builder.build()
 }
 
 internal const val LIBRARY_NAME: String = "fire-cfg-ktx"

--- a/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
+++ b/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
@@ -38,13 +38,13 @@ operator fun FirebaseRemoteConfig.get(key: String): FirebaseRemoteConfigValue {
     return this.getValue(key)
 }
 
-fun remoteConfigSettings(init: FirebaseRemoteConfigSettings.Builder.() -> Unit) : FirebaseRemoteConfigSettings {
+fun remoteConfigSettings(init: FirebaseRemoteConfigSettings.Builder.() -> Unit): FirebaseRemoteConfigSettings {
     val builder = FirebaseRemoteConfigSettings.Builder()
     builder.init()
     return builder.build()
 }
 
-fun FirebaseRemoteConfig.setConfigSettingsAsync(init: FirebaseRemoteConfigSettings.Builder.() -> Unit) : Task<Void> {
+fun FirebaseRemoteConfig.setConfigSettingsAsync(init: FirebaseRemoteConfigSettings.Builder.() -> Unit): Task<Void> {
     val builder = FirebaseRemoteConfigSettings.Builder()
     builder.init()
     return setConfigSettingsAsync(builder.build())

--- a/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
+++ b/firebase-config/ktx/src/main/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfig.kt
@@ -44,12 +44,6 @@ fun remoteConfigSettings(init: FirebaseRemoteConfigSettings.Builder.() -> Unit):
     return builder.build()
 }
 
-fun FirebaseRemoteConfig.setConfigSettingsAsync(init: FirebaseRemoteConfigSettings.Builder.() -> Unit): Task<Void> {
-    val builder = FirebaseRemoteConfigSettings.Builder()
-    builder.init()
-    return setConfigSettingsAsync(builder.build())
-}
-
 internal const val LIBRARY_NAME: String = "fire-cfg-ktx"
 
 /** @suppress */

--- a/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
+++ b/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
@@ -112,8 +112,8 @@ class ConfigTests : BaseTestCase() {
         val minFetchInterval = 3600L
         val fetchTimeout = 60L
         val configSettings = remoteConfigSettings {
-            setMinimumFetchIntervalInSeconds(minFetchInterval)
-            setFetchTimeoutInSeconds(fetchTimeout)
+            minimumFetchIntervalInSeconds = minFetchInterval
+            fetchTimeoutInSeconds = fetchTimeout
         }
         assertThat(configSettings.minimumFetchIntervalInSeconds).isEqualTo(minFetchInterval)
         assertThat(configSettings.fetchTimeoutInSeconds).isEqualTo(fetchTimeout)

--- a/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
+++ b/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
@@ -108,6 +108,18 @@ class ConfigTests : BaseTestCase() {
     }
 
     @Test
+    fun `FirebaseRemoteConfigSettings builder works`() {
+        val minFetchInterval = 3600L
+        val fetchTimeout = 60L
+        val configSettings = remoteConfigSettings {
+            setMinimumFetchIntervalInSeconds(minFetchInterval)
+            setFetchTimeoutInSeconds(fetchTimeout)
+        }
+        assertThat(configSettings.minimumFetchIntervalInSeconds).isEqualTo(minFetchInterval)
+        assertThat(configSettings.fetchTimeoutInSeconds).isEqualTo(fetchTimeout)
+    }
+
+    @Test
     fun `Overloaded get() operator returns value when key exists`() {
         val mockGetHandler = mock(ConfigGetParameterHandler::class.java)
         val directExecutor = MoreExecutors.directExecutor()

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
@@ -135,6 +135,21 @@ public class FirebaseRemoteConfigSettings {
     }
 
     /**
+     * Returns the fetch timeout in seconds.
+     *
+     * <p>The timeout specifies how long the client should wait for a connection to the Firebase
+     * Remote Config servers.
+     */
+    public long getFetchTimeoutInSeconds() {
+      return fetchTimeoutInSeconds;
+    }
+
+    /** Returns the minimum interval between successive fetches calls in seconds. */
+    public long getMinimumFetchIntervalInSeconds() {
+      return minimumFetchInterval;
+    }
+
+    /**
      * Returns a {@link FirebaseRemoteConfigSettings} with the settings provided to this builder.
      */
     @NonNull


### PR DESCRIPTION
Add Kotlin Extensions:
1. Building `FirebaseRemoteConfigSettings` objects 
```kotlin
val configSettings = remoteConfigSettings {
    setMinimumFetchIntervalInSeconds(3600)
    setFetchTimeoutInSeconds(60)
}
```

2. Setting Config Settings on a FirebaseRemoteConfig object
```kotlin
remoteConfig.setConfigSettingsAsync {
    setMinimumFetchIntervalInSeconds(3600)
    setFetchTimeoutInSeconds(60)
}
```