### PR TITLE
Initial implementation of reflective encoder.

### DIFF
--- a/encoders/firebase-encoders-json/api.txt
+++ b/encoders/firebase-encoders-json/api.txt
@@ -40,15 +40,15 @@ package com.google.firebase.encoders {
 
 package com.google.firebase.encoders.annotations {
 
-  @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE) @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS) public @interface Encodable {
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE) @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME) public @interface Encodable {
   }
 
-  @java.lang.annotation.Target(java.lang.annotation.ElementType.METHOD) @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS) public static @interface Encodable.Field {
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.METHOD) @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME) public static @interface Encodable.Field {
     method public abstract boolean inline() default false;
     method public abstract String name() default "";
   }
 
-  @java.lang.annotation.Target(java.lang.annotation.ElementType.METHOD) @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS) public static @interface Encodable.Ignore {
+  @java.lang.annotation.Target(java.lang.annotation.ElementType.METHOD) @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME) public static @interface Encodable.Ignore {
   }
 
 }
@@ -74,6 +74,7 @@ package com.google.firebase.encoders.json {
     method @NonNull public com.google.firebase.encoders.json.JsonDataEncoderBuilder configureWith(@NonNull com.google.firebase.encoders.config.Configurator);
     method @NonNull public <T> com.google.firebase.encoders.json.JsonDataEncoderBuilder registerEncoder(@NonNull Class<T>, @NonNull com.google.firebase.encoders.ObjectEncoder<? super T>);
     method @NonNull public <T> com.google.firebase.encoders.json.JsonDataEncoderBuilder registerEncoder(@NonNull Class<T>, @NonNull com.google.firebase.encoders.ValueEncoder<? super T>);
+    method @NonNull public com.google.firebase.encoders.json.JsonDataEncoderBuilder registerFallbackEncoder(@NonNull com.google.firebase.encoders.ObjectEncoder<java.lang.Object>);
   }
 
 }

--- a/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
+++ b/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
@@ -15,7 +15,6 @@
 package com.google.firebase.encoders.json;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.google.firebase.encoders.DataEncoder;
 import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
@@ -36,8 +35,15 @@ import java.util.TimeZone;
 
 public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncoderBuilder> {
 
+  private final ObjectEncoder<Object> DEFAULT_FALLBACK_ENCODER =
+      (o, ctx) -> {
+        throw new EncodingException(
+            "Couldn't find encoder for type " + o.getClass().getCanonicalName());
+      };
+
   private final Map<Class<?>, ObjectEncoder<?>> objectEncoders = new HashMap<>();
   private final Map<Class<?>, ValueEncoder<?>> valueEncoders = new HashMap<>();
+  private ObjectEncoder<Object> fallbackEncoder = DEFAULT_FALLBACK_ENCODER;
 
   private static final class TimestampEncoder implements ValueEncoder<Date> {
     private static final DateFormat rfc339;
@@ -48,7 +54,7 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
     }
 
     @Override
-    public void encode(@Nullable Date o, @NonNull ValueEncoderContext ctx)
+    public void encode(@NonNull Date o, @NonNull ValueEncoderContext ctx)
         throws EncodingException, IOException {
       ctx.add(rfc339.format(o));
     }
@@ -84,6 +90,14 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
     return this;
   }
 
