### PR TITLE
Modify ConfigFetchHttpClient to log all successful Fetch calls.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -210,14 +210,14 @@ public class ConfigFetchHttpClient {
       }
     }
 
+    long endTime = System.currentTimeMillis();
+    configLogger.logFetchEvent(/* networkLatencyMillis= */ endTime - startTime);
+
     if (!backendHasUpdates(fetchResponse)) {
       return FetchResponse.forBackendHasNoUpdates(currentTime);
     }
 
     ConfigContainer fetchedConfigs = extractConfigs(fetchResponse, currentTime);
-
-    long endTime = System.currentTimeMillis();
-    configLogger.logFetchEvent(/* networkLatencyMillis= */ endTime - startTime);
 
     return FetchResponse.forBackendUpdatesFetched(fetchedConfigs, fetchResponseETag);
   }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -187,6 +187,15 @@ public class ConfigFetchHttpClientTest {
   }
 
   @Test
+  public void fetch_noChange_logsClientLogEvent() throws Exception {
+    setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
+
+    fetch(SECOND_ETAG);
+
+    verify(mockConfigLogger).logFetchEvent(/* networkLatencyMillis= */ anyLong());
+  }
+
+  @Test
   public void fetch_setsAllHeaders_sendsAllHeadersToServer() throws Exception {
     setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
     Map<String, String> customHeaders = ImmutableMap.of("x-enable-fetch", "true");


### PR DESCRIPTION
Modify ConfigFetchHttpClient so that metrics will be logged in Fetch even when the backend doesn't have an update. 