### PR TITLE
[Smoke-tests] Move tests into a single package.

### DIFF
--- a/smoke-tests/src/main/AndroidManifest.xml
+++ b/smoke-tests/src/main/AndroidManifest.xml
@@ -12,6 +12,6 @@
     </activity>
 
     <meta-data android:name="com.google.firebase.testing.classes"
-      android:value="com.google.firebase.testing.combined.AllTests" />
+      android:value="com.google.firebase.testing.TestSuite" />
   </application>
 </manifest>

--- a/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.testing.buildonly;
+package com.google.firebase.testing;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/smoke-tests/src/main/java/com/google/firebase/testing/DatabaseTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/DatabaseTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.testing.database;
+package com.google.firebase.testing;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/smoke-tests/src/main/java/com/google/firebase/testing/DynamicLinksTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/DynamicLinksTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.testing.dynamiclinks;
+package com.google.firebase.testing;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/smoke-tests/src/main/java/com/google/firebase/testing/FirestoreTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/FirestoreTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.testing.firestore;
+package com.google.firebase.testing;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/smoke-tests/src/main/java/com/google/firebase/testing/FunctionsTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/FunctionsTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.testing.functions;
+package com.google.firebase.testing;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/smoke-tests/src/main/java/com/google/firebase/testing/RemoteConfigTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/RemoteConfigTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.testing.remoteconfig;
+package com.google.firebase.testing;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.testing.common.Tasks2.waitForSuccess;

--- a/smoke-tests/src/main/java/com/google/firebase/testing/StorageTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/StorageTest.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.testing.storage;
+package com.google.firebase.testing;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/smoke-tests/src/main/java/com/google/firebase/testing/TestSuite.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/TestSuite.java
@@ -12,20 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.testing.combined;
+package com.google.firebase.testing;
 
-import com.google.firebase.testing.buildonly.BuildOnlyTest;
-import com.google.firebase.testing.database.DatabaseTest;
-import com.google.firebase.testing.dynamiclinks.DynamicLinksTest;
-import com.google.firebase.testing.firestore.FirestoreTest;
-import com.google.firebase.testing.functions.FunctionsTest;
-import com.google.firebase.testing.remoteconfig.RemoteConfigTest;
-import com.google.firebase.testing.storage.StorageTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 /**
- * A test suite combining the individual product flavors.
+ * A test suite combining the individual tests.
+ *
+ * <p>Note, tests *must* be added to this suite in order to run.
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -37,4 +32,4 @@ import org.junit.runners.Suite;
   RemoteConfigTest.class,
   StorageTest.class,
 })
-public final class AllTests {}
+public final class TestSuite {}


### PR DESCRIPTION
This changes places all of the tests into a single package. There is no
reason to separate them and have one file per package.

This change also renames AllTests to TestSuite, as that better
identifies its purpose.