### PR TITLE
Fixed version number to identify Firebase Installations SDK

### DIFF
--- a/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
@@ -176,7 +176,7 @@ public class FirebaseInstallationServiceClient {
     firebaseInstallationData.put("fid", fid);
     firebaseInstallationData.put("appId", appId);
     firebaseInstallationData.put("authVersion", FIREBASE_INSTALLATION_AUTH_VERSION);
-    firebaseInstallationData.put("sdkVersion", "t.1.1.0");
+    firebaseInstallationData.put("sdkVersion", "a:1.0.0");
     return firebaseInstallationData;
   }
 


### PR DESCRIPTION
Fixed version number to identify Firebase Installations Android SDK in order to enable Instance-ID migration auth.