### PR TITLE
Fix race in credentialsProvider.setChangeListener

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -2,6 +2,8 @@
 - [feature] Added an `addSnapshotsInSyncListener()` method to 
   `FirebaseFirestore`that notifies you when all your snapshot listeners are
   in sync with each other.
+- [fixed] Fix a race condition that could cause a `NullPointerException` during
+  client initialization.
 
 # 21.1.2
 - [fixed] Fixed a crash that could occur when a large number of documents were

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -96,19 +96,6 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
 
     TaskCompletionSource<User> firstUser = new TaskCompletionSource<>();
     final AtomicBoolean initialized = new AtomicBoolean(false);
-    credentialsProvider.setChangeListener(
-        (User user) -> {
-          if (initialized.compareAndSet(false, true)) {
-            hardAssert(!firstUser.getTask().isComplete(), "Already fulfilled first user task");
-            firstUser.setResult(user);
-          } else {
-            asyncQueue.enqueueAndForget(
-                () -> {
-                  Logger.debug(LOG_TAG, "Credential changed. Current user: %s", user.getUid());
-                  syncEngine.handleCredentialChange(user);
-                });
-          }
-        });
 
     // Defer initialization until we get the current user from the changeListener. This is
     // guaranteed to be synchronously dispatched onto our worker queue, so we will be initialized
@@ -125,6 +112,21 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
                 settings.getCacheSizeBytes());
           } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
+          }
+        });
+
+    credentialsProvider.setChangeListener(
+        (User user) -> {
+          if (initialized.compareAndSet(false, true)) {
+            hardAssert(!firstUser.getTask().isComplete(), "Already fulfilled first user task");
+            firstUser.setResult(user);
+          } else {
+            // this fires twoce and sync engine isnt' initialized
+            asyncQueue.enqueueAndForget(
+                () -> {
+                  Logger.debug(LOG_TAG, "Credential changed. Current user: %s", user.getUid());
+                  syncEngine.handleCredentialChange(user);
+                });
           }
         });
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -123,7 +123,7 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
           } else {
             asyncQueue.enqueueAndForget(
                 () -> {
-                  hardAssert(syncEngine !== null, "SyncEngine not yet initialized");
+                  hardAssert(syncEngine != null, "SyncEngine not yet initialized");
                   Logger.debug(LOG_TAG, "Credential changed. Current user: %s", user.getUid());
                   syncEngine.handleCredentialChange(user);
                 });

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -121,9 +121,9 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
             hardAssert(!firstUser.getTask().isComplete(), "Already fulfilled first user task");
             firstUser.setResult(user);
           } else {
-            // this fires twoce and sync engine isnt' initialized
             asyncQueue.enqueueAndForget(
                 () -> {
+                  hardAssert(syncEngine !== null, "SyncEngine not yet initialized");
                   Logger.debug(LOG_TAG, "Credential changed. Current user: %s", user.getUid());
                   syncEngine.handleCredentialChange(user);
                 });


### PR DESCRIPTION
If the credentials change listeners fires twice before we enqueue the client initialization on the AsyncQueue, `syncEngine` will be null in the credentials callback. This PR re-orders our initialization to make sure that the first thing we execute on the client is always `FirestoreClient.initialize()`.

Fixes https://github.com/firebase/firebase-android-sdk/issues/875