### PR TITLE
Adds code generation via `@Encodable` annotation. (#1029)

### DIFF
--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/annotations/Encodable.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/annotations/Encodable.java
@@ -1,0 +1,59 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates to automatically generate an encoder capable to encode a given type.
+ *
+ * <p>All fields that need to be encoded <strong>must</strong>must have Java-bean compliant getters,
+ * otherwise they will not be encoded.
+ *
+ * Using the generated encoder:
+ * <pre>{@code
+ * @Encodable
+ * public class MyType {
+ *   public String getField() { return "hello"; }
+ *   public boolean isConditional() { return false; }
+ * }
+ *
+ * DataEncoder encoder = new JsonDataEncoderBuilder()
+ *     .configureWith(AutoMyTypeEncoder.CONFIG)
+ *     .build();
+ *
+ * String json = encoder.encode(new MyType);
+ *
+ * }<pre>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+public @interface Encodable {
+
+  /** Specifies a custom field name for a given property of a type. */
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.CLASS)
+  @interface Field {
+    String name() default "";
+  }
+
+  /** Indicates the code generator to ignore a given property of a type. */
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.CLASS)
+  @interface Ignore {}
+}

--- a/encoders/firebase-encoders-processor/firebase-encoders-processor.gradle
+++ b/encoders/firebase-encoders-processor/firebase-encoders-processor.gradle
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    implementation project(':encoders:firebase-encoders-processor:test-support')
+    implementation 'com.google.auto.service:auto-service-annotations:1.0-rc6'
+    implementation 'com.squareup:javapoet:1.11.1'
+    compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation 'com.google.guava:guava:28.1-jre'
+
+    compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
+
+    annotationProcessor "com.google.auto.value:auto-value:1.6.2"
+
+    annotationProcessor 'com.google.auto.service:auto-service:1.0-rc6'
+
+    testImplementation 'com.google.testing.compile:compile-testing:0.18'
+    testImplementation files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
+
+}
+
+dependencies {
+    implementation 'androidx.annotation:annotation:1.1.0'
+}
+
+test {
+    testLogging.showStandardStreams = true
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
@@ -1,0 +1,205 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor;
+
+import com.google.auto.service.AutoService;
+import com.google.firebase.encoders.annotations.Encodable;
+import com.google.firebase.encoders.processor.getters.Getter;
+import com.google.firebase.encoders.processor.getters.GetterFactory;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.WildcardTypeName;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+@AutoService(Processor.class)
+@SupportedAnnotationTypes(EncodableProcessor.ENCODABLE_ANNOTATION)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class EncodableProcessor extends AbstractProcessor {
+
+  static final String ENCODABLE_ANNOTATION = "com.google.firebase.encoders.annotations.Encodable";
+  private Elements elements;
+  private Types types;
+  private GetterFactory getterFactory;
+  private TypeTraversal traversal;
+
+  @Override
+  public synchronized void init(ProcessingEnvironment processingEnvironment) {
+    super.init(processingEnvironment);
+    elements = processingEnvironment.getElementUtils();
+    types = processingEnvironment.getTypeUtils();
+    getterFactory = new GetterFactory(types, elements, processingEnvironment.getMessager());
+  }
+
+  @Override
+  public boolean process(Set<? extends TypeElement> set, RoundEnvironment roundEnvironment) {
+    for (Element element : roundEnvironment.getElementsAnnotatedWith(Encodable.class)) {
+      processClass(element);
+    }
+    return false;
+  }
+
+  private void processClass(Element element) {
+    // generates class of the following shape:
+    //
+    // public class AutoFooEncoder implements Configurator {
+    //   public static final Configurator CONFIG = new AutoFooEncoder();
+    // }
+    ClassName className =
+        ClassName.bestGuess("Auto" + Names.generatedClassName(element) + "Encoder");
+    ClassName configurator = ClassName.get("com.google.firebase.encoders.config", "Configurator");
+    TypeSpec.Builder encoderBuilder =
+        TypeSpec.classBuilder(className)
+            .addJavadoc("@hide")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .addSuperinterface(configurator)
+            .addAnnotation(
+                AnnotationSpec.builder(ClassName.get("javax.annotation", "Generated"))
+                    .addMember("value", "$S", getClass().getName())
+                    .build())
+            .addField(
+                FieldSpec.builder(
+                        TypeName.INT,
+                        "CODEGEN_VERSION",
+                        Modifier.PUBLIC,
+                        Modifier.STATIC,
+                        Modifier.FINAL)
+                    .initializer("1")
+                    .build())
+            .addField(
+                FieldSpec.builder(
+                        configurator, "CONFIG", Modifier.PUBLIC, Modifier.FINAL, Modifier.STATIC)
+                    .initializer("new $T()", className)
+                    .build())
+            .addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PRIVATE).build());
+
+    Set<Encoder> encoders = TypeTraversal.traverse(element.asType(), new GetterVisitor());
+
+    MethodSpec.Builder configureMethod =
+        MethodSpec.methodBuilder("configure")
+            .addParameter(
+                ParameterizedTypeName.get(
+                    ClassName.get("com.google.firebase.encoders.config", "EncoderConfig"),
+                    WildcardTypeName.subtypeOf(Object.class)),
+                "cfg")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override.class);
+
+    for (Encoder encoder : encoders) {
+      encoderBuilder.addType(encoder.code());
+
+      configureMethod.addCode(
+          "cfg.registerEncoder($T.class, $N.INSTANCE);\n",
+          types.erasure(encoder.type()),
+          encoder.code());
+    }
+    encoderBuilder.addMethod(configureMethod.build());
+
+    JavaFile file = JavaFile.builder(Names.packageName(element), encoderBuilder.build()).build();
+
+    try {
+      file.writeTo(processingEnv.getFiler());
+    } catch (IOException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  class GetterVisitor implements TypeVisitor<Encoder> {
+    final Map<TypeMirror, TypeSpec> encoded = new LinkedHashMap<>();
+
+    @Override
+    public VisitResult<Encoder> visit(TypeMirror type) {
+      if (!(type instanceof DeclaredType)) {
+        return VisitResult.noResult();
+      }
+
+      MethodSpec.Builder methodBuilder =
+          MethodSpec.methodBuilder("encode")
+              .addParameter(TypeName.get(types.erasure(type)), "value")
+              .addParameter(
+                  ClassName.get("com.google.firebase.encoders", "ObjectEncoderContext"), "ctx")
+              .addModifiers(Modifier.PUBLIC)
+              .addException(IOException.class)
+              .addException(ClassName.get("com.google.firebase.encoders", "EncodingException"))
+              .addAnnotation(Override.class);
+
+      Set<TypeMirror> result = new LinkedHashSet<>();
+      for (Getter getter : getterFactory.allGetters((DeclaredType) type)) {
+        if (shouldCreateEncoderFor(getter.getUnderlyingType())) {
+          result.add(getter.getUnderlyingType());
+        }
+        methodBuilder.addCode("ctx.add($S, value.$L);\n", getter.name(), getter.expression());
+      }
+
+      ClassName className =
+          ClassName.bestGuess(Names.generatedClassName(types.asElement(type)) + "Encoder");
+      TypeSpec encoder =
+          TypeSpec.classBuilder(className)
+              .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+              .addSuperinterface(
+                  ParameterizedTypeName.get(
+                      ClassName.get("com.google.firebase.encoders", "ObjectEncoder"),
+                      TypeName.get(types.erasure(type))))
+              .addField(
+                  FieldSpec.builder(className, "INSTANCE", Modifier.FINAL, Modifier.STATIC)
+                      .initializer("new $T()", className)
+                      .build())
+              .addMethod(methodBuilder.build())
+              .build();
+      encoded.put(types.erasure(type), encoder);
+      return VisitResult.of(result, Encoder.create(types.erasure(type), encoder));
+    }
+
+    private boolean shouldCreateEncoderFor(TypeMirror type) {
+      if (type.getKind().isPrimitive()) {
+        return false;
+      }
+      TypeMirror collection =
+          types.erasure(elements.getTypeElement("java.util.Collection").asType());
+      TypeMirror map = types.erasure(elements.getTypeElement("java.util.Map").asType());
+      TypeMirror date = elements.getTypeElement("java.util.Date").asType();
+      if (types.isAssignable(type, collection)
+          || types.isAssignable(type, map)
+          || types.isAssignable(type, date)
+          || "java.lang".equals(Names.packageName(types.asElement(type)))) {
+        return false;
+      }
+      return true;
+    }
+  }
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/Encoder.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/Encoder.java
@@ -1,0 +1,31 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor;
+
+import com.google.auto.value.AutoValue;
+import com.squareup.javapoet.TypeSpec;
+import javax.lang.model.type.TypeMirror;
+
+/** Represents the {@link TypeSpec code} for a given {@link TypeMirror type}. */
+@AutoValue
+abstract class Encoder {
+  abstract TypeMirror type();
+
+  abstract TypeSpec code();
+
+  static Encoder create(TypeMirror type, TypeSpec code) {
+    return new AutoValue_Encoder(type, code);
+  }
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/Names.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/Names.java
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+
+public class Names {
+  /**
+   * Returns the class name that corresponds to a given element.
+   *
+   * <p>For top level classes returns the class name unchanged. For nested classes returns {@code
+   * ParentNested} for {@code Parent$Nested} classes.
+   */
+  static String generatedClassName(Element element) {
+    StringBuilder sb = new StringBuilder(element.getSimpleName().toString());
+    Element enclosingElement = element.getEnclosingElement();
+    while (!(enclosingElement instanceof PackageElement)) {
+      sb.insert(0, enclosingElement.getSimpleName().toString());
+      enclosingElement = enclosingElement.getEnclosingElement();
+    }
+    return sb.toString();
+  }
+
+  /** Returns the package name of an element. */
+  static String packageName(Element element) {
+    Element enclosingElement = element.getEnclosingElement();
+    while (!(enclosingElement instanceof PackageElement)) {
+      enclosingElement = enclosingElement.getEnclosingElement();
+    }
+    return ((PackageElement) enclosingElement).getQualifiedName().toString();
+  }
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/TypeTraversal.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/TypeTraversal.java
@@ -1,0 +1,53 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.lang.model.type.TypeMirror;
+
+final class TypeTraversal {
+
+  /**
+   * Traverses the type graph starting at {@code type}.
+   *
+   * <p>{@link TypeVisitor} is used to process each type in the graph as well as return a list of
+   * types to traverse next based on the type in receives.
+   */
+  static <T> Set<T> traverse(TypeMirror type, TypeVisitor<T> visitor) {
+    Set<String> visited = new HashSet<>();
+    Set<T> accumulated = new LinkedHashSet<>();
+    traverseType(type, visitor, visited, accumulated);
+    return accumulated;
+  }
+
+  private static <T> void traverseType(
+      TypeMirror type, TypeVisitor<T> visitor, Set<String> visited, Set<T> accumulated) {
+    if (visited.contains(type.toString())) {
+      return;
+    }
+    visited.add(type.toString());
+
+    VisitResult<T> result = visitor.visit(type);
+    if (result.isEmpty()) {
+      return;
+    }
+
+    accumulated.add(result.result());
+
+    result.pendingToVisit().forEach(t -> traverseType(t, visitor, visited, accumulated));
+  }
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/TypeVisitor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/TypeVisitor.java
@@ -1,0 +1,22 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor;
+
+import javax.lang.model.type.TypeMirror;
+
+/** Handles type traversal. */
+public interface TypeVisitor<T> {
+  VisitResult<T> visit(TypeMirror type);
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/VisitResult.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/VisitResult.java
@@ -1,0 +1,41 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor;
+
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+import java.util.Collections;
+import java.util.Set;
+import javax.lang.model.type.TypeMirror;
+
+@AutoValue
+abstract class VisitResult<T> {
+  abstract Set<TypeMirror> pendingToVisit();
+
+  @Nullable
+  abstract T result();
+
+  static <T> VisitResult<T> of(Set<TypeMirror> moreToVisit, T result) {
+    return new AutoValue_VisitResult<>(moreToVisit, result);
+  }
+
+  static <T> VisitResult<T> noResult() {
+    return of(Collections.emptySet(), null);
+  }
+
+  boolean isEmpty() {
+    return result() == null;
+  }
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/Getter.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/Getter.java
@@ -1,0 +1,52 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor.getters;
+
+import com.google.auto.value.AutoValue;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+@AutoValue
+public abstract class Getter {
+  /** Encoded name of the getter. */
+  public abstract String name();
+
+  /**
+   * Java expression to get the getter's value
+   *
+   * <p>Usually is of the form: getFoo()
+   */
+  public abstract String expression();
+
+  abstract TypeMirror returnType();
+
+  /**
+   * Getter's underlying Java type.
+   *
+   * <p>The type is fully resolved with respect to generics, i.e. {@code Optional<MyType<String>>},
+   * not {@code Optional<T>}.
+   */
+  public TypeMirror getUnderlyingType() {
+    if (returnType().getKind() != TypeKind.ARRAY) {
+      return returnType();
+    }
+    return ((ArrayType) returnType()).getComponentType();
+  }
+
+  public static Getter create(String name, String expression, TypeMirror returnType) {
+    return new AutoValue_Getter(name, expression, returnType);
+  }
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/GetterFactory.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/GetterFactory.java
@@ -1,0 +1,168 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor.getters;
+
+import com.google.firebase.encoders.annotations.Encodable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+
+public final class GetterFactory {
+  private final Types types;
+  private final Elements elements;
+  private final Messager messager;
+
+  public GetterFactory(Types types, Elements elements, Messager messager) {
+    this.types = types;
+    this.elements = elements;
+    this.messager = messager;
+  }
+
+  /** Returns all getters of a given type. */
+  public Set<Getter> allGetters(DeclaredType type) {
+    if (types.isSameType(type, elements.getTypeElement("java.lang.Object").asType())) {
+      return Collections.emptySet();
+    }
+    Set<Getter> result = new LinkedHashSet<>();
+    TypeMirror superclass = ((TypeElement) types.asElement(type)).getSuperclass();
+
+    if (!superclass.getKind().equals(TypeKind.NONE)) {
+      result.addAll(allGetters((DeclaredType) superclass));
+    }
+    for (ExecutableElement method :
+        ElementFilter.methodsIn(types.asElement(type).getEnclosedElements())) {
+      create(type, method).ifPresent(result::add);
+    }
+    return result;
+  }
+
+  private Optional<Getter> create(DeclaredType ownerType, ExecutableElement element) {
+    if (element.getKind() != ElementKind.METHOD
+        || element.getModifiers().contains(Modifier.STATIC)
+        || !element.getModifiers().contains(Modifier.PUBLIC)) {
+      return Optional.empty();
+    }
+
+    ExecutableType method = (ExecutableType) element.asType();
+    if (!method.getParameterTypes().isEmpty()) {
+      return Optional.empty();
+    }
+
+    if (element.getAnnotation(Encodable.Ignore.class) != null) {
+      return Optional.empty();
+    }
+    Optional<String> fieldName = inferName(element);
+    if (!fieldName.isPresent()) {
+      return Optional.empty();
+    }
+    TypeMirror returnType = resolveTypeArguments(ownerType, element.getReturnType());
+    String getterExpression = element.toString();
+
+    // Fail to compile if Maps with non-string keys are used, if/when we add support for such maps
+    // we should delete this.
+    TypeMirror map = types.erasure(elements.getTypeElement("java.util.Map").asType());
+    if (types.isAssignable(returnType, map)) {
+      TypeMirror keyType = ((DeclaredType) returnType).getTypeArguments().get(0);
+      if (!types.isSameType(keyType, elements.getTypeElement("java.lang.String").asType())) {
+        messager.printMessage(
+            Diagnostic.Kind.ERROR,
+            "Cannot encode Maps with non-String keys.",
+            ((DeclaredType) returnType).asElement());
+      }
+    }
+    if (types.isAssignable(
+        returnType, types.erasure(elements.getTypeElement("java.util.Optional").asType()))) {
+      returnType = ((DeclaredType) returnType).getTypeArguments().get(0);
+      getterExpression = getterExpression + ".orElse(null)";
+    }
+
+    return Optional.of(Getter.create(fieldName.get(), getterExpression, returnType));
+  }
+
+  private TypeMirror resolveTypeArguments(DeclaredType ownerType, TypeMirror genericType) {
+
+    if (genericType instanceof DeclaredType) {
+      DeclaredType dType = (DeclaredType) genericType;
+
+      if (dType.getTypeArguments().isEmpty()) {
+        return genericType;
+      }
+
+      TypeElement genericElement = (TypeElement) dType.asElement();
+
+      List<TypeMirror> result = new ArrayList<>();
+      for (TypeMirror typeArgument : dType.getTypeArguments()) {
+        result.add(resolveTypeArguments(ownerType, typeArgument));
+      }
+
+      return types.getDeclaredType(genericElement, result.toArray(new TypeMirror[0]));
+    } else if (genericType instanceof TypeVariable) {
+      TypeVariable tVar = (TypeVariable) genericType;
+      TypeElement ownerElement = (TypeElement) ownerType.asElement();
+
+      int index = ownerElement.getTypeParameters().indexOf(tVar.asElement());
+      if (index == -1) {
+        messager.printMessage(
+            Diagnostic.Kind.ERROR,
+            String.format(
+                "Could not infer type of %s in %s. Is it a non-static inner class in a generic class?",
+                genericType, ownerType));
+        return genericType;
+      }
+      return resolveTypeArguments(ownerType, ownerType.getTypeArguments().get(index));
+    }
+    return genericType;
+  }
+
+  private static Optional<String> inferName(ExecutableElement element) {
+    Encodable.Field annotation = element.getAnnotation(Encodable.Field.class);
+    if (annotation != null && !annotation.name().isEmpty()) {
+      return Optional.of(annotation.name());
+    }
+
+    String methodName = element.getSimpleName().toString();
+    ExecutableType method = (ExecutableType) element.asType();
+
+    if (methodName.startsWith("is")
+        && methodName.length() != 2
+        && method.getReturnType().getKind() == TypeKind.BOOLEAN) {
+      return Optional.of(Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3));
+    }
+
+    if (methodName.startsWith("get")
+        && methodName.length() != 3
+        && method.getReturnType().getKind() != TypeKind.VOID) {
+      return Optional.of(Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4));
+    }
+    return Optional.empty();
+  }
+}

--- a/encoders/firebase-encoders-processor/src/test/java/com/google/firebase/encoders/processor/EncodableProcessorTest.java
+++ b/encoders/firebase-encoders-processor/src/test/java/com/google/firebase/encoders/processor/EncodableProcessorTest.java
@@ -1,0 +1,200 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class EncodableProcessorTest {
+  @Test
+  public void compile_validClass_shouldProduceValidEncoder() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "SimpleClass",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "@Encodable public class SimpleClass {",
+                    "public int getInt() { return 0; }",
+                    "public boolean isBool() { return false; }",
+                    "public java.util.Map<String, Integer> getMap() { return null; }",
+                    "@Encodable.Ignore public long getIgnored() { return 1; }",
+                    "@Encodable.Field(name = \"foo\")",
+                    "public String getField() { return null; }",
+                    "int getNonPublicFieldIgnored() { return 0; }",
+                    "}"),
+                JavaFileObjects.forSourceLines(
+                    "TestEncoderCompile",
+                    "import com.google.firebase.encoders.config.EncoderConfig;",
+                    "class TestEncoderCompile{",
+                    "void test(EncoderConfig<?> cfg) {",
+                    "AutoSimpleClassEncoder.CONFIG.configure(cfg);",
+                    "}",
+                    "}"));
+
+    String expected = "public class AutoSimpleClassEncoder implements Configurator {}";
+
+    assertThat(result).succeededWithoutWarnings();
+    assertThat(result)
+        .generatedSourceFile("AutoSimpleClassEncoder")
+        .hasSourceEquivalentTo(JavaFileObjects.forResource("ExpectedSimpleClassEncoder.java"));
+  }
+
+  @Test
+  public void compile() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "InvalidMap",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "@Encodable public class InvalidMap {",
+                    "public java.util.Map<Integer, Integer> getMap() { return null; }",
+                    "}"));
+
+    assertThat(result).hadErrorContaining("Cannot encode Maps with non-String keys");
+  }
+
+  @Test
+  public void compileNested_shouldSucceed() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "SimpleClass",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "public class SimpleClass {",
+                    "@Encodable public static class Nested {",
+                    "public int getInt() { return 0; }",
+                    "}}"));
+
+    assertThat(result).succeededWithoutWarnings();
+    assertThat(result).generatedSourceFile("AutoSimpleClassNestedEncoder");
+  }
+
+  @Test
+  public void compile_withNonStaticNestedInsideGenericClass_shouldFail() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "GenericClass",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "public class GenericClass<T> {",
+                    "@Encodable public class Nested {",
+                    "public T getT() { return null; }",
+                    "}",
+                    "}"));
+
+    assertThat(result).hadErrorContaining("Could not infer type");
+  }
+
+  @Test
+  public void compile_withMultipleGenericArgs_shouldCreateEncodersForAllKnownGenericArgs() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "Generics",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "@Encodable public class Generics {",
+                    "public Bar<Member3> getBar3() { return null; }",
+                    "public Bar<Member4> getBar4() { return null; }",
+                    "public Multi<Member, Member2> getMulti() { return null; }",
+                    "}"),
+                JavaFileObjects.forSourceLines(
+                    "Foo", "class Foo<T>{", "public T getT() { return null; }", "}"),
+                JavaFileObjects.forSourceLines(
+                    "Baz", "class Baz<T>{", "public T getT() { return null; }", "}"),
+                JavaFileObjects.forSourceLines(
+                    "Bar", "class Bar<T> {", "public Baz<Foo<T>> getFoo() { return null; }", "}"),
+                JavaFileObjects.forSourceLines(
+                    "Multi",
+                    "class Multi<T, U> {",
+                    "public Baz<Foo<T>> getFooT() { return null; }",
+                    "public Baz<Foo<U>> getFooU() { return null; }",
+                    "}"),
+                JavaFileObjects.forSourceLines("Member", "class Member {}"),
+                JavaFileObjects.forSourceLines("Member2", "class Member2 {}"),
+                JavaFileObjects.forSourceLines("Member3", "class Member3 {}"),
+                JavaFileObjects.forSourceLines("Member3", "class Member4 {}"));
+
+    assertThat(result).succeededWithoutWarnings();
+    assertThat(result)
+        .generatedSourceFile("AutoGenericsEncoder")
+        .hasSourceEquivalentTo(JavaFileObjects.forResource("ExpectedGenericsEncoder.java"));
+  }
+
+  @Test
+  public void compile_withRecursiveGenericTypes_shouldSucceed() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "com.example.MainClass",
+                    "package com.example;",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "@Encodable public class MainClass {",
+                    "public Child<String> getChild() { return null; }",
+                    "}"),
+                JavaFileObjects.forSourceLines(
+                    "com.example.Child",
+                    "package com.example;",
+                    "public class Child<T> {",
+                    "public Child<String> getStringChild() { return null; }",
+                    "public Child<Integer> getIntChild() { return null; }",
+                    "public MainClass getMain() { return null; }",
+                    "}"));
+    assertThat(result).succeededWithoutWarnings();
+    assertThat(result)
+        .generatedSourceFile("com/example/AutoMainClassEncoder")
+        .hasSourceEquivalentTo(JavaFileObjects.forResource("ExpectedRecursiveGenericEncoder.java"));
+  }
+
+  @Test
+  public void compile_withOptional_shouldUseOrElseNull() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "WithOptional",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "import java.util.Optional;",
+                    "@Encodable public class WithOptional {",
+                    "@Encodable.Field(name = \"hello\")",
+                    "public Optional<Member> getOptional() { return Optional.empty(); }",
+                    "}"),
+                JavaFileObjects.forSourceLines("Member", "public class Member {}"));
+
+    assertThat(result)
+        .generatedSourceFile("AutoWithOptionalEncoder")
+        .contentsAsUtf8String()
+        .contains("\"hello\", value.getOptional().orElse(null)");
+  }
+}

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoder.java
@@ -1,0 +1,131 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.ObjectEncoder;
+import com.google.firebase.encoders.ObjectEncoderContext;
+import com.google.firebase.encoders.config.Configurator;
+import com.google.firebase.encoders.config.EncoderConfig;
+import java.io.IOException;
+import java.lang.Override;
+import javax.annotation.Generated;
+
+@Generated("com.google.firebase.encoders.processor.EncodableProcessor")
+public final class AutoGenericsEncoder implements Configurator {
+    public static final int CODEGEN_VERSION = 1;
+
+    public static final Configurator CONFIG = new AutoGenericsEncoder();
+
+    private AutoGenericsEncoder() {
+    }
+
+    @Override
+    public void configure(EncoderConfig<?> cfg) {
+        cfg.registerEncoder(Generics.class, GenericsEncoder.INSTANCE);
+        cfg.registerEncoder(Bar.class, BarEncoder.INSTANCE);
+        cfg.registerEncoder(Baz.class, BazEncoder.INSTANCE);
+        cfg.registerEncoder(Foo.class, FooEncoder.INSTANCE);
+        cfg.registerEncoder(Member3.class, Member3Encoder.INSTANCE);
+        cfg.registerEncoder(Member4.class, Member4Encoder.INSTANCE);
+        cfg.registerEncoder(Multi.class, MultiEncoder.INSTANCE);
+        cfg.registerEncoder(Member.class, MemberEncoder.INSTANCE);
+        cfg.registerEncoder(Member2.class, Member2Encoder.INSTANCE);
+    }
+
+    private static final class GenericsEncoder implements ObjectEncoder<Generics> {
+        static final GenericsEncoder INSTANCE = new GenericsEncoder();
+
+        @Override
+        public void encode(Generics value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+            ctx.add("bar3", value.getBar3());
+            ctx.add("bar4", value.getBar4());
+            ctx.add("multi", value.getMulti());
+        }
+    }
+
+    private static final class BarEncoder implements ObjectEncoder<Bar> {
+        static final BarEncoder INSTANCE = new BarEncoder();
+
+        @Override
+        public void encode(Bar value, ObjectEncoderContext ctx) throws IOException, EncodingException {
+            ctx.add("foo", value.getFoo());
+        }
+    }
+
+    private static final class BazEncoder implements ObjectEncoder<Baz> {
+        static final BazEncoder INSTANCE = new BazEncoder();
+
+        @Override
+        public void encode(Baz value, ObjectEncoderContext ctx) throws IOException, EncodingException {
+            ctx.add("t", value.getT());
+        }
+    }
+
+    private static final class FooEncoder implements ObjectEncoder<Foo> {
+        static final FooEncoder INSTANCE = new FooEncoder();
+
+        @Override
+        public void encode(Foo value, ObjectEncoderContext ctx) throws IOException, EncodingException {
+            ctx.add("t", value.getT());
+        }
+    }
+
+    private static final class Member3Encoder implements ObjectEncoder<Member3> {
+        static final Member3Encoder INSTANCE = new Member3Encoder();
+
+        @Override
+        public void encode(Member3 value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+        }
+    }
+
+    private static final class Member4Encoder implements ObjectEncoder<Member4> {
+        static final Member4Encoder INSTANCE = new Member4Encoder();
+
+        @Override
+        public void encode(Member4 value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+        }
+    }
+
+    private static final class MultiEncoder implements ObjectEncoder<Multi> {
+        static final MultiEncoder INSTANCE = new MultiEncoder();
+
+        @Override
+        public void encode(Multi value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+            ctx.add("fooT", value.getFooT());
+            ctx.add("fooU", value.getFooU());
+        }
+    }
+
+    private static final class MemberEncoder implements ObjectEncoder<Member> {
+        static final MemberEncoder INSTANCE = new MemberEncoder();
+
+        @Override
+        public void encode(Member value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+        }
+    }
+
+    private static final class Member2Encoder implements ObjectEncoder<Member2> {
+        static final Member2Encoder INSTANCE = new Member2Encoder();
+
+        @Override
+        public void encode(Member2 value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+        }
+    }
+}

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedRecursiveGenericEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedRecursiveGenericEncoder.java
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.ObjectEncoder;
+import com.google.firebase.encoders.ObjectEncoderContext;
+import com.google.firebase.encoders.config.Configurator;
+import com.google.firebase.encoders.config.EncoderConfig;
+import java.io.IOException;
+import java.lang.Override;
+import javax.annotation.Generated;
+
+@Generated("com.google.firebase.encoders.processor.EncodableProcessor")
+public final class AutoMainClassEncoder implements Configurator {
+    public static final int CODEGEN_VERSION = 1;
+
+    public static final Configurator CONFIG = new AutoMainClassEncoder();
+
+    private AutoMainClassEncoder() {
+    }
+
+    @Override
+    public void configure(EncoderConfig<?> cfg) {
+        cfg.registerEncoder(MainClass.class, MainClassEncoder.INSTANCE);
+        cfg.registerEncoder(Child.class, ChildEncoder.INSTANCE);
+    }
+
+    private static final class MainClassEncoder implements ObjectEncoder<MainClass> {
+        static final MainClassEncoder INSTANCE = new MainClassEncoder();
+
+        @Override
+        public void encode(MainClass value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+            ctx.add("child", value.getChild());
+        }
+    }
+
+    private static final class ChildEncoder implements ObjectEncoder<Child> {
+        static final ChildEncoder INSTANCE = new ChildEncoder();
+
+        @Override
+        public void encode(Child value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+            ctx.add("stringChild", value.getStringChild());
+            ctx.add("intChild", value.getIntChild());
+            ctx.add("main", value.getMain());
+        }
+    }
+}

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedSimpleClassEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedSimpleClassEncoder.java
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.ObjectEncoder;
+import com.google.firebase.encoders.ObjectEncoderContext;
+import com.google.firebase.encoders.config.Configurator;
+import com.google.firebase.encoders.config.EncoderConfig;
+import java.io.IOException;
+import java.lang.Override;
+import javax.annotation.Generated;
+
+@Generated("com.google.firebase.encoders.processor.EncodableProcessor")
+public final class AutoSimpleClassEncoder implements Configurator {
+  public static final int CODEGEN_VERSION = 1;
+
+  public static final Configurator CONFIG = new AutoSimpleClassEncoder();
+
+  private AutoSimpleClassEncoder() {}
+
+  @Override
+  public void configure(EncoderConfig<?> cfg) {
+    cfg.registerEncoder(SimpleClass.class, SimpleClassEncoder.INSTANCE);
+  }
+
+  private static final class SimpleClassEncoder implements ObjectEncoder<SimpleClass> {
+    static final SimpleClassEncoder INSTANCE = new SimpleClassEncoder();
+
+    @Override
+    public void encode(SimpleClass value, ObjectEncoderContext ctx)
+        throws IOException, EncodingException {
+      ctx.add("int", value.getInt());
+      ctx.add("bool", value.isBool());
+      ctx.add("map", value.getMap());
+      ctx.add("foo", value.getField());
+    }
+  }
+}

