### PR TITLE
Use FetchTimeout value in Remote Config Connection and Read Timeouts

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
@@ -93,8 +93,8 @@ public class FirebaseRemoteConfigSettings {
     }
 
     /**
-     * Sets the connection timeout for fetch requests to the Firebase Remote Config servers in
-     * seconds.
+     * Sets the connection and read timeouts for fetch requests to the Firebase Remote Config
+     * servers in seconds.
      *
      * <p>A fetch call will fail if it takes longer than the specified timeout to connect to the
      * Remote Config servers.

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
@@ -96,8 +96,8 @@ public class FirebaseRemoteConfigSettings {
      * Sets the connection and read timeouts for fetch requests to the Firebase Remote Config
      * servers in seconds.
      *
-     * <p>A fetch call will fail if it takes longer than the specified timeout to connect to the
-     * Remote Config servers.
+     * <p>A fetch call will fail if it takes longer than the specified timeout to connect to or read
+     * from the Remote Config servers.
      *
      * @param duration Timeout duration in seconds. Should be a non-negative number.
      */

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.remoteconfig;
 
-import static com.google.firebase.remoteconfig.RemoteConfigComponent.NETWORK_CONNECTION_TIMEOUT_IN_SECONDS;
+import static com.google.firebase.remoteconfig.RemoteConfigComponent.CONNECTION_TIMEOUT_IN_SECONDS;
 import static com.google.firebase.remoteconfig.internal.ConfigFetchHandler.DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
 
 import androidx.annotation.NonNull;
