### PR TITLE
Add polymorphic encoder registration support.

### DIFF
--- a/encoders/firebase-encoders/api.txt
+++ b/encoders/firebase-encoders/api.txt
@@ -36,13 +36,27 @@ package com.google.firebase.encoders {
 
 }
 
+package com.google.firebase.encoders.config {
+
+  public interface Configurator {
+    method public void configure(@NonNull com.google.firebase.encoders.config.EncoderConfig<?>);
+  }
+
+  public interface EncoderConfig<T extends com.google.firebase.encoders.config.EncoderConfig<T>> {
+    method @NonNull public <U> T registerEncoder(@NonNull Class<U>, @NonNull com.google.firebase.encoders.ObjectEncoder<? super U>);
+    method @NonNull public <U> T registerEncoder(@NonNull Class<U>, @NonNull com.google.firebase.encoders.ValueEncoder<? super U>);
+  }
+
+}
+
 package com.google.firebase.encoders.json {
 
-  public final class JsonDataEncoderBuilder {
+  public final class JsonDataEncoderBuilder implements com.google.firebase.encoders.config.EncoderConfig<com.google.firebase.encoders.json.JsonDataEncoderBuilder> {
     ctor public JsonDataEncoderBuilder();
     method @NonNull public com.google.firebase.encoders.DataEncoder build();
-    method @NonNull public <T> com.google.firebase.encoders.json.JsonDataEncoderBuilder registerEncoder(@NonNull Class<T>, @NonNull com.google.firebase.encoders.ObjectEncoder<T>);
-    method @NonNull public <T> com.google.firebase.encoders.json.JsonDataEncoderBuilder registerEncoder(@NonNull Class<T>, @NonNull com.google.firebase.encoders.ValueEncoder<T>);
+    method @NonNull public com.google.firebase.encoders.json.JsonDataEncoderBuilder configureWith(@NonNull com.google.firebase.encoders.config.Configurator);
+    method @NonNull public <T> com.google.firebase.encoders.json.JsonDataEncoderBuilder registerEncoder(@NonNull Class<T>, @NonNull com.google.firebase.encoders.ObjectEncoder<? super T>);
+    method @NonNull public <T> com.google.firebase.encoders.json.JsonDataEncoderBuilder registerEncoder(@NonNull Class<T>, @NonNull com.google.firebase.encoders.ValueEncoder<? super T>);
   }
 
 }

--- a/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/config/Configurator.java
+++ b/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/config/Configurator.java
@@ -1,0 +1,34 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.config;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Callback that is accepted by encoder builders to configure them.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * DataEncoder encoder = new JsonDataEncoderBuilder()
+ *     .configureWith(cfg ->
+ *         cfg.registerEncoder(Foo.class, new FooEncoder())
+ *            .registerEncoder(Bar.class, new BarEncoder()))
+ *     .build();
+ * }</pre>
+ */
+public interface Configurator {
+  void configure(@NonNull EncoderConfig<?> configuration);
+}

--- a/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/config/EncoderConfig.java
+++ b/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/config/EncoderConfig.java
@@ -1,0 +1,32 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.config;
+
+import androidx.annotation.NonNull;
+import com.google.firebase.encoders.ObjectEncoder;
+import com.google.firebase.encoders.ValueEncoder;
+
+/**
+ * Implemented by concrete {@link com.google.firebase.encoders.DataEncoder} builders.
+ *
+ * <p>Used by clients to configure encoders without coupling to a particular encoder format.
+ */
+public interface EncoderConfig<T extends EncoderConfig<T>> {
+  @NonNull
+  <U> T registerEncoder(@NonNull Class<U> type, @NonNull ObjectEncoder<? super U> encoder);
+
+  @NonNull
+  <U> T registerEncoder(@NonNull Class<U> type, @NonNull ValueEncoder<? super U> encoder);
+}

--- a/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
+++ b/encoders/firebase-encoders/src/main/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
@@ -21,6 +21,8 @@ import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ValueEncoder;
 import com.google.firebase.encoders.ValueEncoderContext;
+import com.google.firebase.encoders.config.Configurator;
+import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -32,7 +34,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-public final class JsonDataEncoderBuilder {
+public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncoderBuilder> {
 
   private final Map<Class<?>, ObjectEncoder<?>> objectEncoders = new HashMap<>();
   private final Map<Class<?>, ValueEncoder<?>> valueEncoders = new HashMap<>();
@@ -63,8 +65,9 @@ public final class JsonDataEncoderBuilder {
   }
 
   @NonNull
+  @Override
   public <T> JsonDataEncoderBuilder registerEncoder(
-      @NonNull Class<T> clazz, @NonNull ObjectEncoder<T> objectEncoder) {
+      @NonNull Class<T> clazz, @NonNull ObjectEncoder<? super T> objectEncoder) {
     if (objectEncoders.containsKey(clazz)) {
       throw new IllegalArgumentException("Encoder already registered for " + clazz.getName());
     }
@@ -73,12 +76,19 @@ public final class JsonDataEncoderBuilder {
   }
 
   @NonNull
+  @Override
   public <T> JsonDataEncoderBuilder registerEncoder(
-      @NonNull Class<T> clazz, @NonNull ValueEncoder<T> encoder) {
+      @NonNull Class<T> clazz, @NonNull ValueEncoder<? super T> encoder) {
     if (valueEncoders.containsKey(clazz)) {
       throw new IllegalArgumentException("Encoder already registered for " + clazz.getName());
     }
     valueEncoders.put(clazz, encoder);
+    return this;
+  }
+
+  @NonNull
+  public JsonDataEncoderBuilder configureWith(@NonNull Configurator config) {
+    config.configure(this);
     return this;
   }
 

--- a/encoders/firebase-encoders/src/test/java/com/google/firebase/encoders/json/JsonDataEncoderBuilderTests.java
+++ b/encoders/firebase-encoders/src/test/java/com/google/firebase/encoders/json/JsonDataEncoderBuilderTests.java
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.json;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.firebase.encoders.DataEncoder;
+import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.ObjectEncoderContext;
+import com.google.firebase.encoders.ValueEncoderContext;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class JsonDataEncoderBuilderTests {
+  static class Foo {}
+
+  @Test
+  public void configureWith_shouldCorrectlyRegisterObjectEncoder() throws EncodingException {
+    DataEncoder encoder =
+        new JsonDataEncoderBuilder()
+            .configureWith(
+                cfg ->
+                    cfg.registerEncoder(
+                        Foo.class,
+                        (Foo s, ObjectEncoderContext ctx) -> {
+                          ctx.add("foo", "value");
+                        }))
+            .build();
+
+    assertThat(encoder.encode(new Foo())).isEqualTo("{\"foo\":\"value\"}");
+  }
+
+  @Test
+  public void configureWith_shouldCorrectlyRegisterValueEncoder() throws EncodingException {
+    DataEncoder encoder =
+        new JsonDataEncoderBuilder()
+            .configureWith(
+                cfg ->
+                    cfg.registerEncoder(
+                        Foo.class,
+                        (Foo s, ValueEncoderContext ctx) -> {
+                          ctx.add("value");
+                        }))
+            .build();
+
+    assertThat(encoder.encode(Collections.singletonMap("foo", new Foo())))
+        .isEqualTo("{\"foo\":\"value\"}");
+  }
+}


### PR DESCRIPTION
This allows clients to configure DataEncoders in a way that does not
couple them to a particular output format, e.g. json.

This mechanism will be used for auto-generated encoders in the future.