### PR TITLE
Add new CrashlyticsReport data model

### DIFF
--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -50,6 +50,9 @@ android {
 }
 
 dependencies {
+    compileOnly project(':encoders:firebase-encoders-json')
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
+
     implementation project(':firebase-common')
     implementation project(':firebase-components')
     implementation ('com.google.firebase:firebase-iid:19.0.0') {
@@ -60,6 +63,9 @@ dependencies {
     implementation "com.google.android.gms:play-services-tasks:17.0.0"
 
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
+
+    annotationProcessor project(":encoders:firebase-encoders-processor")
+    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'org.robolectric:robolectric:4.2'

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -17,16 +17,21 @@ package com.google.firebase.crashlytics.internal.model;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
-import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Application.Organization;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;
-import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.Thread.Frame;
 import com.google.firebase.encoders.annotations.Encodable;
 import com.google.firebase.encoders.annotations.Encodable.Field;
 import com.google.firebase.encoders.annotations.Encodable.Ignore;
 import java.nio.charset.Charset;
-import java.util.List;
 
+/**
+ * This class represents the data captured by and reported to Crashlytics.
+ *
+ * <p>It is an immutable value class implemented by AutoValue.
+ *
+ * @see <a
+ *     href="https://github.com/google/auto/tree/master/value">https://github.com/google/auto/tree/master/value</a>
+ */
 @Encodable
 @AutoValue
 public abstract class CrashlyticsReport {
@@ -58,11 +63,22 @@ public abstract class CrashlyticsReport {
   @NonNull
   public abstract Session getSession();
 
+  /**
+   * Augment an existing {@link CrashlyticsReport} with a given list of events.
+   *
+   * @return a new {@link CrashlyticsReport} with its events list set to the given list of events.
+   */
   @NonNull
-  public CrashlyticsReport withEvents(@NonNull List<Event> events) {
+  public CrashlyticsReport withEvents(@NonNull ImmutableList<Event> events) {
     return toBuilder().setSession(getSession().withEvents(events)).build();
   }
 
+  /**
+   * Augment an existing {@link CrashlyticsReport} with a given organization ID.
+   *
+   * @return a new {@link CrashlyticsReport} with its Session.Application.Organization object
+   *     containing the given organization ID.
+   */
   @NonNull
   public CrashlyticsReport withOrganizationId(@NonNull String organizationId) {
     return toBuilder().setSession(getSession().withOrganizationId(organizationId)).build();
@@ -127,11 +143,11 @@ public abstract class CrashlyticsReport {
 
     public abstract long getStartedAt();
 
-    @Nullable
-    public abstract User getUser();
+    @NonNull
+    public abstract Application getApp();
 
     @Nullable
-    public abstract Application getApp();
+    public abstract User getUser();
 
     @Nullable
     public abstract OperatingSystem getOs();
@@ -146,18 +162,13 @@ public abstract class CrashlyticsReport {
     protected abstract Builder toBuilder();
 
     @NonNull
-    Session withEvents(@NonNull List<Event> events) {
-      return toBuilder().setEvents(ImmutableList.from(events)).build();
+    Session withEvents(@NonNull ImmutableList<Event> events) {
+      return toBuilder().setEvents(events).build();
     }
 
     @NonNull
     Session withOrganizationId(@NonNull String organizationId) {
-      final Application app =
-          (getApp() != null)
-              ? getApp().withOrganizationId(organizationId)
-              : Application.builder()
-                  .setOrganization(Organization.builder().setClsId(organizationId).build())
-                  .build();
+      final Application app = getApp().withOrganizationId(organizationId);
       return toBuilder().setApp(app).build();
     }
 
@@ -443,7 +454,7 @@ public abstract class CrashlyticsReport {
         @NonNull
         public abstract Execution getExecution();
 
-        @NonNull
+        @Nullable
         public abstract ImmutableList<CustomAttribute> getCustomAttributes();
 
         public abstract boolean isBackground();

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -1,0 +1,854 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.model;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Application.Organization;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.Thread.Frame;
+import com.google.firebase.encoders.annotations.Encodable;
+import com.google.firebase.encoders.annotations.Encodable.Field;
+import com.google.firebase.encoders.annotations.Encodable.Ignore;
+import java.nio.charset.Charset;
+import java.util.List;
+
+@Encodable
+@AutoValue
+public abstract class CrashlyticsReport {
+
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @NonNull
+  public static Builder builder() {
+    return new AutoValue_CrashlyticsReport.Builder();
+  }
+
+  @NonNull
+  public abstract String getSdkVersion();
+
+  @NonNull
+  public abstract String getGmpAppId();
+
+  public abstract int getPlatform();
+
+  @NonNull
+  public abstract String getInstallationUuid();
+
+  @NonNull
+  public abstract String getBuildVersion();
+
+  @NonNull
+  public abstract String getDisplayVersion();
+
+  @NonNull
+  public abstract Session getSession();
+
+  @NonNull
+  public CrashlyticsReport withEvents(@NonNull List<Event> events) {
+    return toBuilder().setSession(getSession().withEvents(events)).build();
+  }
+
+  @NonNull
+  public CrashlyticsReport withOrganizationId(@NonNull String organizationId) {
+    return toBuilder().setSession(getSession().withOrganizationId(organizationId)).build();
+  }
+
+  // TODO
+  // @Nullable
+  // public abstract byte[] getNdkPayload();
+
+  @NonNull
+  protected abstract Builder toBuilder();
+
+  @AutoValue
+  public abstract static class CustomAttribute {
+
+    @NonNull
+    public static Builder builder() {
+      return new AutoValue_CrashlyticsReport_CustomAttribute.Builder();
+    }
+
+    @NonNull
+    public abstract String getKey();
+
+    @NonNull
+    public abstract String getValue();
+
+    /** Builder for {@link CustomAttribute}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      @NonNull
+      public abstract Builder setKey(@NonNull String value);
+
+      @NonNull
+      public abstract Builder setValue(@NonNull String value);
+
+      @NonNull
+      public abstract CustomAttribute build();
+    }
+  }
+
+  @AutoValue
+  public abstract static class Session {
+
+    @NonNull
+    public static Builder builder() {
+      return new AutoValue_CrashlyticsReport_Session.Builder();
+    }
+
+    @NonNull
+    public abstract String getGenerator();
+
+    @Ignore
+    @NonNull
+    public abstract String getIdentifier();
+
+    @Field(name = "identifier")
+    @NonNull
+    public byte[] getIdentifierUtf8Bytes() {
+      return getIdentifier().getBytes(UTF_8);
+    }
+
+    public abstract long getStartedAt();
+
+    @Nullable
+    public abstract User getUser();
+
+    @Nullable
+    public abstract Application getApp();
+
+    @Nullable
+    public abstract OperatingSystem getOs();
+
+    @Nullable
+    public abstract Device getDevice();
+
+    @Nullable
+    public abstract ImmutableList<Event> getEvents();
+
+    @NonNull
+    protected abstract Builder toBuilder();
+
+    @NonNull
+    Session withEvents(@NonNull List<Event> events) {
+      return toBuilder().setEvents(ImmutableList.from(events)).build();
+    }
+
+    @NonNull
+    Session withOrganizationId(@NonNull String organizationId) {
+      final Application app =
+          (getApp() != null)
+              ? getApp().withOrganizationId(organizationId)
+              : Application.builder()
+                  .setOrganization(Organization.builder().setClsId(organizationId).build())
+                  .build();
+      return toBuilder().setApp(app).build();
+    }
+
+    /** Builder for {@link Session}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+
+      @NonNull
+      public abstract Builder setGenerator(@NonNull String generator);
+
+      @NonNull
+      public abstract Builder setIdentifier(@NonNull String identifier);
+
+      @NonNull
+      public Builder setIdentifierFromUtf8Bytes(@NonNull byte[] utf8Bytes) {
+        return setIdentifier(new String(utf8Bytes, UTF_8));
+      }
+
+      @NonNull
+      public abstract Builder setStartedAt(long startedAt);
+
+      @NonNull
+      public abstract Builder setUser(@NonNull User value);
+
+      @NonNull
+      public abstract Builder setApp(@NonNull Application application);
+
+      @NonNull
+      public abstract Builder setOs(@NonNull OperatingSystem value);
+
+      @NonNull
+      public abstract Builder setDevice(@NonNull Device value);
+
+      @NonNull
+      public abstract Builder setEvents(@NonNull ImmutableList<Event> value);
+
+      @NonNull
+      public abstract Session build();
+    }
+
+    @AutoValue
+    public abstract static class User {
+
+      @NonNull
+      public static Builder builder() {
+        return new AutoValue_CrashlyticsReport_Session_User.Builder();
+      }
+
+      @NonNull
+      public abstract String getIdentifier();
+
+      /** Builder for {@link User}. */
+      @AutoValue.Builder
+      public abstract static class Builder {
+
+        @NonNull
+        public abstract Builder setIdentifier(@NonNull String value);
+
+        @NonNull
+        public abstract User build();
+      }
+    }
+
+    @AutoValue
+    public abstract static class Application {
+
+      @NonNull
+      public static Builder builder() {
+        return new AutoValue_CrashlyticsReport_Session_Application.Builder();
+      }
+
+      @NonNull
+      public abstract String getIdentifier();
+
+      @NonNull
+      public abstract String getVersion();
+
+      @Nullable
+      public abstract String getDisplayVersion();
+
+      @Nullable
+      public abstract Organization getOrganization();
+
+      @Nullable
+      public abstract String getInstallationUuid();
+
+      @NonNull
+      protected abstract Builder toBuilder();
+
+      @NonNull
+      Application withOrganizationId(@NonNull String organizationId) {
+        final Organization organization = getOrganization();
+        final Organization.Builder builder =
+            (organization != null) ? organization.toBuilder() : Organization.builder();
+        return toBuilder().setOrganization(builder.setClsId(organizationId).build()).build();
+      }
+
+      /** Builder for {@link Application}. */
+      @AutoValue.Builder
+      public abstract static class Builder {
+
+        @NonNull
+        public abstract Builder setIdentifier(@NonNull String identifier);
+
+        @NonNull
+        public abstract Builder setVersion(@NonNull String version);
+
+        @NonNull
+        public abstract Builder setDisplayVersion(@NonNull String displayVersion);
+
+        @NonNull
+        public abstract Builder setOrganization(@NonNull Organization value);
+
+        @NonNull
+        public abstract Builder setInstallationUuid(@NonNull String installationUuid);
+
+        @NonNull
+        public abstract Application build();
+      }
+
+      @AutoValue
+      public abstract static class Organization {
+
+        @NonNull
+        public static Builder builder() {
+          return new AutoValue_CrashlyticsReport_Session_Application_Organization.Builder();
+        }
+
+        @NonNull
+        public abstract String getClsId();
+
+        @NonNull
+        protected abstract Builder toBuilder();
+
+        /** Builder for {@link Organization}. */
+        @AutoValue.Builder
+        public abstract static class Builder {
+
+          @NonNull
+          public abstract Builder setClsId(@NonNull String value);
+
+          @NonNull
+          public abstract Organization build();
+        }
+      }
+    }
+
+    @AutoValue
+    public abstract static class OperatingSystem {
+
+      @NonNull
+      public static Builder builder() {
+        return new AutoValue_CrashlyticsReport_Session_OperatingSystem.Builder();
+      }
+
+      public abstract int getPlatform();
+
+      @NonNull
+      public abstract String getVersion();
+
+      @NonNull
+      public abstract String getBuildVersion();
+
+      public abstract boolean isJailbroken();
+
+      /** Builder for {@link OperatingSystem}. */
+      @AutoValue.Builder
+      public abstract static class Builder {
+
+        @NonNull
+        public abstract Builder setPlatform(int value);
+
+        @NonNull
+        public abstract Builder setVersion(@NonNull String value);
+
+        @NonNull
+        public abstract Builder setBuildVersion(@NonNull String value);
+
+        @NonNull
+        public abstract Builder setJailbroken(boolean value);
+
+        @NonNull
+        public abstract OperatingSystem build();
+      }
+    }
+
+    @AutoValue
+    public abstract static class Device {
+
+      @NonNull
+      public static Builder builder() {
+        return new AutoValue_CrashlyticsReport_Session_Device.Builder();
+      }
+
+      @NonNull
+      public abstract int getArch();
+
+      @NonNull
+      public abstract String getModel();
+
+      public abstract int getCores();
+
+      public abstract long getRam();
+
+      public abstract long getDiskSpace();
+
+      public abstract boolean isSimulator();
+
+      public abstract int getState(); // TODO Use DeviceState enum here for Bitmasking
+
+      @NonNull
+      public abstract String getManufacturer();
+
+      @NonNull
+      public abstract String getModelClass();
+
+      /** Builder for {@link Device}. */
+      @AutoValue.Builder
+      public abstract static class Builder {
+
+        @NonNull
+        public abstract Builder setArch(int value);
+
+        @NonNull
+        public abstract Builder setModel(@NonNull String value);
+
+        @NonNull
+        public abstract Builder setCores(int value);
+
+        @NonNull
+        public abstract Builder setRam(long value);
+
+        @NonNull
+        public abstract Builder setDiskSpace(long value);
+
+        @NonNull
+        public abstract Builder setSimulator(boolean value);
+
+        @NonNull
+        public abstract Builder setState(int value);
+
+        @NonNull
+        public abstract Builder setManufacturer(@NonNull String value);
+
+        @NonNull
+        public abstract Builder setModelClass(@NonNull String value);
+
+        @NonNull
+        public abstract Device build();
+      }
+    }
+
+    @AutoValue
+    public abstract static class Event {
+
+      @NonNull
+      public static Builder builder() {
+        return new AutoValue_CrashlyticsReport_Session_Event.Builder();
+      }
+
+      public abstract long getTimestamp();
+
+      @NonNull
+      public abstract String getType();
+
+      @NonNull
+      public abstract Application getApp();
+
+      @NonNull
+      public abstract Device getDevice();
+
+      @Nullable
+      public abstract Log getLog();
+
+      @AutoValue
+      public abstract static class Application {
+
+        @NonNull
+        public static Builder builder() {
+          return new AutoValue_CrashlyticsReport_Session_Event_Application.Builder();
+        }
+
+        @NonNull
+        public abstract Execution getExecution();
+
+        @NonNull
+        public abstract ImmutableList<CustomAttribute> getCustomAttributes();
+
+        public abstract boolean isBackground();
+
+        public abstract int getUiOrientation();
+
+        @AutoValue
+        public abstract static class Execution {
+
+          @NonNull
+          public static Builder builder() {
+            return new AutoValue_CrashlyticsReport_Session_Event_Application_Execution.Builder();
+          }
+
+          @NonNull
+          public abstract ImmutableList<Thread> getThreads();
+
+          @NonNull
+          public abstract Exception getException();
+
+          @NonNull
+          public abstract Signal getSignal();
+
+          @NonNull
+          public abstract ImmutableList<BinaryImage> getBinaries();
+
+          @AutoValue
+          public abstract static class Thread {
+
+            @NonNull
+            public static Builder builder() {
+              return new AutoValue_CrashlyticsReport_Session_Event_Application_Execution_Thread
+                  .Builder();
+            }
+
+            @NonNull
+            public abstract String getName();
+
+            public abstract int getImportance();
+
+            @NonNull
+            public abstract ImmutableList<Frame> getFrames();
+
+            @AutoValue
+            public abstract static class Frame {
+
+              @NonNull
+              public static Builder builder() {
+                return new AutoValue_CrashlyticsReport_Session_Event_Application_Execution_Thread_Frame
+                    .Builder();
+              }
+
+              public abstract long getPc();
+
+              @NonNull
+              public abstract String getSymbol();
+
+              @Nullable
+              public abstract String getFile();
+
+              public abstract long getOffset();
+
+              public abstract int getImportance();
+
+              /** Builder for {@link Frame}. */
+              @AutoValue.Builder
+              public abstract static class Builder {
+
+                @NonNull
+                public abstract Builder setPc(long value);
+
+                @NonNull
+                public abstract Builder setSymbol(@NonNull String value);
+
+                @NonNull
+                public abstract Builder setFile(@NonNull String value);
+
+                @NonNull
+                public abstract Builder setOffset(long value);
+
+                @NonNull
+                public abstract Builder setImportance(int value);
+
+                @NonNull
+                public abstract Frame build();
+              }
+            }
+
+            /** Builder for {@link Thread}. */
+            @AutoValue.Builder
+            public abstract static class Builder {
+
+              @NonNull
+              public abstract Builder setName(@NonNull String value);
+
+              @NonNull
+              public abstract Builder setImportance(int value);
+
+              @NonNull
+              public abstract Builder setFrames(@NonNull ImmutableList<Frame> value);
+
+              @NonNull
+              public abstract Thread build();
+            }
+          }
+
+          @AutoValue
+          public abstract static class Exception {
+
+            @NonNull
+            public static Builder builder() {
+              return new AutoValue_CrashlyticsReport_Session_Event_Application_Execution_Exception
+                  .Builder();
+            }
+
+            @NonNull
+            public abstract String getType();
+
+            @NonNull
+            public abstract String getReason();
+
+            @NonNull
+            public abstract ImmutableList<Frame> getFrames();
+
+            @Nullable
+            public abstract Exception getCausedBy();
+
+            public abstract int getOverflowCount();
+
+            /** Builder for {@link Exception}. */
+            @AutoValue.Builder
+            public abstract static class Builder {
+
+              @NonNull
+              public abstract Builder setType(@NonNull String value);
+
+              @NonNull
+              public abstract Builder setReason(@NonNull String value);
+
+              @NonNull
+              public abstract Builder setFrames(@NonNull ImmutableList<Frame> value);
+
+              @NonNull
+              public abstract Builder setCausedBy(@NonNull Exception value);
+
+              @NonNull
+              public abstract Builder setOverflowCount(int value);
+
+              @NonNull
+              public abstract Exception build();
+            }
+          }
+
+          @AutoValue
+          public abstract static class Signal {
+
+            @NonNull
+            public static Builder builder() {
+              return new AutoValue_CrashlyticsReport_Session_Event_Application_Execution_Signal
+                  .Builder();
+            }
+
+            @NonNull
+            public abstract String getName();
+
+            @NonNull
+            public abstract String getCode();
+
+            @NonNull
+            public abstract long getAddress();
+
+            /** Builder for {@link Signal}. */
+            @AutoValue.Builder
+            public abstract static class Builder {
+
+              @NonNull
+              public abstract Builder setName(@NonNull String value);
+
+              @NonNull
+              public abstract Builder setCode(@NonNull String value);
+
+              @NonNull
+              public abstract Builder setAddress(long value);
+
+              @NonNull
+              public abstract Signal build();
+            }
+          }
+
+          @AutoValue
+          public abstract static class BinaryImage {
+
+            @NonNull
+            public static Builder builder() {
+              return new AutoValue_CrashlyticsReport_Session_Event_Application_Execution_BinaryImage
+                  .Builder();
+            }
+
+            @NonNull
+            public abstract long getBaseAddress();
+
+            public abstract long getSize();
+
+            @NonNull
+            public abstract String getName();
+
+            @Ignore
+            @NonNull
+            public abstract String getUuid();
+
+            @Field(name = "uuid")
+            @NonNull
+            public byte[] getUuidUtf8Bytes() {
+              return getUuid().getBytes(UTF_8);
+            }
+
+            /** Builder for {@link BinaryImage}. */
+            @AutoValue.Builder
+            public abstract static class Builder {
+
+              @NonNull
+              public abstract Builder setBaseAddress(long value);
+
+              @NonNull
+              public abstract Builder setSize(long value);
+
+              @NonNull
+              public abstract Builder setName(@NonNull String value);
+
+              @NonNull
+              public abstract Builder setUuid(@NonNull String value);
+
+              @NonNull
+              public Builder setUuidFromUtf8Bytes(@NonNull byte[] utf8Bytes) {
+                return setUuid(new String(utf8Bytes, UTF_8));
+              }
+
+              @NonNull
+              public abstract BinaryImage build();
+            }
+          }
+
+          /** Builder for {@link Execution}. */
+          @AutoValue.Builder
+          public abstract static class Builder {
+
+            @NonNull
+            public abstract Builder setThreads(@NonNull ImmutableList<Thread> value);
+
+            @NonNull
+            public abstract Builder setException(@NonNull Exception value);
+
+            @NonNull
+            public abstract Builder setSignal(@NonNull Signal value);
+
+            @NonNull
+            public abstract Builder setBinaries(@NonNull ImmutableList<BinaryImage> value);
+
+            @NonNull
+            public abstract Execution build();
+          }
+        }
+
+        /** Builder for {@link Application}. */
+        @AutoValue.Builder
+        public abstract static class Builder {
+
+          @NonNull
+          public abstract Builder setExecution(@NonNull Execution value);
+
+          @NonNull
+          public abstract Builder setCustomAttributes(
+              @NonNull ImmutableList<CustomAttribute> value);
+
+          @NonNull
+          public abstract Builder setBackground(boolean value);
+
+          @NonNull
+          public abstract Builder setUiOrientation(int value);
+
+          @NonNull
+          public abstract Application build();
+        }
+      }
+
+      @AutoValue
+      public abstract static class Device {
+
+        @NonNull
+        public static Builder builder() {
+          return new AutoValue_CrashlyticsReport_Session_Event_Device.Builder();
+        }
+
+        public abstract double getBatteryLevel();
+
+        public abstract int getBatteryVelocity();
+
+        public abstract boolean isProximityOn();
+
+        public abstract int getOrientation();
+
+        public abstract long getRamUsed();
+
+        public abstract long getDiskUsed();
+
+        /** Builder for {@link Device}. */
+        @AutoValue.Builder
+        public abstract static class Builder {
+
+          @NonNull
+          public abstract Builder setBatteryLevel(double value);
+
+          @NonNull
+          public abstract Builder setBatteryVelocity(int value);
+
+          @NonNull
+          public abstract Builder setProximityOn(boolean value);
+
+          @NonNull
+          public abstract Builder setOrientation(int value);
+
+          @NonNull
+          public abstract Builder setRamUsed(long value);
+
+          @NonNull
+          public abstract Builder setDiskUsed(long value);
+
+          @NonNull
+          public abstract Device build();
+        }
+      }
+
+      @AutoValue
+      public abstract static class Log {
+
+        @NonNull
+        public static Builder builder() {
+          return new AutoValue_CrashlyticsReport_Session_Event_Log.Builder();
+        }
+
+        @NonNull
+        public abstract String getContent();
+
+        /** Builder for {@link Log}. */
+        @AutoValue.Builder
+        public abstract static class Builder {
+
+          @NonNull
+          public abstract Builder setContent(@NonNull String value);
+
+          @NonNull
+          public abstract Log build();
+        }
+      }
+
+      /** Builder for {@link Event}. */
+      @AutoValue.Builder
+      public abstract static class Builder {
+
+        @NonNull
+        public abstract Builder setTimestamp(long value);
+
+        @NonNull
+        public abstract Builder setType(@NonNull String value);
+
+        @NonNull
+        public abstract Builder setApp(@NonNull Application value);
+
+        @NonNull
+        public abstract Builder setDevice(@NonNull Device value);
+
+        @NonNull
+        public abstract Builder setLog(@NonNull Log value);
+
+        @NonNull
+        public abstract Event build();
+      }
+    }
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    @NonNull
+    public abstract Builder setSdkVersion(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setGmpAppId(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setPlatform(int value);
+
+    @NonNull
+    public abstract Builder setInstallationUuid(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setBuildVersion(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setDisplayVersion(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setSession(@NonNull Session value);
+
+    @NonNull
+    public abstract CrashlyticsReport build();
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/ImmutableList.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/ImmutableList.java
@@ -1,0 +1,177 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.model;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.RandomAccess;
+
+/** Immutable list implementation for use with AutoValue */
+public final class ImmutableList<E> implements List<E>, RandomAccess {
+
+  @NonNull
+  public static <E> ImmutableList<E> from(E... elements) {
+    return new ImmutableList<>(Arrays.asList(elements));
+  }
+
+  @NonNull
+  public static <E> ImmutableList<E> from(@NonNull List<E> mutableList) {
+    return new ImmutableList<>(mutableList);
+  }
+
+  private final List<E> immutableList;
+
+  private ImmutableList(List<E> mutableList) {
+    this.immutableList = Collections.unmodifiableList(mutableList);
+  }
+
+  @Override
+  public int size() {
+    return immutableList.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return immutableList.isEmpty();
+  }
+
+  @Override
+  public boolean contains(@Nullable Object o) {
+    return immutableList.contains(o);
+  }
+
+  @NonNull
+  @Override
+  public Iterator<E> iterator() {
+    return immutableList.iterator();
+  }
+
+  @Nullable
+  @Override
+  public Object[] toArray() {
+    return immutableList.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(@Nullable T[] a) {
+    return immutableList.toArray(a);
+  }
+
+  @Override
+  public boolean add(@NonNull E e) {
+    return immutableList.add(e);
+  }
+
+  @Override
+  public boolean remove(@Nullable Object o) {
+    return immutableList.remove(o);
+  }
+
+  @Override
+  public boolean containsAll(@NonNull Collection<?> c) {
+    return immutableList.containsAll(c);
+  }
+
+  @Override
+  public boolean addAll(@NonNull Collection<? extends E> c) {
+    return immutableList.addAll(c);
+  }
+
+  @Override
+  public boolean addAll(int index, @NonNull Collection<? extends E> c) {
+    return immutableList.addAll(index, c);
+  }
+
+  @Override
+  public boolean removeAll(@NonNull Collection<?> c) {
+    return immutableList.removeAll(c);
+  }
+
+  @Override
+  public boolean retainAll(@NonNull Collection<?> c) {
+    return immutableList.retainAll(c);
+  }
+
+  @Override
+  public void clear() {
+    immutableList.clear();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    return immutableList.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return immutableList.hashCode();
+  }
+
+  @NonNull
+  @Override
+  public E get(int index) {
+    return immutableList.get(index);
+  }
+
+  @NonNull
+  @Override
+  public E set(int index, @NonNull E element) {
+    return immutableList.set(index, element);
+  }
+
+  @Override
+  public void add(int index, @NonNull E element) {
+    immutableList.add(index, element);
+  }
+
+  @Override
+  public E remove(int index) {
+    return immutableList.remove(index);
+  }
+
+  @Override
+  public int indexOf(@Nullable Object o) {
+    return immutableList.indexOf(o);
+  }
+
+  @Override
+  public int lastIndexOf(@Nullable Object o) {
+    return immutableList.lastIndexOf(o);
+  }
+
+  @NonNull
+  @Override
+  public ListIterator<E> listIterator() {
+    return immutableList.listIterator();
+  }
+
+  @NonNull
+  @Override
+  public ListIterator<E> listIterator(int index) {
+    return immutableList.listIterator(index);
+  }
+
+  @NonNull
+  @Override
+  public List<E> subList(int fromIndex, int toIndex) {
+    return immutableList.subList(fromIndex, toIndex);
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/package-info.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/package-info.java
@@ -1,0 +1,16 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @hide */
+package com.google.firebase.crashlytics.internal.model;

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReportTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReportTest.java
@@ -1,0 +1,231 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.model;
+
+import static org.junit.Assert.*;
+
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Application;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.BinaryImage;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.Signal;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.Thread.Frame;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class CrashlyticsReportTest {
+
+  @Test
+  public void testWithEvents_returnsNewReportWithEvents() {
+    final CrashlyticsReport testReport = makeTestReport();
+
+    assertNull(testReport.getSession().getEvents());
+
+    final CrashlyticsReport withEventsReport = testReport.withEvents(makeTestEvents(2));
+
+    assertNotEquals(testReport, withEventsReport);
+    assertNotNull(withEventsReport.getSession().getEvents());
+    assertEquals(2, withEventsReport.getSession().getEvents().size());
+  }
+
+  @Test
+  public void testWithOrganizationId_returnsNewReportWithOrganizationId() {
+    final CrashlyticsReport testReport = makeTestReport();
+
+    assertNull(testReport.getSession().getApp().getOrganization());
+
+    final CrashlyticsReport withOrganizationIdReport =
+        testReport.withOrganizationId("organizationId");
+
+    assertNotEquals(testReport, withOrganizationIdReport);
+    assertNotNull(withOrganizationIdReport.getSession().getApp().getOrganization());
+    assertEquals(
+        "organizationId",
+        withOrganizationIdReport.getSession().getApp().getOrganization().getClsId());
+  }
+
+  @Test
+  public void testGetSessionIdUtf8Bytes_returnsProperBytes() {
+    final CrashlyticsReport testReport = makeTestReport();
+    final byte[] expectedBytes = "identifier".getBytes(Charset.forName("UTF-8"));
+
+    assertArrayEquals(expectedBytes, testReport.getSession().getIdentifierUtf8Bytes());
+  }
+
+  @Test
+  public void testGetBinaryImageUuidUtf8Bytes_returnsProperBytes() {
+    final String expectedUuid = "expectedUuid";
+    final byte[] expectedBytes = expectedUuid.getBytes(Charset.forName("UTF-8"));
+    final BinaryImage binaryImage =
+        BinaryImage.builder()
+            .setName("binary")
+            .setBaseAddress(0)
+            .setSize(100000)
+            .setUuid(expectedUuid)
+            .build();
+    assertArrayEquals(expectedBytes, binaryImage.getUuidUtf8Bytes());
+  }
+
+  @Test
+  public void testSetSessionIdUtf8Bytes_returnsProperSessionId() {
+    final CrashlyticsReport testReport = makeTestReport();
+    final String testSessionId = "testSessionId";
+    final byte[] utf8Bytes = testSessionId.getBytes(Charset.forName("UTF-8"));
+
+    assertNotEquals(testSessionId, testReport.getSession().getIdentifier());
+
+    final CrashlyticsReport updatedReport =
+        testReport
+            .toBuilder()
+            .setSession(
+                testReport.getSession().toBuilder().setIdentifierFromUtf8Bytes(utf8Bytes).build())
+            .build();
+
+    assertEquals(testSessionId, updatedReport.getSession().getIdentifier());
+  }
+
+  @Test
+  public void testSetBinaryImageUuidUtf8Bytes_returnsProperUuid() {
+    final String expectedUuid = "expectedUuid";
+    final byte[] expectedBytes = expectedUuid.getBytes(Charset.forName("UTF-8"));
+    final BinaryImage binaryImage =
+        BinaryImage.builder()
+            .setName("binary")
+            .setBaseAddress(0)
+            .setSize(100000)
+            .setUuidFromUtf8Bytes(expectedBytes)
+            .build();
+    assertEquals(expectedUuid, binaryImage.getUuid());
+  }
+
+  private static CrashlyticsReport makeTestReport() {
+    return CrashlyticsReport.builder()
+        .setSdkVersion("sdkVersion")
+        .setGmpAppId("gmpAppId")
+        .setPlatform(1)
+        .setInstallationUuid("installationId")
+        .setBuildVersion("1")
+        .setDisplayVersion("1.0.0")
+        .setSession(makeTestSession())
+        .build();
+  }
+
+  private static CrashlyticsReport.Session makeTestSession() {
+    return Session.builder()
+        .setGenerator("generator")
+        .setIdentifier("identifier")
+        .setStartedAt(0)
+        .setApp(makeTestApplication())
+        .build();
+  }
+
+  private static Application makeTestApplication() {
+    return Application.builder()
+        .setIdentifier("applicationId")
+        .setVersion("version")
+        .setDisplayVersion("displayVersion")
+        .build();
+  }
+
+  private static ImmutableList<Event> makeTestEvents(int numEvents) {
+    List<Event> events = new ArrayList<>();
+    for (int i = 0; i < numEvents; i++) {
+      events.add(makeTestEvent());
+    }
+    return ImmutableList.from(events);
+  }
+
+  private static Event makeTestEvent() {
+    return Event.builder()
+        .setType("type")
+        .setTimestamp(1000)
+        .setApp(
+            Session.Event.Application.builder()
+                .setBackground(false)
+                .setExecution(
+                    Execution.builder()
+                        .setBinaries(
+                            ImmutableList.from(
+                                Execution.BinaryImage.builder()
+                                    .setBaseAddress(0)
+                                    .setName("name")
+                                    .setSize(100000)
+                                    .setUuid("uuid")
+                                    .build()))
+                        .setException(
+                            Execution.Exception.builder()
+                                .setFrames(makeTestFrames())
+                                .setOverflowCount(0)
+                                .setReason("reason")
+                                .setType("java.lang.Exception")
+                                .build())
+                        .setSignal(Signal.builder().setCode("0").setName("0").setAddress(0).build())
+                        .setThreads(
+                            ImmutableList.from(
+                                Session.Event.Application.Execution.Thread.builder()
+                                    .setName("name")
+                                    .setImportance(4)
+                                    .setFrames(makeTestFrames())
+                                    .build()))
+                        .build())
+                .setUiOrientation(1)
+                .build())
+        .setDevice(
+            Session.Event.Device.builder()
+                .setBatteryLevel(0.5)
+                .setBatteryVelocity(3)
+                .setDiskUsed(10000000)
+                .setOrientation(1)
+                .setProximityOn(true)
+                .setRamUsed(10000000)
+                .build())
+        .build();
+  }
+
+  private static ImmutableList<Frame> makeTestFrames() {
+    return ImmutableList.from(
+        Frame.builder()
+            .setPc(0)
+            .setSymbol("func1")
+            .setFile("Test.java")
+            .setOffset(36)
+            .setImportance(4)
+            .build(),
+        Frame.builder()
+            .setPc(0)
+            .setSymbol("func2")
+            .setFile("Test.java")
+            .setOffset(5637)
+            .setImportance(4)
+            .build(),
+        Frame.builder()
+            .setPc(0)
+            .setSymbol("func3")
+            .setFile("Test.java")
+            .setOffset(22429)
+            .setImportance(4)
+            .build(),
+        Frame.builder()
+            .setPc(0)
+            .setSymbol("func4")
+            .setFile("Test.java")
+            .setOffset(751)
+            .setImportance(4)
+            .build());
+  }
+}


### PR DESCRIPTION
New data model is an AutoValue data class representing the
hierarchical Crashlytics report data structure, to be used for
passing report data to the new Transport API. It is serialized
via the firebase-encoders-json `@Encodable` annotation.