### PR TITLE
Add support for fully generic classes.

### DIFF
--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/GetterFactory.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/GetterFactory.java
@@ -142,6 +142,14 @@ public final class GetterFactory {
                 genericType, ownerType));
         return genericType;
       }
+      if (ownerType.getTypeArguments().get(index) instanceof TypeVariable) {
+        messager.printMessage(
+            Diagnostic.Kind.WARNING,
+            String.format(
+                "%s is a generic type, make sure you register encoders for types of %s that you plan to use.",
+                ownerType, genericType));
+        return genericType;
+      }
       return resolveTypeArguments(ownerType, ownerType.getTypeArguments().get(index));
     }
     return genericType;

--- a/encoders/firebase-encoders-processor/src/test/java/com/google/firebase/encoders/processor/EncodableProcessorTest.java
+++ b/encoders/firebase-encoders-processor/src/test/java/com/google/firebase/encoders/processor/EncodableProcessorTest.java
@@ -115,6 +115,27 @@ public class EncodableProcessorTest {
   }
 
   @Test
+  public void compile_withGenericClass_ShouldWarnAboutPotentialProblems() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "GenericClass",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "@Encodable public class GenericClass<T, U> {",
+                    "public T getT() { return null; }",
+                    "public U getU() { return null; }",
+                    "}"));
+
+    assertThat(result).hadWarningContaining("GenericClass<T,U> is a generic type");
+    assertThat(result)
+        .generatedSourceFile("AutoGenericClassEncoder")
+        .hasSourceEquivalentTo(
+            JavaFileObjects.forResource("ExpectedGenericsEncoderWithUnknownType.java"));
+  }
+
+  @Test
   public void compile_withMultipleGenericArgs_shouldCreateEncodersForAllKnownGenericArgs() {
     Compilation result =
         javac()

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoderWithUnknownType.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoderWithUnknownType.java
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.ObjectEncoder;
+import com.google.firebase.encoders.ObjectEncoderContext;
+import com.google.firebase.encoders.config.Configurator;
+import com.google.firebase.encoders.config.EncoderConfig;
+import java.io.IOException;
+import java.lang.Override;
+import javax.annotation.Generated;
+
+/**
+ * @hide */
+@Generated("com.google.firebase.encoders.processor.EncodableProcessor")
+public final class AutoGenericClassEncoder implements Configurator {
+    public static final int CODEGEN_VERSION = 1;
+
+    public static final Configurator CONFIG = new AutoGenericClassEncoder();
+
+    private AutoGenericClassEncoder() {
+    }
+
+    @Override
+    public void configure(EncoderConfig<?> cfg) {
+        cfg.registerEncoder(GenericClass.class, GenericClassEncoder.INSTANCE);
+    }
+
+    private static final class GenericClassEncoder implements ObjectEncoder<GenericClass> {
+        static final GenericClassEncoder INSTANCE = new GenericClassEncoder();
+
+        @Override
+        public void encode(GenericClass value, ObjectEncoderContext ctx) throws IOException,
+                EncodingException {
+            ctx.add("t", value.getT());
+            ctx.add("u", value.getU());
+        }
+    }
+}


### PR DESCRIPTION
Until now it was possible to annotate non-generic classes with
`@Encodable`, while their properties could be generic with fully bound
type variables.

This change makes it possible to generate encoders for generic classes
with generic properties, but with a compiler warning.

Example:
```java
@Encodable
public class GenericClass<T, U> {
  public T getT(); // warning generated

  public U getU(); // warning generated
}
```