### PR TITLE
Change the default FTL bucket to "fireescape-ftl-test-results".

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/device/FirebaseTestServer.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/device/FirebaseTestServer.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.Project
 
 
 class FirebaseTestServer extends TestServer {
-    private static final String DEFAULT_BUCKET_NAME = 'android-ci'
+    private static final String DEFAULT_BUCKET_NAME = 'fireescape-ftl-test-results'
     final Project project
     final FirebaseTestLabExtension extension
     final Random random

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/device/FirebaseTestServer.groovy
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/device/FirebaseTestServer.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.Project
 
 
 class FirebaseTestServer extends TestServer {
-    private static final String DEFAULT_BUCKET_NAME = 'fireescape-ftl-test-results'
     final Project project
     final FirebaseTestLabExtension extension
     final Random random
@@ -68,7 +67,10 @@ class FirebaseTestServer extends TestServer {
         Optional<String> resultsBucket = Optional.ofNullable(System.getenv('FTL_RESULTS_BUCKET')).map(Environment.&expand)
         Optional<String> resultsDir = Optional.ofNullable(System.getenv('FTL_RESULTS_DIR')).map(Environment.&expand)
 
-        List<String> args = ['--results-bucket', resultsBucket.orElse(DEFAULT_BUCKET_NAME)]
+        List<String> args = []
+        if (resultsBucket.isPresent()) {
+            args += ['--results-bucket', resultsBucket.get()]
+        }
         if (resultsDir.isPresent()) {
             args += ['--results-dir', Paths.get(resultsDir.get(), "${project.path}_${random.nextLong()}")]
         }


### PR DESCRIPTION
FTL tests started from local will upload artifacts/logs to the new
bucket. This avoids clutter in the bucket "android-ci".