### PR TITLE
[1/3] Split Query and Target and make RemoteStore and LocalStore work with Targets

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
@@ -30,10 +30,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-/** Represents the internal structure of a Firestore Query */
+/**
+ * Encapsulates all the query attributes we support in the SDK. It can be run against the
+ * LocalStore, as well as be converted to a {@code Target} to query the RemoteStore results.
+ */
 public final class Query {
-  public static final long NO_LIMIT = -1;
-
   /**
    * Creates and returns a new Query.
    *
@@ -52,6 +53,9 @@ public final class Query {
   private final List<OrderBy> explicitSortOrder;
 
   private List<OrderBy> memoizedOrderBy;
+
+  // The corresponding Target of this Query instance.
+  private @Nullable Target memorizedTarget;
 
   private final List<Filter> filters;
 
@@ -92,7 +96,7 @@ public final class Query {
         collectionGroup,
         Collections.emptyList(),
         Collections.emptyList(),
-        NO_LIMIT,
+        Target.NO_LIMIT,
         null,
         null);
   }
@@ -122,7 +126,7 @@ public final class Query {
    */
   public boolean matchesAllDocuments() {
     return filters.isEmpty()
-        && limit == NO_LIMIT
+        && limit == Target.NO_LIMIT
         && startAt == null
         && endAt == null
         && (getExplicitOrderBy().isEmpty()
@@ -144,7 +148,7 @@ public final class Query {
   }
 
   public boolean hasLimit() {
-    return limit != NO_LIMIT;
+    return limit != Target.NO_LIMIT;
   }
 
   /** An optional bound to start the query at. */
@@ -425,50 +429,29 @@ public final class Query {
     }
   }
 
+  /** @return A {@code Target} instance this query will be mapped to in backend and local store. */
+  public Target toTarget() {
+    if (this.memorizedTarget == null) {
+      this.memorizedTarget =
+          new Target(
+              this.getPath(),
+              this.getCollectionGroup(),
+              this.getFilters(),
+              this.getOrderBy(),
+              this.limit,
+              this.getStartAt(),
+              this.getEndAt());
+    }
+
+    return this.memorizedTarget;
+  }
+
   /**
    * Returns a canonical string representing this query. This should match the iOS and Android
    * canonical ids for a query exactly.
    */
   public String getCanonicalId() {
-    // TODO: Cache the return value.
-    StringBuilder builder = new StringBuilder();
-    builder.append(getPath().canonicalString());
-
-    if (collectionGroup != null) {
-      builder.append("|cg:");
-      builder.append(collectionGroup);
-    }
-
-    // Add filters.
-    builder.append("|f:");
-    for (Filter filter : getFilters()) {
-      builder.append(filter.getCanonicalId());
-    }
-
-    // Add order by.
-    builder.append("|ob:");
-    for (OrderBy orderBy : getOrderBy()) {
-      builder.append(orderBy.getField().canonicalString());
-      builder.append(orderBy.getDirection().equals(Direction.ASCENDING) ? "asc" : "desc");
-    }
-
-    // Add limit.
-    if (hasLimit()) {
-      builder.append("|l:");
-      builder.append(getLimit());
-    }
-
-    if (startAt != null) {
-      builder.append("|lb:");
-      builder.append(startAt.canonicalString());
-    }
-
-    if (endAt != null) {
-      builder.append("|ub:");
-      builder.append(endAt.canonicalString());
-    }
-
-    return builder.toString();
+    return this.toTarget().getCanonicalId();
   }
 
   @Override
@@ -482,70 +465,19 @@ public final class Query {
 
     Query query = (Query) o;
 
-    if (collectionGroup != null
-        ? !collectionGroup.equals(query.collectionGroup)
-        : query.collectionGroup != null) {
-      return false;
-    }
-    if (limit != query.limit) {
-      return false;
-    }
-    if (!getOrderBy().equals(query.getOrderBy())) {
-      return false;
-    }
-    if (!filters.equals(query.filters)) {
-      return false;
-    }
-    if (!path.equals(query.path)) {
-      return false;
-    }
-    if (startAt != null ? !startAt.equals(query.startAt) : query.startAt != null) {
-      return false;
-    }
-    return endAt != null ? endAt.equals(query.endAt) : query.endAt == null;
+    return this.toTarget().equals(query.toTarget());
   }
 
   @Override
   public int hashCode() {
-    int result = getOrderBy().hashCode();
-    result = 31 * result + (collectionGroup != null ? collectionGroup.hashCode() : 0);
-    result = 31 * result + filters.hashCode();
-    result = 31 * result + path.hashCode();
-    result = 31 * result + (int) (limit ^ (limit >>> 32));
-    result = 31 * result + (startAt != null ? startAt.hashCode() : 0);
-    result = 31 * result + (endAt != null ? endAt.hashCode() : 0);
-    return result;
+    return this.toTarget().hashCode();
   }
 
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    builder.append("Query(");
-    builder.append(path.canonicalString());
-    if (collectionGroup != null) {
-      builder.append(" collectionGroup=");
-      builder.append(collectionGroup);
-    }
-    if (!filters.isEmpty()) {
-      builder.append(" where ");
-      for (int i = 0; i < filters.size(); i++) {
-        if (i > 0) {
-          builder.append(" and ");
-        }
-        builder.append(filters.get(i).toString());
-      }
-    }
-
-    if (!explicitSortOrder.isEmpty()) {
-      builder.append(" order by ");
-      for (int i = 0; i < explicitSortOrder.size(); i++) {
-        if (i > 0) {
-          builder.append(", ");
-        }
-        builder.append(explicitSortOrder.get(i));
-      }
-    }
-
+    builder.append("Query(target=");
+    builder.append(this.toTarget().toString());
     builder.append(")");
     return builder.toString();
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
@@ -55,7 +55,7 @@ public final class Query {
   private List<OrderBy> memoizedOrderBy;
 
   // The corresponding Target of this Query instance.
-  private @Nullable Target memorizedTarget;
+  private @Nullable Target memoizedTarget;
 
   private final List<Filter> filters;
 
@@ -431,8 +431,8 @@ public final class Query {
 
   /** @return A {@code Target} instance this query will be mapped to in backend and local store. */
   public Target toTarget() {
-    if (this.memorizedTarget == null) {
-      this.memorizedTarget =
+    if (this.memoizedTarget == null) {
+      this.memoizedTarget =
           new Target(
               this.getPath(),
               this.getCollectionGroup(),
@@ -443,13 +443,14 @@ public final class Query {
               this.getEndAt());
     }
 
-    return this.memorizedTarget;
+    return this.memoizedTarget;
   }
 
   /**
    * Returns a canonical string representing this query. This should match the iOS and Android
    * canonical ids for a query exactly.
    */
+  // TODO(wuandy): This is now only used in tests and SpecTestCase. Maybe we can delete it?
   public String getCanonicalId() {
     return this.toTarget().getCanonicalId();
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -1,0 +1,240 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.core;
+
+import static com.google.firebase.firestore.util.Assert.hardAssert;
+
+import androidx.annotation.Nullable;
+import com.google.firebase.firestore.core.OrderBy.Direction;
+import com.google.firebase.firestore.model.DocumentKey;
+import com.google.firebase.firestore.model.ResourcePath;
+import java.util.List;
+
+/**
+ * A Target represents the WatchTarget representation of a Query, which is used by the LocalStore
+ * and the RemoteStore to keep track of and to execute backend queries. While multiple Query can map
+ * to the same Target, each Targets maps to a single WatchTarget in RemoteStore and a single
+ * TargetData entry in persistence.
+ */
+public final class Target {
+  public static final long NO_LIMIT = -1;
+
+  private @Nullable String memorizedCannonicalId;
+
+  private final List<OrderBy> explicitSortOrder;
+  private final List<Filter> filters;
+
+  private final ResourcePath path;
+
+  private final @Nullable String collectionGroup;
+
+  private final long limit;
+
+  private final @Nullable Bound startAt;
+  private final @Nullable Bound endAt;
+
+  /**
+   * Initializes a Target with a path and additional query constraints. Path must currently be empty
+   * if this is a collection group query.
+   *
+   * <p>NOTE: you should always construct Target from {@code Query.toTarget} instead of using this
+   * constructor, because Query provides an implicit {@code orderBy} property.
+   */
+  public Target(
+      ResourcePath path,
+      @Nullable String collectionGroup,
+      List<Filter> filters,
+      List<OrderBy> explicitSortOrder,
+      long limit,
+      @Nullable Bound startAt,
+      @Nullable Bound endAt) {
+    this.path = path;
+    this.collectionGroup = collectionGroup;
+    this.explicitSortOrder = explicitSortOrder;
+    this.filters = filters;
+    this.limit = limit;
+    this.startAt = startAt;
+    this.endAt = endAt;
+  }
+
+  /** The base path of the query. */
+  public ResourcePath getPath() {
+    return path;
+  }
+
+  /** An optional collection group within which to query. */
+  public @Nullable String getCollectionGroup() {
+    return collectionGroup;
+  }
+
+  /** Returns true if this Query is for a specific document. */
+  public boolean isDocumentQuery() {
+    return DocumentKey.isDocumentKey(path) && collectionGroup == null && filters.isEmpty();
+  }
+
+  /** The filters on the documents returned by the query. */
+  public List<Filter> getFilters() {
+    return filters;
+  }
+
+  /**
+   * The maximum number of results to return. If there is no limit on the query, then this will
+   * cause an assertion failure.
+   */
+  public long getLimit() {
+    hardAssert(hasLimit(), "Called getLimit when no limit was set");
+    return limit;
+  }
+
+  public boolean hasLimit() {
+    return limit != NO_LIMIT;
+  }
+
+  /** An optional bound to start the query at. */
+  public @Nullable Bound getStartAt() {
+    return startAt;
+  }
+
+  /** An optional bound to end the query at. */
+  public @Nullable Bound getEndAt() {
+    return endAt;
+  }
+
+  public List<OrderBy> getOrderBy() {
+    return this.explicitSortOrder;
+  }
+
+  /** Returns a canonical string representing this target. */
+  public String getCanonicalId() {
+    // TODO: Cache the return value.
+    StringBuilder builder = new StringBuilder();
+    builder.append(getPath().canonicalString());
+
+    if (collectionGroup != null) {
+      builder.append("|cg:");
+      builder.append(collectionGroup);
+    }
+
+    // Add filters.
+    builder.append("|f:");
+    for (Filter filter : getFilters()) {
+      builder.append(filter.getCanonicalId());
+    }
+
+    // Add order by.
+    builder.append("|ob:");
+    for (OrderBy orderBy : getOrderBy()) {
+      builder.append(orderBy.getField().canonicalString());
+      builder.append(orderBy.getDirection().equals(Direction.ASCENDING) ? "asc" : "desc");
+    }
+
+    // Add limit.
+    if (hasLimit()) {
+      builder.append("|l:");
+      builder.append(getLimit());
+    }
+
+    if (startAt != null) {
+      builder.append("|lb:");
+      builder.append(startAt.canonicalString());
+    }
+
+    if (endAt != null) {
+      builder.append("|ub:");
+      builder.append(endAt.canonicalString());
+    }
+
+    return builder.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Target target = (Target) o;
+
+    if (collectionGroup != null
+        ? !collectionGroup.equals(target.collectionGroup)
+        : target.collectionGroup != null) {
+      return false;
+    }
+    if (limit != target.limit) {
+      return false;
+    }
+    if (!getOrderBy().equals(target.getOrderBy())) {
+      return false;
+    }
+    if (!filters.equals(target.filters)) {
+      return false;
+    }
+    if (!path.equals(target.path)) {
+      return false;
+    }
+    if (startAt != null ? !startAt.equals(target.startAt) : target.startAt != null) {
+      return false;
+    }
+    return endAt != null ? endAt.equals(target.endAt) : target.endAt == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getOrderBy().hashCode();
+    result = 31 * result + (collectionGroup != null ? collectionGroup.hashCode() : 0);
+    result = 31 * result + filters.hashCode();
+    result = 31 * result + path.hashCode();
+    result = 31 * result + (int) (limit ^ (limit >>> 32));
+    result = 31 * result + (startAt != null ? startAt.hashCode() : 0);
+    result = 31 * result + (endAt != null ? endAt.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("Query(");
+    builder.append(path.canonicalString());
+    if (collectionGroup != null) {
+      builder.append(" collectionGroup=");
+      builder.append(collectionGroup);
+    }
+    if (!filters.isEmpty()) {
+      builder.append(" where ");
+      for (int i = 0; i < filters.size(); i++) {
+        if (i > 0) {
+          builder.append(" and ");
+        }
+        builder.append(filters.get(i).toString());
+      }
+    }
+
+    if (!explicitSortOrder.isEmpty()) {
+      builder.append(" order by ");
+      for (int i = 0; i < explicitSortOrder.size(); i++) {
+        if (i > 0) {
+          builder.append(", ");
+        }
+        builder.append(explicitSortOrder.get(i));
+      }
+    }
+
+    builder.append(")");
+    return builder.toString();
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryCache.java
@@ -16,17 +16,17 @@ package com.google.firebase.firestore.local;
 
 import androidx.annotation.Nullable;
 import com.google.firebase.database.collection.ImmutableSortedSet;
-import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.core.Target;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firebase.firestore.util.Consumer;
 
 /**
- * Represents cached queries received from the remote backend. This contains both a mapping between
- * queries and the documents that matched them according to the server, but also metadata about the
- * queries.
+ * Represents cached targets received from the remote backend. This contains both a mapping between
+ * targets and the documents that matched them according to the server, but also metadata about the
+ * targets.
  *
- * <p>The cache is keyed by {@link Query} and entries in the cache are {@link QueryData} instances.
+ * <p>The cache is keyed by {@link Target} and entries in the cache are {@link QueryData} instances.
  */
 interface QueryCache {
   /**
@@ -70,7 +70,7 @@ interface QueryCache {
   /**
    * Adds an entry in the cache. This entry should not already exist.
    *
-   * <p>The cache key is extracted from {@link QueryData#getQuery}.
+   * <p>The cache key is extracted from {@link QueryData#getTarget}.
    *
    * @param queryData A QueryData instance to put in the cache.
    */
@@ -79,7 +79,7 @@ interface QueryCache {
   /**
    * Replaces an entry in the cache. An entry with the same key should already exist.
    *
-   * <p>The cache key is extracted from {@link QueryData#getQuery()}.
+   * <p>The cache key is extracted from {@link QueryData#getTarget()}.
    *
    * @param queryData A QueryData to replace an existing entry in the cache.
    */
@@ -95,11 +95,11 @@ interface QueryCache {
   /**
    * Looks up a QueryData entry in the cache.
    *
-   * @param query The query corresponding to the entry to look up.
+   * @param target The target corresponding to the entry to look up.
    * @return The cached QueryData entry, or null if the cache has no entry for the query.
    */
   @Nullable
-  QueryData getQueryData(Query query);
+  QueryData getQueryData(Target target);
 
   /** Adds the given document keys to cached query results of the given target ID. */
   void addMatchingKeys(ImmutableSortedSet<DocumentKey> keys, int targetId);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryData.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryData.java
@@ -16,14 +16,14 @@ package com.google.firebase.firestore.local;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.core.Target;
 import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firebase.firestore.remote.WatchStream;
 import com.google.protobuf.ByteString;
 
-/** An immutable set of metadata that the store will need to keep track of for each query. */
+/** An immutable set of metadata that the store will need to keep track of for each target. */
 public final class QueryData {
-  private final Query query;
+  private final Target target;
   private final int targetId;
   private final long sequenceNumber;
   private final QueryPurpose purpose;
@@ -34,27 +34,27 @@ public final class QueryData {
   /**
    * Creates a new QueryData with the given values.
    *
-   * @param query The query being listened to.
-   * @param targetId The target to which the query corresponds, assigned by the LocalStore for user
-   *     queries or the SyncEngine for limbo queries.
-   * @param sequenceNumber The sequence number, denoting the last time this query was used.
-   * @param purpose The purpose of the query.
+   * @param target The target being listened to.
+   * @param targetId The target id to which the target corresponds, assigned by the LocalStore for
+   *     user queries or the SyncEngine for limbo queries.
+   * @param sequenceNumber The sequence number, denoting the last time this target was used.
+   * @param purpose The purpose of the target.
    * @param snapshotVersion The latest snapshot version seen for this target.
-   * @param lastLimboFreeSnapshotVersion The maximum snapshot version at which the associated query
+   * @param lastLimboFreeSnapshotVersion The maximum snapshot version at which the associated target
    *     view contained no limbo documents.
-   * @param resumeToken An opaque, server-assigned token that allows watching a query to be resumed
-   *     after disconnecting without retransmitting all the data that matches the query. The resume
+   * @param resumeToken An opaque, server-assigned token that allows watching a target to be resumed
+   *     after disconnecting without retransmitting all the data that matches the target. The resume
    *     token essentially identifies a point in time from which the server should resume sending
    */
   QueryData(
-      Query query,
+      Target target,
       int targetId,
       long sequenceNumber,
       QueryPurpose purpose,
       SnapshotVersion snapshotVersion,
       SnapshotVersion lastLimboFreeSnapshotVersion,
       ByteString resumeToken) {
-    this.query = checkNotNull(query);
+    this.target = checkNotNull(target);
     this.targetId = targetId;
     this.sequenceNumber = sequenceNumber;
     this.lastLimboFreeSnapshotVersion = lastLimboFreeSnapshotVersion;
@@ -64,9 +64,9 @@ public final class QueryData {
   }
 
   /** Convenience constructor for use when creating a QueryData for the first time. */
-  public QueryData(Query query, int targetId, long sequenceNumber, QueryPurpose purpose) {
+  public QueryData(Target target, int targetId, long sequenceNumber, QueryPurpose purpose) {
     this(
-        query,
+        target,
         targetId,
         sequenceNumber,
         purpose,
@@ -75,10 +75,10 @@ public final class QueryData {
         WatchStream.EMPTY_RESUME_TOKEN);
   }
 
-  /** Creates a new query data instance with an updated sequence number. */
+  /** Creates a new target data instance with an updated sequence number. */
   public QueryData withSequenceNumber(long sequenceNumber) {
     return new QueryData(
-        query,
+        target,
         targetId,
         sequenceNumber,
         purpose,
@@ -87,10 +87,10 @@ public final class QueryData {
         resumeToken);
   }
 
-  /** Creates a new query data instance with an updated resume token and snapshot version. */
+  /** Creates a new target data instance with an updated resume token and snapshot version. */
   public QueryData withResumeToken(ByteString resumeToken, SnapshotVersion snapshotVersion) {
     return new QueryData(
-        query,
+        target,
         targetId,
         sequenceNumber,
         purpose,
@@ -99,10 +99,10 @@ public final class QueryData {
         resumeToken);
   }
 
-  /** Creates a new query data instance with an updated last limbo free snapshot version number. */
+  /** Creates a new target data instance with an updated last limbo free snapshot version number. */
   public QueryData withLastLimboFreeSnapshotVersion(SnapshotVersion lastLimboFreeSnapshotVersion) {
     return new QueryData(
-        query,
+        target,
         targetId,
         sequenceNumber,
         purpose,
@@ -111,8 +111,8 @@ public final class QueryData {
         resumeToken);
   }
 
-  public Query getQuery() {
-    return query;
+  public Target getTarget() {
+    return target;
   }
 
   public int getTargetId() {
@@ -152,7 +152,7 @@ public final class QueryData {
     }
 
     QueryData queryData = (QueryData) o;
-    return query.equals(queryData.query)
+    return target.equals(queryData.target)
         && targetId == queryData.targetId
         && sequenceNumber == queryData.sequenceNumber
         && purpose.equals(queryData.purpose)
@@ -163,7 +163,7 @@ public final class QueryData {
 
   @Override
   public int hashCode() {
-    int result = query.hashCode();
+    int result = target.hashCode();
     result = 31 * result + targetId;
     result = 31 * result + (int) sequenceNumber;
     result = 31 * result + purpose.hashCode();
@@ -176,8 +176,8 @@ public final class QueryData {
   @Override
   public String toString() {
     return "QueryData{"
-        + "query="
-        + query
+        + "target="
+        + target
         + ", targetId="
         + targetId
         + ", sequenceNumber="

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
@@ -678,12 +678,12 @@ public final class RemoteSerializer {
 
   public Target encodeTarget(QueryData queryData) {
     Target.Builder builder = Target.newBuilder();
-    Query query = queryData.getQuery();
+    com.google.firebase.firestore.core.Target target = queryData.getTarget();
 
-    if (query.isDocumentQuery()) {
-      builder.setDocuments(encodeDocumentsTarget(query));
+    if (target.isDocumentQuery()) {
+      builder.setDocuments(encodeDocumentsTarget(target));
     } else {
-      builder.setQuery(encodeQueryTarget(query));
+      builder.setQuery(encodeQueryTarget(target));
     }
 
     builder.setTargetId(queryData.getTargetId());
@@ -692,36 +692,36 @@ public final class RemoteSerializer {
     return builder.build();
   }
 
-  public DocumentsTarget encodeDocumentsTarget(Query query) {
+  public DocumentsTarget encodeDocumentsTarget(com.google.firebase.firestore.core.Target target) {
     DocumentsTarget.Builder builder = DocumentsTarget.newBuilder();
-    builder.addDocuments(encodeQueryPath(query.getPath()));
+    builder.addDocuments(encodeQueryPath(target.getPath()));
     return builder.build();
   }
 
-  public Query decodeDocumentsTarget(DocumentsTarget target) {
+  public com.google.firebase.firestore.core.Target decodeDocumentsTarget(DocumentsTarget target) {
     int count = target.getDocumentsCount();
     hardAssert(count == 1, "DocumentsTarget contained other than 1 document %d", count);
 
     String name = target.getDocuments(0);
-    return Query.atPath(decodeQueryPath(name));
+    return Query.atPath(decodeQueryPath(name)).toTarget();
   }
 
-  public QueryTarget encodeQueryTarget(Query query) {
+  public QueryTarget encodeQueryTarget(com.google.firebase.firestore.core.Target target) {
     // Dissect the path into parent, collectionId, and optional key filter.
     QueryTarget.Builder builder = QueryTarget.newBuilder();
     StructuredQuery.Builder structuredQueryBuilder = StructuredQuery.newBuilder();
-    ResourcePath path = query.getPath();
-    if (query.getCollectionGroup() != null) {
-      Assert.hardAssert(
+    ResourcePath path = target.getPath();
+    if (target.getCollectionGroup() != null) {
+      hardAssert(
           path.length() % 2 == 0,
           "Collection Group queries should be within a document path or root.");
       builder.setParent(encodeQueryPath(path));
       CollectionSelector.Builder from = CollectionSelector.newBuilder();
-      from.setCollectionId(query.getCollectionGroup());
+      from.setCollectionId(target.getCollectionGroup());
       from.setAllDescendants(true);
       structuredQueryBuilder.addFrom(from);
     } else {
-      Assert.hardAssert(path.length() % 2 != 0, "Document queries with filters are not supported.");
+      hardAssert(path.length() % 2 != 0, "Document queries with filters are not supported.");
       builder.setParent(encodeQueryPath(path.popLast()));
       CollectionSelector.Builder from = CollectionSelector.newBuilder();
       from.setCollectionId(path.getLastSegment());
@@ -729,33 +729,33 @@ public final class RemoteSerializer {
     }
 
     // Encode the filters.
-    if (query.getFilters().size() > 0) {
-      structuredQueryBuilder.setWhere(encodeFilters(query.getFilters()));
+    if (target.getFilters().size() > 0) {
+      structuredQueryBuilder.setWhere(encodeFilters(target.getFilters()));
     }
 
     // Encode the orders.
-    for (OrderBy orderBy : query.getOrderBy()) {
+    for (OrderBy orderBy : target.getOrderBy()) {
       structuredQueryBuilder.addOrderBy(encodeOrderBy(orderBy));
     }
 
     // Encode the limit.
-    if (query.hasLimit()) {
-      structuredQueryBuilder.setLimit(Int32Value.newBuilder().setValue((int) query.getLimit()));
+    if (target.hasLimit()) {
+      structuredQueryBuilder.setLimit(Int32Value.newBuilder().setValue((int) target.getLimit()));
     }
 
-    if (query.getStartAt() != null) {
-      structuredQueryBuilder.setStartAt(encodeBound(query.getStartAt()));
+    if (target.getStartAt() != null) {
+      structuredQueryBuilder.setStartAt(encodeBound(target.getStartAt()));
     }
 
-    if (query.getEndAt() != null) {
-      structuredQueryBuilder.setEndAt(encodeBound(query.getEndAt()));
+    if (target.getEndAt() != null) {
+      structuredQueryBuilder.setEndAt(encodeBound(target.getEndAt()));
     }
 
     builder.setStructuredQuery(structuredQueryBuilder);
     return builder.build();
   }
 
-  public Query decodeQueryTarget(QueryTarget target) {
+  public com.google.firebase.firestore.core.Target decodeQueryTarget(QueryTarget target) {
     ResourcePath path = decodeQueryPath(target.getParent());
 
     StructuredQuery query = target.getStructuredQuery();
@@ -792,7 +792,7 @@ public final class RemoteSerializer {
       orderBy = Collections.emptyList();
     }
 
-    long limit = Query.NO_LIMIT;
+    long limit = com.google.firebase.firestore.core.Target.NO_LIMIT;
     if (query.hasLimit()) {
       limit = query.getLimit().getValue();
     }
@@ -807,7 +807,7 @@ public final class RemoteSerializer {
       endAt = decodeBound(query.getEndAt());
     }
 
-    return new Query(path, collectionGroup, filterBy, orderBy, limit, startAt, endAt);
+    return new Query(path, collectionGroup, filterBy, orderBy, limit, startAt, endAt).toTarget();
   }
 
   // Filters

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
@@ -529,7 +529,7 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
         // reconnect).
         QueryData requestQueryData =
             new QueryData(
-                queryData.getQuery(),
+                queryData.getTarget(),
                 targetId,
                 queryData.getSequenceNumber(),
                 QueryPurpose.EXISTENCE_FILTER_MISMATCH);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/WatchChangeAggregator.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/WatchChangeAggregator.java
@@ -20,7 +20,7 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 import androidx.annotation.Nullable;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.core.DocumentViewChange;
-import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.core.Target;
 import com.google.firebase.firestore.local.QueryData;
 import com.google.firebase.firestore.local.QueryPurpose;
 import com.google.firebase.firestore.model.Document;
@@ -176,14 +176,14 @@ public class WatchChangeAggregator {
 
     QueryData queryData = queryDataForActiveTarget(targetId);
     if (queryData != null) {
-      Query query = queryData.getQuery();
-      if (query.isDocumentQuery()) {
+      Target target = queryData.getTarget();
+      if (target.isDocumentQuery()) {
         if (expectedCount == 0) {
           // The existence filter told us the document does not exist. We deduce that this document
           // does not exist and apply a deleted document to our updates. Without applying this
           // deleted document there might be another query that will raise this document as part of
           // a snapshot  until it is resolved, essentially exposing inconsistency between queries.
-          DocumentKey key = DocumentKey.fromPath(query.getPath());
+          DocumentKey key = DocumentKey.fromPath(target.getPath());
           removeDocumentFromTarget(
               targetId,
               key,
@@ -217,12 +217,12 @@ public class WatchChangeAggregator {
 
       QueryData queryData = queryDataForActiveTarget(targetId);
       if (queryData != null) {
-        if (targetState.isCurrent() && queryData.getQuery().isDocumentQuery()) {
+        if (targetState.isCurrent() && queryData.getTarget().isDocumentQuery()) {
           // Document queries for document that don't exist can produce an empty result set. To
           // update our local cache, we synthesize a document delete if we have not previously
           // received the document. This resolves the limbo state of the document, removing it from
           // limboDocumentRefs.
-          DocumentKey key = DocumentKey.fromPath(queryData.getQuery().getPath());
+          DocumentKey key = DocumentKey.fromPath(queryData.getTarget().getPath());
           if (pendingDocumentUpdates.get(key) == null && !targetContainsDocument(targetId, key)) {
             removeDocumentFromTarget(
                 targetId,

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalSerializerTest.java
@@ -209,7 +209,7 @@ public final class LocalSerializerTest {
 
     QueryData queryData =
         new QueryData(
-            query,
+            query.toTarget(),
             targetId,
             sequenceNumber,
             QueryPurpose.LISTEN,
@@ -219,7 +219,7 @@ public final class LocalSerializerTest {
 
     // Let the RPC serializer test various permutations of query serialization.
     com.google.firestore.v1.Target.QueryTarget queryTarget =
-        remoteSerializer.encodeQueryTarget(query);
+        remoteSerializer.encodeQueryTarget(query.toTarget());
 
     com.google.firebase.firestore.proto.Target expected =
         com.google.firebase.firestore.proto.Target.newBuilder()

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
@@ -102,7 +102,7 @@ public abstract class LruGarbageCollectorTestCase {
     int targetId = ++previousTargetId;
     long sequenceNumber = persistence.getReferenceDelegate().getCurrentSequenceNumber();
     Query query = query("path" + targetId);
-    return new QueryData(query, targetId, sequenceNumber, QueryPurpose.LISTEN);
+    return new QueryData(query.toTarget(), targetId, sequenceNumber, QueryPurpose.LISTEN);
   }
 
   private void updateTargetInTransaction(QueryData queryData) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/QueryCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/QueryCacheTestCase.java
@@ -72,7 +72,7 @@ public abstract class QueryCacheTestCase {
 
   @Test
   public void testReadQueryNotInCache() {
-    assertNull(queryCache.getQueryData(query("rooms")));
+    assertNull(queryCache.getQueryData(query("rooms").toTarget()));
   }
 
   @Test
@@ -80,9 +80,9 @@ public abstract class QueryCacheTestCase {
     QueryData queryData = newQueryData(query("rooms"), 1, 1);
     addQueryData(queryData);
 
-    QueryData result = queryCache.getQueryData(query("rooms"));
+    QueryData result = queryCache.getQueryData(query("rooms").toTarget());
     assertNotNull(result);
-    assertEquals(queryData.getQuery(), result.getQuery());
+    assertEquals(queryData.getTarget(), result.getTarget());
     assertEquals(queryData.getTargetId(), result.getTargetId());
     assertEquals(queryData.getResumeToken(), result.getResumeToken());
   }
@@ -99,24 +99,24 @@ public abstract class QueryCacheTestCase {
     addQueryData(data1);
 
     // Using the other query should not return the query cache entry despite equal canonicalIDs.
-    assertNull(queryCache.getQueryData(q2));
-    assertEquals(data1, queryCache.getQueryData(q1));
+    assertNull(queryCache.getQueryData(q2.toTarget()));
+    assertEquals(data1, queryCache.getQueryData(q1.toTarget()));
 
     QueryData data2 = newQueryData(q2, 2, 1);
     addQueryData(data2);
     assertEquals(2, queryCache.getTargetCount());
 
-    assertEquals(data1, queryCache.getQueryData(q1));
-    assertEquals(data2, queryCache.getQueryData(q2));
+    assertEquals(data1, queryCache.getQueryData(q1.toTarget()));
+    assertEquals(data2, queryCache.getQueryData(q2.toTarget()));
 
     removeQueryData(data1);
-    assertNull(queryCache.getQueryData(q1));
-    assertEquals(data2, queryCache.getQueryData(q2));
+    assertNull(queryCache.getQueryData(q1.toTarget()));
+    assertEquals(data2, queryCache.getQueryData(q2.toTarget()));
     assertEquals(1, queryCache.getTargetCount());
 
     removeQueryData(data2);
-    assertNull(queryCache.getQueryData(q1));
-    assertNull(queryCache.getQueryData(q2));
+    assertNull(queryCache.getQueryData(q1.toTarget()));
+    assertNull(queryCache.getQueryData(q2.toTarget()));
     assertEquals(0, queryCache.getTargetCount());
   }
 
@@ -128,7 +128,7 @@ public abstract class QueryCacheTestCase {
     QueryData queryData2 = newQueryData(query("rooms"), 1, 2);
     addQueryData(queryData2);
 
-    QueryData result = queryCache.getQueryData(query("rooms"));
+    QueryData result = queryCache.getQueryData(query("rooms").toTarget());
 
     // There's no assertArrayNotEquals
     assertThat(queryData2.getResumeToken(), not(equalTo(queryData1.getResumeToken())));
@@ -145,14 +145,14 @@ public abstract class QueryCacheTestCase {
 
     removeQueryData(queryData1);
 
-    QueryData result = queryCache.getQueryData(query("rooms"));
+    QueryData result = queryCache.getQueryData(query("rooms").toTarget());
     assertNull(result);
   }
 
   @Test
   public void testRemoveNonExistentQuery() {
     // no-op, but make sure it doesn't throw.
-    assertDoesNotThrow(() -> queryCache.getQueryData(query("rooms")));
+    assertDoesNotThrow(() -> queryCache.getQueryData(query("rooms").toTarget()));
   }
 
   @Test
@@ -240,9 +240,9 @@ public abstract class QueryCacheTestCase {
     Query halls = query("halls");
     Query garages = query("garages");
 
-    QueryData query1 = new QueryData(rooms, 1, 10, QueryPurpose.LISTEN);
+    QueryData query1 = new QueryData(rooms.toTarget(), 1, 10, QueryPurpose.LISTEN);
     addQueryData(query1);
-    QueryData query2 = new QueryData(halls, 2, 20, QueryPurpose.LISTEN);
+    QueryData query2 = new QueryData(halls.toTarget(), 2, 20, QueryPurpose.LISTEN);
     addQueryData(query2);
     assertEquals(20, queryCache.getHighestListenSequenceNumber());
 
@@ -250,7 +250,7 @@ public abstract class QueryCacheTestCase {
     removeQueryData(query2);
     assertEquals(20, queryCache.getHighestListenSequenceNumber());
 
-    QueryData query3 = new QueryData(garages, 42, 100, QueryPurpose.LISTEN);
+    QueryData query3 = new QueryData(garages.toTarget(), 42, 100, QueryPurpose.LISTEN);
     addQueryData(query3);
     assertEquals(100, queryCache.getHighestListenSequenceNumber());
 
@@ -264,7 +264,7 @@ public abstract class QueryCacheTestCase {
   public void testHighestTargetId() {
     assertEquals(0, queryCache.getHighestTargetId());
 
-    QueryData query1 = new QueryData(query("rooms"), 1, 10, QueryPurpose.LISTEN);
+    QueryData query1 = new QueryData(query("rooms").toTarget(), 1, 10, QueryPurpose.LISTEN);
     addQueryData(query1);
 
     DocumentKey key1 = key("rooms/bar");
@@ -272,7 +272,7 @@ public abstract class QueryCacheTestCase {
     addMatchingKey(key1, 1);
     addMatchingKey(key2, 1);
 
-    QueryData query2 = new QueryData(query("halls"), 2, 20, QueryPurpose.LISTEN);
+    QueryData query2 = new QueryData(query("halls").toTarget(), 2, 20, QueryPurpose.LISTEN);
     addQueryData(query2);
     DocumentKey key3 = key("halls/foo");
     addMatchingKey(key3, 2);
@@ -283,7 +283,7 @@ public abstract class QueryCacheTestCase {
     assertEquals(2, queryCache.getHighestTargetId());
 
     // A query with an empty result set still counts.
-    QueryData query3 = new QueryData(query("garages"), 42, 100, QueryPurpose.LISTEN);
+    QueryData query3 = new QueryData(query("garages").toTarget(), 42, 100, QueryPurpose.LISTEN);
     addQueryData(query3);
     assertEquals(42, queryCache.getHighestTargetId());
 
@@ -324,7 +324,7 @@ public abstract class QueryCacheTestCase {
   private QueryData newQueryData(Query query, int targetId, long version) {
     long sequenceNumber = ++previousSequenceNumber;
     return new QueryData(
-        query,
+        query.toTarget(),
         targetId,
         sequenceNumber,
         QueryPurpose.LISTEN,

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteQueryCacheTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteQueryCacheTest.java
@@ -49,7 +49,7 @@ public final class SQLiteQueryCacheTest extends QueryCacheTestCase {
 
     Query query = query("rooms");
     QueryData queryData =
-        new QueryData(query, targetId, originalSequenceNumber, QueryPurpose.LISTEN);
+        new QueryData(query.toTarget(), targetId, originalSequenceNumber, QueryPurpose.LISTEN);
     db1.runTransaction(
         "add query data",
         () -> {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/MockDatastore.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/MockDatastore.java
@@ -82,7 +82,7 @@ public class MockDatastore extends Datastore {
       String resumeToken = Util.toDebugString(queryData.getResumeToken());
       SpecTestCase.log(
           "      watchQuery("
-              + queryData.getQuery()
+              + queryData.getTarget()
               + ", "
               + queryData.getTargetId()
               + ", "

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/RemoteSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/RemoteSerializerTest.java
@@ -451,16 +451,16 @@ public final class RemoteSerializerTest {
   @Test
   public void testEncodesListenRequestLabels() {
     Query query = query("collection/key");
-    QueryData queryData = new QueryData(query, 2, 3, QueryPurpose.LISTEN);
+    QueryData queryData = new QueryData(query.toTarget(), 2, 3, QueryPurpose.LISTEN);
 
     Map<String, String> result = serializer.encodeListenRequestLabels(queryData);
     assertNull(result);
 
-    queryData = new QueryData(query, 2, 3, QueryPurpose.LIMBO_RESOLUTION);
+    queryData = new QueryData(query.toTarget(), 2, 3, QueryPurpose.LIMBO_RESOLUTION);
     result = serializer.encodeListenRequestLabels(queryData);
     assertEquals(map("goog-listen-tags", "limbo-document"), result);
 
-    queryData = new QueryData(query, 2, 3, QueryPurpose.EXISTENCE_FILTER_MISMATCH);
+    queryData = new QueryData(query.toTarget(), 2, 3, QueryPurpose.EXISTENCE_FILTER_MISMATCH);
     result = serializer.encodeListenRequestLabels(queryData);
     assertEquals(map("goog-listen-tags", "existence-filter-mismatch"), result);
   }
@@ -468,7 +468,7 @@ public final class RemoteSerializerTest {
   @Test
   public void testEncodesFirstLevelKeyQueries() {
     Query q = Query.atPath(ResourcePath.fromString("docs/1"));
-    Target actual = serializer.encodeTarget(new QueryData(q, 1, 2, QueryPurpose.LISTEN));
+    Target actual = serializer.encodeTarget(new QueryData(q.toTarget(), 1, 2, QueryPurpose.LISTEN));
 
     DocumentsTarget.Builder docs =
         DocumentsTarget.newBuilder().addDocuments("projects/p/databases/d/documents/docs/1");
@@ -480,7 +480,9 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeDocumentsTarget(serializer.encodeDocumentsTarget(q)), q);
+    assertEquals(
+        serializer.decodeDocumentsTarget(serializer.encodeDocumentsTarget(q.toTarget())),
+        q.toTarget());
   }
 
   @Test
@@ -504,7 +506,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
@@ -529,7 +532,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
@@ -564,7 +568,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
@@ -625,7 +630,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
@@ -739,7 +745,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
@@ -767,7 +774,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
@@ -801,7 +809,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
@@ -826,7 +835,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
@@ -866,14 +876,15 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   @Test
   public void testEncodesResumeTokens() {
     Query q = Query.atPath(ResourcePath.fromString("docs"));
     QueryData queryData =
-        new QueryData(q, 1, 2, QueryPurpose.LISTEN)
+        new QueryData(q.toTarget(), 1, 2, QueryPurpose.LISTEN)
             .withResumeToken(TestUtil.resumeToken(1000), SnapshotVersion.NONE);
     Target actual = serializer.encodeTarget(queryData);
 
@@ -894,7 +905,8 @@ public final class RemoteSerializerTest {
             .build();
 
     assertEquals(expected, actual);
-    assertEquals(serializer.decodeQueryTarget(serializer.encodeQueryTarget(q)), q);
+    assertEquals(
+        serializer.decodeQueryTarget(serializer.encodeQueryTarget(q.toTarget())), q.toTarget());
   }
 
   /**
@@ -902,7 +914,7 @@ public final class RemoteSerializerTest {
    * QueryData, but for the most part we're just testing variations on Query.
    */
   private QueryData wrapQueryData(Query query) {
-    return new QueryData(query, 1, 2, QueryPurpose.LISTEN);
+    return new QueryData(query.toTarget(), 1, 2, QueryPurpose.LISTEN);
   }
 
   @Test

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -912,7 +912,8 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
           // spec tests. For now, hard-code that it's a listen despite the fact that it's not always
           // the right value.
           QueryData queryData =
-              new QueryData(query, targetId, ARBITRARY_SEQUENCE_NUMBER, QueryPurpose.LISTEN)
+              new QueryData(
+                      query.toTarget(), targetId, ARBITRARY_SEQUENCE_NUMBER, QueryPurpose.LISTEN)
                   .withResumeToken(ByteString.copyFromUtf8(resumeToken), SnapshotVersion.NONE);
           expectedActiveTargets.put(targetId, queryData);
         }
@@ -997,7 +998,7 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
       // TODO: validate the purpose of the target once it's possible to encode that in the
       // spec tests. For now, only validate properties that can be validated.
       // assertEquals(expectedTarget, actualTarget);
-      assertEquals(expectedTarget.getQuery(), actualTarget.getQuery());
+      assertEquals(expectedTarget.getTarget(), actualTarget.getTarget());
       assertEquals(expectedTarget.getTargetId(), actualTarget.getTargetId());
       assertEquals(expectedTarget.getSnapshotVersion(), actualTarget.getSnapshotVersion());
       assertEquals(

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -288,7 +288,7 @@ public class TestUtil {
   }
 
   public static QueryData queryData(int targetId, QueryPurpose queryPurpose, String path) {
-    return new QueryData(query(path), targetId, ARBITRARY_SEQUENCE_NUMBER, queryPurpose);
+    return new QueryData(query(path).toTarget(), targetId, ARBITRARY_SEQUENCE_NUMBER, queryPurpose);
   }
 
   public static ImmutableSortedMap<DocumentKey, MaybeDocument> docUpdates(MaybeDocument... docs) {
@@ -350,7 +350,7 @@ public class TestUtil {
     Map<Integer, QueryData> listenMap = new HashMap<>();
     for (Integer targetId : targets) {
       QueryData queryData =
-          new QueryData(query, targetId, ARBITRARY_SEQUENCE_NUMBER, QueryPurpose.LISTEN);
+          new QueryData(query.toTarget(), targetId, ARBITRARY_SEQUENCE_NUMBER, QueryPurpose.LISTEN);
       listenMap.put(targetId, queryData);
     }
     return listenMap;
@@ -366,7 +366,8 @@ public class TestUtil {
     Map<Integer, QueryData> listenMap = new HashMap<>();
     for (Integer targetId : targets) {
       QueryData queryData =
-          new QueryData(query, targetId, ARBITRARY_SEQUENCE_NUMBER, QueryPurpose.LIMBO_RESOLUTION);
+          new QueryData(
+              query.toTarget(), targetId, ARBITRARY_SEQUENCE_NUMBER, QueryPurpose.LIMBO_RESOLUTION);
       listenMap.put(targetId, queryData);
     }
     return listenMap;


### PR DESCRIPTION
First PR to implement limitToLast on Android.

Corresponding JS PR: https://github.com/firebase/firebase-js-sdk/pull/2254

Future PR will be:

[2/3] Make SyncEngine able to handle Query/Target Mapping.

[3/3] Implement limitToLast