### PR TITLE
Change coverage build status configuration.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,12 +9,14 @@ coverage:
       default: off
       FirebaseCommon:
         flags: FirebaseCommon
-        informational: true
+        informational: false
+        threshold: 5
     patch:
       default: off
       FirebaseCommon:
         flags: FirebaseCommon
-        informational: true
+        informational: false
+        threshold: 5
 
 comment:
-  layout: "header, flags, files, footer"
+  layout: "flags, files, footer"


### PR DESCRIPTION
Mark as failures if the coverage drop is over a threshold.