### PR TITLE
Add firebaseLibrary.exports mechanism.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
@@ -30,6 +30,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.publish.maven.MavenPom;
 
 public class FirebaseLibraryExtension {
+  public static final String FIREBASE_LIBRARY_EXPORTS = "firebaseLibraryExports";
   private final Project project;
   private final Set<FirebaseLibraryExtension> librariesToCoRelease = new HashSet<>();
 
@@ -147,5 +148,19 @@ public class FirebaseLibraryExtension {
 
   public void staticAnalysis(Action<FirebaseStaticAnalysis> action) {
     action.execute(staticAnalysis);
+  }
+
+  /** Registers a java-library project to be vendored into the current firebaseLibrary. */
+  public void exports(Project depProject) {
+    project.getDependencies().add(FIREBASE_LIBRARY_EXPORTS, depProject);
+
+    depProject
+        .getConfigurations()
+        .all(
+            c -> {
+              if (c.getName().equals("implementation")) {
+                project.getDependencies().add("api", c);
+              }
+            });
   }
 }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/VendorTransform.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/VendorTransform.java
@@ -1,0 +1,161 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins;
+
+import com.android.build.api.transform.DirectoryInput;
+import com.android.build.api.transform.Format;
+import com.android.build.api.transform.JarInput;
+import com.android.build.api.transform.QualifiedContent;
+import com.android.build.api.transform.Transform;
+import com.android.build.api.transform.TransformInput;
+import com.android.build.api.transform.TransformInvocation;
+import com.android.build.api.transform.TransformOutputProvider;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.logging.Logger;
+
+/** Gradle transform that copies classes from "exports" dependencies into the final aar. */
+class VendorTransform extends Transform {
+  private static final String TRANSFORM_NAME = "firebaseVendorTransform";
+
+  private final Logger logger;
+  private final Configuration configuration;
+
+  VendorTransform(Logger logger, Configuration configuration) {
+    this.logger = logger;
+    this.configuration = configuration;
+  }
+
+  @Override
+  public String getName() {
+    return TRANSFORM_NAME;
+  }
+
+  @Override
+  public Set<QualifiedContent.ContentType> getInputTypes() {
+    return Collections.singleton(QualifiedContent.DefaultContentType.CLASSES);
+  }
+
+  @Override
+  public Set<? super QualifiedContent.Scope> getScopes() {
+    return Collections.singleton(QualifiedContent.Scope.PROJECT);
+  }
+
+  @Override
+  public boolean isIncremental() {
+    return true;
+  }
+
+  @Override
+  public void transform(TransformInvocation transformInvocation) throws IOException {
+    TransformOutputProvider outputProvider = transformInvocation.getOutputProvider();
+
+    for (TransformInput transformInput : transformInvocation.getInputs()) {
+      for (DirectoryInput input : transformInput.getDirectoryInputs()) {
+        moveDirectoriesUnchanged(
+            input,
+            outputProvider.getContentLocation(
+                TRANSFORM_NAME, input.getContentTypes(), input.getScopes(), Format.DIRECTORY));
+      }
+
+      for (JarInput input : transformInput.getJarInputs()) {
+        unpackAndMoveJar(
+            input.getFile(),
+            outputProvider.getContentLocation(
+                TRANSFORM_NAME, input.getContentTypes(), input.getScopes(), Format.DIRECTORY));
+      }
+
+      List<Pattern> directDeps =
+          configuration.getDependencies().stream()
+              .map(
+                  d -> {
+                    if (d instanceof ProjectDependency) {
+                      return Pattern.compile(
+                          String.format(".*build/libs/%s.*\\.jar$", d.getName()));
+                    }
+                    return Pattern.compile(
+                        String.format(".*%s/%s/%s$", d.getGroup(), d.getName(), d.getVersion()));
+                  })
+              .collect(Collectors.toList());
+      for (File jar : configuration.resolve()) {
+        if (directDeps.stream().noneMatch(dep -> dep.matcher(jar.getAbsolutePath()).matches())) {
+          continue;
+        }
+
+        unpackAndMoveJar(
+            jar,
+            outputProvider.getContentLocation(
+                TRANSFORM_NAME,
+                Collections.singleton(QualifiedContent.DefaultContentType.CLASSES),
+                Collections.singleton(QualifiedContent.Scope.PROJECT),
+                Format.DIRECTORY));
+      }
+    }
+  }
+
+  private void moveDirectoriesUnchanged(DirectoryInput directoryInput, File outDir)
+      throws IOException {
+    logger.debug("Moving directory {} into {}", directoryInput, outDir);
+    FileUtils.deleteDirectory(outDir);
+    FileUtils.copyDirectory(directoryInput.getFile(), outDir);
+  }
+
+  /** Note wee must unpack the JARs due to the limitation of the retrolambda plugin. */
+  private void unpackAndMoveJar(File jarInput, File outDir) throws IOException {
+    logger.debug("Unpacking jar {} into {}", jarInput, outDir);
+    if (outDir.getParentFile().mkdirs() || outDir.getParentFile().isDirectory()) {
+
+      JarInputStream jis =
+          new JarInputStream(new BufferedInputStream(new FileInputStream(jarInput)));
+
+      JarEntry inEntry;
+      while ((inEntry = jis.getNextJarEntry()) != null) {
+
+        final String name = inEntry.getName();
+
+        if (!inEntry.isDirectory()) {
+          File outFile = new File(/* pathname */ outDir, name);
+          outFile.getParentFile().mkdirs();
+          outFile.createNewFile();
+
+          try (BufferedOutputStream fos = new BufferedOutputStream(new FileOutputStream(outFile))) {
+            IOUtils.copy(jis, fos);
+          } finally {
+            jis.closeEntry();
+          }
+        }
+      }
+
+    } else {
+      throw new IOException("Couldn't create transform output: " + outDir.getParentFile());
+    }
+  }
+}

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/FirebaseLibraryProject.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/FirebaseLibraryProject.groovy
@@ -1,0 +1,100 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins.publish
+
+import groovy.text.SimpleTemplateEngine
+
+import java.util.zip.ZipFile
+
+
+class FirebaseLibraryProject implements HasBuild {
+    static final String BUILD_TEMPLATE = '''
+        plugins {
+            id 'firebase-library'
+        }
+        group = '${group}'
+        version = '${version}'
+        <% if (latestReleasedVersion) println "ext.latestReleasedVersion = $latestReleasedVersion" %>
+        firebaseLibrary {
+          <% if (releaseWith != null) println "releaseWith project(':$releaseWith.name')" %>
+          <% if (customizePom != null) println "customizePom {$customizePom}" %>
+        }
+        android.compileSdkVersion = 26
+
+        repositories {
+            google()
+            jcenter()
+	    }
+        dependencies {
+            <%dependencies.each { c ->
+              c.value.each { d ->
+                println "$c.key project(':$d.name')"
+              }
+            } %>
+            <%externalDependencies.each { c ->
+              c.value.each { d ->
+                println "$c.key '$d'"
+              }
+            } %>
+        }
+        '''
+    String name
+    String group = 'com.example'
+    String version = 'undefined'
+    String latestReleasedVersion = ''
+    Map<String, List<FirebaseLibraryProject>> projectDependencies = [:]
+    Map<String, List<String>> externalDependencies = [:]
+    FirebaseLibraryProject releaseWith = null
+    String customizePom = null
+    List<String> classNames = []
+
+    @Override
+    String generateBuildFile() {
+        def text = new SimpleTemplateEngine().createTemplate(BUILD_TEMPLATE).make([
+                name: name,
+                group: group,
+                version: version,
+                dependencies: projectDependencies,
+                externalDependencies: externalDependencies,
+                releaseWith: releaseWith,
+                latestReleasedVersion: latestReleasedVersion,
+                customizePom: customizePom,
+        ])
+
+        return text
+    }
+
+    Optional<File> getPublishedPom(String rootFolder) {
+        def v = releaseWith == null ? version : releaseWith.version
+        def poms = new FileNameFinder().getFileNames(rootFolder,
+                "${group.replaceAll('\\.', '/')}/${name}/${v}*/*.pom")
+
+        if(poms.empty) {
+            return Optional.empty()
+        }
+        return Optional.of(new File(poms[0]))
+    }
+
+    Optional<ZipFile> getPublishedAar(String rootFolder) {
+        def v = releaseWith == null ? version : releaseWith.version
+        def poms = new FileNameFinder().getFileNames(rootFolder,
+                "${group.replaceAll('\\.', '/')}/${name}/${v}*/*.aar")
+
+        if(poms.empty) {
+            return Optional.empty()
+        }
+        return Optional.of(new ZipFile(new File(poms[0])))
+    }
+}

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/HasBuild.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/HasBuild.groovy
@@ -1,0 +1,20 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins.publish;
+
+interface HasBuild {
+    String generateBuildFile()
+    List<String> getClassNames()
+}

--- a/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/JavaLibraryProject.groovy
+++ b/buildSrc/src/test/groovy/com/google/firebase/gradle/plugins/publish/JavaLibraryProject.groovy
@@ -1,0 +1,58 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins.publish
+
+import groovy.text.SimpleTemplateEngine
+
+
+class JavaLibraryProject implements HasBuild {
+    static final String BUILD_TEMPLATE = '''
+        plugins {
+            id 'java-library'
+        }
+        group = '${group}'
+        version = '${version}'
+
+        repositories {
+            google()
+            jcenter()
+	    }
+        dependencies {
+            <%externalDependencies.each { c ->
+              c.value.each { d ->
+                println "$c.key '$d'"
+              }
+            } %>
+        }
+        '''
+    String name
+    String group = 'com.example'
+    String version = 'undefined'
+    List<String> classNames = []
+
+    Map<String, List<String>> externalDependencies = [:]
+
+    @Override
+    String generateBuildFile() {
+        def text = new SimpleTemplateEngine().createTemplate(BUILD_TEMPLATE).make([
+                name: name,
+                group: group,
+                version: version,
+                externalDependencies: externalDependencies,
+        ])
+
+        return text
+    }
+}


### PR DESCRIPTION
Allows to vendor an java library module into an firebase-library.

When a firebase-library exports a java library the following happens:
* all classes of the java library are vendored into the firebase-library's aar
* firebase-library inherits all pom dependencies of the java library

To use:

```
plugins {
  id 'firebase-library'
}

firebaseLibrary {
  exports project(':some-java-library')
}
```