--- a/encoders/firebase-encoders-processor/test-support/src/main/java/com
+++ b/encoders/firebase-encoders-processor/test-support/src/main/java/com
@@ -1,0 +1,1 @@
+../../../../../firebase-encoders-json/src/main/java/com

--- a/encoders/firebase-encoders-processor/test-support/test-support.gradle
+++ b/encoders/firebase-encoders-processor/test-support/test-support.gradle
@@ -1,0 +1,21 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    implementation 'androidx.annotation:annotation:1.1.0'
+}

--- a/root-project.gradle
+++ b/root-project.gradle
@@ -80,7 +80,7 @@ configure(subprojects) {
     }
     tasks.googleJavaFormat {
         source '.'
-        include '**/*.java'
+        include '**/java/**/*.java'
         exclude '**/generated/**'
         exclude 'src/testUtil/java/com/google/firebase/firestore/testutil/Assert.java'
         exclude 'src/testUtil/java/com/google/firebase/firestore/testutil/ThrowingRunnable.java'
@@ -88,7 +88,7 @@ configure(subprojects) {
     }
     tasks.verifyGoogleJavaFormat {
         source '.'
-        include '**/*.java'
+        include '**/java/**/*.java'
         exclude '**/generated/**'
         exclude 'src/testUtil/java/com/google/firebase/firestore/testutil/Assert.java'
         exclude 'src/testUtil/java/com/google/firebase/firestore/testutil/ThrowingRunnable.java'

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -29,6 +29,8 @@ protolite-well-known-types
 
 encoders
 encoders:firebase-encoders-json
+encoders:firebase-encoders-processor
+encoders:firebase-encoders-processor:test-support
 
 tools:errorprone
 tools:lint


### PR DESCRIPTION
Supported features:

* Codegen is based on public java-bean style getters, fields are not encoded
  directly
* Full support for generics
* Supports `java.util.Optional` via `value.getOrElse(null)`
* Fields can be marked as `@Encodable.Ignore` to skip them during encoding
* Fields can be marked as `@Encodable.Field(name="foo")` for custom encoded name