### PR TITLE
Add encoding support multiple types

### DIFF
--- a/encoders/firebase-encoders/api.txt
+++ b/encoders/firebase-encoders/api.txt
@@ -18,6 +18,7 @@ package com.google.firebase.encoders {
     method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, @Nullable Object) throws com.google.firebase.encoders.EncodingException;
     method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, double) throws com.google.firebase.encoders.EncodingException;
     method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, int) throws com.google.firebase.encoders.EncodingException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, long) throws com.google.firebase.encoders.EncodingException;
     method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, boolean) throws com.google.firebase.encoders.EncodingException;
   }
 
@@ -28,6 +29,7 @@ package com.google.firebase.encoders {
     method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(@Nullable String) throws com.google.firebase.encoders.EncodingException;
     method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(double) throws com.google.firebase.encoders.EncodingException;
     method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(int) throws com.google.firebase.encoders.EncodingException;
+    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(long) throws com.google.firebase.encoders.EncodingException;
     method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(boolean) throws com.google.firebase.encoders.EncodingException;
     method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(@NonNull byte[]) throws com.google.firebase.encoders.EncodingException;
   }

--- a/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/ObjectEncoderContext.java
+++ b/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/ObjectEncoderContext.java
@@ -56,10 +56,13 @@ public interface ObjectEncoderContext {
   ObjectEncoderContext add(@NonNull String name, double value)
       throws IOException, EncodingException;
 
-  // TODO: Add support for `long`.
   /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
   @NonNull
   ObjectEncoderContext add(@NonNull String name, int value) throws IOException, EncodingException;
+
+  /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
+  @NonNull
+  ObjectEncoderContext add(@NonNull String name, long value) throws IOException, EncodingException;
 
   /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
   @NonNull

--- a/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/ValueEncoderContext.java
+++ b/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/ValueEncoderContext.java
@@ -34,10 +34,13 @@ public interface ValueEncoderContext {
   @NonNull
   ValueEncoderContext add(double value) throws IOException, EncodingException;
 
-  // TODO: Add support for `long`.
   /** Adds {@code value} as a primitive encoded value. */
   @NonNull
   ValueEncoderContext add(int value) throws IOException, EncodingException;
+
+  /** Adds {@code value} as a primitive encoded value. */
+  @NonNull
+  ValueEncoderContext add(long value) throws IOException, EncodingException;
 
   /** Adds {@code value} as a primitive encoded value. */
   @NonNull

--- a/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
+++ b/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
@@ -53,15 +53,11 @@ public final class JsonDataEncoderBuilder {
   }
 
   private static final ValueEncoder<String> STRING_ENCODER = (o, ctx) -> ctx.add(o);
-  private static final ValueEncoder<Integer> INTEGER_ENCODER = (o, ctx) -> ctx.add(o);
-  private static final ValueEncoder<Double> DOUBLE_ENCODER = (o, ctx) -> ctx.add(o);
   private static final ValueEncoder<Boolean> BOOLEAN_ENCODER = (o, ctx) -> ctx.add(o);
   private static final TimestampEncoder TIMESTAMP_ENCODER = new TimestampEncoder();
 
   public JsonDataEncoderBuilder() {
     registerEncoder(String.class, STRING_ENCODER);
-    registerEncoder(Integer.class, INTEGER_ENCODER);
-    registerEncoder(Double.class, DOUBLE_ENCODER);
     registerEncoder(Boolean.class, BOOLEAN_ENCODER);
     registerEncoder(Date.class, TIMESTAMP_ENCODER);
   }

--- a/encoders/firebase-encoders/src/test/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContextTest.java
+++ b/encoders/firebase-encoders/src/test/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContextTest.java
@@ -61,6 +61,7 @@ public class JsonValueObjectEncoderContextTest {
         (o, ctx) -> {
           ctx.add("String", "string")
               .add("int", 2)
+              .add("long", 42L)
               .add("double", 2.2d)
               .add("boolean", false)
               .add("null", null);
@@ -74,7 +75,7 @@ public class JsonValueObjectEncoderContextTest {
 
     assertThat(result)
         .isEqualTo(
-            "{\"String\":\"string\",\"int\":2,\"double\":2.2,\"boolean\":false,\"null\":null}");
+            "{\"String\":\"string\",\"int\":2,\"long\":42,\"double\":2.2,\"boolean\":false,\"null\":null}");
   }
 
   @Test

--- a/encoders/firebase-encoders/src/test/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContextTest.java
+++ b/encoders/firebase-encoders/src/test/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContextTest.java
@@ -60,10 +60,10 @@ public class JsonValueObjectEncoderContextTest {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("String", "string")
-              .add("Integer", 2)
-              .add("Double", 2.2d)
-              .add("Boolean", false)
-              .add("Null", null);
+              .add("int", 2)
+              .add("double", 2.2d)
+              .add("boolean", false)
+              .add("null", null);
         };
 
     String result =
@@ -74,7 +74,7 @@ public class JsonValueObjectEncoderContextTest {
 
     assertThat(result)
         .isEqualTo(
-            "{\"String\":\"string\",\"Integer\":2,\"Double\":2.2,\"Boolean\":false,\"Null\":null}");
+            "{\"String\":\"string\",\"int\":2,\"double\":2.2,\"boolean\":false,\"null\":null}");
   }
 
   @Test
@@ -98,10 +98,11 @@ public class JsonValueObjectEncoderContextTest {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("String", new String[] {"string1", "string2"})
-              .add("Integer", new int[] {1, 2})
-              .add("Double", new double[] {1.1d, 2.2d})
-              .add("Boolean", new boolean[] {true, false})
-              .add("Null", new String[] {null, null});
+              .add("int", new int[] {1, 2})
+              .add("long", new long[] {3L, 4L})
+              .add("double", new double[] {1.1d, 2.2d})
+              .add("boolean", new boolean[] {true, false})
+              .add("null", new String[] {null, null});
         };
 
     String result =
@@ -113,8 +114,64 @@ public class JsonValueObjectEncoderContextTest {
     assertThat(result)
         .isEqualTo(
             String.format(
-                "{\"String\":%s,\"Integer\":%s,\"Double\":%s,\"Boolean\":%s,\"Null\":%s}",
-                "[\"string1\",\"string2\"]", "[1,2]", "[1.1,2.2]", "[true,false]", "[null,null]"));
+                "{\"String\":%s,\"int\":%s,\"long\":%s,\"double\":%s,\"boolean\":%s,\"null\":%s}",
+                "[\"string1\",\"string2\"]",
+                "[1,2]",
+                "[3,4]",
+                "[1.1,2.2]",
+                "[true,false]",
+                "[null,null]"));
+  }
+
+  @Test
+  public void testEncodingNumbers() throws EncodingException {
+    ObjectEncoder<DummyClass> objectEncoder =
+        (o, ctx) -> ctx.add("Number", new Number[] {1, 2473946328429347632L, 0.0d});
+
+    String result =
+        new JsonDataEncoderBuilder()
+            .registerEncoder(DummyClass.class, objectEncoder)
+            .build()
+            .encode(DummyClass.INSTANCE);
+
+    assertThat(result).isEqualTo(String.format("{\"Number\":%s}", "[1,2473946328429347632,0.0]"));
+  }
+
+  @Test
+  public void testEncodingLongs() throws EncodingException {
+    ObjectEncoder<DummyClass> objectEncoder =
+        (o, ctx) -> ctx.add("long", new long[] {1L, 2473946328429347632L});
+
+    String result =
+        new JsonDataEncoderBuilder()
+            .registerEncoder(DummyClass.class, objectEncoder)
+            .build()
+            .encode(DummyClass.INSTANCE);
+
+    assertThat(result).isEqualTo(String.format("{\"long\":%s}", "[1,2473946328429347632]"));
+  }
+
+  enum MyEnum {
+    VALUE_1,
+    VALUE_2
+  }
+
+  @Test
+  public void testEncodingEnum_withNoCustomEncoder() throws EncodingException {
+    String result =
+        new JsonDataEncoderBuilder().build().encode(new MyEnum[] {MyEnum.VALUE_1, MyEnum.VALUE_2});
+    assertThat(result).isEqualTo("[\"VALUE_1\",\"VALUE_2\"]");
+  }
+
+  @Test
+  public void testEncodingEnum_withCustomEncoder() throws EncodingException {
+    ValueEncoder<MyEnum> encoder = (o, ctx) -> ctx.add(o.name().toLowerCase());
+    String result =
+        new JsonDataEncoderBuilder()
+            .registerEncoder(MyEnum.class, encoder)
+            .build()
+            .encode(new MyEnum[] {MyEnum.VALUE_1, MyEnum.VALUE_2});
+    assertThat(result).isEqualTo("[\"value_1\",\"value_2\"]");
   }
 
   @Test


### PR DESCRIPTION
* primitive longs
* Enums with ability to register custom encoders if desired
* All java.lang.Number subclasses

Note that longs and all Numbers are represented as numeric values, not
strings. While this could be a problem when parsed with a JavaScript parser,
it is not an issue for us since JS is not involved on the client or the
server.