@@ -75,7 +75,7 @@ public class FirebaseRemoteConfigSettings {
   public static class Builder {
     private boolean enableDeveloperMode = false;
     // TODO(issues/257): Move constants to Constants file.
-    private long fetchTimeoutInSeconds = NETWORK_CONNECTION_TIMEOUT_IN_SECONDS;
+    private long fetchTimeoutInSeconds = CONNECTION_TIMEOUT_IN_SECONDS;
     private long minimumFetchInterval = DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
 
     /**

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -232,8 +232,8 @@ public class RemoteConfigComponent {
         appId,
         apiKey,
         namespace,
-        metadataClient.getFetchTimeoutInSeconds(),
-        NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
+        /* connectTimeoutInSeconds= */ metadataClient.getFetchTimeoutInSeconds(),
+        /* readTimeoutInSeconds= */ metadataClient.getFetchTimeoutInSeconds());
   }
 
   @VisibleForTesting

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -60,7 +60,7 @@ public class RemoteConfigComponent {
   /** Name of the file where defaults configs are stored. */
   public static final String DEFAULTS_FILE_NAME = "defaults";
   /** Timeout for the call to the Firebase Remote Config servers in second. */
-  public static final long NETWORK_CONNECTION_TIMEOUT_IN_SECONDS = 60;
+  public static final long CONNECTION_TIMEOUT_IN_SECONDS = 60;
 
   private static final String FIREBASE_REMOTE_CONFIG_FILE_NAME_PREFIX = "frc";
   private static final String PREFERENCES_FILE_NAME = "settings";

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClient.java
@@ -18,7 +18,7 @@ import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_S
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_STATUS_NO_FETCH_YET;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_STATUS_SUCCESS;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_STATUS_THROTTLED;
-import static com.google.firebase.remoteconfig.RemoteConfigComponent.NETWORK_CONNECTION_TIMEOUT_IN_SECONDS;
+import static com.google.firebase.remoteconfig.RemoteConfigComponent.CONNECTION_TIMEOUT_IN_SECONDS;
 import static com.google.firebase.remoteconfig.internal.ConfigFetchHandler.DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
@@ -84,7 +84,7 @@ public class ConfigMetadataClient {
   }
 
   public long getFetchTimeoutInSeconds() {
-    return frcMetadata.getLong(FETCH_TIMEOUT_IN_SECONDS_KEY, NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
+    return frcMetadata.getLong(FETCH_TIMEOUT_IN_SECONDS_KEY, CONNECTION_TIMEOUT_IN_SECONDS);
   }
 
   public long getMinimumFetchIntervalInSeconds() {
@@ -124,7 +124,7 @@ public class ConfigMetadataClient {
               .setDeveloperModeEnabled(frcMetadata.getBoolean(DEVELOPER_MODE_KEY, false))
               .setFetchTimeoutInSeconds(
                   frcMetadata.getLong(
-                      FETCH_TIMEOUT_IN_SECONDS_KEY, NETWORK_CONNECTION_TIMEOUT_IN_SECONDS))
+                      FETCH_TIMEOUT_IN_SECONDS_KEY, CONNECTION_TIMEOUT_IN_SECONDS))
               .setMinimumFetchIntervalInSeconds(
                   frcMetadata.getLong(
                       MINIMUM_FETCH_INTERVAL_IN_SECONDS_KEY,

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClient.java
@@ -123,8 +123,7 @@ public class ConfigMetadataClient {
           new FirebaseRemoteConfigSettings.Builder()
               .setDeveloperModeEnabled(frcMetadata.getBoolean(DEVELOPER_MODE_KEY, false))
               .setFetchTimeoutInSeconds(
-                  frcMetadata.getLong(
-                      FETCH_TIMEOUT_IN_SECONDS_KEY, CONNECTION_TIMEOUT_IN_SECONDS))
+                  frcMetadata.getLong(FETCH_TIMEOUT_IN_SECONDS_KEY, CONNECTION_TIMEOUT_IN_SECONDS))
               .setMinimumFetchIntervalInSeconds(
                   frcMetadata.getLong(
                       MINIMUM_FETCH_INTERVAL_IN_SECONDS_KEY,

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -18,8 +18,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.firebase.remoteconfig.AbtExperimentHelper.createAbtExperiment;
 import static com.google.firebase.remoteconfig.AbtExperimentHelper.createAbtExperiments;
-import static com.google.firebase.remoteconfig.RemoteConfigComponent.DEFAULT_NAMESPACE;
 import static com.google.firebase.remoteconfig.RemoteConfigComponent.CONNECTION_TIMEOUT_IN_SECONDS;
+import static com.google.firebase.remoteconfig.RemoteConfigComponent.DEFAULT_NAMESPACE;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -142,8 +142,7 @@ public class RemoteConfigComponentTest {
       getFrcBackendApiClient_fetchTimeoutIsNotSet_buildsConfigFetchHttpClientWithDefaultConnectionTimeout() {
 
     RemoteConfigComponent frcComponent = defaultApp.get(RemoteConfigComponent.class);
-    when(mockMetadataClient.getFetchTimeoutInSeconds())
-        .thenReturn(CONNECTION_TIMEOUT_IN_SECONDS);
+    when(mockMetadataClient.getFetchTimeoutInSeconds()).thenReturn(CONNECTION_TIMEOUT_IN_SECONDS);
 
     ConfigFetchHttpClient frcBackendClient =
         frcComponent.getFrcBackendApiClient(DUMMY_API_KEY, DEFAULT_NAMESPACE, mockMetadataClient);

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -19,7 +19,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.firebase.remoteconfig.AbtExperimentHelper.createAbtExperiment;
 import static com.google.firebase.remoteconfig.AbtExperimentHelper.createAbtExperiments;
 import static com.google.firebase.remoteconfig.RemoteConfigComponent.DEFAULT_NAMESPACE;
-import static com.google.firebase.remoteconfig.RemoteConfigComponent.NETWORK_CONNECTION_TIMEOUT_IN_SECONDS;
+import static com.google.firebase.remoteconfig.RemoteConfigComponent.CONNECTION_TIMEOUT_IN_SECONDS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -143,15 +143,15 @@ public class RemoteConfigComponentTest {
 
     RemoteConfigComponent frcComponent = defaultApp.get(RemoteConfigComponent.class);
     when(mockMetadataClient.getFetchTimeoutInSeconds())
-        .thenReturn(NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
+        .thenReturn(CONNECTION_TIMEOUT_IN_SECONDS);
 
     ConfigFetchHttpClient frcBackendClient =
         frcComponent.getFrcBackendApiClient(DUMMY_API_KEY, DEFAULT_NAMESPACE, mockMetadataClient);
 
     int actualConnectTimeout = getConnectTimeoutInSeconds(frcBackendClient);
     int actualReadTimeout = getReadTimeoutInSeconds(frcBackendClient);
-    assertThat(actualConnectTimeout).isEqualTo(NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
-    assertThat(actualReadTimeout).isEqualTo(NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
+    assertThat(actualConnectTimeout).isEqualTo(CONNECTION_TIMEOUT_IN_SECONDS);
+    assertThat(actualReadTimeout).isEqualTo(CONNECTION_TIMEOUT_IN_SECONDS);
   }
 
   @Test
@@ -160,17 +160,17 @@ public class RemoteConfigComponentTest {
 
     RemoteConfigComponent frcComponent = defaultApp.get(RemoteConfigComponent.class);
 
-    long customNetworkConnectionTimeoutInSeconds = 2 * NETWORK_CONNECTION_TIMEOUT_IN_SECONDS;
+    long customConnectionTimeoutInSeconds = 2 * CONNECTION_TIMEOUT_IN_SECONDS;
     when(mockMetadataClient.getFetchTimeoutInSeconds())
-        .thenReturn(customNetworkConnectionTimeoutInSeconds);
+        .thenReturn(customConnectionTimeoutInSeconds);
 
     ConfigFetchHttpClient frcBackendClient =
         frcComponent.getFrcBackendApiClient(DUMMY_API_KEY, DEFAULT_NAMESPACE, mockMetadataClient);
 
     int actualConnectTimeout = getConnectTimeoutInSeconds(frcBackendClient);
     int actualReadTimeout = getReadTimeoutInSeconds(frcBackendClient);
-    assertThat(actualConnectTimeout).isEqualTo(customNetworkConnectionTimeoutInSeconds);
-    assertThat(actualReadTimeout).isEqualTo(NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
+    assertThat(actualConnectTimeout).isEqualTo(customConnectionTimeoutInSeconds);
+    assertThat(actualReadTimeout).isEqualTo(customConnectionTimeoutInSeconds);
   }
 
   private RemoteConfigComponent getNewFrcComponent() {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClientTest.java
@@ -80,8 +80,7 @@ public class ConfigMetadataClientTest {
 
   @Test
   public void getFetchTimeoutInSeconds_isNotSet_returnsDefault() {
-    assertThat(metadataClient.getFetchTimeoutInSeconds())
-        .isEqualTo(CONNECTION_TIMEOUT_IN_SECONDS);
+    assertThat(metadataClient.getFetchTimeoutInSeconds()).isEqualTo(CONNECTION_TIMEOUT_IN_SECONDS);
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClientTest.java
@@ -19,7 +19,7 @@ import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_S
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_STATUS_NO_FETCH_YET;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_STATUS_SUCCESS;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.LAST_FETCH_STATUS_THROTTLED;
-import static com.google.firebase.remoteconfig.RemoteConfigComponent.NETWORK_CONNECTION_TIMEOUT_IN_SECONDS;
+import static com.google.firebase.remoteconfig.RemoteConfigComponent.CONNECTION_TIMEOUT_IN_SECONDS;
 import static com.google.firebase.remoteconfig.internal.ConfigFetchHandler.DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
 import static com.google.firebase.remoteconfig.internal.ConfigMetadataClient.LAST_FETCH_TIME_IN_MILLIS_NO_FETCH_YET;
 import static com.google.firebase.remoteconfig.internal.ConfigMetadataClient.LAST_FETCH_TIME_NO_FETCH_YET;
@@ -81,7 +81,7 @@ public class ConfigMetadataClientTest {
   @Test
   public void getFetchTimeoutInSeconds_isNotSet_returnsDefault() {
     assertThat(metadataClient.getFetchTimeoutInSeconds())
-        .isEqualTo(NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
+        .isEqualTo(CONNECTION_TIMEOUT_IN_SECONDS);
   }
 
   @Test
@@ -199,7 +199,7 @@ public class ConfigMetadataClientTest {
     assertThat(info.getLastFetchStatus()).isEqualTo(LAST_FETCH_STATUS_NO_FETCH_YET);
     assertThat(info.getConfigSettings().isDeveloperModeEnabled()).isFalse();
     assertThat(info.getConfigSettings().getFetchTimeoutInSeconds())
-        .isEqualTo(NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
+        .isEqualTo(CONNECTION_TIMEOUT_IN_SECONDS);
     assertThat(info.getConfigSettings().getMinimumFetchIntervalInSeconds())
         .isEqualTo(DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS);
   }
@@ -311,7 +311,7 @@ public class ConfigMetadataClientTest {
     assertThat(info.getLastFetchStatus()).isEqualTo(LAST_FETCH_STATUS_NO_FETCH_YET);
     assertThat(info.getConfigSettings().isDeveloperModeEnabled()).isFalse();
     assertThat(info.getConfigSettings().getFetchTimeoutInSeconds())
-        .isEqualTo(NETWORK_CONNECTION_TIMEOUT_IN_SECONDS);
+        .isEqualTo(CONNECTION_TIMEOUT_IN_SECONDS);
     assertThat(info.getConfigSettings().getMinimumFetchIntervalInSeconds())
         .isEqualTo(DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS);
   }


### PR DESCRIPTION
At the moment, `FirebaseRemoteConfigSettings#FetchTimeoutInSeconds` is used only to set the HTTP Connection timeout, and there's no way for a developer to set the Read timeout (Definitions in http://stackoverflow.com/q/3069382)

To match RC iOS behavior, we use the FetchTimeout value for both the Connection and Read timeouts.