### PR TITLE
Allow encoder registration override.

### DIFF
--- a/encoders/firebase-encoders-json/api.txt
+++ b/encoders/firebase-encoders-json/api.txt
@@ -37,6 +37,20 @@ package com.google.firebase.encoders {
 
 }
 
+package com.google.firebase.encoders.annotations {
+
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS) public @interface Encodable {
+  }
+
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS) public static @interface Encodable.Field {
+    method public abstract String name() default "";
+  }
+
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS) public static @interface Encodable.Ignore {
+  }
+
+}
+
 package com.google.firebase.encoders.config {
 
   public interface Configurator {

--- a/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
+++ b/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
@@ -79,6 +79,7 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
   public <T> JsonDataEncoderBuilder registerEncoder(
       @NonNull Class<T> clazz, @NonNull ValueEncoder<? super T> encoder) {
     valueEncoders.put(clazz, encoder);
+    // Remove it from the other map if present.
     objectEncoders.remove(clazz);
     return this;
   }

--- a/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
+++ b/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
@@ -68,10 +68,9 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
   @Override
   public <T> JsonDataEncoderBuilder registerEncoder(
       @NonNull Class<T> clazz, @NonNull ObjectEncoder<? super T> objectEncoder) {
-    if (objectEncoders.containsKey(clazz)) {
-      throw new IllegalArgumentException("Encoder already registered for " + clazz.getName());
-    }
     objectEncoders.put(clazz, objectEncoder);
+    // Remove it from the other map if present.
+    valueEncoders.remove(clazz);
     return this;
   }
 
@@ -79,10 +78,8 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
   @Override
   public <T> JsonDataEncoderBuilder registerEncoder(
       @NonNull Class<T> clazz, @NonNull ValueEncoder<? super T> encoder) {
-    if (valueEncoders.containsKey(clazz)) {
-      throw new IllegalArgumentException("Encoder already registered for " + clazz.getName());
-    }
     valueEncoders.put(clazz, encoder);
+    objectEncoders.remove(clazz);
     return this;
   }
 


### PR DESCRIPTION
Instead of throwing an error, we allow encoders to override previously registered ones.