### PR TITLE
Update Crashlytics NDK README

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ projects may be published as follows.
     publishProjectsToMavenLocal
 ```
 
+**Note:** Firebase Crashlytics NDK requires NDK version r17c to build. Please
+see the [README](firebase-crashlytics-ndk/README.md) for setup instructions.
+Alternatively, if you do not need to build this project, you can safely disable
+it by commenting out its reference in [subprojects.cfg](subprojects.cfg).
+
 ### Code Formatting
 
 Code in this repo is formatted with the google-java-format tool. You can enable

--- a/firebase-crashlytics-ndk/README.md
+++ b/firebase-crashlytics-ndk/README.md
@@ -2,7 +2,22 @@
 
 This component enables NDK crash reporting with Crashlytics.
 
-Requires NDK version r17c to build.
+## Prerequisites
+
+This project depends on two submodules in the `third_party` directory.
+Initialize them by running the following commands:
+
+`git submodule init && git submodule update`
+
+In addition, **this project requires NDK version r17c to build.**
+
+### Setting up NDK r17c
+
+1. Download the appropriate zip for your build environment
+[here](https://developer.android.com/ndk/downloads/older_releases.html).
+2. Unzip the package into an accessible directory.
+3. In your `local.properties` file in the root of this project, add
+`ndk.dir=/path/to/android-ndk-r17c` with the path to the unzipped package.
 
 ## Building
 


### PR DESCRIPTION
Add more detailed notes about how to set up the build environment
for Crashlytics NDK.