### PR TITLE
Make EncoderException a RuntimeException

### DIFF
--- a/encoders/firebase-encoders-json/api.txt
+++ b/encoders/firebase-encoders-json/api.txt
@@ -2,11 +2,11 @@
 package com.google.firebase.encoders {
 
   public interface DataEncoder {
-    method public void encode(@NonNull Object, @NonNull java.io.Writer) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public String encode(@NonNull Object) throws com.google.firebase.encoders.EncodingException;
+    method public void encode(@NonNull Object, @NonNull java.io.Writer) throws java.io.IOException;
+    method @NonNull public String encode(@NonNull Object);
   }
 
-  public final class EncodingException extends java.lang.Exception {
+  public final class EncodingException extends java.lang.RuntimeException {
     ctor public EncodingException(@NonNull String);
     ctor public EncodingException(@NonNull String, @NonNull Exception);
   }
@@ -15,12 +15,12 @@ package com.google.firebase.encoders {
   }
 
   public interface ObjectEncoderContext {
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, @Nullable Object) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, double) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, int) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, long) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, boolean) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext inline(@Nullable Object) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, @Nullable Object) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, double) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, int) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, long) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, boolean) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext inline(@Nullable Object) throws java.io.IOException;
     method @NonNull public com.google.firebase.encoders.ObjectEncoderContext nested(@NonNull String) throws java.io.IOException;
   }
 
@@ -28,12 +28,12 @@ package com.google.firebase.encoders {
   }
 
   public interface ValueEncoderContext {
-    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(@Nullable String) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(double) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(int) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(long) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(boolean) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(@NonNull byte[]) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(@Nullable String) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(double) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(int) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(long) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(boolean) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ValueEncoderContext add(@NonNull byte[]) throws java.io.IOException;
   }
 
 }

--- a/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
+++ b/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonDataEncoderBuilder.java
@@ -54,8 +54,7 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
     }
 
     @Override
-    public void encode(@NonNull Date o, @NonNull ValueEncoderContext ctx)
-        throws EncodingException, IOException {
+    public void encode(@NonNull Date o, @NonNull ValueEncoderContext ctx) throws IOException {
       ctx.add(rfc339.format(o));
     }
   }
