### PR TITLE
Add an ObjectValue builder

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -117,7 +117,7 @@ public final class UserDataConverter {
 
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.Update);
     ParseContext context = accumulator.rootContext();
-    ObjectValue.Builder updateData = ObjectValue.Builder.emptyBuilder();
+    ObjectValue.Builder updateData = ObjectValue.newBuilder();
 
     for (Entry<String, Object> entry : data.entrySet()) {
       FieldPath fieldPath =
@@ -155,7 +155,7 @@ public final class UserDataConverter {
 
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.Update);
     ParseContext context = accumulator.rootContext();
-    ObjectValue.Builder updateData = ObjectValue.Builder.emptyBuilder();
+    ObjectValue.Builder updateData = ObjectValue.newBuilder();
 
     Iterator<Object> iterator = fieldsAndValues.iterator();
     while (iterator.hasNext()) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataConverter.java
@@ -117,7 +117,7 @@ public final class UserDataConverter {
 
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.Update);
     ParseContext context = accumulator.rootContext();
-    ObjectValue updateData = ObjectValue.emptyObject();
+    ObjectValue.Builder updateData = ObjectValue.Builder.emptyBuilder();
 
     for (Entry<String, Object> entry : data.entrySet()) {
       FieldPath fieldPath =
@@ -134,12 +134,12 @@ public final class UserDataConverter {
             convertAndParseFieldData(fieldValue, context.childContext(fieldPath));
         if (parsedValue != null) {
           context.addToFieldMask(fieldPath);
-          updateData = updateData.set(fieldPath, parsedValue);
+          updateData.set(fieldPath, parsedValue);
         }
       }
     }
 
-    return accumulator.toUpdateData(updateData);
+    return accumulator.toUpdateData(updateData.build());
   }
 
   /**
@@ -155,7 +155,7 @@ public final class UserDataConverter {
 
     ParseAccumulator accumulator = new ParseAccumulator(UserData.Source.Update);
     ParseContext context = accumulator.rootContext();
-    ObjectValue updateData = ObjectValue.emptyObject();
+    ObjectValue.Builder updateData = ObjectValue.Builder.emptyBuilder();
 
     Iterator<Object> iterator = fieldsAndValues.iterator();
     while (iterator.hasNext()) {
@@ -185,12 +185,12 @@ public final class UserDataConverter {
             convertAndParseFieldData(fieldValue, context.childContext(parsedField));
         if (parsedValue != null) {
           context.addToFieldMask(parsedField);
-          updateData = updateData.set(parsedField, parsedValue);
+          updateData.set(parsedField, parsedValue);
         }
       }
     }
 
-    return accumulator.toUpdateData(updateData);
+    return accumulator.toUpdateData(updateData.build());
   }
 
   /** Parse a "query value" (e.g. value in a where filter or a value in a cursor bound). */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Document.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Document.java
