### PR TITLE
[2.9/3] Implement limitToLast and add unit/integration tests.

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -91,57 +91,6 @@ public class QueryTest {
         "limitToLast() queries require specifying at least one orderBy() clause");
   }
 
-  @Test
-  public void testGetLimitToLastResultUsingDescendingOrder() {
-    CollectionReference collection =
-        testCollectionWithDocs(
-            map(
-                "a", map("k", "a", "sort", 0),
-                "b", map("k", "b", "sort", 1),
-                "c", map("k", "c", "sort", 1),
-                "d", map("k", "d", "sort", 2)));
-
-    Query query = collection.limitToLast(2).orderBy("sort", Direction.DESCENDING);
-    QuerySnapshot set = waitFor(query.get());
-    List<Map<String, Object>> data = querySnapshotToValues(set);
-    assertEquals(asList(map("k", "b", "sort", 1L), map("k", "a", "sort", 0L)), data);
-  }
-
-  @Test
-  public void testListenToLimitToLastViaSnapshot() {
-    CollectionReference collection =
-        testCollectionWithDocs(
-            map(
-                "a", map("k", "a", "sort", 0),
-                "b", map("k", "b", "sort", 1),
-                "c", map("k", "c", "sort", 1),
-                "d", map("k", "d", "sort", 2)));
-
-    List<QuerySnapshot> snapshots = new ArrayList<>();
-    Semaphore testCounter = new Semaphore(0);
-    Query query = collection.limitToLast(2).orderBy("sort", Direction.DESCENDING);
-
-    query.addSnapshotListener(
-        (snapshot, error) -> {
-          assertNull(error);
-          snapshots.add(snapshot);
-          testCounter.release();
-        });
-
-    waitFor(testCounter);
-
-    assertEquals(1, snapshots.size());
-    List<Map<String, Object>> data = querySnapshotToValues(snapshots.get(0));
-    assertEquals(asList(map("k", "b", "sort", 1L), map("k", "a", "sort", 0L)), data);
-
-    waitFor(collection.add(map("k", "e", "sort", -1)));
-    waitFor(testCounter);
-
-    assertEquals(2, snapshots.size());
-    data = querySnapshotToValues(snapshots.get(1));
-    assertEquals(asList(map("k", "a", "sort", 0L), map("k", "e", "sort", -1L)), data);
-  }
-
   // Two queries that mapped to the same target ID are referred to as
   // "mirror queries". An example for a mirror query is a limitToLast()
   // query and a limit() query that share the same backend Target ID.