@@ -108,8 +107,7 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
   public DataEncoder build() {
     return new DataEncoder() {
       @Override
-      public void encode(@NonNull Object o, @NonNull Writer writer)
-          throws IOException, EncodingException {
+      public void encode(@NonNull Object o, @NonNull Writer writer) throws IOException {
         JsonValueObjectEncoderContext encoderContext =
             new JsonValueObjectEncoderContext(
                 writer, objectEncoders, valueEncoders, fallbackEncoder);
@@ -118,7 +116,7 @@ public final class JsonDataEncoderBuilder implements EncoderConfig<JsonDataEncod
       }
 
       @Override
-      public String encode(@NonNull Object o) throws EncodingException {
+      public String encode(@NonNull Object o) {
         StringWriter stringWriter = new StringWriter();
         try {
           encode(o, stringWriter);

--- a/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContext.java
+++ b/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContext.java
@@ -59,7 +59,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
   @NonNull
   @Override
   public JsonValueObjectEncoderContext add(@NonNull String name, @Nullable Object o)
-      throws IOException, EncodingException {
+      throws IOException {
     maybeUnNest();
     jsonWriter.name(name);
     if (o == null) {
@@ -71,8 +71,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(@NonNull String name, double value)
-      throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(@NonNull String name, double value) throws IOException {
     maybeUnNest();
     jsonWriter.name(name);
     return add(value);
@@ -80,8 +79,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(@NonNull String name, int value)
-      throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(@NonNull String name, int value) throws IOException {
     maybeUnNest();
     jsonWriter.name(name);
     return add(value);
@@ -89,8 +87,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(@NonNull String name, long value)
-      throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(@NonNull String name, long value) throws IOException {
     maybeUnNest();
     jsonWriter.name(name);
     return add(value);
@@ -98,8 +95,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(@NonNull String name, boolean value)
-      throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(@NonNull String name, boolean value) throws IOException {
     maybeUnNest();
     jsonWriter.name(name);
     return add(value);
@@ -107,7 +103,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public ObjectEncoderContext inline(@Nullable Object value) throws IOException, EncodingException {
+  public ObjectEncoderContext inline(@Nullable Object value) throws IOException {
     return add(value, true);
   }
 
@@ -123,8 +119,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(@Nullable String value)
-      throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(@Nullable String value) throws IOException {
     maybeUnNest();
     jsonWriter.value(value);
     return this;
@@ -132,7 +127,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(double value) throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(double value) throws IOException {
     maybeUnNest();
     jsonWriter.value(value);
     return this;
@@ -140,7 +135,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(int value) throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(int value) throws IOException {
     maybeUnNest();
     jsonWriter.value(value);
     return this;
@@ -148,7 +143,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(long value) throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(long value) throws IOException {
     maybeUnNest();
     jsonWriter.value(value);
     return this;
@@ -156,7 +151,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(boolean value) throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(boolean value) throws IOException {
     maybeUnNest();
     jsonWriter.value(value);
     return this;
@@ -164,8 +159,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
-  public JsonValueObjectEncoderContext add(@Nullable byte[] bytes)
-      throws IOException, EncodingException {
+  public JsonValueObjectEncoderContext add(@Nullable byte[] bytes) throws IOException {
     maybeUnNest();
     if (bytes == null) {
       jsonWriter.nullValue();
@@ -176,8 +170,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
   }
 
   @NonNull
-  JsonValueObjectEncoderContext add(@Nullable Object o, boolean inline)
-      throws IOException, EncodingException {
+  JsonValueObjectEncoderContext add(@Nullable Object o, boolean inline) throws IOException {
     if (inline && cannotBeInline(o)) {
       throw new EncodingException(
           String.format("%s cannot be encoded inline", o == null ? null : o.getClass()));
@@ -278,7 +271,7 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
   }
 
   JsonValueObjectEncoderContext doEncode(ObjectEncoder<Object> encoder, Object o, boolean inline)
-      throws IOException, EncodingException {
+      throws IOException {
     if (!inline) jsonWriter.beginObject();
     encoder.encode(o, this);
     if (!inline) jsonWriter.endObject();

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/DataEncoder.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/DataEncoder.java
@@ -28,9 +28,9 @@ import java.io.Writer;
 public interface DataEncoder {
 
   /** Encodes {@code obj} into {@code writer}. */
-  void encode(@NonNull Object obj, @NonNull Writer writer) throws IOException, EncodingException;
+  void encode(@NonNull Object obj, @NonNull Writer writer) throws IOException;
 
   /** Returns the string-encoded representation of {@code obj}. */
   @NonNull
-  String encode(@NonNull Object obj) throws EncodingException;
+  String encode(@NonNull Object obj);
 }

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/Encoder.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/Encoder.java
@@ -25,5 +25,5 @@ import java.io.IOException;
 interface Encoder<TValue, TContext> {
 
   /** Encode {@code obj} using {@code TContext}. */
-  void encode(@NonNull TValue obj, @NonNull TContext context) throws EncodingException, IOException;
+  void encode(@NonNull TValue obj, @NonNull TContext context) throws IOException;
 }

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/EncodingException.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/EncodingException.java
@@ -20,7 +20,7 @@ import androidx.annotation.NonNull;
  * An exception thrown when an {@code Encoder} ends up in an invalid state, or if the provided
  * object is in an state that cannot be encoded.
  */
-public final class EncodingException extends Exception {
+public final class EncodingException extends RuntimeException {
 
   /** Creates a {@code EncodingException} with the given message. */
   public EncodingException(@NonNull String message) {

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/ObjectEncoderContext.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/ObjectEncoderContext.java
@@ -48,26 +48,23 @@ public interface ObjectEncoderContext {
    * by the encoders will be propagated.
    */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, @Nullable Object obj)
-      throws IOException, EncodingException;
+  ObjectEncoderContext add(@NonNull String name, @Nullable Object obj) throws IOException;
 
   /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, double value)
-      throws IOException, EncodingException;
+  ObjectEncoderContext add(@NonNull String name, double value) throws IOException;
 
   /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, int value) throws IOException, EncodingException;
+  ObjectEncoderContext add(@NonNull String name, int value) throws IOException;
 
   /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, long value) throws IOException, EncodingException;
+  ObjectEncoderContext add(@NonNull String name, long value) throws IOException;
 
   /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, boolean value)
-      throws IOException, EncodingException;
+  ObjectEncoderContext add(@NonNull String name, boolean value) throws IOException;
 
   /**
    * Encodes a given object inline in current context.
@@ -87,7 +84,7 @@ public interface ObjectEncoderContext {
    * }</pre>
    */
   @NonNull
-  ObjectEncoderContext inline(@Nullable Object value) throws IOException, EncodingException;
+  ObjectEncoderContext inline(@Nullable Object value) throws IOException;
 
   /**
    * Begin a nested JSON object.

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/ValueEncoderContext.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/ValueEncoderContext.java
@@ -28,25 +28,25 @@ public interface ValueEncoderContext {
 
   /** Adds {@code value} as a primitive encoded value. */
   @NonNull
-  ValueEncoderContext add(@Nullable String value) throws IOException, EncodingException;
+  ValueEncoderContext add(@Nullable String value) throws IOException;
 
   /** Adds {@code value} as a primitive encoded value. */
   @NonNull
-  ValueEncoderContext add(double value) throws IOException, EncodingException;
+  ValueEncoderContext add(double value) throws IOException;
 
   /** Adds {@code value} as a primitive encoded value. */
   @NonNull
-  ValueEncoderContext add(int value) throws IOException, EncodingException;
+  ValueEncoderContext add(int value) throws IOException;
 
   /** Adds {@code value} as a primitive encoded value. */
   @NonNull
-  ValueEncoderContext add(long value) throws IOException, EncodingException;
+  ValueEncoderContext add(long value) throws IOException;
 
   /** Adds {@code value} as a primitive encoded value. */
   @NonNull
-  ValueEncoderContext add(boolean value) throws IOException, EncodingException;
+  ValueEncoderContext add(boolean value) throws IOException;
 
   /** Adds {@code value} as a encoded array of bytes. */
   @NonNull
-  ValueEncoderContext add(@NonNull byte[] bytes) throws IOException, EncodingException;
+  ValueEncoderContext add(@NonNull byte[] bytes) throws IOException;
 }

--- a/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/JsonDataEncoderBuilderTests.java
+++ b/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/JsonDataEncoderBuilderTests.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.encoders.DataEncoder;
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.ValueEncoderContext;
 import java.util.Collections;
@@ -30,7 +29,7 @@ public class JsonDataEncoderBuilderTests {
   static class Foo {}
 
   @Test
-  public void configureWith_shouldCorrectlyRegisterObjectEncoder() throws EncodingException {
+  public void configureWith_shouldCorrectlyRegisterObjectEncoder() {
     DataEncoder encoder =
         new JsonDataEncoderBuilder()
             .configureWith(
@@ -46,7 +45,7 @@ public class JsonDataEncoderBuilderTests {
   }
 
   @Test
-  public void configureWith_shouldCorrectlyRegisterValueEncoder() throws EncodingException {
+  public void configureWith_shouldCorrectlyRegisterValueEncoder() {
     DataEncoder encoder =
         new JsonDataEncoderBuilder()
             .configureWith(

--- a/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/JsonDataEncoderBuilderTests.java
+++ b/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/JsonDataEncoderBuilderTests.java
@@ -63,8 +63,7 @@ public class JsonDataEncoderBuilderTests {
   }
 
   @Test
-  public void ignoreNullValues_shouldCorrectlyEncodeObjectIgnoringNullObjects()
-      throws EncodingException {
+  public void ignoreNullValues_shouldCorrectlyEncodeObjectIgnoringNullObjects() {
     DataEncoder encoder =
         new JsonDataEncoderBuilder()
             .configureWith(
@@ -82,8 +81,7 @@ public class JsonDataEncoderBuilderTests {
   }
 
   @Test
-  public void ignoreNullValues_shouldCorrectlyEncodeValueIgnoringNullObjects()
-      throws EncodingException {
+  public void ignoreNullValues_shouldCorrectlyEncodeValueIgnoringNullObjects() {
     DataEncoder encoder =
         new JsonDataEncoderBuilder()
             .configureWith(

--- a/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContextTest.java
+++ b/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContextTest.java
@@ -63,7 +63,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testRegisterOverride() throws IOException, EncodingException {
+  public void testRegisterOverride() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("Inner", InnerDummyClass.INSTANCE);
@@ -100,7 +100,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingPrimitiveTypes() throws IOException, EncodingException {
+  public void testEncodingPrimitiveTypes() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("String", "string")
@@ -123,7 +123,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingTimestamp() throws IOException, EncodingException {
+  public void testEncodingTimestamp() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("Timestamp", CALENDAR.getTime());
@@ -139,7 +139,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingArrayPrimitives() throws IOException, EncodingException {
+  public void testEncodingArrayPrimitives() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("String", new String[] {"string1", "string2"})
@@ -169,7 +169,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingNumbers() throws EncodingException {
+  public void testEncodingNumbers() {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> ctx.add("Number", new Number[] {1, 2473946328429347632L, 0.0d});
 
@@ -183,7 +183,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingLongs() throws EncodingException {
+  public void testEncodingLongs() {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> ctx.add("long", new long[] {1L, 2473946328429347632L});
 
@@ -202,14 +202,14 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingEnum_withNoCustomEncoder() throws EncodingException {
+  public void testEncodingEnum_withNoCustomEncoder() {
     String result =
         new JsonDataEncoderBuilder().build().encode(new MyEnum[] {MyEnum.VALUE_1, MyEnum.VALUE_2});
     assertThat(result).isEqualTo("[\"VALUE_1\",\"VALUE_2\"]");
   }
 
   @Test
-  public void testEncodingEnum_withCustomEncoder() throws EncodingException {
+  public void testEncodingEnum_withCustomEncoder() {
     ValueEncoder<MyEnum> encoder = (o, ctx) -> ctx.add(o.name().toLowerCase());
     String result =
         new JsonDataEncoderBuilder()
@@ -220,7 +220,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingCollection() throws IOException, EncodingException {
+  public void testEncodingCollection() throws IOException {
     ObjectEncoder<InnerDummyClass> anotherObjectEncoder =
         (o, ctx) -> {
           ctx.add("Name", "innerClass");
@@ -249,7 +249,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingMap_withStringKey_shouldSucceed() throws EncodingException {
+  public void testEncodingMap_withStringKey_shouldSucceed() {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("map", Collections.singletonMap("key", true));
@@ -281,7 +281,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingBytes() throws IOException, EncodingException {
+  public void testEncodingBytes() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("Bytes", "My {custom} value.".getBytes(Charset.forName("UTF-8")));
@@ -297,7 +297,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingCollectionBoxedPrimitives() throws IOException, EncodingException {
+  public void testEncodingCollectionBoxedPrimitives() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("Integer", Lists.newArrayList(1, 2, 3))
@@ -320,7 +320,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingNestedCollection() throws IOException, EncodingException {
+  public void testEncodingNestedCollection() throws IOException {
     ObjectEncoder<InnerDummyClass> anotherObjectEncoder =
         (o, ctx) -> {
           ctx.add("Name", "innerClass");
@@ -351,7 +351,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingComplexTypes_InnerEncoder() throws IOException, EncodingException {
+  public void testEncodingComplexTypes_InnerEncoder() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("String", "string")
@@ -382,8 +382,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testEncodingComplexTypes_InnerExtendedEncoder()
-      throws IOException, EncodingException {
+  public void testEncodingComplexTypes_InnerExtendedEncoder() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("String", "string")
@@ -410,13 +409,13 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testMissingEncoder() throws IOException, EncodingException {
+  public void testMissingEncoder() throws IOException {
     DataEncoder dataEncoder = new JsonDataEncoderBuilder().build();
     assertThrows(EncodingException.class, () -> dataEncoder.encode(DummyClass.INSTANCE));
   }
 
   @Test
-  public void testEncoderError() throws IOException, EncodingException {
+  public void testEncoderError() throws IOException {
     ObjectEncoder<DummyClass> objectEncoder = (o, ctx) -> ctx.add("name", "value");
     Writer mockWriter = mock(Writer.class);
     doThrow(IOException.class).when(mockWriter).write(any(String.class));
@@ -431,7 +430,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testNested_whenUsedCorrectly_shouldProduceNestedJson() throws EncodingException {
+  public void testNested_whenUsedCorrectly_shouldProduceNestedJson() {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("name", "value");
@@ -454,7 +453,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testTwiceNested_whenUsedCorrectly_shouldProduceNestedJson() throws EncodingException {
+  public void testTwiceNested_whenUsedCorrectly_shouldProduceNestedJson() {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> {
           ctx.add("name", "value");
@@ -489,7 +488,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testInline_shouldProduceValuesInParentObject() throws EncodingException {
+  public void testInline_shouldProduceValuesInParentObject() {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> ctx.add("name", "value").inline(InnerDummyClass.INSTANCE).add("after1", true);
     ObjectEncoder<InnerDummyClass> innerEncoder = (o, ctx) -> ctx.add("inner", "class");
@@ -505,7 +504,7 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
-  public void testNestedInline_shouldProduceValuesInParentObject() throws EncodingException {
+  public void testNestedInline_shouldProduceValuesInParentObject() {
     ObjectEncoder<DummyClass> objectEncoder =
         (o, ctx) -> ctx.add("name", "value").inline(InnerDummyClass.INSTANCE).add("after1", true);
     ObjectEncoder<InnerDummyClass> innerEncoder =

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
@@ -253,7 +253,6 @@ public class EncodableProcessor extends AbstractProcessor {
                   ClassName.get("com.google.firebase.encoders", "ObjectEncoderContext"), "ctx")
               .addModifiers(Modifier.PUBLIC)
               .addException(IOException.class)
-              .addException(ClassName.get("com.google.firebase.encoders", "EncodingException"))
               .addAnnotation(Override.class);
 
       Set<TypeMirror> result = new LinkedHashSet<>();

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoder.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -47,8 +46,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final GenericsEncoder INSTANCE = new GenericsEncoder();
 
         @Override
-        public void encode(Generics value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(Generics value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("bar3", value.getBar3());
             ctx.add("bar4", value.getBar4());
             ctx.add("multi", value.getMulti());
@@ -59,7 +57,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final BarEncoder INSTANCE = new BarEncoder();
 
         @Override
-        public void encode(Bar value, ObjectEncoderContext ctx) throws IOException, EncodingException {
+        public void encode(Bar value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("foo", value.getFoo());
         }
     }
@@ -68,7 +66,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final BazEncoder INSTANCE = new BazEncoder();
 
         @Override
-        public void encode(Baz value, ObjectEncoderContext ctx) throws IOException, EncodingException {
+        public void encode(Baz value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("t", value.getT());
         }
     }
@@ -77,7 +75,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final FooEncoder INSTANCE = new FooEncoder();
 
         @Override
-        public void encode(Foo value, ObjectEncoderContext ctx) throws IOException, EncodingException {
+        public void encode(Foo value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("t", value.getT());
         }
     }
@@ -86,8 +84,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final Member3Encoder INSTANCE = new Member3Encoder();
 
         @Override
-        public void encode(Member3 value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(Member3 value, ObjectEncoderContext ctx) throws IOException {
         }
     }
 
@@ -95,8 +92,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final Member4Encoder INSTANCE = new Member4Encoder();
 
         @Override
-        public void encode(Member4 value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(Member4 value, ObjectEncoderContext ctx) throws IOException {
         }
     }
 
@@ -104,8 +100,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final MultiEncoder INSTANCE = new MultiEncoder();
 
         @Override
-        public void encode(Multi value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(Multi value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("fooT", value.getFooT());
             ctx.add("fooU", value.getFooU());
         }
@@ -115,8 +110,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final MemberEncoder INSTANCE = new MemberEncoder();
 
         @Override
-        public void encode(Member value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(Member value, ObjectEncoderContext ctx) throws IOException {
         }
     }
 
@@ -124,8 +118,7 @@ public final class AutoGenericsEncoder implements Configurator {
         static final Member2Encoder INSTANCE = new Member2Encoder();
 
         @Override
-        public void encode(Member2 value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(Member2 value, ObjectEncoderContext ctx) throws IOException {
         }
     }
 }

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoderWithUnknownType.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoderWithUnknownType.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -41,8 +40,7 @@ public final class AutoGenericClassEncoder implements Configurator {
         static final GenericClassEncoder INSTANCE = new GenericClassEncoder();
 
         @Override
-        public void encode(GenericClass value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(GenericClass value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("t", value.getT());
             ctx.add("u", value.getU());
         }

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedRecursiveGenericEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedRecursiveGenericEncoder.java
@@ -14,7 +14,6 @@
 
 package com.example;
 
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -42,8 +41,7 @@ public final class AutoMainClassEncoder implements Configurator {
         static final MainClassEncoder INSTANCE = new MainClassEncoder();
 
         @Override
-        public void encode(MainClass value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(MainClass value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("child", value.getChild());
         }
     }
@@ -52,8 +50,7 @@ public final class AutoMainClassEncoder implements Configurator {
         static final ChildEncoder INSTANCE = new ChildEncoder();
 
         @Override
-        public void encode(Child value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(Child value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("stringChild", value.getStringChild());
             ctx.add("intChild", value.getIntChild());
             ctx.add("main", value.getMain());

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedSimpleClassEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedSimpleClassEncoder.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -39,7 +38,7 @@ public final class AutoSimpleClassEncoder implements Configurator {
 
     @Override
     public void encode(SimpleClass value, ObjectEncoderContext ctx)
-        throws IOException, EncodingException {
+        throws IOException {
       ctx.add("int", value.getInt());
       ctx.add("bool", value.isBool());
       ctx.add("map", value.getMap());

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedTypeWithListEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedTypeWithListEncoder.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -42,8 +41,7 @@ public final class AutoTypeWithListEncoder implements Configurator {
         static final TypeWithListEncoder INSTANCE = new TypeWithListEncoder();
 
         @Override
-        public void encode(TypeWithList value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(TypeWithList value, ObjectEncoderContext ctx) throws IOException {
             ctx.add("member", value.getMember());
         }
     }
@@ -52,8 +50,7 @@ public final class AutoTypeWithListEncoder implements Configurator {
         static final MemberEncoder INSTANCE = new MemberEncoder();
 
         @Override
-        public void encode(Member value, ObjectEncoderContext ctx) throws IOException,
-                EncodingException {
+        public void encode(Member value, ObjectEncoderContext ctx) throws IOException {
         }
     }
 }

--- a/encoders/firebase-encoders-reflective/api.txt
+++ b/encoders/firebase-encoders-reflective/api.txt
@@ -3,7 +3,7 @@ package com.google.firebase.encoders.reflective {
 
   public class ReflectiveObjectEncoder implements com.google.firebase.encoders.ObjectEncoder<java.lang.Object> {
     ctor public ReflectiveObjectEncoder(boolean);
-    method public void encode(@NonNull Object, @NonNull com.google.firebase.encoders.ObjectEncoderContext) throws com.google.firebase.encoders.EncodingException, java.io.IOException;
+    method public void encode(@NonNull Object, @NonNull com.google.firebase.encoders.ObjectEncoderContext) throws java.io.IOException;
     field @NonNull public static final com.google.firebase.encoders.reflective.ReflectiveObjectEncoder DEFAULT;
   }
 

--- a/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoder.java
+++ b/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoder.java
@@ -15,7 +15,6 @@
 package com.google.firebase.encoders.reflective;
 
 import androidx.annotation.NonNull;
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import java.io.IOException;
@@ -40,7 +39,7 @@ public class ReflectiveObjectEncoder implements ObjectEncoder<Object> {
 
   @Override
   public void encode(@NonNull Object obj, @NonNull ObjectEncoderContext ctx)
-      throws EncodingException, IOException {
+      throws IOException {
 
     @SuppressWarnings("unchecked")
     ObjectEncoder<Object> encoder = getEncoder((Class<Object>) obj.getClass());

--- a/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoder.java
+++ b/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoder.java
@@ -38,8 +38,7 @@ public class ReflectiveObjectEncoder implements ObjectEncoder<Object> {
   }
 
   @Override
-  public void encode(@NonNull Object obj, @NonNull ObjectEncoderContext ctx)
-      throws IOException {
+  public void encode(@NonNull Object obj, @NonNull ObjectEncoderContext ctx) throws IOException {
 
     @SuppressWarnings("unchecked")
     ObjectEncoder<Object> encoder = getEncoder((Class<Object>) obj.getClass());

--- a/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderProvider.java
+++ b/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderProvider.java
@@ -40,7 +40,7 @@ final class ReflectiveObjectEncoderProvider implements ObjectEncoderProvider {
 
     @Override
     public void encode(@Nullable Object obj, @NonNull ObjectEncoderContext ctx)
-        throws EncodingException, IOException {
+        throws IOException {
       for (Map.Entry<String, EncodingDescriptor> entry : fields.entrySet()) {
         String fieldName = entry.getKey();
         EncodingDescriptor descriptor = entry.getValue();

--- a/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderProvider.java
+++ b/encoders/firebase-encoders-reflective/src/main/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderProvider.java
@@ -39,8 +39,7 @@ final class ReflectiveObjectEncoderProvider implements ObjectEncoderProvider {
     }
 
     @Override
-    public void encode(@Nullable Object obj, @NonNull ObjectEncoderContext ctx)
-        throws IOException {
+    public void encode(@Nullable Object obj, @NonNull ObjectEncoderContext ctx) throws IOException {
       for (Map.Entry<String, EncodingDescriptor> entry : fields.entrySet()) {
         String fieldName = entry.getKey();
         EncodingDescriptor descriptor = entry.getValue();

--- a/encoders/firebase-encoders-reflective/src/test/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderTest.java
+++ b/encoders/firebase-encoders-reflective/src/test/java/com/google/firebase/encoders/reflective/ReflectiveObjectEncoderTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.encoders.DataEncoder;
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.annotations.Encodable;
 import com.google.firebase.encoders.json.JsonDataEncoderBuilder;
 import java.math.BigDecimal;
@@ -55,7 +54,7 @@ public class ReflectiveObjectEncoderTest {
   }
 
   @Test
-  public void test() throws EncodingException {
+  public void test() {
     DataEncoder encoder =
         new JsonDataEncoderBuilder()
             .registerFallbackEncoder(ReflectiveObjectEncoder.DEFAULT)

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/AndroidClientInfoEncoder.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/AndroidClientInfoEncoder.java
@@ -16,7 +16,6 @@ package com.google.android.datatransport.cct.internal;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import java.io.IOException;
@@ -25,7 +24,7 @@ public final class AndroidClientInfoEncoder implements ObjectEncoder<AutoValue_A
   @Override
   public void encode(
       @Nullable AutoValue_AndroidClientInfo obj, @NonNull ObjectEncoderContext objectEncoderContext)
-      throws EncodingException, IOException {
+      throws IOException {
     if (obj.getSdkVersion() != Integer.MIN_VALUE) {
       objectEncoderContext.add("sdkVersion", obj.getSdkVersion());
     }

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/BatchedLogRequestEncoder.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/BatchedLogRequestEncoder.java
@@ -16,7 +16,6 @@ package com.google.android.datatransport.cct.internal;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import java.io.IOException;
@@ -25,7 +24,7 @@ public final class BatchedLogRequestEncoder implements ObjectEncoder<AutoValue_B
   @Override
   public void encode(
       @Nullable AutoValue_BatchedLogRequest obj, @NonNull ObjectEncoderContext objectEncoderContext)
-      throws EncodingException, IOException {
+      throws IOException {
     objectEncoderContext.add("logRequest", obj.getLogRequests());
   }
 }

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/ClientInfoEncoder.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/ClientInfoEncoder.java
@@ -16,7 +16,6 @@ package com.google.android.datatransport.cct.internal;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import java.io.IOException;
@@ -25,7 +24,7 @@ public final class ClientInfoEncoder implements ObjectEncoder<AutoValue_ClientIn
   @Override
   public void encode(
       @Nullable AutoValue_ClientInfo obj, @NonNull ObjectEncoderContext objectEncoderContext)
-      throws EncodingException, IOException {
+      throws IOException {
     if (obj.getClientType() != null) {
       objectEncoderContext.add("clientType", obj.getClientType().name());
     }

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/LogEventEncoder.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/LogEventEncoder.java
@@ -16,7 +16,6 @@ package com.google.android.datatransport.cct.internal;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import java.io.IOException;
@@ -26,7 +25,7 @@ public final class LogEventEncoder implements ObjectEncoder<AutoValue_LogEvent> 
   @Override
   public void encode(
       @Nullable AutoValue_LogEvent obj, @NonNull ObjectEncoderContext objectEncoderContext)
-      throws EncodingException, IOException {
+      throws IOException {
     objectEncoderContext
         .add("eventTimeMs", obj.getEventTimeMs())
         .add("eventUptimeMs", obj.getEventUptimeMs())

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/LogRequestEncoder.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/LogRequestEncoder.java
@@ -30,7 +30,7 @@ public final class LogRequestEncoder implements ObjectEncoder<AutoValue_LogReque
    */
   private void encodeLogSource(
       @Nullable AutoValue_LogRequest obj, @NonNull ObjectEncoderContext objectEncoderContext)
-      throws EncodingException, IOException {
+      throws IOException {
     if (obj.getLogSourceName() != null) {
       objectEncoderContext.add("logSourceName", obj.getLogSourceName());
     } else if (obj.getLogSource() != Integer.MIN_VALUE) {
@@ -43,7 +43,7 @@ public final class LogRequestEncoder implements ObjectEncoder<AutoValue_LogReque
   @Override
   public void encode(
       @Nullable AutoValue_LogRequest obj, @NonNull ObjectEncoderContext objectEncoderContext)
-      throws EncodingException, IOException {
+      throws IOException {
     objectEncoderContext
         .add("requestTimeMs", obj.getRequestTimeMs())
         .add("requestUptimeMs", obj.getRequestUptimeMs());

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/NetworkConnectionInfoEncoder.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/internal/NetworkConnectionInfoEncoder.java
@@ -16,7 +16,6 @@ package com.google.android.datatransport.cct.internal;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import java.io.IOException;
@@ -27,7 +26,7 @@ public final class NetworkConnectionInfoEncoder
   public void encode(
       @Nullable AutoValue_NetworkConnectionInfo obj,
       @NonNull ObjectEncoderContext objectEncoderContext)
-      throws EncodingException, IOException {
+      throws IOException {
     if (obj.getMobileSubtype() != null) {
       objectEncoderContext.add("mobileSubtype", obj.getMobileSubtype().name());
     }

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/internal/LogRequestTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/internal/LogRequestTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 
 import com.google.android.datatransport.cct.proto.BatchedLogRequest;
-import com.google.firebase.encoders.EncodingException;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
@@ -182,7 +181,7 @@ public class LogRequestTest {
 
   @Test
   public void testLogRequest_jsontToProto()
-      throws EncodingException, InvalidProtocolBufferException {
+      throws InvalidProtocolBufferException {
     List<LogEvent> events = new ArrayList<>();
     events.add(
         LogEvent.protoBuilder(EMPTY_BYTE_ARRAY)

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/internal/LogRequestTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/internal/LogRequestTest.java
@@ -180,8 +180,7 @@ public class LogRequestTest {
   }
 
   @Test
-  public void testLogRequest_jsontToProto()
-      throws InvalidProtocolBufferException {
+  public void testLogRequest_jsontToProto() throws InvalidProtocolBufferException {
     List<LogEvent> events = new ArrayList<>();
     events.add(
         LogEvent.protoBuilder(EMPTY_BYTE_ARRAY)


### PR DESCRIPTION
An error encoding a message is more likely to be unrecoverable than the other way around. Making EncoderException unchecked would reflect this case, instead of forcing teams to use the catch-log-rethrow pattern.

For reference, GSON does something similar

https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/JsonParseException.html

> This exception is a RuntimeException because it is exposed to the client. Using a RuntimeException avoids bad coding practices on the client side where they catch the exception and do nothing. It is often the case that you want to blow up if there is a parsing error (i.e. often clients do not know how to recover from a JsonParseException.