### PR TITLE
feat(common-ktx): add FirebaseOptions builder KTX

### DIFF
--- a/firebase-common/api.txt
+++ b/firebase-common/api.txt
@@ -33,6 +33,12 @@ package com.google.firebase {
     ctor public FirebaseOptions.Builder();
     ctor public FirebaseOptions.Builder(@NonNull com.google.firebase.FirebaseOptions);
     method @NonNull public com.google.firebase.FirebaseOptions build();
+    method @NonNull public String getApiKey();
+    method @NonNull public String getApplicationId();
+    method @Nullable public String getDatabaseUrl();
+    method @Nullable public String getGcmSenderId();
+    method @Nullable public String getProjectId();
+    method @Nullable public String getStorageBucket();
     method @NonNull public com.google.firebase.FirebaseOptions.Builder setApiKey(@NonNull String);
     method @NonNull public com.google.firebase.FirebaseOptions.Builder setApplicationId(@NonNull String);
     method @NonNull public com.google.firebase.FirebaseOptions.Builder setDatabaseUrl(@Nullable String);

--- a/firebase-common/ktx/api.txt
+++ b/firebase-common/ktx/api.txt
@@ -8,6 +8,7 @@ package com.google.firebase.ktx {
   public final class FirebaseKt {
     ctor public FirebaseKt();
     method @NonNull public static com.google.firebase.FirebaseApp app(@NonNull com.google.firebase.ktx.Firebase, @NonNull String name);
+    method @NonNull public static com.google.firebase.FirebaseOptions firebaseOptions(@NonNull kotlin.jvm.functions.Function1<? super com.google.firebase.FirebaseOptions.Builder,kotlin.Unit> init);
     method @NonNull public static com.google.firebase.FirebaseApp getApp(@NonNull com.google.firebase.ktx.Firebase);
     method @NonNull public static com.google.firebase.FirebaseOptions getOptions(@NonNull com.google.firebase.ktx.Firebase);
     method @Nullable public static com.google.firebase.FirebaseApp initialize(@NonNull com.google.firebase.ktx.Firebase, @NonNull android.content.Context context);

--- a/firebase-common/ktx/src/main/kotlin/com/google/firebase/ktx/Firebase.kt
+++ b/firebase-common/ktx/src/main/kotlin/com/google/firebase/ktx/Firebase.kt
@@ -50,6 +50,13 @@ fun Firebase.initialize(context: Context, options: FirebaseOptions, name: String
 val Firebase.options: FirebaseOptions
     get() = Firebase.app.options
 
+/** Returns a [FirebaseOptions] instance initialized using the [init] function. */
+fun firebaseOptions(init: FirebaseOptions.Builder.() -> Unit): FirebaseOptions {
+    val builder = FirebaseOptions.Builder()
+    builder.init()
+    return builder.build()
+}
+
 internal const val LIBRARY_NAME: String = "fire-core-ktx"
 
 /** @suppress */

--- a/firebase-common/ktx/src/test/kotlin/com/google/firebase/ktx/Tests.kt
+++ b/firebase-common/ktx/src/test/kotlin/com/google/firebase/ktx/Tests.kt
@@ -100,4 +100,30 @@ class KtxTests {
             app.delete()
         }
     }
+
+    @Test
+    fun `FirebaseOptions builder works`() {
+        val key = "API_KEY"
+        val appId = "APP_ID"
+        val dbUrl = "common-ktx.database.io"
+        val senderId = "1234567"
+        val project = "123"
+        val bucket = "common-ktx.appspot.com"
+
+        val options = firebaseOptions {
+            apiKey = key
+            applicationId = appId
+            databaseUrl = dbUrl
+            gcmSenderId = senderId
+            projectId = project
+            storageBucket = bucket
+        }
+
+        assertThat(key).isEqualTo(options.apiKey)
+        assertThat(appId).isEqualTo(options.applicationId)
+        assertThat(dbUrl).isEqualTo(options.databaseUrl)
+        assertThat(senderId).isEqualTo(options.gcmSenderId)
+        assertThat(project).isEqualTo(options.projectId)
+        assertThat(bucket).isEqualTo(options.storageBucket)
+    }
 }

--- a/firebase-common/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -77,15 +77,30 @@ public final class FirebaseOptions {
     }
 
     @NonNull
+    public String getApiKey() {
+      return this.apiKey;
+    }
+
+    @NonNull
     public Builder setApiKey(@NonNull String apiKey) {
       this.apiKey = checkNotEmpty(apiKey, "ApiKey must be set.");
       return this;
     }
 
     @NonNull
+    public String getApplicationId() {
+      return this.applicationId;
+    }
+
+    @NonNull
     public Builder setApplicationId(@NonNull String applicationId) {
       this.applicationId = checkNotEmpty(applicationId, "ApplicationId must be set.");
       return this;
+    }
+
+    @Nullable
+    public String getDatabaseUrl() {
+      return this.databaseUrl;
     }
 
     @NonNull
@@ -103,16 +118,31 @@ public final class FirebaseOptions {
       return this;
     }
 
+    @Nullable
+    public String getGcmSenderId() {
+      return this.gcmSenderId;
+    }
+
     @NonNull
     public Builder setGcmSenderId(@Nullable String gcmSenderId) {
       this.gcmSenderId = gcmSenderId;
       return this;
     }
 
+    @Nullable
+    public String getStorageBucket() {
+      return this.storageBucket;
+    }
+
     @NonNull
     public Builder setStorageBucket(@Nullable String storageBucket) {
       this.storageBucket = storageBucket;
       return this;
+    }
+
+    @Nullable
+    public String getProjectId() {
+      return this.projectId;
     }
 
     @NonNull


### PR DESCRIPTION
This PR should add a FirebaseOptions builder extension function, so that FirebaseOptions can be created like:

```kotlin
val options = firebaseOptions {
            apiKey = "API_KEY"
            applicationId = "APP_ID"
            databaseUrl = "DB_URL"
            gcmSenderId = "GCM_ID"
            projectId = "123"
            storageBucket = "my-bucket.appspot.com"
}
```

Please note that this PR also adds the missing java getters to `FirebaseOptions.Builder`.