@@ -95,14 +95,14 @@ public final class Document extends MaybeDocument {
     if (objectValue == null) {
       hardAssert(proto != null && converter != null, "Expected proto and converter to be non-null");
 
-      ObjectValue result = ObjectValue.emptyObject();
+      ObjectValue.Builder result = ObjectValue.Builder.emptyBuilder();
       for (Map.Entry<String, com.google.firestore.v1.Value> entry :
           proto.getFieldsMap().entrySet()) {
         FieldPath path = FieldPath.fromSingleSegment(entry.getKey());
         FieldValue value = converter.apply(entry.getValue());
-        result = result.set(path, value);
+        result.set(path, value);
       }
-      objectValue = result;
+      objectValue = result.build();
 
       // Once objectValue is computed, values inside the fieldValueCache are no longer accessed.
       fieldValueCache = null;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Document.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Document.java
@@ -95,7 +95,7 @@ public final class Document extends MaybeDocument {
     if (objectValue == null) {
       hardAssert(proto != null && converter != null, "Expected proto and converter to be non-null");
 
-      ObjectValue.Builder result = ObjectValue.Builder.emptyBuilder();
+      ObjectValue.Builder result = ObjectValue.newBuilder();
       for (Map.Entry<String, com.google.firestore.v1.Value> entry :
           proto.getFieldsMap().entrySet()) {
         FieldPath path = FieldPath.fromSingleSegment(entry.getKey());

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/PatchMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/PatchMutation.java
@@ -151,16 +151,17 @@ public final class PatchMutation extends Mutation {
   }
 
   private ObjectValue patchObject(ObjectValue obj) {
+    ObjectValue.Builder builder = obj.toBuilder();
     for (FieldPath path : mask.getMask()) {
       if (!path.isEmpty()) {
         FieldValue newValue = value.get(path);
         if (newValue == null) {
-          obj = obj.delete(path);
+          builder.delete(path);
         } else {
-          obj = obj.set(path, newValue);
+          builder.set(path, newValue);
         }
       }
     }
-    return obj;
+    return builder.build();
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/TransformMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/TransformMutation.java
@@ -135,8 +135,7 @@ public final class TransformMutation extends Mutation {
       FieldValue coercedValue = transform.getOperation().computeBaseValue(existingValue);
       if (coercedValue != null) {
         if (baseObject == null) {
-          baseObject =
-              ObjectValue.Builder.emptyBuilder().set(transform.getFieldPath(), coercedValue);
+          baseObject = ObjectValue.newBuilder().set(transform.getFieldPath(), coercedValue);
         } else {
           baseObject = baseObject.set(transform.getFieldPath(), coercedValue);
         }
@@ -232,7 +231,7 @@ public final class TransformMutation extends Mutation {
     for (int i = 0; i < fieldTransforms.size(); i++) {
       FieldTransform fieldTransform = fieldTransforms.get(i);
       FieldPath fieldPath = fieldTransform.getFieldPath();
-      builder.set(fieldPath, transformResults.get(i)).build();
+      builder.set(fieldPath, transformResults.get(i));
     }
     return builder.build();
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/TransformMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/TransformMutation.java
@@ -124,7 +124,7 @@ public final class TransformMutation extends Mutation {
   @Nullable
   @Override
   public ObjectValue extractBaseValue(@Nullable MaybeDocument maybeDoc) {
-    ObjectValue baseObject = null;
+    ObjectValue.Builder baseObject = null;
 
     for (FieldTransform transform : fieldTransforms) {
       FieldValue existingValue = null;
@@ -135,14 +135,15 @@ public final class TransformMutation extends Mutation {
       FieldValue coercedValue = transform.getOperation().computeBaseValue(existingValue);
       if (coercedValue != null) {
         if (baseObject == null) {
-          baseObject = ObjectValue.emptyObject().set(transform.getFieldPath(), coercedValue);
+          baseObject =
+              ObjectValue.Builder.emptyBuilder().set(transform.getFieldPath(), coercedValue);
         } else {
           baseObject = baseObject.set(transform.getFieldPath(), coercedValue);
         }
       }
     }
 
-    return baseObject;
+    return baseObject != null ? baseObject.build() : null;
   }
 
   /**
@@ -227,11 +228,12 @@ public final class TransformMutation extends Mutation {
     hardAssert(
         transformResults.size() == fieldTransforms.size(), "Transform results length mismatch.");
 
+    ObjectValue.Builder builder = objectValue.toBuilder();
     for (int i = 0; i < fieldTransforms.size(); i++) {
       FieldTransform fieldTransform = fieldTransforms.get(i);
       FieldPath fieldPath = fieldTransform.getFieldPath();
-      objectValue = objectValue.set(fieldPath, transformResults.get(i));
+      builder.set(fieldPath, transformResults.get(i)).build();
     }
-    return objectValue;
+    return builder.build();
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/value/ObjectValue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/value/ObjectValue.java
@@ -142,55 +142,6 @@ public class ObjectValue extends FieldValue {
   }
 
   /**
-   * Returns a new ObjectValue with the field at the named path set to value.
-   *
-   * @param path The field path to set.
-   * @param value The value to set.
-   * @return A new ObjectValue with the field set.
-   */
-  public ObjectValue set(FieldPath path, FieldValue value) {
-    hardAssert(!path.isEmpty(), "Cannot set field for empty path on ObjectValue");
-    String childName = path.getFirstSegment();
-    if (path.length() == 1) {
-      return setChild(childName, value);
-    } else {
-      FieldValue child = internalValue.get(childName);
-      ObjectValue obj;
-      if (child instanceof ObjectValue) {
-        obj = (ObjectValue) child;
-      } else {
-        obj = emptyObject();
-      }
-      ObjectValue newChild = obj.set(path.popFirst(), value);
-      return setChild(childName, newChild);
-    }
-  }
-
-  /**
-   * Returns an ObjectValue with the field path deleted. If there is no field at the specified path
-   * nothing is changed.
-   *
-   * @param path The field path to remove
-   * @return An ObjectValue with the field path removed.
-   */
-  public ObjectValue delete(FieldPath path) {
-    hardAssert(!path.isEmpty(), "Cannot delete field for empty path on ObjectValue");
-    String childName = path.getFirstSegment();
-    if (path.length() == 1) {
-      return fromImmutableMap(internalValue.remove(childName));
-    } else {
-      FieldValue child = internalValue.get(childName);
-      if (child instanceof ObjectValue) {
-        ObjectValue newChild = ((ObjectValue) child).delete(path.popFirst());
-        return setChild(childName, newChild);
-      } else {
-        // Don't actually change a primitive value to an object for a delete.
-        return this;
-      }
-    }
-  }
-
-  /**
    * Returns the value at the given path or null.
    *
    * @param fieldPath the path to search
@@ -207,7 +158,81 @@ public class ObjectValue extends FieldValue {
     return current;
   }
 
-  private ObjectValue setChild(String childName, FieldValue value) {
-    return fromImmutableMap(internalValue.insert(childName, value));
+  /** Creates a ObjectValue.Builder instance that is based on the current value. */
+  public Builder toBuilder() {
+    return new Builder(internalValue);
+  }
+
+  /**
+   * An ObjectValue.Builder provides APIs to set and delete fields from an ObjectValue. All
+   * operations mutate the existing instance.
+   */
+  public static class Builder {
+
+    private ImmutableSortedMap<String, FieldValue> internalValue;
+
+    Builder(ImmutableSortedMap<String, FieldValue> internalValue) {
+      this.internalValue = internalValue;
+    }
+
+    public static Builder emptyBuilder() {
+      return new Builder(ImmutableSortedMap.Builder.emptyMap(Util.<String>comparator()));
+    }
+
+    /**
+     * Sets the field to the provided value.
+     *
+     * @param path The field path to set.
+     * @param value The value to set.
+     * @return The current Builder instance.
+     */
+    public Builder set(FieldPath path, FieldValue value) {
+      hardAssert(!path.isEmpty(), "Cannot set field for empty path on ObjectValue");
+      String childName = path.getFirstSegment();
+      if (path.length() == 1) {
+        internalValue = internalValue.insert(childName, value);
+      } else {
+        FieldValue child = internalValue.get(childName);
+        ObjectValue obj;
+        if (child instanceof ObjectValue) {
+          obj = (ObjectValue) child;
+        } else {
+          obj = emptyObject();
+        }
+        ObjectValue newChild = obj.toBuilder().set(path.popFirst(), value).build();
+        internalValue = internalValue.insert(childName, newChild);
+      }
+
+      return this;
+    }
+
+    /**
+     * Removes the field at the current path. If there is no field at the specified path nothing is
+     * changed.
+     *
+     * @param path The field path to remove
+     * @return The current Builder instance.
+     */
+    public Builder delete(FieldPath path) {
+      hardAssert(!path.isEmpty(), "Cannot delete field for empty path on ObjectValue");
+      String childName = path.getFirstSegment();
+      if (path.length() == 1) {
+        internalValue = internalValue.remove(childName);
+      } else {
+        FieldValue child = internalValue.get(childName);
+        if (child instanceof ObjectValue) {
+          ObjectValue newChild = ((ObjectValue) child).toBuilder().delete(path.popFirst()).build();
+          internalValue = internalValue.insert(childName, newChild);
+        } else {
+          // Don't actually change a primitive value to an object for a delete.
+        }
+      }
+
+      return this;
+    }
+
+    public ObjectValue build() {
+      return new ObjectValue(internalValue);
+    }
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/value/ObjectValue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/value/ObjectValue.java
@@ -49,6 +49,11 @@ public class ObjectValue extends FieldValue {
     return EMPTY_INSTANCE;
   }
 
+  /** Returns a new Builder instance that is based on an empty object. */
+  public static Builder newBuilder() {
+    return new Builder(ImmutableSortedMap.Builder.emptyMap(Util.<String>comparator()));
+  }
+
   private final ImmutableSortedMap<String, FieldValue> internalValue;
 
   private ObjectValue(ImmutableSortedMap<String, FieldValue> value) {
@@ -173,10 +178,6 @@ public class ObjectValue extends FieldValue {
 
     Builder(ImmutableSortedMap<String, FieldValue> internalValue) {
       this.internalValue = internalValue;
-    }
-
-    public static Builder emptyBuilder() {
-      return new Builder(ImmutableSortedMap.Builder.emptyMap(Util.<String>comparator()));
     }
 
     /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
@@ -369,13 +369,13 @@ public final class RemoteSerializer {
   // involve creating a temporary map.
 
   public ObjectValue decodeFields(Map<String, com.google.firestore.v1.Value> fields) {
-    ObjectValue result = ObjectValue.emptyObject();
+    ObjectValue.Builder result = ObjectValue.Builder.emptyBuilder();
     for (Map.Entry<String, com.google.firestore.v1.Value> entry : fields.entrySet()) {
       FieldPath path = FieldPath.fromSingleSegment(entry.getKey());
       FieldValue value = decodeValue(entry.getValue());
-      result = result.set(path, value);
+      result.set(path, value);
     }
-    return result;
+    return result.build();
   }
 
   // Documents

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
@@ -369,7 +369,7 @@ public final class RemoteSerializer {
   // involve creating a temporary map.
 
   public ObjectValue decodeFields(Map<String, com.google.firestore.v1.Value> fields) {
-    ObjectValue.Builder result = ObjectValue.Builder.emptyBuilder();
+    ObjectValue.Builder result = ObjectValue.newBuilder();
     for (Map.Entry<String, com.google.firestore.v1.Value> entry : fields.entrySet()) {
       FieldPath path = FieldPath.fromSingleSegment(entry.getKey());
       FieldValue value = decodeValue(entry.getValue());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
@@ -375,11 +375,11 @@ public class FieldValueTest {
         .testCompare();
   }
 
-  private ObjectValue setField(ObjectValue objectValue, String a, FieldValue mod) {
-    return objectValue.toBuilder().set(field(a), mod).build();
+  private ObjectValue setField(ObjectValue objectValue, String fieldPath, FieldValue value) {
+    return objectValue.toBuilder().set(field(fieldPath), value).build();
   }
 
-  private ObjectValue deleteField(ObjectValue objectValue, String s) {
-    return objectValue.toBuilder().delete(field(s)).build();
+  private ObjectValue deleteField(ObjectValue objectValue, String fieldPath) {
+    return objectValue.toBuilder().delete(field(fieldPath)).build();
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
@@ -105,7 +105,7 @@ public class FieldValueTest {
   @Test
   public void testOverwritesExistingFields() {
     ObjectValue old = wrapObject("a", "old");
-    ObjectValue mod = old.set(field("a"), wrap("mod"));
+    ObjectValue mod = setField(old, "a", wrap("mod"));
     assertNotEquals(old, mod);
     assertEquals(wrapObject("a", "old"), old);
     assertEquals(wrapObject("a", "mod"), mod);
@@ -114,20 +114,29 @@ public class FieldValueTest {
   @Test
   public void testAddsNewFields() {
     ObjectValue empty = ObjectValue.emptyObject();
-    ObjectValue mod = empty.set(field("a"), wrap("mod"));
+    ObjectValue mod = setField(empty, "a", wrap("mod"));
     assertEquals(wrap(new TreeMap<String, FieldValue>()), empty);
     assertEquals(wrapObject("a", "mod"), mod);
 
     ObjectValue old = mod;
-    mod = old.set(field("b"), wrap(1));
+    mod = setField(old, "b", wrap(1));
     assertEquals(wrapObject("a", "mod"), old);
     assertEquals(wrapObject("a", "mod", "b", 1), mod);
   }
 
   @Test
+  public void testAddsMultipleNewFields() {
+    ObjectValue object = ObjectValue.emptyObject();
+    object = object.toBuilder().set(field("a"), wrap("a")).build();
+    object = object.toBuilder().set(field("b"), wrap("b")).set(field("c"), wrap("c")).build();
+
+    assertEquals(wrapObject("a", "a", "b", "b", "c", "c"), object);
+  }
+
+  @Test
   public void testImplicitlyCreatesObjects() {
     ObjectValue old = wrapObject("a", "old");
-    ObjectValue mod = old.set(field("b.c.d"), wrap("mod"));
+    ObjectValue mod = setField(old, "b.c.d", wrap("mod"));
 
     assertNotEquals(old, mod);
     assertEquals(wrapObject("a", "old"), old);
@@ -137,7 +146,7 @@ public class FieldValueTest {
   @Test
   public void testCanOverwritePrimitivesWithObjects() {
     ObjectValue old = wrapObject("a", map("b", "old"));
-    ObjectValue mod = old.set(field("a"), wrapObject("b", "mod"));
+    ObjectValue mod = setField(old, "a", wrapObject("b", "mod"));
     assertNotEquals(old, mod);
     assertEquals(wrapObject("a", map("b", "old")), old);
     assertEquals(wrapObject("a", map("b", "mod")), mod);
@@ -146,7 +155,7 @@ public class FieldValueTest {
   @Test
   public void testAddsToNestedObjects() {
     ObjectValue old = wrapObject("a", map("b", "old"));
-    ObjectValue mod = old.set(field("a.c"), wrap("mod"));
+    ObjectValue mod = setField(old, "a.c", wrap("mod"));
     assertNotEquals(old, mod);
     assertEquals(wrapObject("a", map("b", "old")), old);
     assertEquals(wrapObject("a", map("b", "old", "c", "mod")), mod);
@@ -155,13 +164,13 @@ public class FieldValueTest {
   @Test
   public void testDeletesKey() {
     ObjectValue old = wrapObject("a", 1, "b", 2);
-    ObjectValue mod = old.delete(field("a"));
+    ObjectValue mod = deleteField(old, "a");
 
     assertNotEquals(old, mod);
     assertEquals(wrapObject("a", 1, "b", 2), old);
     assertEquals(wrapObject("b", 2), mod);
 
-    ObjectValue empty = mod.delete(field("b"));
+    ObjectValue empty = deleteField(mod, "b");
     assertNotEquals(mod, empty);
     assertEquals(wrapObject("b", 2), mod);
     assertEquals(ObjectValue.emptyObject(), empty);
@@ -170,15 +179,15 @@ public class FieldValueTest {
   @Test
   public void testDeletesHandleMissingKeys() {
     ObjectValue old = wrapObject("a", map("b", 1, "c", 2));
-    ObjectValue mod = old.delete(field("b"));
+    ObjectValue mod = deleteField(old, "b");
     assertEquals(mod, old);
     assertEquals(wrapObject("a", map("b", 1, "c", 2)), mod);
 
-    mod = old.delete(field("a.d"));
+    mod = deleteField(old, "a.d");
     assertEquals(mod, old);
     assertEquals(wrapObject("a", map("b", 1, "c", 2)), mod);
 
-    mod = old.delete(field("a.b.c"));
+    mod = deleteField(old, "a.b.c");
     assertEquals(mod, old);
     assertEquals(wrapObject("a", map("b", 1, "c", 2)), mod);
   }
@@ -187,7 +196,7 @@ public class FieldValueTest {
   public void testDeletesNestedKeys() {
     Map<String, Object> orig = map("a", map("b", 1, "c", map("d", 2, "e", 3)));
     ObjectValue old = wrapObject(orig);
-    ObjectValue mod = old.delete(field("a.c.d"));
+    ObjectValue mod = deleteField(old, "a.c.d");
 
     assertNotEquals(mod, old);
     assertEquals(wrapObject(orig), old);
@@ -196,7 +205,7 @@ public class FieldValueTest {
     assertEquals(wrapObject(second), mod);
 
     old = mod;
-    mod = old.delete(field("a.c"));
+    mod = deleteField(old, "a.c");
 
     assertNotEquals(old, mod);
     assertEquals(wrapObject(second), old);
@@ -205,11 +214,20 @@ public class FieldValueTest {
     assertEquals(wrapObject(third), mod);
 
     old = mod;
-    mod = old.delete(field("a"));
+    mod = deleteField(old, "a");
 
     assertNotEquals(old, mod);
     assertEquals(wrapObject(third), old);
     assertEquals(ObjectValue.emptyObject(), mod);
+  }
+
+  @Test
+  public void testDeletesMultipleNewFields() {
+    ObjectValue object = wrapObject("a", "a", "b", "b", "c", "c");
+    object = object.toBuilder().delete(field("a")).build();
+    object = object.toBuilder().delete(field("b")).delete(field("c")).build();
+
+    assertEquals(ObjectValue.emptyObject(), object);
   }
 
   @Test
@@ -355,5 +373,13 @@ public class FieldValueTest {
         .addEqualityGroup(wrapObject(map("foo", 2)))
         .addEqualityGroup(wrapObject(map("foo", "0")))
         .testCompare();
+  }
+
+  private ObjectValue setField(ObjectValue empty, String a, FieldValue mod) {
+    return empty.toBuilder().set(field(a), mod).build();
+  }
+
+  private ObjectValue deleteField(ObjectValue objectValue, String s) {
+    return objectValue.toBuilder().delete(field(s)).build();
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldValueTest.java
@@ -375,8 +375,8 @@ public class FieldValueTest {
         .testCompare();
   }
 
-  private ObjectValue setField(ObjectValue empty, String a, FieldValue mod) {
-    return empty.toBuilder().set(field(a), mod).build();
+  private ObjectValue setField(ObjectValue objectValue, String a, FieldValue mod) {
+    return objectValue.toBuilder().set(field(a), mod).build();
   }
 
   private ObjectValue deleteField(ObjectValue objectValue, String s) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutationTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutationTest.java
@@ -158,9 +158,12 @@ public class MutationTest {
     ObjectValue expectedData =
         wrapObject(map("foo", map("bar", "<server-timestamp>"), "baz", "baz-value"));
     expectedData =
-        expectedData.set(
-            field("foo.bar"),
-            new ServerTimestampValue(timestamp, StringValue.valueOf("bar-value")));
+        expectedData
+            .toBuilder()
+            .set(
+                field("foo.bar"),
+                new ServerTimestampValue(timestamp, StringValue.valueOf("bar-value")))
+            .build();
 
     Document expectedDoc =
         new Document(

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -478,14 +478,14 @@ public class TestUtil {
 
   public static PatchMutation patchMutation(
       String path, Map<String, Object> values, @Nullable List<FieldPath> updateMask) {
-    ObjectValue objectValue = ObjectValue.emptyObject();
+    ObjectValue.Builder objectValue = ObjectValue.Builder.emptyBuilder();
     ArrayList<FieldPath> objectMask = new ArrayList<>();
     for (Entry<String, Object> entry : values.entrySet()) {
       FieldPath fieldPath = field(entry.getKey());
       objectMask.add(fieldPath);
       if (!entry.getValue().equals(DELETE_SENTINEL)) {
         FieldValue parsedValue = wrap(entry.getValue());
-        objectValue = objectValue.set(fieldPath, parsedValue);
+        objectValue.set(fieldPath, parsedValue);
       }
     }
 
@@ -498,7 +498,7 @@ public class TestUtil {
 
     return new PatchMutation(
         key(path),
-        objectValue,
+        objectValue.build(),
         FieldMask.fromSet(fieldMaskPaths),
         merge ? Precondition.NONE : Precondition.exists(true));
   }

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -478,7 +478,7 @@ public class TestUtil {
 
   public static PatchMutation patchMutation(
       String path, Map<String, Object> values, @Nullable List<FieldPath> updateMask) {
-    ObjectValue.Builder objectValue = ObjectValue.Builder.emptyBuilder();
+    ObjectValue.Builder objectValue = ObjectValue.newBuilder();
     ArrayList<FieldPath> objectMask = new ArrayList<>();
     for (Entry<String, Object> entry : values.entrySet()) {
       FieldPath fieldPath = field(entry.getKey());


### PR DESCRIPTION
This PR is meant to pave the way for a mutable ObjectValue that is based on a Value.Builder. It proves that we only need `set()` and `delete()` (and not `equals()` and `compareTo()`) on the mutable type since most parts of the code still deal with immutable ObjectValues.

This is meant for an feature branch until we finish the Proto conversion as ObjectValue.Builder().set() is somewhat inefficient for nested field updates.