### PR TITLE
Add Crashlytics data capture class

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/core/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/core/CrashlyticsControllerTest.java
@@ -46,6 +46,7 @@ import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
 import com.google.firebase.crashlytics.internal.MissingNativeComponent;
 import com.google.firebase.crashlytics.internal.NativeSessionFileProvider;
 import com.google.firebase.crashlytics.internal.breadcrumbs.BreadcrumbsReceiver;
+import com.google.firebase.crashlytics.internal.common.AppData;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.common.DataCollectionArbiter;
 import com.google.firebase.crashlytics.internal.common.IdManager;

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/BatteryStateTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/BatteryStateTest.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.crashlytics.core;
+package com.google.firebase.crashlytics.internal.common;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
@@ -1,0 +1,241 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.common;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.runner.AndroidJUnit4;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution;
+import com.google.firebase.crashlytics.internal.stacktrace.StackTraceTrimmingStrategy;
+import com.google.firebase.iid.internal.FirebaseInstanceIdInternal;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(AndroidJUnit4.class)
+public class CrashlyticsReportDataCaptureTest {
+
+  private CrashlyticsReportDataCapture dataCapture;
+  private long timestamp;
+  private String eventType;
+  private int eventThreadImportance;
+  private int maxChainedExceptions;
+
+  @Mock private StackTraceTrimmingStrategy stackTraceTrimmingStrategy;
+
+  @Mock private FirebaseInstanceIdInternal instanceIdMock;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(instanceIdMock.getId()).thenReturn("installId");
+    when(stackTraceTrimmingStrategy.getTrimmedStackTrace(any(StackTraceElement[].class)))
+        .thenAnswer(i -> i.getArguments()[0]);
+    final Context context = ApplicationProvider.getApplicationContext();
+    final IdManager idManager = new IdManager(context, context.getPackageName(), instanceIdMock);
+    final AppData appData = AppData.create(context, idManager, "googleAppId", "buildId");
+    dataCapture =
+        new CrashlyticsReportDataCapture(context, idManager, appData, stackTraceTrimmingStrategy);
+    timestamp = System.currentTimeMillis();
+    eventType = "crash";
+    eventThreadImportance = 4;
+    maxChainedExceptions = 8;
+  }
+
+  @Test
+  public void testEventBuilderHandler_noChainedExceptionsAllThreads() {
+    final RuntimeException eventException = new RuntimeException("fatal");
+    final Thread eventThread = Thread.currentThread();
+
+    final CrashlyticsReport.Session.Event event =
+        dataCapture.captureEventData(
+            eventException,
+            eventThread,
+            eventType,
+            timestamp,
+            eventThreadImportance,
+            maxChainedExceptions);
+
+    assertEquals(eventType, event.getType());
+    assertEquals(timestamp, event.getTimestamp());
+    final List<Execution.Thread> threads = event.getApp().getExecution().getThreads();
+    assertTrue(threads.size() > 1);
+    final Execution.Thread firstThread = threads.get(0);
+    assertThread(firstThread, eventThread.getName(), eventThreadImportance);
+    for (int i = 1; i < threads.size(); ++i) {
+      assertThread(threads.get(i), 0);
+    }
+
+    final Execution.Exception builtException = event.getApp().getExecution().getException();
+    assertException(eventException, builtException, 0, eventThreadImportance);
+    assertNull(builtException.getCausedBy());
+
+    assertArrayEquals(firstThread.getFrames().toArray(), builtException.getFrames().toArray());
+
+    assertEquals(1, event.getApp().getExecution().getBinaries().size());
+
+    assertNotNull(event.getApp().getExecution().getSignal());
+  }
+
+  @Test
+  public void testEventBuilderHandler_someChainedExceptionsAllThreads() {
+    final IllegalStateException cause2 = new IllegalStateException("cause 2");
+    final IllegalArgumentException cause = new IllegalArgumentException("cause", cause2);
+    final RuntimeException eventException = new RuntimeException("fatal", cause);
+    final Thread eventThread = Thread.currentThread();
+
+    final CrashlyticsReport.Session.Event event =
+        dataCapture.captureEventData(
+            eventException,
+            eventThread,
+            eventType,
+            timestamp,
+            eventThreadImportance,
+            maxChainedExceptions);
+
+    assertEquals(eventType, event.getType());
+    assertEquals(timestamp, event.getTimestamp());
+    final List<Execution.Thread> threads = event.getApp().getExecution().getThreads();
+    assertTrue(threads.size() > 1);
+    final Execution.Thread firstThread = threads.get(0);
+    assertThread(firstThread, eventThread.getName(), eventThreadImportance);
+    for (int i = 1; i < threads.size(); ++i) {
+      assertThread(threads.get(i), 0);
+    }
+
+    final Execution.Exception builtException = event.getApp().getExecution().getException();
+    assertException(eventException, builtException, 0, eventThreadImportance);
+
+    Execution.Exception builtCause = builtException.getCausedBy();
+    assertNotNull(builtCause);
+
+    assertException(cause, builtCause, 0, eventThreadImportance);
+
+    builtCause = builtCause.getCausedBy();
+    assertNotNull(builtCause);
+
+    assertException(cause2, builtCause, 0, eventThreadImportance);
+
+    assertNull(builtCause.getCausedBy());
+
+    assertEquals(1, event.getApp().getExecution().getBinaries().size());
+
+    assertNotNull(event.getApp().getExecution().getSignal());
+  }
+
+  @Test
+  public void testEventBuilderHandler_noChainedExceptionsOneThread() {
+    final RuntimeException eventException = new RuntimeException("fatal");
+    final Thread eventThread = Thread.currentThread();
+
+    final CrashlyticsReport.Session.Event event =
+        dataCapture.captureEventData(
+            eventException,
+            eventThread,
+            eventType,
+            timestamp,
+            eventThreadImportance,
+            maxChainedExceptions,
+            false);
+
+    assertEquals(eventType, event.getType());
+    assertEquals(timestamp, event.getTimestamp());
+    final List<Execution.Thread> threads = event.getApp().getExecution().getThreads();
+    assertEquals(1, threads.size());
+    final Execution.Thread firstThread = threads.get(0);
+    assertThread(firstThread, eventThread.getName(), eventThreadImportance);
+
+    final Execution.Exception builtException = event.getApp().getExecution().getException();
+    assertException(eventException, builtException, 0, eventThreadImportance);
+    assertNull(builtException.getCausedBy());
+
+    assertEquals(1, event.getApp().getExecution().getBinaries().size());
+
+    assertNotNull(event.getApp().getExecution().getSignal());
+  }
+
+  @Test
+  public void testEventBuilderHandler_overflowChainedExceptionsOneThread() {
+    final IllegalStateException cause2 = new IllegalStateException("cause 2");
+    final IllegalArgumentException cause = new IllegalArgumentException("cause", cause2);
+    final RuntimeException eventException = new RuntimeException("fatal", cause);
+    final Thread eventThread = Thread.currentThread();
+
+    final CrashlyticsReport.Session.Event event =
+        dataCapture.captureEventData(
+            eventException, eventThread, eventType, timestamp, eventThreadImportance, 1, false);
+
+    assertEquals(eventType, event.getType());
+    assertEquals(timestamp, event.getTimestamp());
+    final List<Execution.Thread> threads = event.getApp().getExecution().getThreads();
+    assertEquals(1, threads.size());
+    final Execution.Thread firstThread = threads.get(0);
+    assertThread(firstThread, eventThread.getName(), eventThreadImportance);
+
+    final Execution.Exception builtException = event.getApp().getExecution().getException();
+    assertException(eventException, builtException, 0, eventThreadImportance);
+
+    Execution.Exception builtCause = builtException.getCausedBy();
+    assertNotNull(builtCause);
+
+    assertException(cause, builtCause, 1, eventThreadImportance);
+    assertNull(builtCause.getCausedBy());
+
+    assertEquals(1, event.getApp().getExecution().getBinaries().size());
+
+    assertNotNull(event.getApp().getExecution().getSignal());
+  }
+
+  private static void assertThread(
+      Execution.Thread thread, String expectedName, int expectedImportance) {
+    assertEquals(expectedName, thread.getName());
+    assertThread(thread, expectedImportance);
+  }
+
+  private static void assertThread(Execution.Thread thread, int expectedImportance) {
+    int threadImportance = thread.getImportance();
+    assertEquals(expectedImportance, threadImportance);
+    assertFalse(thread.getFrames().isEmpty());
+    assertFrameImportance(thread.getFrames(), threadImportance);
+  }
+
+  private static void assertException(
+      Exception actualException,
+      Execution.Exception builtException,
+      int expectedOverflowCount,
+      int expectedImportance) {
+    assertEquals(actualException.getMessage(), builtException.getReason());
+    assertEquals(expectedOverflowCount, builtException.getOverflowCount());
+    assertFalse(builtException.getFrames().isEmpty());
+    for (Execution.Thread.Frame frame : builtException.getFrames()) {
+      assertEquals(expectedImportance, frame.getImportance());
+    }
+  }
+
+  private static void assertFrameImportance(
+      List<Execution.Thread.Frame> frames, int expectedImportance) {
+    for (Execution.Thread.Frame frame : frames) {
+      assertEquals(expectedImportance, frame.getImportance());
+    }
+  }
+}

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
@@ -215,7 +215,6 @@ public class CrashlyticsReportDataCaptureTest {
   private static void assertThread(Execution.Thread thread, int expectedImportance) {
     int threadImportance = thread.getImportance();
     assertEquals(expectedImportance, threadImportance);
-    assertFalse(thread.getFrames().isEmpty());
     assertFrameImportance(thread.getFrames(), threadImportance);
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsController.java
@@ -34,6 +34,8 @@ import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.NativeSessionFileProvider;
 import com.google.firebase.crashlytics.internal.breadcrumbs.BreadcrumbsReceiver;
+import com.google.firebase.crashlytics.internal.common.AppData;
+import com.google.firebase.crashlytics.internal.common.BatteryState;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.common.DataCollectionArbiter;
 import com.google.firebase.crashlytics.internal.common.DeliveryMechanism;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsCore.java
@@ -27,6 +27,7 @@ import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.breadcrumbs.AnalyticsConnectorBreadcrumbsReceiver;
 import com.google.firebase.crashlytics.internal.breadcrumbs.AnalyticsConnectorBreadcrumbsReceiver.BreadcrumbHandler;
 import com.google.firebase.crashlytics.internal.breadcrumbs.BreadcrumbsReceiver;
+import com.google.firebase.crashlytics.internal.common.AppData;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.common.DataCollectionArbiter;
 import com.google.firebase.crashlytics.internal.common.ExecutorUtils;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/AppData.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/AppData.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.crashlytics.core;
+package com.google.firebase.crashlytics.internal.common;
 
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import com.google.firebase.crashlytics.internal.common.IdManager;
 
 /** Carries static information about the app. */
-class AppData {
+public class AppData {
   public final String googleAppId;
   public final String buildId;
 
@@ -30,7 +29,8 @@ class AppData {
   public final String versionCode;
   public final String versionName;
 
-  static AppData create(Context context, IdManager idManager, String googleAppId, String buildId)
+  public static AppData create(
+      Context context, IdManager idManager, String googleAppId, String buildId)
       throws PackageManager.NameNotFoundException {
     final String packageName = context.getPackageName();
     final String installerPackageName = idManager.getInstallerPackageName();
@@ -44,7 +44,7 @@ class AppData {
         googleAppId, buildId, installerPackageName, packageName, versionCode, versionName);
   }
 
-  AppData(
+  public AppData(
       String googleAppId,
       String buildId,
       String installerPackageName,

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/BatteryState.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/BatteryState.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.crashlytics.core;
+package com.google.firebase.crashlytics.internal.common;
 
 import android.content.Context;
 import android.content.Intent;
@@ -20,7 +20,7 @@ import android.content.IntentFilter;
 import android.os.BatteryManager;
 
 /** A utility class representing the state of the battery. */
-class BatteryState {
+public class BatteryState {
   static final int VELOCITY_UNPLUGGED = 1;
   static final int VELOCITY_CHARGING = 2;
   static final int VELOCITY_FULL = 3;
@@ -41,7 +41,7 @@ class BatteryState {
    * Returns the battery level in the range of [0, 1], if present. May return null, if Android
    * returns a null or malformed Intent.
    */
-  Float getBatteryLevel() {
+  public Float getBatteryLevel() {
     return level;
   }
 
@@ -51,7 +51,7 @@ class BatteryState {
    *
    * @return an int value that mimics the UIDeviceBatteryState enum.
    */
-  int getBatteryVelocity() {
+  public int getBatteryVelocity() {
     if (!powerConnected || level == null) {
       return VELOCITY_UNPLUGGED;
     } else if (level < 0.99) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
@@ -1,0 +1,397 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.common;
+
+import android.app.ActivityManager;
+import android.app.ActivityManager.RunningAppProcessInfo;
+import android.content.Context;
+import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.Environment;
+import android.os.StatFs;
+import android.text.TextUtils;
+import com.google.firebase.crashlytics.BuildConfig;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Architecture;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.BinaryImage;
+import com.google.firebase.crashlytics.internal.model.ImmutableList;
+import com.google.firebase.crashlytics.internal.stacktrace.StackTraceTrimmingStrategy;
+import com.google.firebase.crashlytics.internal.stacktrace.TrimmedThrowableData;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * This class is responsible for capturing information from the system and exception objects,
+ * parsing them, and returning canonical CrashlyticsReport and Event objects.
+ */
+public class CrashlyticsReportDataCapture {
+
+  private static final String GENERATOR =
+      String.format(Locale.US, "Crashlytics Android SDK/%s", BuildConfig.VERSION_NAME);
+
+  private static final int REPORT_ANDROID_PLATFORM = 4;
+  private static final int SESSION_ANDROID_PLATFORM = 3;
+  private static final String SIGNAL_DEFAULT = "0";
+
+  private static final Map<String, Integer> ARCHITECTURES_BY_NAME = new HashMap<>();
+
+  static {
+    ARCHITECTURES_BY_NAME.put("armeabi", Architecture.ARMV6);
+    ARCHITECTURES_BY_NAME.put("armeabi-v7a", Architecture.ARMV7);
+    ARCHITECTURES_BY_NAME.put("arm64-v8a", Architecture.ARM64);
+    ARCHITECTURES_BY_NAME.put("x86", Architecture.X86_32);
+    ARCHITECTURES_BY_NAME.put("x86_64", Architecture.X86_64);
+  }
+
+  private final Context context;
+  private final IdManager idManager;
+  private final AppData appData;
+  private final StackTraceTrimmingStrategy stackTraceTrimmingStrategy;
+
+  public CrashlyticsReportDataCapture(
+      Context context,
+      IdManager idManager,
+      AppData appData,
+      StackTraceTrimmingStrategy stackTraceTrimmingStrategy) {
+    this.context = context;
+    this.idManager = idManager;
+    this.appData = appData;
+    this.stackTraceTrimmingStrategy = stackTraceTrimmingStrategy;
+  }
+
+  public CrashlyticsReport captureReportData(String identifier, long timestamp) {
+    return CrashlyticsReport.builder()
+        .setSdkVersion(BuildConfig.VERSION_NAME)
+        .setGmpAppId(appData.googleAppId)
+        .setInstallationUuid(idManager.getCrashlyticsInstallId())
+        .setBuildVersion(appData.versionCode)
+        .setDisplayVersion(appData.versionName)
+        .setPlatform(REPORT_ANDROID_PLATFORM)
+        .setSession(populateSessionData(identifier, timestamp))
+        .build();
+  }
+
+  public Event captureEventData(
+      Throwable event,
+      Thread eventThread,
+      String type,
+      long timestamp,
+      int eventThreadImportance,
+      int maxChainedExceptions) {
+    return captureEventData(
+        event, eventThread, type, timestamp, eventThreadImportance, maxChainedExceptions, true);
+  }
+
+  public Event captureEventData(
+      Throwable event,
+      Thread eventThread,
+      String type,
+      long timestamp,
+      int eventThreadImportance,
+      int maxChainedExceptions,
+      boolean includeAllThreads) {
+    final int orientation = context.getResources().getConfiguration().orientation;
+    final TrimmedThrowableData trimmedEvent =
+        new TrimmedThrowableData(event, stackTraceTrimmingStrategy);
+
+    return Event.builder()
+        .setType(type)
+        .setTimestamp(timestamp)
+        .setApp(
+            populateEventApplicationData(
+                orientation,
+                trimmedEvent,
+                eventThread,
+                eventThreadImportance,
+                maxChainedExceptions,
+                includeAllThreads))
+        .setDevice(populateEventDeviceData(orientation))
+        .build();
+  }
+
+  private CrashlyticsReport.Session populateSessionData(String identifier, long timestamp) {
+    return CrashlyticsReport.Session.builder()
+        .setStartedAt(timestamp)
+        .setIdentifier(identifier)
+        .setGenerator(GENERATOR)
+        .setApp(populateSessionApplicationData())
+        .setOs(populateSessionOperatingSystemData())
+        .setDevice(populateSessionDeviceData())
+        .build();
+  }
+
+  private CrashlyticsReport.Session.Application populateSessionApplicationData() {
+    return CrashlyticsReport.Session.Application.builder()
+        .setIdentifier(idManager.getAppIdentifier())
+        .setVersion(appData.versionCode)
+        .setDisplayVersion(appData.versionName)
+        .setInstallationUuid(idManager.getCrashlyticsInstallId())
+        .build();
+  }
+
+  private CrashlyticsReport.Session.OperatingSystem populateSessionOperatingSystemData() {
+    return CrashlyticsReport.Session.OperatingSystem.builder()
+        .setPlatform(SESSION_ANDROID_PLATFORM)
+        .setVersion(VERSION.RELEASE)
+        .setBuildVersion(VERSION.CODENAME)
+        .setJailbroken(CommonUtils.isRooted(context))
+        .build();
+  }
+
+  private CrashlyticsReport.Session.Device populateSessionDeviceData() {
+    final StatFs statFs = new StatFs(Environment.getDataDirectory().getPath());
+    final int arch = getDeviceArchitecture();
+    final int availableProcessors = Runtime.getRuntime().availableProcessors();
+    final long totalRam = CommonUtils.getTotalRamInBytes();
+    final long diskSpace = (long) statFs.getBlockCount() * (long) statFs.getBlockSize();
+    final boolean isEmulator = CommonUtils.isEmulator(context);
+    final int state = CommonUtils.getDeviceState(context);
+    final String manufacturer = Build.MANUFACTURER;
+    final String modelClass = Build.PRODUCT;
+
+    return CrashlyticsReport.Session.Device.builder()
+        .setArch(arch)
+        .setModel(Build.MODEL)
+        .setCores(availableProcessors)
+        .setRam(totalRam)
+        .setDiskSpace(diskSpace)
+        .setSimulator(isEmulator)
+        .setState(state)
+        .setManufacturer(manufacturer)
+        .setModelClass(modelClass)
+        .build();
+  }
+
+  private Event.Application populateEventApplicationData(
+      int orientation,
+      TrimmedThrowableData trimmedEvent,
+      Thread eventThread,
+      int eventThreadImportance,
+      int maxChainedExceptions,
+      boolean includeAllThreads) {
+    Boolean isBackground = null;
+    final RunningAppProcessInfo runningAppProcessInfo =
+        CommonUtils.getAppProcessInfo(appData.packageName, context);
+    if (runningAppProcessInfo != null) {
+      // Several different types of "background" states, easiest to check for not foreground.
+      isBackground =
+          runningAppProcessInfo.importance
+              != ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+    }
+
+    return Event.Application.builder()
+        .setBackground(isBackground)
+        .setUiOrientation(orientation)
+        .setExecution(
+            populateExecutionData(
+                trimmedEvent,
+                eventThread,
+                eventThreadImportance,
+                maxChainedExceptions,
+                includeAllThreads))
+        .build();
+  }
+
+  private Event.Device populateEventDeviceData(int orientation) {
+    final BatteryState battery = BatteryState.get(context);
+    final double batteryLevel = (double) battery.getBatteryLevel();
+    final int batteryVelocity = battery.getBatteryVelocity();
+    final boolean proximityEnabled = CommonUtils.getProximitySensorEnabled(context);
+    final long usedRamBytes =
+        CommonUtils.getTotalRamInBytes() - CommonUtils.calculateFreeRamInBytes(context);
+    final long diskUsedBytes =
+        CommonUtils.calculateUsedDiskSpaceInBytes(Environment.getDataDirectory().getPath());
+
+    return Event.Device.builder()
+        .setBatteryLevel(batteryLevel)
+        .setBatteryVelocity(batteryVelocity)
+        .setProximityOn(proximityEnabled)
+        .setOrientation(orientation)
+        .setRamUsed(usedRamBytes)
+        .setDiskUsed(diskUsedBytes)
+        .build();
+  }
+
+  private Execution populateExecutionData(
+      TrimmedThrowableData trimmedEvent,
+      Thread eventThread,
+      int eventThreadImportance,
+      int maxChainedExceptions,
+      boolean includeAllThreads) {
+    return Execution.builder()
+        .setThreads(
+            populateThreadsList(
+                trimmedEvent, eventThread, eventThreadImportance, includeAllThreads))
+        .setException(
+            populateExceptionData(trimmedEvent, eventThreadImportance, maxChainedExceptions))
+        .setSignal(populateSignalData())
+        .setBinaries(populateBinaryImagesList())
+        .build();
+  }
+
+  private ImmutableList<Execution.Thread> populateThreadsList(
+      TrimmedThrowableData trimmedEvent,
+      Thread eventThread,
+      int eventThreadImportance,
+      boolean includeAllThreads) {
+    List<Execution.Thread> threadsList = new ArrayList<>();
+
+    threadsList.add(
+        populateThreadData(eventThread, trimmedEvent.stacktrace, eventThreadImportance));
+
+    if (includeAllThreads) {
+      final Map<Thread, StackTraceElement[]> allStackTraces = Thread.getAllStackTraces();
+      for (Map.Entry<Thread, StackTraceElement[]> entry : allStackTraces.entrySet()) {
+        final Thread thread = entry.getKey();
+        // Skip the event thread, since we populated it first.
+        if (!thread.equals(eventThread)) {
+          threadsList.add(
+              populateThreadData(
+                  thread, stackTraceTrimmingStrategy.getTrimmedStackTrace(entry.getValue())));
+        }
+      }
+    }
+
+    return ImmutableList.from(threadsList);
+  }
+
+  private Execution.Thread populateThreadData(Thread thread, StackTraceElement[] stacktrace) {
+    return populateThreadData(thread, stacktrace, 0);
+  }
+
+  private Execution.Thread populateThreadData(
+      Thread thread, StackTraceElement[] stacktrace, int importance) {
+    return Execution.Thread.builder()
+        .setName(thread.getName())
+        .setImportance(importance)
+        .setFrames(ImmutableList.from(populateFramesList(stacktrace, importance)))
+        .build();
+  }
+
+  private ImmutableList<Execution.Thread.Frame> populateFramesList(
+      StackTraceElement[] stacktrace, int importance) {
+    final List<Execution.Thread.Frame> framesList = new ArrayList<>();
+    for (StackTraceElement element : stacktrace) {
+      framesList.add(
+          populateFrameData(element, Execution.Thread.Frame.builder().setImportance(importance)));
+    }
+    return ImmutableList.from(framesList);
+  }
+
+  private Execution.Exception populateExceptionData(
+      TrimmedThrowableData trimmedEvent, int eventThreadImportance, int maxChainedExceptions) {
+    return populateExceptionData(trimmedEvent, eventThreadImportance, maxChainedExceptions, 0);
+  }
+
+  private Execution.Exception populateExceptionData(
+      TrimmedThrowableData trimmedEvent,
+      int eventThreadImportance,
+      int maxChainedExceptions,
+      int chainDepth) {
+    final String type = trimmedEvent.className;
+    final String reason = trimmedEvent.localizedMessage;
+    final StackTraceElement[] stacktrace =
+        trimmedEvent.stacktrace != null ? trimmedEvent.stacktrace : new StackTraceElement[0];
+    final TrimmedThrowableData cause = trimmedEvent.cause;
+
+    int overflowCount = 0;
+    if (chainDepth >= maxChainedExceptions) {
+      TrimmedThrowableData skipped = cause;
+      while (skipped != null) {
+        skipped = skipped.cause;
+        ++overflowCount;
+      }
+    }
+
+    final Execution.Exception.Builder builder =
+        Execution.Exception.builder()
+            .setType(type)
+            .setReason(reason)
+            .setFrames(ImmutableList.from(populateFramesList(stacktrace, eventThreadImportance)))
+            .setOverflowCount(overflowCount);
+
+    if (cause != null && overflowCount == 0) {
+      builder.setCausedBy(
+          populateExceptionData(
+              cause, eventThreadImportance, maxChainedExceptions, chainDepth + 1));
+    }
+
+    return builder.build();
+  }
+
+  private Execution.Thread.Frame populateFrameData(
+      StackTraceElement element, Execution.Thread.Frame.Builder frameBuilder) {
+    long pc = 0L;
+    if (element.isNativeMethod()) {
+      // certain ProGuard configs will result in negative line numbers,
+      // which cannot - by design - be mapped back to the source file.
+      pc = Math.max(element.getLineNumber(), 0L);
+    }
+
+    final String symbol = element.getClassName() + "." + element.getMethodName();
+    final String file = element.getFileName();
+
+    // Same as with pc, ProGuard sometimes generates negative numbers.
+    // Here the field is optional, so we can just skip it if we're negative.
+    long offset = 0L;
+    if (!element.isNativeMethod() && element.getLineNumber() > 0) {
+      offset = element.getLineNumber();
+    }
+
+    return frameBuilder.setPc(pc).setSymbol(symbol).setFile(file).setOffset(offset).build();
+  }
+
+  private ImmutableList<BinaryImage> populateBinaryImagesList() {
+    return ImmutableList.from(populateBinaryImageData());
+  }
+
+  private Execution.BinaryImage populateBinaryImageData() {
+    return Execution.BinaryImage.builder()
+        .setBaseAddress(0L)
+        .setSize(0L)
+        .setName(appData.packageName)
+        .setUuid(appData.buildId)
+        .build();
+  }
+
+  private Execution.Signal populateSignalData() {
+    return Execution.Signal.builder()
+        .setName(SIGNAL_DEFAULT)
+        .setCode(SIGNAL_DEFAULT)
+        .setAddress(0L)
+        .build();
+  }
+
+  @Architecture
+  private static int getDeviceArchitecture() {
+    final String primaryAbi = Build.CPU_ABI;
+
+    if (TextUtils.isEmpty(primaryAbi)) {
+      return Architecture.UNKNOWN;
+    }
+
+    final Integer arch = ARCHITECTURES_BY_NAME.get(primaryAbi.toLowerCase(Locale.US));
+    if (arch == null) {
+      return Architecture.UNKNOWN;
+    }
+
+    return arch;
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.crashlytics.internal.model;
 
+import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
@@ -22,6 +23,8 @@ import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.
 import com.google.firebase.encoders.annotations.Encodable;
 import com.google.firebase.encoders.annotations.Encodable.Field;
 import com.google.firebase.encoders.annotations.Encodable.Ignore;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.nio.charset.Charset;
 
 /**
@@ -35,6 +38,24 @@ import java.nio.charset.Charset;
 @Encodable
 @AutoValue
 public abstract class CrashlyticsReport {
+
+  @IntDef({
+    Architecture.ARMV6,
+    Architecture.ARMV7,
+    Architecture.ARM64,
+    Architecture.X86_32,
+    Architecture.X86_64,
+    Architecture.UNKNOWN
+  })
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface Architecture {
+    int ARMV6 = 5;
+    int ARMV7 = 6;
+    int ARM64 = 9;
+    int X86_32 = 0;
+    int X86_64 = 1;
+    int UNKNOWN = 7;
+  }
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
@@ -363,6 +384,7 @@ public abstract class CrashlyticsReport {
         return new AutoValue_CrashlyticsReport_Session_Device.Builder();
       }
 
+      @Architecture
       @NonNull
       public abstract int getArch();
 
@@ -390,7 +412,7 @@ public abstract class CrashlyticsReport {
       public abstract static class Builder {
 
         @NonNull
-        public abstract Builder setArch(int value);
+        public abstract Builder setArch(@Architecture int value);
 
         @NonNull
         public abstract Builder setModel(@NonNull String value);


### PR DESCRIPTION
Handles capturing appropriate data from the underlying OS, build
information, and exception information and constructing
CrashlyticsReport and Event objects from it.

Moved AppData and BatteryState utility classes into the "internal"
package, since it was necessary to make them public anyway.