### PR TITLE
Fix modifiers to address warnings

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/UploadMeasurementsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/UploadMeasurementsTask.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 
@@ -34,7 +35,7 @@ import org.gradle.api.tasks.TaskAction
  * property, {@code database_config} for connecting to the database. The format of this file is
  * dictated by the uploader tool.
  */
-public class UploadMeasurementsTask extends DefaultTask {
+class UploadMeasurementsTask extends DefaultTask {
 
     /**
      * The URL of the uploader tool.
@@ -83,6 +84,7 @@ public class UploadMeasurementsTask extends DefaultTask {
         }
     }
 
+    @Internal
     def getUploaderUrl() {
         return new URL(uploader)
     }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/coverage/GenerateMeasurementsTask.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/coverage/GenerateMeasurementsTask.groovy
@@ -24,14 +24,14 @@ import com.google.firebase.gradle.plugins.FirebaseLibraryExtension
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
 
-public class GenerateMeasurementsTask extends DefaultTask {
+class GenerateMeasurementsTask extends DefaultTask {
 
     @OutputFile
     File reportFile
 
-    XmlSlurper parser
+    private XmlSlurper parser
 
-    String coverageTaskName
+    private String coverageTaskName
 
     GenerateMeasurementsTask() {
         parser = new XmlSlurper()


### PR DESCRIPTION
Groovy classes are public by default, and fields/methods that are internal should be either private or marked as @internal. This PR addresses warnings from the groovy compiler.