### PR TITLE
Fix unit test running from within Android Studio

### DIFF
--- a/.idea/runConfigurations/Firestore_Unit_Tests.xml
+++ b/.idea/runConfigurations/Firestore_Unit_Tests.xml
@@ -1,24 +1,14 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Firestore Unit Tests" type="AndroidJUnit" factoryName="Android JUnit">
-    <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
     <module name="firebase-firestore" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
-    <option name="ALTERNATIVE_JRE_PATH" />
-    <option name="PACKAGE_NAME" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="directory" />
-    <option name="VM_PARAMETERS" value="-ea" />
     <option name="PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$/firebase-firestore" />
-    <option name="ENV_VARIABLES" />
-    <option name="PASS_PARENT_ENVS" value="true" />
-    <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
-    </option>
-    <envs />
-    <dir value="$PROJECT_DIR$/firebase-firestore/src/test/java/com/google/firebase" />
-    <patterns />
-    <method />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/firebase-firestore" />
+    <dir value="$PROJECT_DIR$/firebase-firestore/src/test/java/" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -141,7 +141,9 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation ('org.robolectric:robolectric:4.2') {
+        exclude group: 'com.google.protobuf', module: 'protobuf-java'
+    }
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     testImplementation 'com.google.guava:guava-testlib:12.0-rc2'


### PR DESCRIPTION
Somewhat counterintuitively, robolectric has a dependency on protobuf-java, and occasionally our tests will all fail with messages about unable to find methods like `makeImmutable()` on our messages. This only happens with Android Studio's JUnit runner, not in Gradle.

We don't use any features that require this, so just exclude that dependency.

Also fix the runner definition to actually find tests.