+  /** Encoder used if no encoders are found among explicitly registered ones. */
+  @NonNull
+  public JsonDataEncoderBuilder registerFallbackEncoder(
+      @NonNull ObjectEncoder<Object> fallbackEncoder) {
+    this.fallbackEncoder = fallbackEncoder;
+    return this;
+  }
+
   @NonNull
   public JsonDataEncoderBuilder configureWith(@NonNull Configurator config) {
     config.configure(this);
@@ -97,7 +111,8 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
       public void encode(@NonNull Object o, @NonNull Writer writer)
           throws IOException, EncodingException {
         JsonValueObjectEncoderContext encoderContext =
-            new JsonValueObjectEncoderContext(writer, objectEncoders, valueEncoders);
+            new JsonValueObjectEncoderContext(
+                writer, objectEncoders, valueEncoders, fallbackEncoder);
         encoderContext.add(o, false);
         encoderContext.close();
       }

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/annotations/Encodable.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/annotations/Encodable.java
@@ -42,12 +42,12 @@ import java.lang.annotation.Target;
  * }<pre>
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface Encodable {
 
   /** Field configuration. */
   @Target(ElementType.METHOD)
-  @Retention(RetentionPolicy.CLASS)
+  @Retention(RetentionPolicy.RUNTIME)
   @interface Field {
     /** Specifies a custom field name for a given property of a type. */
     String name() default "";
@@ -62,6 +62,6 @@ public @interface Encodable {
 
   /** Indicates the code generator to ignore a given property of a type. */
   @Target(ElementType.METHOD)
-  @Retention(RetentionPolicy.CLASS)
+  @Retention(RetentionPolicy.RUNTIME)
   @interface Ignore {}
 }

--- a/encoders/firebase-encoders-reflective/api.txt
+++ b/encoders/firebase-encoders-reflective/api.txt
@@ -1,0 +1,11 @@
+// Signature format: 2.0
+package com.google.firebase.encoders.reflective {
+
+  public class ReflectiveObjectEncoder implements com.google.firebase.encoders.ObjectEncoder<java.lang.Object> {
+    ctor public ReflectiveObjectEncoder(boolean);
+    method public void encode(@NonNull Object, @NonNull com.google.firebase.encoders.ObjectEncoderContext) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
+    field @NonNull public static final com.google.firebase.encoders.reflective.ReflectiveObjectEncoder DEFAULT;
+  }
+
+}
+

--- a/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
+++ b/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
@@ -1,0 +1,55 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id 'firebase-library'
+}
+
+firebaseLibrary {
+    publishSources = true
+    publishJavadoc = false
+}
+
+android {
+    compileSdkVersion project.targetSdkVersion
+    defaultConfig {
+        minSdkVersion project.minSdkVersion
+        targetSdkVersion project.targetSdkVersion
+        versionName version
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation project(':encoders:firebase-encoders-json')
+
+    testImplementation 'androidx.test:runner:1.2.0'
+    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation 'junit:junit:4.13-rc-1'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+
+}

--- a/encoders/firebase-encoders-reflective/src/main/AndroidManifest.xml
+++ b/encoders/firebase-encoders-reflective/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.encoders.reflective">
+    <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
+    <!--<uses-sdk android:minSdkVersion="14"/>-->
+</manifest>

--- a/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ObjectEncoderProvider.java
+++ b/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ObjectEncoderProvider.java
@@ -12,18 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.encoders;
+package com.google.firebase.encoders.reflective;
 
 import androidx.annotation.NonNull;
-import java.io.IOException;
+import com.google.firebase.encoders.ObjectEncoder;
 
-/**
- * An {@link Encoder} takes objects and writes them in {@code EncoderContext}.
- *
- * <p>This interface should be used as base for interfaces with concrete {@code Contexts}.
- */
-interface Encoder<TValue, TContext> {
-
-  /** Encode {@code obj} using {@code TContext}. */
-  void encode(@NonNull TValue obj, @NonNull TContext context) throws EncodingException, IOException;
+interface ObjectEncoderProvider {
+  @NonNull
+  <T> ObjectEncoder<T> get(@NonNull Class<T> type);
 }

--- a/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoder.java
+++ b/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoder.java
@@ -1,0 +1,69 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.reflective;
+
+import androidx.annotation.NonNull;
+import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.ObjectEncoder;
+import com.google.firebase.encoders.ObjectEncoderContext;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Uses Java reflection to encode arbitrary objects. */
+public class ReflectiveObjectEncoder implements ObjectEncoder<Object> {
+  @NonNull public static final ReflectiveObjectEncoder DEFAULT = new ReflectiveObjectEncoder(true);
+  private final Map<Class<?>, ObjectEncoder<?>> cache;
+  private final ObjectEncoderProvider provider;
+
+  private ReflectiveObjectEncoder(ObjectEncoderProvider provider, boolean threadSafe) {
+    this.provider = provider;
+    this.cache = threadSafe ? new ConcurrentHashMap<>() : new HashMap<>();
+  }
+
+  public ReflectiveObjectEncoder(boolean threadSafe) {
+    this(ReflectiveObjectEncoderProvider.INSTANCE, threadSafe);
+  }
+
+  @Override
+  public void encode(@NonNull Object obj, @NonNull ObjectEncoderContext ctx)
+      throws EncodingException, IOException {
+
+    @SuppressWarnings("unchecked")
+    ObjectEncoder<Object> encoder = getEncoder((Class<Object>) obj.getClass());
+    encoder.encode(obj, ctx);
+  }
+
+  private <T> ObjectEncoder<T> getEncoder(Class<T> type) {
+
+    ObjectEncoder<T> encoder = get(type);
+
+    if (encoder == null) {
+      encoder = provider.get(type);
+      put(type, encoder);
+    }
+    return encoder;
+  }
+
+  private <T> void put(Class<T> type, ObjectEncoder<T> encoder) {
+    cache.put(type, encoder);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> ObjectEncoder<T> get(Class<T> type) {
+    return (ObjectEncoder<T>) cache.get(type);
+  }
+}

--- a/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderProvider.java
+++ b/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderProvider.java
@@ -1,0 +1,128 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.reflective;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.ObjectEncoder;
+import com.google.firebase.encoders.ObjectEncoderContext;
+import com.google.firebase.encoders.annotations.Encodable;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+final class ReflectiveObjectEncoderProvider implements ObjectEncoderProvider {
+  static final ObjectEncoderProvider INSTANCE = new ReflectiveObjectEncoderProvider();
+
+  private static class ReflectiveObjectEncoderImpl implements ObjectEncoder<Object> {
+
+    private final Map<String, EncodingDescriptor> fields;
+
+    private ReflectiveObjectEncoderImpl(Map<String, EncodingDescriptor> fields) {
+      this.fields = fields;
+    }
+
+    @Override
+    public void encode(@Nullable Object obj, @NonNull ObjectEncoderContext ctx)
+        throws EncodingException, IOException {
+      for (Map.Entry<String, EncodingDescriptor> entry : fields.entrySet()) {
+        String fieldName = entry.getKey();
+        EncodingDescriptor descriptor = entry.getValue();
+        try {
+          if (descriptor.inline) {
+            ctx.inline(descriptor.method.invoke(obj));
+          } else {
+            ctx.add(fieldName, descriptor.method.invoke(obj));
+          }
+        } catch (IllegalAccessException e) {
+          throw new EncodingException(
+              String.format("Could not encode field '%s' of %s.", fieldName, obj.getClass()), e);
+        } catch (InvocationTargetException e) {
+          throw new EncodingException(
+              String.format("Could not encode field '%s' of %s.", fieldName, obj.getClass()), e);
+        }
+      }
+    }
+  }
+
+  @NonNull
+  @Override
+  public <T> ObjectEncoder<T> get(@NonNull Class<T> type) {
+    Map<String, EncodingDescriptor> fields = new HashMap<>();
+    for (Method method : type.getMethods()) {
+      if (method.isAnnotationPresent(Encodable.Ignore.class)) {
+        continue;
+      }
+
+      Encodable.Field fieldAnnotation = method.getAnnotation(Encodable.Field.class);
+      String getter = toGetterName(method, fieldAnnotation);
+      if (getter != null) {
+        method.setAccessible(true);
+        fields.put(
+            getter,
+            new EncodingDescriptor(fieldAnnotation != null && fieldAnnotation.inline(), method));
+      }
+    }
+    @SuppressWarnings("unchecked")
+    ObjectEncoder<T> encoder = (ObjectEncoder<T>) new ReflectiveObjectEncoderImpl(fields);
+    return encoder;
+  }
+
+  @Nullable
+  private static String toGetterName(Method m, @Nullable Encodable.Field fieldAnnotation) {
+    Class<?> returnType = m.getReturnType();
+    if (Modifier.isStatic(m.getModifiers())
+        || !Modifier.isPublic(m.getModifiers())
+        || m.getParameterTypes().length > 0
+        || returnType.equals(void.class)
+        || m.getDeclaringClass().equals(Object.class)) {
+      return null;
+    }
+
+    if (fieldAnnotation != null) {
+      String annotationName = fieldAnnotation.name();
+      if (!annotationName.isEmpty()) {
+        return annotationName;
+      }
+    }
+
+    String methodName = m.getName();
+
+    if (returnType.equals(boolean.class)
+        && methodName.startsWith("is")
+        && methodName.length() > 2) {
+      return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+    }
+
+    if (methodName.startsWith("get") && methodName.length() > 3) {
+      return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+    }
+    return null;
+  }
+
+  private static class EncodingDescriptor {
+    final boolean inline;
+    final Method method;
+
+    EncodingDescriptor(boolean inline, Method method) {
+      this.inline = inline;
+      this.method = method;
+    }
+  }
+}

--- a/encoders/firebase-encoders-reflective/src/test/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderTest.java
+++ b/encoders/firebase-encoders-reflective/src/test/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderTest.java
@@ -1,0 +1,70 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.reflective;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.firebase.encoders.DataEncoder;
+import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.annotations.Encodable;
+import com.google.firebase.encoders.json.JsonDataEncoderBuilder;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class ReflectiveObjectEncoderTest {
+  static class Foo {
+    public String getString() {
+      return "hello";
+    }
+
+    public Member getMember() {
+      return new Member();
+    }
+
+    @Encodable.Field(inline = true)
+    public Member getInlineMember() {
+      return new Member();
+    }
+
+    public Map<String, Number> getMap() {
+      return Collections.singletonMap("key", BigDecimal.valueOf(22));
+    }
+  }
+
+  static class Member {
+    public boolean getBool() {
+      return false;
+    }
+  }
+
+  @Test
+  public void test() throws EncodingException {
+    DataEncoder encoder =
+        new JsonDataEncoderBuilder()
+            .registerFallbackEncoder(ReflectiveObjectEncoder.DEFAULT)
+            .build();
+
+    String result = encoder.encode(new Foo());
+
+    assertThat(result)
+        .isEqualTo(
+            "{\"string\":\"hello\",\"member\":{\"bool\":false},\"map\":{\"key\":22},\"bool\":false}");
+  }
+}

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -33,6 +33,7 @@ encoders
 encoders:firebase-encoders-json
 encoders:firebase-encoders-processor
 encoders:firebase-encoders-processor:test-support
+encoders:firebase-encoders-reflective
 
 tools:errorprone
 tools:lint


### PR DESCRIPTION
The change introduces the concept of a "fallback" encoder that is used
for any type that does not have an explicitly registered encoder.

The reflective encoder itself is currently implemented in terms of
public getters and does not look at class fields, this can be made
configurable in the future.