### PR TITLE
keep sNetworkRequestUrl public

### DIFF
--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
@@ -68,7 +68,7 @@ public abstract class NetworkRequest {
   private static final String CONTENT_LENGTH = "Content-Length";
   private static final String UTF_8 = "UTF-8";
 
-  @NonNull static Uri sNetworkRequestUrl = Uri.parse("https://firebasestorage.googleapis.com/v0");
+  @NonNull public static Uri sNetworkRequestUrl = Uri.parse("https://firebasestorage.googleapis.com/v0");
 
   // For test purposes only.
   /*package*/ static HttpURLConnectionFactory connectionFactory =


### PR DESCRIPTION
Since there are no option to set a custom hostname for firebasestorage api, please keep NetworkRequest.sNetworkRequestUrl public, so that developers can override it with their own reverse proxy, this is particularly useful if *.googleapis.com being blocked.