@@ -149,7 +98,7 @@ public class QueryTest {
   // orderBy() clause, they can map to the same target representation as
   // limit() query, even if both queries appear separate to the user.
   @Test
-  public void testListenToMirrorQueries() {
+  public void testListenUnlistenRelistenSequenceOfMirrorQueries() {
     CollectionReference collection =
         testCollectionWithDocs(
             map(
@@ -158,203 +107,49 @@ public class QueryTest {
                 "c", map("k", "c", "sort", 1),
                 "d", map("k", "d", "sort", 2)));
 
-    List<QuerySnapshot> limitSnapshots = new ArrayList<>();
-    Semaphore limitTestCounter = new Semaphore(0);
+    // Setup `limit` query.
     Query limit = collection.limit(2).orderBy("sort", Direction.ASCENDING);
+    EventAccumulator<QuerySnapshot> limitAccumulator = new EventAccumulator<>();
+    ListenerRegistration limitRegistration = limit.addSnapshotListener(limitAccumulator.listener());
 
-    limit.addSnapshotListener(
-        (snapshot, error) -> {
-          assertNull(error);
-          limitSnapshots.add(snapshot);
-          limitTestCounter.release();
-        });
-
-    List<QuerySnapshot> limitToLastSnapshots = new ArrayList<>();
-    Semaphore limitToLastTestCounter = new Semaphore(0);
+    // Setup mirroring `limitToLast` query.
     Query limitToLast = collection.limitToLast(2).orderBy("sort", Direction.DESCENDING);
+    EventAccumulator<QuerySnapshot> limitToLastAccumulator = new EventAccumulator<>();
+    ListenerRegistration limitToLastRegistration =
+        limitToLast.addSnapshotListener(limitToLastAccumulator.listener());
 
-    limitToLast.addSnapshotListener(
-        (snapshot, error) -> {
-          assertNull(error);
-          limitToLastSnapshots.add(snapshot);
-          limitToLastTestCounter.release();
-        });
-
-    waitFor(limitTestCounter);
-    assertEquals(1, limitSnapshots.size());
-    List<Map<String, Object>> data = querySnapshotToValues(limitSnapshots.get(0));
+    // Verify both query get expected result.
+    List<Map<String, Object>> data = querySnapshotToValues(limitAccumulator.await());
     assertEquals(asList(map("k", "a", "sort", 0L), map("k", "b", "sort", 1L)), data);
-
-    waitFor(limitToLastTestCounter);
-    assertEquals(1, limitToLastSnapshots.size());
-    data = querySnapshotToValues(limitToLastSnapshots.get(0));
+    data = querySnapshotToValues(limitToLastAccumulator.await());
     assertEquals(asList(map("k", "b", "sort", 1L), map("k", "a", "sort", 0L)), data);
-
-    waitFor(collection.add(map("k", "e", "sort", -1)));
-
-    waitFor(limitTestCounter);
-    assertEquals(2, limitSnapshots.size());
-    data = querySnapshotToValues(limitSnapshots.get(1));
-    assertEquals(asList(map("k", "e", "sort", -1L), map("k", "a", "sort", 0L)), data);
-
-    waitFor(limitToLastTestCounter);
-    assertEquals(2, limitToLastSnapshots.size());
-    data = querySnapshotToValues(limitToLastSnapshots.get(1));
-    assertEquals(asList(map("k", "a", "sort", 0L), map("k", "e", "sort", -1L)), data);
-  }
-
-  @Test
-  public void testUnlistenFromMirrorQueries() {
-    CollectionReference collection =
-        testCollectionWithDocs(
-            map(
-                "a", map("k", "a", "sort", 0),
-                "b", map("k", "b", "sort", 1),
-                "c", map("k", "c", "sort", 1),
-                "d", map("k", "d", "sort", 2)));
-
-    List<QuerySnapshot> limitSnapshots = new ArrayList<>();
-    Semaphore limitTestCounter = new Semaphore(0);
-    Query limit = collection.limit(2).orderBy("sort", Direction.ASCENDING);
-
-    ListenerRegistration limitRegistration =
-        limit.addSnapshotListener(
-            (snapshot, error) -> {
-              assertNull(error);
-              limitSnapshots.add(snapshot);
-              limitTestCounter.release();
-            });
-
-    List<QuerySnapshot> limitToLastSnapshots = new ArrayList<>();
-    Semaphore limitToLastTestCounter = new Semaphore(0);
-    Query limitToLast = collection.limitToLast(2).orderBy("sort", Direction.DESCENDING);
-
-    ListenerRegistration limitToLastRegistration =
-        limitToLast.addSnapshotListener(
-            (snapshot, error) -> {
-              assertNull(error);
-              limitToLastSnapshots.add(snapshot);
-              limitToLastTestCounter.release();
-            });
-
-    waitFor(limitTestCounter);
-    assertEquals(1, limitSnapshots.size());
-
-    waitFor(limitToLastTestCounter);
-    assertEquals(1, limitToLastSnapshots.size());
-
-    limitRegistration.remove();
-
-    waitFor(collection.add(map("k", "e", "sort", -1)));
-
-    waitFor(limitToLastTestCounter);
-    assertEquals(2, limitToLastSnapshots.size());
-    List<Map<String, Object>> data = querySnapshotToValues(limitToLastSnapshots.get(1));
-    assertEquals(asList(map("k", "a", "sort", 0L), map("k", "e", "sort", -1L)), data);
-
-    limitToLastRegistration.remove();
-
-    waitFor(
-        collection
-            .add(map("k", "f", "sort", -1))
-            .continueWith(
-                task -> {
-                  limitTestCounter.release();
-                  limitToLastTestCounter.release();
-                  return null;
-                }));
-
-    waitFor(limitTestCounter);
-    waitFor(limitToLastTestCounter);
-
-    assertEquals(1, limitSnapshots.size());
-    assertEquals(2, limitToLastSnapshots.size());
-  }
-
-  @Test
-  public void testRelistenToMirrorQueries() {
-    CollectionReference collection =
-        testCollectionWithDocs(
-            map(
-                "a", map("k", "a", "sort", 0),
-                "b", map("k", "b", "sort", 1),
-                "c", map("k", "c", "sort", 1),
-                "d", map("k", "d", "sort", 2)));
-
-    List<QuerySnapshot> limitSnapshots = new ArrayList<>();
-    Semaphore limitTestCounter = new Semaphore(0);
-    Query limit = collection.limit(2).orderBy("sort", Direction.ASCENDING);
-
-    ListenerRegistration limitRegistration =
-        limit.addSnapshotListener(
-            (snapshot, error) -> {
-              assertNull(error);
-              limitSnapshots.add(snapshot);
-              limitTestCounter.release();
-            });
-
-    List<QuerySnapshot> limitToLastSnapshots = new ArrayList<>();
-    Semaphore limitToLastTestCounter = new Semaphore(0);
-    Query limitToLast = collection.limitToLast(2).orderBy("sort", Direction.DESCENDING);
-
-    ListenerRegistration limitToLastRegistration =
-        limitToLast.addSnapshotListener(
-            (snapshot, error) -> {
-              assertNull(error);
-              limitToLastSnapshots.add(snapshot);
-              limitToLastTestCounter.release();
-            });
-
-    waitFor(limitTestCounter);
-    assertEquals(1, limitSnapshots.size());
-
-    waitFor(limitToLastTestCounter);
-    assertEquals(1, limitToLastSnapshots.size());
 
     // Unlisten then re-listen limit query.
     limitRegistration.remove();
-    limit.addSnapshotListener(
-        (snapshot, error) -> {
-          assertNull(error);
-          limitSnapshots.add(snapshot);
-          limitTestCounter.release();
-        });
+    limit.addSnapshotListener(limitAccumulator.listener());
 
-    waitFor(limitTestCounter);
-    assertEquals(2, limitSnapshots.size());
-    List<Map<String, Object>> data = querySnapshotToValues(limitSnapshots.get(1));
+    // Verify `limit` query still works.
+    data = querySnapshotToValues(limitAccumulator.await());
     assertEquals(asList(map("k", "a", "sort", 0L), map("k", "b", "sort", 1L)), data);
 
+    // Add a document that would change the result set.
     waitFor(collection.add(map("k", "e", "sort", -1)));
 
-    waitFor(limitTestCounter);
-    assertEquals(3, limitSnapshots.size());
-    data = querySnapshotToValues(limitSnapshots.get(2));
+    // Verify both query get expected result.
+    data = querySnapshotToValues(limitAccumulator.await());
     assertEquals(asList(map("k", "e", "sort", -1L), map("k", "a", "sort", 0L)), data);
-
-    waitFor(limitToLastTestCounter);
-    assertEquals(2, limitToLastSnapshots.size());
-    data = querySnapshotToValues(limitToLastSnapshots.get(1));
+    data = querySnapshotToValues(limitToLastAccumulator.await());
     assertEquals(asList(map("k", "a", "sort", 0L), map("k", "e", "sort", -1L)), data);
 
     // Unlisten to limitToLast, update a doc, then relisten to limitToLast
     limitToLastRegistration.remove();
     waitFor(collection.document("a").update(map("k", "a", "sort", -2)));
-    limitToLast.addSnapshotListener(
-        (snapshot, error) -> {
-          assertNull(error);
-          limitToLastSnapshots.add(snapshot);
-          limitToLastTestCounter.release();
-        });
+    limitToLast.addSnapshotListener(limitToLastAccumulator.listener());
 
-    waitFor(limitTestCounter);
-    assertEquals(4, limitSnapshots.size());
-    data = querySnapshotToValues(limitSnapshots.get(3));
+    // Verify both query get expected result.
+    data = querySnapshotToValues(limitAccumulator.await());
     assertEquals(asList(map("k", "a", "sort", -2L), map("k", "e", "sort", -1L)), data);
-
-    waitFor(limitToLastTestCounter);
-    assertEquals(3, limitToLastSnapshots.size());
-    data = querySnapshotToValues(limitToLastSnapshots.get(2));
+    data = querySnapshotToValues(limitToLastAccumulator.await());
     assertEquals(asList(map("k", "e", "sort", -1L), map("k", "a", "sort", -2L)), data);
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -401,6 +401,12 @@ public class ValidationTest {
     expectError(
         () -> collection.limit(-1),
         "Invalid Query. Query limit (-1) is invalid. Limit must be positive.");
+    expectError(
+        () -> collection.limitToLast(0),
+        "Invalid Query. Query limitToLast (0) is invalid. Limit must be positive.");
+    expectError(
+        () -> collection.limitToLast(-1),
+        "Invalid Query. Query limitToLast (-1) is invalid. Limit must be positive.");
   }
 
   @Test

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -574,8 +574,8 @@ public class Query {
   }
 
   /**
-   * Creates and returns a new {@code Query} that's additionally limited to only return up to the
-   * specified number of documents.
+   * Creates and returns a new {@code Query} that only returns the first matching documents up to
+   * the specified number.
    *
    * @param limit The maximum number of items to return.
    * @return The created {@code Query}.
@@ -587,6 +587,25 @@ public class Query {
           "Invalid Query. Query limit (" + limit + ") is invalid. Limit must be positive.");
     }
     return new Query(query.limit(limit), firestore);
+  }
+
+  /**
+   * Creates and returns a new {@code Query} that only returns the last matching documents up to the
+   * specified number.
+   *
+   * <p>You must specify at least one {@code orderBy} clause for {@code limitToLast} queries,
+   * otherwise an exception will be thrown during execution.
+   *
+   * @param limit The maximum number of items to return.
+   * @return The created {@code Query}.
+   */
+  @NonNull
+  public Query limitToLast(long limit) {
+    if (limit <= 0) {
+      throw new IllegalArgumentException(
+          "Invalid Query. Query limit (" + limit + ") is invalid. Limit must be positive.");
+    }
+    return new Query(query.limitToLast(limit), firestore);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Query.java
@@ -152,13 +152,31 @@ public final class Query {
    * The maximum number of results to return. If there is no limit on the query, then this will
    * cause an assertion failure.
    */
-  public long getLimit() {
-    hardAssert(hasLimit(), "Called getLimit when no limit was set");
+  public long getLimitToFirst() {
+    hardAssert(hasLimitToFirst(), "Called getLimitToFirst when no limit was set");
     return limit;
   }
 
-  public boolean hasLimit() {
-    return limit != Target.NO_LIMIT;
+  public boolean hasLimitToFirst() {
+    return limitType == LimitType.LIMIT_TO_FIRST && limit != Target.NO_LIMIT;
+  }
+
+  /**
+   * The maximum number of last-matching results to return. If there is no limit on the query, then
+   * this will cause an assertion failure.
+   */
+  public long getLimitToLast() {
+    hardAssert(hasLimitToLast(), "Called getLimitToLast when no limit was set");
+    return limit;
+  }
+
+  public boolean hasLimitToLast() {
+    return limitType == LimitType.LIMIT_TO_LAST && limit != Target.NO_LIMIT;
+  }
+
+  public LimitType getLimitType() {
+    hardAssert(hasLimitToLast() || hasLimitToFirst(), "Called getLimitType when no limit was set");
+    return limitType;
   }
 
   /** An optional bound to start the query at. */
@@ -268,7 +286,7 @@ public final class Query {
    * @param limit The maximum number of results to return. If {@code limit == NO_LIMIT}, then no
    *     limit is applied. Otherwise, if {@code limit <= 0}, behavior is unspecified.
    */
-  public Query limit(long limit) {
+  public Query limitToFirst(long limit) {
     return new Query(
         path,
         collectionGroup,

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
@@ -144,8 +144,12 @@ public class View {
     // Note that this should never get used in a refill (when previousChanges is set), because there
     // will only be adds -- no deletes or updates.
     Document lastDocInLimit =
-        (query.hasLimit() && oldDocumentSet.size() == query.getLimit())
+        (query.hasLimitToFirst() && oldDocumentSet.size() == query.getLimitToFirst())
             ? oldDocumentSet.getLastDocument()
+            : null;
+    Document firstDocInLimit =
+        (query.hasLimitToLast() && oldDocumentSet.size() == query.getLimitToLast())
+            ? oldDocumentSet.getFirstDocument()
             : null;
 
     for (Map.Entry<DocumentKey, ? extends MaybeDocument> entry : docChanges) {
@@ -190,9 +194,11 @@ public class View {
             changeSet.addChange(DocumentViewChange.create(Type.MODIFIED, newDoc));
             changeApplied = true;
 
-            if (lastDocInLimit != null && query.comparator().compare(newDoc, lastDocInLimit) > 0) {
-              // This doc moved from inside the limit to after the limit. That means there may be
-              // some doc in the local cache that's actually less than this one.
+            if ((lastDocInLimit != null && query.comparator().compare(newDoc, lastDocInLimit) > 0)
+                || (firstDocInLimit != null
+                    && query.comparator().compare(newDoc, firstDocInLimit) < 0)) {
+              // This doc moved from inside the limit to outside the limit. That means there may be
+              // some doc in the local cache that should be included instead.
               needsRefill = true;
             }
           }
@@ -206,7 +212,7 @@ public class View {
       } else if (oldDoc != null && newDoc == null) {
         changeSet.addChange(DocumentViewChange.create(Type.REMOVED, oldDoc));
         changeApplied = true;
-        if (lastDocInLimit != null) {
+        if (lastDocInLimit != null || firstDocInLimit != null) {
           // A doc was removed from a full limit query. We'll need to requery from the local cache
           // to see if we know about some other doc that should be in the results.
           needsRefill = true;
@@ -228,9 +234,14 @@ public class View {
       }
     }
 
-    if (query.hasLimit()) {
-      for (long i = newDocumentSet.size() - this.query.getLimit(); i > 0; --i) {
-        Document oldDoc = newDocumentSet.getLastDocument();
+    // Drop documents out to meet limitToFirst/limitToLast requirement.
+    if (query.hasLimitToFirst() || query.hasLimitToLast()) {
+      long limit = query.hasLimitToFirst() ? query.getLimitToFirst() : query.getLimitToLast();
+      for (long i = newDocumentSet.size() - limit; i > 0; --i) {
+        Document oldDoc =
+            query.hasLimitToFirst()
+                ? newDocumentSet.getLastDocument()
+                : newDocumentSet.getFirstDocument();
         newDocumentSet = newDocumentSet.remove(oldDoc.getKey());
         newMutatedKeys = newMutatedKeys.remove(oldDoc.getKey());
         changeSet.addChange(DocumentViewChange.create(Type.REMOVED, oldDoc));

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -584,16 +584,14 @@ public final class LocalStore {
   /**
    * Unpin all the documents associated with the given target.
    *
-   * <p>Releasing a non-existing target is a no-op.
+   * <p>Releasing a non-existing target is an error.
    */
   public void releaseTarget(int targetId) {
     persistence.runTransaction(
         "Release target",
         () -> {
           QueryData queryData = queryDataByTarget.get(targetId);
-          if (queryData == null) {
-            return;
-          }
+          hardAssert(queryData != null, "Tried to release nonexistent target: %s", targetId);
 
           // References for documents sent via Watch are automatically removed when we delete a
           // query's target data from the reference delegate. Since this does not remove references

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
@@ -807,7 +807,16 @@ public final class RemoteSerializer {
       endAt = decodeBound(query.getEndAt());
     }
 
-    return new Query(path, collectionGroup, filterBy, orderBy, limit, startAt, endAt).toTarget();
+    return new Query(
+            path,
+            collectionGroup,
+            filterBy,
+            orderBy,
+            limit,
+            Query.LimitType.LIMIT_TO_FIRST,
+            startAt,
+            endAt)
+        .toTarget();
   }
 
   // Filters

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
@@ -351,17 +351,15 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
   /**
    * Stops listening to the target with the given target ID.
    *
-   * <p>It is a no-op if the given target id is not being listened to.
+   * <p>It is an error if the given target id is not being listened to.
    *
    * <p>If this is called with the last active targetId, the watch stream enters idle mode and will
    * be torn down after one minute of inactivity.
    */
   public void stopListening(int targetId) {
-    if (!listenTargets.containsKey(targetId)) {
-      return;
-    }
-
-    listenTargets.remove(targetId);
+    QueryData queryData = listenTargets.remove(targetId);
+    hardAssert(
+        queryData != null, "stopListening called on target no currently watched: %d", targetId);
 
     // The watch stream might not be started if we're in a disconnected state
     if (watchStream.isOpen()) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
@@ -479,7 +479,7 @@ public class QueryTest {
             .filter(filter("bar", ">", 2))
             .orderBy(orderBy("bar"));
 
-    Query q7a = Query.atPath(ResourcePath.fromString("foo")).limit(10);
+    Query q7a = Query.atPath(ResourcePath.fromString("foo")).limitToFirst(10);
 
     // TODO: Add test cases with{Lower,Upper}Bound once cursors are implemented.
     testEquality(
@@ -544,7 +544,7 @@ public class QueryTest {
     query = baseQuery.filter(filter("foo", "==", "bar"));
     assertFalse(query.matchesAllDocuments());
 
-    query = baseQuery.limit(1);
+    query = baseQuery.limitToFirst(1);
     assertFalse(query.matchesAllDocuments());
 
     query = baseQuery.startAt(new Bound(Collections.emptyList(), true));

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewTest.java
@@ -198,7 +198,7 @@ public class ViewTest {
 
   @Test
   public void testRemovesDocumentsForQueryWithLimit() {
-    Query query = messageQuery().limit(2);
+    Query query = messageQuery().limitToFirst(2);
     View view = new View(query, DocumentKey.emptyKeySet());
 
     Document doc1 = doc("rooms/eros/messages/1", 0, map("text", "msg1"));
@@ -225,7 +225,7 @@ public class ViewTest {
 
   @Test
   public void testDoesNotReportChangesForDocumentBeyondLimit() {
-    Query query = messageQuery().orderBy(orderBy("num")).limit(2);
+    Query query = messageQuery().orderBy(orderBy("num")).limitToFirst(2);
     View view = new View(query, DocumentKey.emptyKeySet());
 
     Document doc1 = doc("rooms/eros/messages/1", 0, map("num", 1));
@@ -345,7 +345,7 @@ public class ViewTest {
 
   @Test
   public void testReturnsNeedsRefillOnDeleteInLimitQuery() {
-    Query query = messageQuery().limit(2);
+    Query query = messageQuery().limitToFirst(2);
     Document doc1 = doc("rooms/eros/messages/0", 0, map());
     Document doc2 = doc("rooms/eros/messages/1", 0, map());
     View view = new View(query, DocumentKey.emptyKeySet());
@@ -372,7 +372,7 @@ public class ViewTest {
 
   @Test
   public void testReturnsNeedsRefillOnReorderInLimitQuery() {
-    Query query = messageQuery().orderBy(orderBy("order")).limit(2);
+    Query query = messageQuery().orderBy(orderBy("order")).limitToFirst(2);
     Document doc1 = doc("rooms/eros/messages/0", 0, map("order", 1));
     Document doc2 = doc("rooms/eros/messages/1", 0, map("order", 2));
     Document doc3 = doc("rooms/eros/messages/2", 0, map("order", 3));
@@ -401,7 +401,7 @@ public class ViewTest {
 
   @Test
   public void testDoesNotNeedRefillOnReorderWithinLimit() {
-    Query query = messageQuery().orderBy(orderBy("order")).limit(3);
+    Query query = messageQuery().orderBy(orderBy("order")).limitToFirst(3);
     Document doc1 = doc("rooms/eros/messages/0", 0, map("order", 1));
     Document doc2 = doc("rooms/eros/messages/1", 0, map("order", 2));
     Document doc3 = doc("rooms/eros/messages/2", 0, map("order", 3));
@@ -427,7 +427,7 @@ public class ViewTest {
 
   @Test
   public void testDoesNotNeedRefillOnReorderAfterLimitQuery() {
-    Query query = messageQuery().orderBy(orderBy("order")).limit(3);
+    Query query = messageQuery().orderBy(orderBy("order")).limitToFirst(3);
     Document doc1 = doc("rooms/eros/messages/0", 0, map("order", 1));
     Document doc2 = doc("rooms/eros/messages/1", 0, map("order", 2));
     Document doc3 = doc("rooms/eros/messages/2", 0, map("order", 3));
@@ -453,7 +453,7 @@ public class ViewTest {
 
   @Test
   public void testDoesNotNeedRefillForAdditionAfterTheLimit() {
-    Query query = messageQuery().limit(2);
+    Query query = messageQuery().limitToFirst(2);
     Document doc1 = doc("rooms/eros/messages/0", 0, map());
     Document doc2 = doc("rooms/eros/messages/1", 0, map());
     View view = new View(query, DocumentKey.emptyKeySet());
@@ -475,7 +475,7 @@ public class ViewTest {
 
   @Test
   public void testDoesNotNeedRefillForDeletionsWhenNotNearTheLimit() {
-    Query query = messageQuery().limit(20);
+    Query query = messageQuery().limitToFirst(20);
     Document doc1 = doc("rooms/eros/messages/0", 0, map());
     Document doc2 = doc("rooms/eros/messages/1", 0, map());
     View view = new View(query, DocumentKey.emptyKeySet());
@@ -496,7 +496,7 @@ public class ViewTest {
 
   @Test
   public void testHandlesApplyingIrrelevantDocs() {
-    Query query = messageQuery().limit(2);
+    Query query = messageQuery().limitToFirst(2);
     Document doc1 = doc("rooms/eros/messages/0", 0, map());
     Document doc2 = doc("rooms/eros/messages/1", 0, map());
     View view = new View(query, DocumentKey.emptyKeySet());
@@ -536,7 +536,7 @@ public class ViewTest {
 
   @Test
   public void testRemovesKeysFromMutatedDocumentKeysWhenNewDocDoesNotHaveChanges() {
-    Query query = messageQuery().limit(2);
+    Query query = messageQuery().limitToFirst(2);
     Document doc1 = doc("rooms/eros/messages/0", 0, map());
     Document doc2 = doc("rooms/eros/messages/1", 0, map(), Document.DocumentState.LOCAL_MUTATIONS);
     View view = new View(query, DocumentKey.emptyKeySet());
@@ -555,7 +555,7 @@ public class ViewTest {
 
   @Test
   public void testRemembersLocalMutationsFromPreviousSnapshot() {
-    Query query = messageQuery().limit(2);
+    Query query = messageQuery().limitToFirst(2);
     Document doc1 = doc("rooms/eros/messages/0", 0, map());
     Document doc2 = doc("rooms/eros/messages/1", 0, map(), Document.DocumentState.LOCAL_MUTATIONS);
     View view = new View(query, DocumentKey.emptyKeySet());
@@ -572,7 +572,7 @@ public class ViewTest {
 
   @Test
   public void testRemembersLocalMutationsFromPreviousCallToComputeChanges() {
-    Query query = messageQuery().limit(2);
+    Query query = messageQuery().limitToFirst(2);
     Document doc1 = doc("rooms/eros/messages/0", 0, map());
     Document doc2 = doc("rooms/eros/messages/1", 0, map(), Document.DocumentState.LOCAL_MUTATIONS);
     View view = new View(query, DocumentKey.emptyKeySet());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexFreeQueryEngineTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexFreeQueryEngineTest.java
@@ -217,7 +217,26 @@ public class IndexFreeQueryEngineTest {
 
   @Test
   public void doesNotUseInitialResultsForLimitQueryWithDocumentRemoval() throws Exception {
-    Query query = query("coll").filter(filter("matches", "==", true)).limit(1);
+    Query query = query("coll").filter(filter("matches", "==", true)).limitToFirst(1);
+
+    // While the backend would never add DocA to the set of remote keys, this allows us to easily
+    // simulate what would happen when a document no longer matches due to an out-of-band update.
+    addDocument(NON_MATCHING_DOC_A);
+    persistQueryMapping(NON_MATCHING_DOC_A.getKey());
+
+    addDocument(MATCHING_DOC_B);
+
+    DocumentSet docs = expectFullCollectionQuery(() -> runQuery(query, LAST_LIMBO_FREE_SNAPSHOT));
+    assertEquals(docSet(query.comparator(), MATCHING_DOC_B), docs);
+  }
+
+  @Test
+  public void doesNotUseInitialResultsForLimitToLastQueryWithDocumentRemoval() throws Exception {
+    Query query =
+        query("coll")
+            .filter(filter("matches", "==", true))
+            .orderBy(orderBy("order", "desc"))
+            .limitToLast(1);
 
     // While the backend would never add DocA to the set of remote keys, this allows us to easily
     // simulate what would happen when a document no longer matches due to an out-of-band update.
@@ -237,7 +256,27 @@ public class IndexFreeQueryEngineTest {
         query("coll")
             .filter(filter("matches", "==", true))
             .orderBy(orderBy("order", "desc"))
-            .limit(1);
+            .limitToFirst(1);
+
+    // Add a query mapping for a document that matches, but that sorts below another document due to
+    // a pending write.
+    addDocument(PENDING_MATCHING_DOC_A);
+    persistQueryMapping(PENDING_MATCHING_DOC_A.getKey());
+
+    addDocument(MATCHING_DOC_B);
+
+    DocumentSet docs = expectFullCollectionQuery(() -> runQuery(query, LAST_LIMBO_FREE_SNAPSHOT));
+    assertEquals(docSet(query.comparator(), MATCHING_DOC_B), docs);
+  }
+
+  @Test
+  public void doesNotUseInitialResultsForLimitToLastQueryWhenLastDocumentHasPendingWrite()
+      throws Exception {
+    Query query =
+        query("coll")
+            .filter(filter("matches", "==", true))
+            .orderBy(orderBy("order", "asc"))
+            .limitToLast(1);
 
     // Add a query mapping for a document that matches, but that sorts below another document due to
     // a pending write.
@@ -257,7 +296,27 @@ public class IndexFreeQueryEngineTest {
         query("coll")
             .filter(filter("matches", "==", true))
             .orderBy(orderBy("order", "desc"))
-            .limit(1);
+            .limitToFirst(1);
+
+    // Add a query mapping for a document that matches, but that sorts below another document based
+    // due to an update that the SDK received after the query's snapshot was persisted.
+    addDocument(UPDATED_DOC_A);
+    persistQueryMapping(UPDATED_DOC_A.getKey());
+
+    addDocument(MATCHING_DOC_B);
+
+    DocumentSet docs = expectFullCollectionQuery(() -> runQuery(query, LAST_LIMBO_FREE_SNAPSHOT));
+    assertEquals(docSet(query.comparator(), MATCHING_DOC_B), docs);
+  }
+
+  @Test
+  public void doesNotUseInitialResultsForLimitToLastQueryWhenFirstDocumentHasBeenUpdatedOutOfBand()
+      throws Exception {
+    Query query =
+        query("coll")
+            .filter(filter("matches", "==", true))
+            .orderBy(orderBy("order", "asc"))
+            .limitToLast(1);
 
     // Add a query mapping for a document that matches, but that sorts below another document based
     // due to an update that the SDK received after the query's snapshot was persisted.
@@ -272,7 +331,7 @@ public class IndexFreeQueryEngineTest {
 
   @Test
   public void limitQueriesUseInitialResultsIfLastDocumentInLimitIsUnchanged() throws Exception {
-    Query query = query("coll").orderBy(orderBy("order")).limit(2);
+    Query query = query("coll").orderBy(orderBy("order")).limitToFirst(2);
 
     addDocument(doc("coll/a", 1, map("order", 1)));
     addDocument(doc("coll/b", 1, map("order", 3)));

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/RemoteSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/RemoteSerializerTest.java
@@ -815,7 +815,7 @@ public final class RemoteSerializerTest {
 
   @Test
   public void testEncodesLimits() {
-    Query q = Query.atPath(ResourcePath.fromString("docs")).limit(26);
+    Query q = Query.atPath(ResourcePath.fromString("docs")).limitToFirst(26);
     Target actual = serializer.encodeTarget(wrapQueryData(q));
 
     StructuredQuery.Builder structuredQueryBuilder =

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -337,7 +337,7 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
           queryDict.has("collectionGroup") ? queryDict.getString("collectionGroup") : null;
       Query query = new Query(ResourcePath.fromString(path), collectionGroup);
       if (queryDict.has("limit")) {
-        query = query.limit(queryDict.getLong("limit"));
+        query = query.limitToFirst(queryDict.getLong("limit"));
       }
       if (queryDict.has("filters")) {
         JSONArray array = queryDict.getJSONArray("filters");


### PR DESCRIPTION
This PR implements limitToLast and adds unit and integration tests to test limitToLast and mirror queries.

We still have one more PR to do, which is make spec test work with both query and target and add a spec tests where backend rejects mirror queries.