### PR TITLE
Fix queriesCannotBeSortedByAnUncommittedServerTimestamp test

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -461,37 +461,40 @@ public class ValidationTest {
     TaskCompletionSource<Void> offlineCallbackDone = new TaskCompletionSource<>();
     TaskCompletionSource<Void> onlineCallbackDone = new TaskCompletionSource<>();
 
-    collection.addSnapshotListener(
-        (snapshot, error) -> {
-          assertNotNull(snapshot);
+    ListenerRegistration listenerRegistration =
+        collection.addSnapshotListener(
+            (snapshot, error) -> {
+              assertNotNull(snapshot);
 
-          // Skip the initial empty snapshot.
-          if (snapshot.isEmpty()) return;
+              // Skip the initial empty snapshot.
+              if (snapshot.isEmpty()) return;
 
-          assertThat(snapshot.getDocuments()).hasSize(1);
-          DocumentSnapshot docSnap = snapshot.getDocuments().get(0);
+              assertThat(snapshot.getDocuments()).hasSize(1);
+              DocumentSnapshot docSnap = snapshot.getDocuments().get(0);
 
-          if (snapshot.getMetadata().hasPendingWrites()) {
-            // Offline snapshot. Since the server timestamp is uncommitted, we shouldn't be able to
-            // query by it.
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    collection
-                        .orderBy("timestamp")
-                        .endAt(docSnap)
-                        .addSnapshotListener((snapshot2, error2) -> {}));
-            offlineCallbackDone.setResult(null);
-          } else {
-            // Online snapshot. Since the server timestamp is committed, we should be able to query
-            // by it.
-            collection
-                .orderBy("timestamp")
-                .endAt(docSnap)
-                .addSnapshotListener((snapshot2, error2) -> {});
-            onlineCallbackDone.setResult(null);
-          }
-        });
+              if (snapshot.getMetadata().hasPendingWrites()) {
+                // Offline snapshot. Since the server timestamp is uncommitted, we shouldn't be able
+                // to query by it.
+                assertThrows(
+                    IllegalArgumentException.class,
+                    () ->
+                        collection
+                            .orderBy("timestamp")
+                            .endAt(docSnap)
+                            .addSnapshotListener((snapshot2, error2) -> {}));
+                // Use `trySetResult` since the callbacks fires twice if the WatchStream
+                // acknowledges the Write before the WriteStream.
+                offlineCallbackDone.trySetResult(null);
+              } else {
+                // Online snapshot. Since the server timestamp is committed, we should be able to
+                // query by it.
+                collection
+                    .orderBy("timestamp")
+                    .endAt(docSnap)
+                    .addSnapshotListener((snapshot2, error2) -> {});
+                onlineCallbackDone.trySetResult(null);
+              }
+            });
 
     DocumentReference document = collection.document();
     document.set(map("timestamp", FieldValue.serverTimestamp()));
@@ -499,6 +502,8 @@ public class ValidationTest {
 
     waitFor(collection.firestore.getClient().enableNetwork());
     waitFor(onlineCallbackDone.getTask());
+
+    listenerRegistration.remove();
   }
 
   @Test


### PR DESCRIPTION
This test fails in my FieldValue rewrite when not run under the debugger.

I believe the failure is expected when the WatchStream acknowledges the Write before the WriteStream does. I see three snapshots:

```
isFromCache:true, hasPendingWrites:true
offlineCallbackDone.setResult()

Watch updates arrives
isFromCache:false, hasPendingWrites:true
We now try to set the result for `offlineCallbackDone` again, which raises an exception.

Write updates arrives
isFromCache:false, hasPendingWrites:false
onlineCallbackDone.setResult()
```

I believe a similar failure occurs today if the order is switched:

```
isFromCache:true, hasPendingWrites:true
offlineCallbackDone.setResult()

Write updates arrives
isFromCache:true, hasPendingWrites:false
onlineCallbackDone.setResult()

isFromCache:false, hasPendingWrites:false
We now try to set the result for `onlineCallbackDone` again, which raises an exception. 
This exceptions is however swallowed since it happens after the test finishes.
```