### PR TITLE
Get the IID token before fetching Remote Config.

### DIFF
--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -48,6 +48,9 @@ dependencies {
     implementation project(':firebase-common:ktx')
     implementation project(':firebase-config')
     implementation project (':firebase-abt')
+    implementation ('com.google.firebase:firebase-iid:20.0.1') {
+        exclude group: "com.google.firebase", module: "firebase-common"
+    }
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/TestConstructorUtil.kt
+++ b/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/TestConstructorUtil.kt
@@ -22,12 +22,14 @@ import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
 import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import java.util.concurrent.Executor
 import com.google.firebase.abt.FirebaseABTesting
+import com.google.firebase.iid.FirebaseInstanceId
 
 // This method is a workaround for testing. It enable us to create a FirebaseRemoteConfig object
 // with mocks using the package-private constructor.
 fun createRemoteConfig(
     context: Context?,
     firebaseApp: FirebaseApp,
+    firebaseInstanceId: FirebaseInstanceId,
     firebaseAbt: FirebaseABTesting?,
     executor: Executor,
     fetchedConfigsCache: ConfigCacheClient,
@@ -40,6 +42,7 @@ fun createRemoteConfig(
         return FirebaseRemoteConfig(
             context,
             firebaseApp,
+            firebaseInstanceId,
             firebaseAbt,
             executor,
             fetchedConfigsCache,

--- a/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
+++ b/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
@@ -26,6 +26,7 @@ import com.google.firebase.remoteconfig.internal.ConfigFetchHandler
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
 import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import com.google.common.util.concurrent.MoreExecutors
+import com.google.firebase.iid.FirebaseInstanceId
 import com.google.firebase.ktx.app
 import com.google.firebase.ktx.initialize
 import org.junit.After
@@ -127,6 +128,7 @@ class ConfigTests : BaseTestCase() {
         val remoteConfig = createRemoteConfig(
             context = null,
             firebaseApp = Firebase.app(EXISTING_APP),
+            firebaseInstanceId = mock(FirebaseInstanceId::class.java),
             firebaseAbt = null,
             executor = directExecutor,
             fetchedConfigsCache = mock(ConfigCacheClient::class.java),

--- a/firebase-config/src/androidTest/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigIntegrationTest.java
+++ b/firebase-config/src/androidTest/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigIntegrationTest.java
@@ -30,6 +30,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.abt.FirebaseABTesting;
+import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.remoteconfig.internal.ConfigCacheClient;
 import com.google.firebase.remoteconfig.internal.ConfigContainer;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
@@ -63,6 +64,7 @@ public class FirebaseRemoteConfigIntegrationTest {
   @Mock private ConfigCacheClient mockFireperfActivatedCache;
 
   @Mock private FirebaseABTesting mockFirebaseAbt;
+  @Mock private FirebaseInstanceId mockFirebaseInstanceId;
   private FirebaseRemoteConfig frc;
 
   // We use a HashMap so that Mocking is easier.
@@ -101,7 +103,8 @@ public class FirebaseRemoteConfigIntegrationTest {
             mockDefaultsCache,
             mockFetchHandler,
             mockGetHandler,
-            metadataClient);
+            metadataClient,
+            mockFirebaseInstanceId);
   }
 
   @Test

--- a/firebase-config/src/androidTest/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigIntegrationTest.java
+++ b/firebase-config/src/androidTest/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigIntegrationTest.java
@@ -96,6 +96,7 @@ public class FirebaseRemoteConfigIntegrationTest {
         new FirebaseRemoteConfig(
             context,
             firebaseApp,
+            mockFirebaseInstanceId,
             mockFirebaseAbt,
             directExecutor,
             mockFetchedCache,
@@ -103,8 +104,7 @@ public class FirebaseRemoteConfigIntegrationTest {
             mockDefaultsCache,
             mockFetchHandler,
             mockGetHandler,
-            metadataClient,
-            mockFirebaseInstanceId);
+            metadataClient);
   }
 
   @Test

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -159,6 +159,7 @@ public class FirebaseRemoteConfig {
   FirebaseRemoteConfig(
       Context context,
       FirebaseApp firebaseApp,
+      FirebaseInstanceId firebaseInstanceId,
       @Nullable FirebaseABTesting firebaseAbt,
       Executor executor,
       ConfigCacheClient fetchedConfigsCache,
@@ -166,10 +167,10 @@ public class FirebaseRemoteConfig {
       ConfigCacheClient defaultConfigsCache,
       ConfigFetchHandler fetchHandler,
       ConfigGetParameterHandler getHandler,
-      ConfigMetadataClient frcMetadata,
-      FirebaseInstanceId firebaseInstanceId) {
+      ConfigMetadataClient frcMetadata) {
     this.context = context;
     this.firebaseApp = firebaseApp;
+    this.firebaseInstanceId = firebaseInstanceId;
     this.firebaseAbt = firebaseAbt;
     this.executor = executor;
     this.fetchedConfigsCache = fetchedConfigsCache;
@@ -178,7 +179,6 @@ public class FirebaseRemoteConfig {
     this.fetchHandler = fetchHandler;
     this.getHandler = getHandler;
     this.frcMetadata = frcMetadata;
-    this.firebaseInstanceId = firebaseInstanceId;
   }
 
   /**

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -26,6 +26,8 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.abt.AbtException;
 import com.google.firebase.abt.FirebaseABTesting;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.remoteconfig.internal.ConfigCacheClient;
 import com.google.firebase.remoteconfig.internal.ConfigContainer;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
@@ -147,6 +149,7 @@ public class FirebaseRemoteConfig {
   private final ConfigFetchHandler fetchHandler;
   private final ConfigGetParameterHandler getHandler;
   private final ConfigMetadataClient frcMetadata;
+  private final FirebaseInstanceId firebaseInstanceId;
 
   /**
    * Firebase Remote Config constructor.
@@ -163,7 +166,8 @@ public class FirebaseRemoteConfig {
       ConfigCacheClient defaultConfigsCache,
       ConfigFetchHandler fetchHandler,
       ConfigGetParameterHandler getHandler,
-      ConfigMetadataClient frcMetadata) {
+      ConfigMetadataClient frcMetadata,
+      FirebaseInstanceId firebaseInstanceId) {
     this.context = context;
     this.firebaseApp = firebaseApp;
     this.firebaseAbt = firebaseAbt;
@@ -174,6 +178,7 @@ public class FirebaseRemoteConfig {
     this.fetchHandler = fetchHandler;
     this.getHandler = getHandler;
     this.frcMetadata = frcMetadata;
+    this.firebaseInstanceId = firebaseInstanceId;
   }
 
   /**
@@ -186,9 +191,14 @@ public class FirebaseRemoteConfig {
     Task<ConfigContainer> defaultsConfigsTask = defaultConfigsCache.get();
     Task<ConfigContainer> fetchedConfigsTask = fetchedConfigsCache.get();
     Task<FirebaseRemoteConfigInfo> metadataTask = Tasks.call(executor, this::getInfo);
+    Task<InstanceIdResult> instanceIdTask = firebaseInstanceId.getInstanceId();
 
     return Tasks.whenAllComplete(
-            activatedConfigsTask, defaultsConfigsTask, fetchedConfigsTask, metadataTask)
+            activatedConfigsTask,
+            defaultsConfigsTask,
+            fetchedConfigsTask,
+            metadataTask,
+            instanceIdTask)
         .continueWith(executor, (unusedListOfCompletedTasks) -> metadataTask.getResult());
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -156,6 +156,7 @@ public class RemoteConfigComponent {
     return get(
         firebaseApp,
         namespace,
+        firebaseInstanceId,
         firebaseAbt,
         executorService,
         fetchedCacheClient,
@@ -170,6 +171,7 @@ public class RemoteConfigComponent {
   synchronized FirebaseRemoteConfig get(
       FirebaseApp firebaseApp,
       String namespace,
+      FirebaseInstanceId firebaseInstanceId,
       FirebaseABTesting firebaseAbt,
       Executor executor,
       ConfigCacheClient fetchedClient,
@@ -183,6 +185,7 @@ public class RemoteConfigComponent {
           new FirebaseRemoteConfig(
               context,
               firebaseApp,
+              firebaseInstanceId,
               isAbtSupported(firebaseApp, namespace) ? firebaseAbt : null,
               executor,
               fetchedClient,
@@ -190,8 +193,7 @@ public class RemoteConfigComponent {
               defaultsClient,
               fetchHandler,
               getHandler,
-              metadataClient,
-              firebaseInstanceId);
+              metadataClient);
       in.startLoadingConfigsFromDisk();
       frcNamespaceInstances.put(namespace, in);
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -190,7 +190,8 @@ public class RemoteConfigComponent {
               defaultsClient,
               fetchHandler,
               getHandler,
-              metadataClient);
+              metadataClient,
+              firebaseInstanceId);
       in.startLoadingConfigsFromDisk();
       frcNamespaceInstances.put(namespace, in);
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -36,6 +36,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.analytics.connector.AnalyticsConnector;
 import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigClientException;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigException;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigFetchThrottledException;
@@ -188,7 +189,18 @@ public class ConfigFetchHandler {
                   createThrottledMessage(backoffEndTime.getTime() - currentTime.getTime()),
                   backoffEndTime.getTime()));
     } else {
-      fetchResponseTask = fetchFromBackendAndCacheResponse(currentTime);
+      Task<InstanceIdResult> instanceIdTask = firebaseInstanceId.getInstanceId();
+      fetchResponseTask = instanceIdTask
+              .continueWithTask(executor, (completedIidTask) -> {
+                if (!instanceIdTask.isSuccessful()) {
+                  return Tasks.forException(new FirebaseRemoteConfigClientException(
+                          "Failed to get Firebase Instance ID token for fetch.",
+                          instanceIdTask.getException()));
+                }
+
+                InstanceIdResult instanceIdResult = completedIidTask.getResult();
+                return fetchFromBackendAndCacheResponse(instanceIdResult, currentTime);
+              });
     }
 
     return fetchResponseTask.continueWithTask(
@@ -246,9 +258,9 @@ public class ConfigFetchHandler {
    * Fetches configs from the FRC backend. If there are any updates, writes the configs to the
    * {@code fetchedConfigsCache}.
    */
-  private Task<FetchResponse> fetchFromBackendAndCacheResponse(Date fetchTime) {
+  private Task<FetchResponse> fetchFromBackendAndCacheResponse(InstanceIdResult instanceId, Date fetchTime) {
     try {
-      FetchResponse fetchResponse = fetchFromBackend(fetchTime);
+      FetchResponse fetchResponse = fetchFromBackend(instanceId, fetchTime);
       if (fetchResponse.getStatus() != Status.BACKEND_UPDATES_FETCHED) {
         return Tasks.forResult(fetchResponse);
       }
@@ -270,15 +282,15 @@ public class ConfigFetchHandler {
    *     error connecting to the server.
    */
   @WorkerThread
-  private FetchResponse fetchFromBackend(Date currentTime) throws FirebaseRemoteConfigException {
+  private FetchResponse fetchFromBackend(InstanceIdResult instanceId, Date currentTime) throws FirebaseRemoteConfigException {
     try {
       HttpURLConnection urlConnection = frcBackendApiClient.createHttpURLConnection();
 
       FetchResponse response =
           frcBackendApiClient.fetch(
               urlConnection,
-              firebaseInstanceId.getId(),
-              firebaseInstanceId.getToken(),
+              instanceId.getId(),
+              instanceId.getToken(),
               getUserProperties(),
               frcMetadata.getLastFetchETag(),
               customHttpHeaders,

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -194,7 +194,7 @@ public class ConfigFetchHandler {
           instanceIdTask.continueWithTask(
               executor,
               (completedIidTask) -> {
-                if (!instanceIdTask.isSuccessful()) {
+                if (!completedIidTask.isSuccessful()) {
                   return Tasks.forException(
                       new FirebaseRemoteConfigClientException(
                           "Failed to get Firebase Instance ID token for fetch.",

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -198,7 +198,7 @@ public class ConfigFetchHandler {
                   return Tasks.forException(
                       new FirebaseRemoteConfigClientException(
                           "Failed to get Firebase Instance ID token for fetch.",
-                          instanceIdTask.getException()));
+                          completedIidTask.getException()));
                 }
 
                 InstanceIdResult instanceIdResult = completedIidTask.getResult();

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -190,10 +190,13 @@ public class ConfigFetchHandler {
                   backoffEndTime.getTime()));
     } else {
       Task<InstanceIdResult> instanceIdTask = firebaseInstanceId.getInstanceId();
-      fetchResponseTask = instanceIdTask
-              .continueWithTask(executor, (completedIidTask) -> {
+      fetchResponseTask =
+          instanceIdTask.continueWithTask(
+              executor,
+              (completedIidTask) -> {
                 if (!instanceIdTask.isSuccessful()) {
-                  return Tasks.forException(new FirebaseRemoteConfigClientException(
+                  return Tasks.forException(
+                      new FirebaseRemoteConfigClientException(
                           "Failed to get Firebase Instance ID token for fetch.",
                           instanceIdTask.getException()));
                 }
@@ -258,7 +261,8 @@ public class ConfigFetchHandler {
    * Fetches configs from the FRC backend. If there are any updates, writes the configs to the
    * {@code fetchedConfigsCache}.
    */
-  private Task<FetchResponse> fetchFromBackendAndCacheResponse(InstanceIdResult instanceId, Date fetchTime) {
+  private Task<FetchResponse> fetchFromBackendAndCacheResponse(
+      InstanceIdResult instanceId, Date fetchTime) {
     try {
       FetchResponse fetchResponse = fetchFromBackend(instanceId, fetchTime);
       if (fetchResponse.getStatus() != Status.BACKEND_UPDATES_FETCHED) {
@@ -282,7 +286,8 @@ public class ConfigFetchHandler {
    *     error connecting to the server.
    */
   @WorkerThread
-  private FetchResponse fetchFromBackend(InstanceIdResult instanceId, Date currentTime) throws FirebaseRemoteConfigException {
+  private FetchResponse fetchFromBackend(InstanceIdResult instanceId, Date currentTime)
+      throws FirebaseRemoteConfigException {
     try {
       HttpURLConnection urlConnection = frcBackendApiClient.createHttpURLConnection();
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -180,7 +180,7 @@ public class ConfigFetchHttpClient {
               .toString()
               .getBytes("utf-8");
       setFetchRequestBody(urlConnection, requestBody);
-      
+
       urlConnection.connect();
 
       int responseCode = urlConnection.getResponseCode();

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -181,6 +181,9 @@ public class ConfigFetchHttpClient {
               .getBytes("utf-8");
       setFetchRequestBody(urlConnection, requestBody);
 
+      Log.i("ConfigFetchHttpClient", "fetching with request body " + createFetchRequestBody(instanceId, instanceIdToken, analyticsUserProperties)
+              .toString());
+
       urlConnection.connect();
 
       int responseCode = urlConnection.getResponseCode();

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -180,10 +180,7 @@ public class ConfigFetchHttpClient {
               .toString()
               .getBytes("utf-8");
       setFetchRequestBody(urlConnection, requestBody);
-
-      Log.i("ConfigFetchHttpClient", "fetching with request body " + createFetchRequestBody(instanceId, instanceIdToken, analyticsUserProperties)
-              .toString());
-
+      
       urlConnection.connect();
 
       int responseCode = urlConnection.getResponseCode();

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FakeInstanceIdResult.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FakeInstanceIdResult.java
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.remoteconfig;
 
 import com.google.firebase.iid.InstanceIdResult;

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FakeInstanceIdResult.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FakeInstanceIdResult.java
@@ -22,21 +22,21 @@ import com.google.firebase.iid.InstanceIdResult;
  * @author Dana Silver
  */
 public class FakeInstanceIdResult implements InstanceIdResult {
-    private final String id;
-    private final String token;
+  private final String id;
+  private final String token;
 
-    public FakeInstanceIdResult(String id, String token) {
-        this.id = id;
-        this.token = token;
-    }
+  public FakeInstanceIdResult(String id, String token) {
+    this.id = id;
+    this.token = token;
+  }
 
-    @Override
-    public String getId() {
-        return id;
-    }
+  @Override
+  public String getId() {
+    return id;
+  }
 
-    @Override
-    public String getToken() {
-        return token;
-    }
+  @Override
+  public String getToken() {
+    return token;
+  }
 }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FakeInstanceIdResult.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FakeInstanceIdResult.java
@@ -1,0 +1,28 @@
+package com.google.firebase.remoteconfig;
+
+import com.google.firebase.iid.InstanceIdResult;
+
+/**
+ * Implementation of InstanceIdResult intended for testing.
+ *
+ * @author Dana Silver
+ */
+public class FakeInstanceIdResult implements InstanceIdResult {
+    private final String id;
+    private final String token;
+
+    public FakeInstanceIdResult(String id, String token) {
+        this.id = id;
+        this.token = token;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getToken() {
+        return token;
+    }
+}

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -45,6 +45,8 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.abt.AbtException;
 import com.google.firebase.abt.FirebaseABTesting;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.remoteconfig.internal.ConfigCacheClient;
 import com.google.firebase.remoteconfig.internal.ConfigContainer;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
@@ -94,6 +96,11 @@ public final class FirebaseRemoteConfigTest {
 
   private static final String ETAG = "ETag";
 
+  private static final String INSTANCE_ID_STRING = "fake instance id";
+  private static final String INSTANCE_ID_TOKEN_STRING = "fake instance id token";
+  private static final InstanceIdResult INSTANCE_ID_RESULT =
+      new FakeInstanceIdResult(INSTANCE_ID_STRING, INSTANCE_ID_TOKEN_STRING);
+
   // We use a HashMap so that Mocking is easier.
   private static final HashMap<String, Object> DEFAULTS_MAP = new HashMap<>();
   private static final HashMap<String, String> DEFAULTS_STRING_MAP = new HashMap<>();
@@ -114,6 +121,7 @@ public final class FirebaseRemoteConfigTest {
   @Mock private FirebaseRemoteConfigInfo mockFrcInfo;
 
   @Mock private FirebaseABTesting mockFirebaseAbt;
+  @Mock private FirebaseInstanceId mockFirebaseInstanceId;
 
   private FirebaseRemoteConfig frc;
   private FirebaseRemoteConfig fireperfFrc;
@@ -157,7 +165,8 @@ public final class FirebaseRemoteConfigTest {
             mockDefaultsCache,
             mockFetchHandler,
             mockGetHandler,
-            metadataClient);
+            metadataClient,
+            mockFirebaseInstanceId);
 
     // Set up an FRC instance for the Fireperf namespace that uses mocked clients.
     fireperfFrc =
@@ -196,6 +205,7 @@ public final class FirebaseRemoteConfigTest {
   public void ensureInitialized_notInitialized_isNotComplete() {
     loadCacheWithConfig(mockFetchedCache, /*container=*/ null);
     loadCacheWithConfig(mockDefaultsCache, /*container=*/ null);
+    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(Tasks.forResult(INSTANCE_ID_RESULT));
     loadActivatedCacheWithIncompleteTask();
 
     Task<FirebaseRemoteConfigInfo> initStatus = frc.ensureInitialized();
@@ -210,6 +220,7 @@ public final class FirebaseRemoteConfigTest {
     loadCacheWithConfig(mockFetchedCache, /*container=*/ null);
     loadCacheWithConfig(mockDefaultsCache, /*container=*/ null);
     loadCacheWithConfig(mockActivatedCache, /*container=*/ null);
+    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(Tasks.forResult(INSTANCE_ID_RESULT));
 
     Task<FirebaseRemoteConfigInfo> initStatus = frc.ensureInitialized();
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -158,6 +158,7 @@ public final class FirebaseRemoteConfigTest {
         new FirebaseRemoteConfig(
             context,
             firebaseApp,
+            mockFirebaseInstanceId,
             mockFirebaseAbt,
             directExecutor,
             mockFetchedCache,
@@ -165,8 +166,7 @@ public final class FirebaseRemoteConfigTest {
             mockDefaultsCache,
             mockFetchHandler,
             mockGetHandler,
-            metadataClient,
-            mockFirebaseInstanceId);
+            metadataClient);
 
     // Set up an FRC instance for the Fireperf namespace that uses mocked clients.
     fireperfFrc =
@@ -175,6 +175,7 @@ public final class FirebaseRemoteConfigTest {
             .get(
                 firebaseApp,
                 FIREPERF_NAMESPACE,
+                mockFirebaseInstanceId,
                 /*firebaseAbt=*/ null,
                 directExecutor,
                 mockFireperfFetchedCache,

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -206,8 +206,8 @@ public final class FirebaseRemoteConfigTest {
   public void ensureInitialized_notInitialized_isNotComplete() {
     loadCacheWithConfig(mockFetchedCache, /*container=*/ null);
     loadCacheWithConfig(mockDefaultsCache, /*container=*/ null);
-    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(Tasks.forResult(INSTANCE_ID_RESULT));
     loadActivatedCacheWithIncompleteTask();
+    loadInstanceIdAndToken();
 
     Task<FirebaseRemoteConfigInfo> initStatus = frc.ensureInitialized();
 
@@ -221,7 +221,7 @@ public final class FirebaseRemoteConfigTest {
     loadCacheWithConfig(mockFetchedCache, /*container=*/ null);
     loadCacheWithConfig(mockDefaultsCache, /*container=*/ null);
     loadCacheWithConfig(mockActivatedCache, /*container=*/ null);
-    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(Tasks.forResult(INSTANCE_ID_RESULT));
+    loadInstanceIdAndToken();
 
     Task<FirebaseRemoteConfigInfo> initStatus = frc.ensureInitialized();
 
@@ -1176,6 +1176,10 @@ public final class FirebaseRemoteConfigTest {
   private void load2pFetchHandlerWithResponse() {
     when(mockFireperfFetchHandler.fetch())
         .thenReturn(Tasks.forResult(firstFetchedContainerResponse));
+  }
+
+  private void loadInstanceIdAndToken() {
+    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(Tasks.forResult(INSTANCE_ID_RESULT));
   }
 
   private static int getResourceId(String xmlResourceName) {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -202,6 +202,7 @@ public class RemoteConfigComponentTest {
     return frcComponent.get(
         mockFirebaseApp,
         namespace,
+        mockFirebaseIid,
         mockFirebaseAbt,
         directExecutor,
         mockFetchedCache,

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -60,7 +60,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.firebase.analytics.connector.AnalyticsConnector;
 import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.remoteconfig.FakeInstanceIdResult;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigClientException;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigFetchThrottledException;
@@ -178,26 +177,28 @@ public class ConfigFetchHandlerTest {
     fetchCallToHttpClientReturnsConfigWithCurrentTime(firstFetchedContainer);
 
     assertWithMessage("Fetch() does not include IID token.")
-            .that(fetchHandler.fetch().isSuccessful())
-            .isTrue();
+        .that(fetchHandler.fetch().isSuccessful())
+        .isTrue();
 
     verify(mockBackendFetchApiClient)
-            .fetch(
-                    any(HttpURLConnection.class),
-                    /* instanceId= */ any(),
-                    /* instanceIdToken= */ eq(INSTANCE_ID_TOKEN_STRING),
-                    /* analyticsUserProperties= */ any(),
-                    /* lastFetchETag= */ any(),
-                    /* customHeaders= */ any(),
-                    /* currentTime= */ any());
+        .fetch(
+            any(HttpURLConnection.class),
+            /* instanceId= */ any(),
+            /* instanceIdToken= */ eq(INSTANCE_ID_TOKEN_STRING),
+            /* analyticsUserProperties= */ any(),
+            /* lastFetchETag= */ any(),
+            /* customHeaders= */ any(),
+            /* currentTime= */ any());
   }
 
   @Test
   public void fetch_failToGetIidToken_throwsRemoteConfigException() throws Exception {
-    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(Tasks.forException(new IOException("SERVICE_NOT_AVAILABLE")));
+    when(mockFirebaseInstanceId.getInstanceId())
+        .thenReturn(Tasks.forException(new IOException("SERVICE_NOT_AVAILABLE")));
     fetchCallToHttpClientReturnsConfigWithCurrentTime(firstFetchedContainer);
 
-    assertThrowsClientException(fetchHandler.fetch(), "Failed to get Firebase Instance ID token for fetch.");
+    assertThrowsClientException(
+        fetchHandler.fetch(), "Failed to get Firebase Instance ID token for fetch.");
 
     verifyBackendIsNeverCalled();
   }
@@ -897,8 +898,10 @@ public class ConfigFetchHandlerTest {
   }
 
   private void loadInstanceIdAndToken() {
-    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(
-            Tasks.forResult(new FakeInstanceIdResult(INSTANCE_ID_STRING, INSTANCE_ID_TOKEN_STRING)));
+    when(mockFirebaseInstanceId.getInstanceId())
+        .thenReturn(
+            Tasks.forResult(
+                new FakeInstanceIdResult(INSTANCE_ID_STRING, INSTANCE_ID_TOKEN_STRING)));
   }
 
   private void loadCacheAndClockWithConfig(

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -60,6 +60,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.firebase.analytics.connector.AnalyticsConnector;
 import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.remoteconfig.FakeInstanceIdResult;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigClientException;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigFetchThrottledException;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigServerException;
@@ -169,6 +171,35 @@ public class ConfigFetchHandlerTest {
         .isTrue();
 
     verifyBackendIsCalled();
+  }
+
+  @Test
+  public void fetch_firstFetch_includesIidToken() throws Exception {
+    fetchCallToHttpClientReturnsConfigWithCurrentTime(firstFetchedContainer);
+
+    assertWithMessage("Fetch() does not include IID token.")
+            .that(fetchHandler.fetch().isSuccessful())
+            .isTrue();
+
+    verify(mockBackendFetchApiClient)
+            .fetch(
+                    any(HttpURLConnection.class),
+                    /* instanceId= */ any(),
+                    /* instanceIdToken= */ eq(INSTANCE_ID_TOKEN_STRING),
+                    /* analyticsUserProperties= */ any(),
+                    /* lastFetchETag= */ any(),
+                    /* customHeaders= */ any(),
+                    /* currentTime= */ any());
+  }
+
+  @Test
+  public void fetch_failToGetIidToken_throwsRemoteConfigException() throws Exception {
+    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(Tasks.forException(new IOException("SERVICE_NOT_AVAILABLE")));
+    fetchCallToHttpClientReturnsConfigWithCurrentTime(firstFetchedContainer);
+
+    assertThrowsClientException(fetchHandler.fetch(), "Failed to get Firebase Instance ID token for fetch.");
+
+    verifyBackendIsNeverCalled();
   }
 
   @Test
@@ -866,8 +897,8 @@ public class ConfigFetchHandlerTest {
   }
 
   private void loadInstanceIdAndToken() {
-    when(mockFirebaseInstanceId.getId()).thenReturn(INSTANCE_ID_STRING);
-    when(mockFirebaseInstanceId.getToken()).thenReturn(INSTANCE_ID_TOKEN_STRING);
+    when(mockFirebaseInstanceId.getInstanceId()).thenReturn(
+            Tasks.forResult(new FakeInstanceIdResult(INSTANCE_ID_STRING, INSTANCE_ID_TOKEN_STRING)));
   }
 
   private void loadCacheAndClockWithConfig(


### PR DESCRIPTION
Remote Config requires an IID token to evaluate certain conditions, but does not currently wait for the token from `FirebaseInstanceId#getToken()` before fetching. This returns the default condition value in some cases (ex. percentage conditions) rather than the evaluated result for an app instance.

This change replaces the use of the deprecated `#getToken()` with `#getInstanceId()`, which returns an async `Task` we can wait to complete before fetching, without otherwise blocking.