### PR TITLE
Pass User Properties to RC Fetch Request as a JSONObject

### DIFF
--- a/firebase-config/bandwagoner/bandwagoner.gradle
+++ b/firebase-config/bandwagoner/bandwagoner.gradle
@@ -53,6 +53,7 @@ android {
 
 firebaseTestLab {
     device 'model=walleye,version=26,locale=en,orientation=portrait'
+    device 'model=walleye,version=17,locale=en,orientation=portrait'
 
 }
 

--- a/firebase-config/bandwagoner/bandwagoner.gradle
+++ b/firebase-config/bandwagoner/bandwagoner.gradle
@@ -52,10 +52,8 @@ android {
 }
 
 firebaseTestLab {
-    devices = [
-      'model=walleye,version=26,locale=en,orientation=portrait',
-      'model=walleye,version=16,locale=en,orientation=portrait',
-    ]
+    device 'model=walleye,version=26,locale=en,orientation=portrait'
+    device 'model=walleye,version=16,locale=en,orientation=portrait'
 }
 
 dependencies {

--- a/firebase-config/bandwagoner/bandwagoner.gradle
+++ b/firebase-config/bandwagoner/bandwagoner.gradle
@@ -52,9 +52,10 @@ android {
 }
 
 firebaseTestLab {
-    device 'model=walleye,version=26,locale=en,orientation=portrait'
-    device 'model=walleye,version=17,locale=en,orientation=portrait'
-
+    devices = [
+      'model=walleye,version=26,locale=en,orientation=portrait',
+      'model=walleye,version=16,locale=en,orientation=portrait',
+    ]
 }
 
 dependencies {

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -310,7 +310,7 @@ public class ConfigFetchHttpClient {
     requestBodyMap.put(PACKAGE_NAME, context.getPackageName());
     requestBodyMap.put(SDK_VERSION, BuildConfig.VERSION_NAME);
 
-    requestBodyMap.put(ANALYTICS_USER_PROPERTIES, analyticsUserProperties);
+    requestBodyMap.put(ANALYTICS_USER_PROPERTIES, new JSONObject(analyticsUserProperties));
 
     return new JSONObject(requestBodyMap);
   }


### PR DESCRIPTION
Previously, the Remote Config SDK would directly `put` a String Map of GA User Properties as value in the Fetch Request JSONObject. This is undocumented behavior as `JSONObject#put` doesn't accept a `Map` as a value: https://developer.android.com/reference/org/json/JSONObject.html#put(java.lang.String,%20java.lang.Object)

This was resulting in issues with API 19 and below https://github.com/firebase/firebase-android-sdk/issues/973

The solution is to create a JSONObject out of the Map (https://developer.android.com/reference/org/json/JSONObject.html#JSONObject(java.util.Map)), before passing that into the `put`.

As Integration tests were only run on API Level 26, this issue was not previously caught. As such, as part of this PR, we ensure that Integration Tests are run on API Level 16 as well.