### PR TITLE
Switch Config to only eagerly initialize in default app

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigRegistrar.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigRegistrar.java
@@ -54,7 +54,7 @@ public class RemoteConfigRegistrar implements ComponentRegistrar {
                         container.get(FirebaseInstanceId.class),
                         container.get(AbtComponent.class).get(OriginService.REMOTE_CONFIG),
                         container.get(AnalyticsConnector.class)))
-            .alwaysEager()
+            .eagerInDefaultApp()
             .build(),
         LibraryVersionComponent.create("fire-rc", BuildConfig.VERSION_NAME));
   }


### PR DESCRIPTION
This was added primarily as a performance boost, but we should be able to get the same performance benefit in most cases by just eagerly initializing only in the default app.