### PR TITLE
Disabling javadoc on common ktx

### DIFF
--- a/firebase-common/ktx/ktx.gradle
+++ b/firebase-common/ktx/ktx.gradle
@@ -19,6 +19,7 @@ plugins {
 
 firebaseLibrary {
     releaseWith project(':firebase-common')
+    publishJavadoc = false
 }
 
 android {


### PR DESCRIPTION
Seems to preserve the -javadoc.jar