### PR TITLE
Fix typo in test

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -553,7 +553,7 @@ public class QueryTest {
 
     CollectionReference collection =
         testCollectionWithDocs(
-            map("a", docA, "b", docB, "c", docC, "d", docD, "e", docE, "f", docF));
+            map("a", docA, "b", docB, "c", docC, "d", docD, "e", docE, "f", docF, "g", docG));
 
     // Search for "array" to contain [42, 43].
     QuerySnapshot snapshot =


### PR DESCRIPTION
As I was porting arrayContainsAny, I noticed that I never included `docG` when instantiating the collection.