### PR TITLE
Adjust coverage report format.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,17 +6,15 @@ codecov:
 coverage:
   status:
     project:
-      default: off
+      default:
       FirebaseCommon:
         flags: FirebaseCommon
-        informational: false
-        threshold: 5
+        informational: true
     patch:
-      default: off
+      default:
       FirebaseCommon:
         flags: FirebaseCommon
-        informational: false
-        threshold: 5
+        informational: true
 
 comment:
-  layout: "flags, files, footer"
+  layout: "flags, footer"


### PR DESCRIPTION
- Change commit status for FirebaseCommon coverage to be informational.
- Change the syntax "default: off" to "default:". The former one seems no longer valid.
- Remove the table for affected files, which often contains noise.