### PR TITLE
Add FirebaseCrashlyticsReportManager

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManagerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManagerTest.java
@@ -1,0 +1,186 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.common;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
+import com.google.firebase.crashlytics.internal.persistence.CrashlyticsReportPersistence;
+import com.google.firebase.crashlytics.internal.send.DataTransportCrashlyticsReportSender;
+import com.google.firebase.crashlytics.internal.settings.model.AppSettingsData;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class FirebaseCrashlyticsReportManagerTest {
+
+  @Mock private CrashlyticsReportDataCapture dataCapture;
+
+  @Mock private CrashlyticsReportPersistence reportPersistence;
+
+  @Mock private DataTransportCrashlyticsReportSender reportSender;
+
+  @Mock private CurrentTimeProvider mockCurrentTimeProvider;
+
+  private FirebaseCrashlyticsReportManager reportManager;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    reportManager =
+        new FirebaseCrashlyticsReportManager(
+            dataCapture, reportPersistence, reportSender, mockCurrentTimeProvider);
+  }
+
+  @Test
+  public void testOnSessionBegin_persistsReportForSessionId() {
+    final String sessionId = "testSessionId";
+    final long timestamp = System.currentTimeMillis();
+    when(mockCurrentTimeProvider.getCurrentTimeMillis()).thenReturn(timestamp);
+    final long timestampSeconds = timestamp / 1000;
+    final CrashlyticsReport mockReport = mock(CrashlyticsReport.class);
+    when(dataCapture.captureReportData(anyString(), anyLong())).thenReturn(mockReport);
+
+    reportManager.onSessionBegin(sessionId);
+
+    verify(dataCapture).captureReportData(sessionId, timestampSeconds);
+    verify(reportPersistence).persistReport(mockReport);
+  }
+
+  @Test
+  public void testOnFatalEvent_persistsFatalEventForSessionId() {
+    final String eventType = "crash";
+    final Exception exceptionEvent = new Exception("fatal");
+    final Thread eventThread = Thread.currentThread();
+
+    final String sessionId = "testSessionId";
+    final long timestamp = System.currentTimeMillis();
+    when(mockCurrentTimeProvider.getCurrentTimeMillis()).thenReturn(timestamp);
+    final long timestampSeconds = timestamp / 1000;
+    final CrashlyticsReport.Session.Event mockEvent = mock(CrashlyticsReport.Session.Event.class);
+    when(dataCapture.captureEventData(
+            any(Throwable.class), any(Thread.class), anyString(), anyLong(), anyInt(), anyInt()))
+        .thenReturn(mockEvent);
+
+    reportManager.onSessionBegin(sessionId);
+    reportManager.onFatalEvent(exceptionEvent, eventThread);
+
+    verify(dataCapture)
+        .captureEventData(exceptionEvent, eventThread, eventType, timestampSeconds, 4, 8);
+    verify(reportPersistence).persistEvent(mockEvent, sessionId);
+  }
+
+  @Test
+  public void onSessionsFinalize_finalizesReports() {
+    final String sessionId = "testSessionId";
+    reportManager.onSessionBegin(sessionId);
+    reportManager.onSessionsFinalize();
+
+    verify(reportPersistence).finalizeReports(sessionId);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void onReportSend_successfulReportsAreDeleted() {
+    final String orgId = "testOrgId";
+    final String sessionId1 = "sessionId1";
+    final String sessionId2 = "sessionId2";
+
+    final AppSettingsData appSettings =
+        new AppSettingsData(null, null, null, null, null, orgId, false);
+
+    final List<CrashlyticsReport> finalizedReports = new ArrayList<>();
+    final CrashlyticsReport mockReport1 = mockReport(sessionId1, orgId);
+    final CrashlyticsReport mockReport2 = mockReport(sessionId2, orgId);
+    finalizedReports.add(mockReport1);
+    finalizedReports.add(mockReport2);
+
+    when(reportPersistence.loadFinalizedReports()).thenReturn(finalizedReports);
+
+    final ArgumentCaptor<OnCompleteListener> testCompletionListener1 =
+        ArgumentCaptor.forClass(OnCompleteListener.class);
+    final ArgumentCaptor<OnCompleteListener> testCompletionListener2 =
+        ArgumentCaptor.forClass(OnCompleteListener.class);
+
+    final Task<CrashlyticsReport> mockTask1 =
+        mockSuccessfulTask(mockReport1, testCompletionListener1);
+    final Task<CrashlyticsReport> mockTask2 =
+        mockFailedTask(new Exception("fail"), testCompletionListener2);
+
+    when(reportSender.sendReport(mockReport1)).thenReturn(mockTask1);
+    when(reportSender.sendReport(mockReport2)).thenReturn(mockTask2);
+
+    reportManager.onReportSend(appSettings);
+
+    verify(reportSender).sendReport(mockReport1);
+    verify(reportSender).sendReport(mockReport2);
+
+    testCompletionListener1.getValue().onComplete(mockTask1);
+    testCompletionListener2.getValue().onComplete(mockTask2);
+
+    verify(reportPersistence).deleteFinalizedReport(sessionId1);
+    verify(reportPersistence, never()).deleteFinalizedReport(sessionId2);
+  }
+
+  private CrashlyticsReport mockReport(String sessionId, String orgId) {
+    final CrashlyticsReport mockReport = mock(CrashlyticsReport.class);
+    final CrashlyticsReport.Session mockSession = mock(CrashlyticsReport.Session.class);
+    when(mockSession.getIdentifier()).thenReturn(sessionId);
+    when(mockReport.getSession()).thenReturn(mockSession);
+    when(mockReport.withOrganizationId(orgId)).thenReturn(mockReport);
+    return mockReport;
+  }
+
+  private Task<CrashlyticsReport> mockSuccessfulTask(
+      CrashlyticsReport result, ArgumentCaptor<OnCompleteListener> completionListener) {
+    return mockTask(result, null, completionListener);
+  }
+
+  private Task<CrashlyticsReport> mockFailedTask(
+      Exception exception, ArgumentCaptor<OnCompleteListener> completionListener) {
+    return mockTask(null, exception, completionListener);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Task<CrashlyticsReport> mockTask(
+      CrashlyticsReport result,
+      Exception exception,
+      ArgumentCaptor<OnCompleteListener> completionListener) {
+    final boolean isSuccessful = result != null;
+    final Task<CrashlyticsReport> mockTask = (Task<CrashlyticsReport>) mock(Task.class);
+    when(mockTask.isSuccessful()).thenReturn(isSuccessful);
+    if (isSuccessful) {
+      when(mockTask.getResult()).thenReturn(result);
+    } else {
+      when(mockTask.getException()).thenReturn(exception);
+    }
+    when(mockTask.addOnCompleteListener(completionListener.capture())).thenReturn(mockTask);
+    return mockTask;
+  }
+}

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManagerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManagerTest.java
@@ -31,7 +31,6 @@ import com.google.firebase.crashlytics.internal.send.DataTransportCrashlyticsRep
 import com.google.firebase.crashlytics.internal.settings.model.AppSettingsData;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -133,13 +132,6 @@ public class FirebaseCrashlyticsReportManagerTest {
 
     verify(reportSender).sendReport(mockReport1);
     verify(reportSender).sendReport(mockReport2);
-
-    try {
-      Tasks.await(successfulTask);
-      Tasks.await(failedTask);
-    } catch (ExecutionException ex) {
-      // Allow this to fall through.
-    }
 
     verify(reportPersistence).deleteFinalizedReport(sessionId1);
     verify(reportPersistence, never()).deleteFinalizedReport(sessionId2);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsLifecycleEvents.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsLifecycleEvents.java
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.common;
+
+import com.google.firebase.crashlytics.internal.settings.model.AppSettingsData;
+
+/** This class defines Crashlytics lifecycle events */
+interface CrashlyticsLifecycleEvents {
+
+  /**
+   * Called when a new session is opened.
+   *
+   * @param sessionId the identifier for the new session
+   */
+  void onBeginSession(String sessionId);
+
+  /**
+   * Called when a fatal event occurs.
+   *
+   * @param event the fatal event
+   * @param thread the thread on which the fatal event occurred
+   */
+  void onFatalEvent(Throwable event, Thread thread);
+
+  /** Called when the current session should be closed */
+  void onEndSession();
+
+  /**
+   * Called before sending reports to clean up any still-open sessions, attach any associated events
+   * to those sessions, and prepare finalized reports to be sent.
+   */
+  void onFinalizeSessions();
+
+  /**
+   * Called when Crashlytics can send reports, after app settings data is available.
+   *
+   * @param appSettingsData app settings data for augmenting the report, if necessary
+   */
+  void onSendReports(AppSettingsData appSettingsData);
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManager.java
@@ -1,0 +1,102 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.common;
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
+import com.google.firebase.crashlytics.internal.persistence.CrashlyticsReportPersistence;
+import com.google.firebase.crashlytics.internal.send.DataTransportCrashlyticsReportSender;
+import com.google.firebase.crashlytics.internal.settings.model.AppSettingsData;
+import java.util.List;
+
+/**
+ * This class handles Crashlytics lifecycle events and manages capture, persistence, and sending of
+ * reports to Firebase Crashlytics.
+ */
+public class FirebaseCrashlyticsReportManager {
+
+  private static final String EVENT_TYPE_CRASH = "crash";
+  private static final int EVENT_THREAD_IMPORTANCE = 4;
+  private static final int MAX_CHAINED_EXCEPTION_DEPTH = 8;
+
+  private final CrashlyticsReportDataCapture dataCapture;
+  private final CrashlyticsReportPersistence reportPersistence;
+  private final DataTransportCrashlyticsReportSender reportsSender;
+  private final CurrentTimeProvider currentTimeProvider;
+
+  private String currentSessionId;
+
+  public FirebaseCrashlyticsReportManager(
+      CrashlyticsReportDataCapture dataCapture,
+      CrashlyticsReportPersistence reportPersistence,
+      DataTransportCrashlyticsReportSender reportsSender,
+      CurrentTimeProvider currentTimeProvider) {
+    this.dataCapture = dataCapture;
+    this.reportPersistence = reportPersistence;
+    this.reportsSender = reportsSender;
+    this.currentTimeProvider = currentTimeProvider;
+  }
+
+  public void onSessionBegin(String sessionId) {
+    final long timestamp = currentTimeProvider.getCurrentTimeMillis() / 1000;
+    currentSessionId = sessionId;
+
+    final CrashlyticsReport capturedReport = dataCapture.captureReportData(sessionId, timestamp);
+
+    reportPersistence.persistReport(capturedReport);
+  }
+
+  public void onFatalEvent(Throwable event, Thread thread) {
+    final long timestamp = currentTimeProvider.getCurrentTimeMillis() / 1000;
+
+    final CrashlyticsReport.Session.Event capturedEvent =
+        dataCapture.captureEventData(
+            event,
+            thread,
+            EVENT_TYPE_CRASH,
+            timestamp,
+            EVENT_THREAD_IMPORTANCE,
+            MAX_CHAINED_EXCEPTION_DEPTH);
+
+    reportPersistence.persistEvent(capturedEvent, currentSessionId);
+  }
+
+  public void onSessionEnd() {
+    currentSessionId = null;
+  }
+
+  public void onSessionsFinalize() {
+    reportPersistence.finalizeReports(currentSessionId);
+  }
+
+  public void onReportSend(AppSettingsData appSettingsData) {
+    final List<CrashlyticsReport> reportsToSend = reportPersistence.loadFinalizedReports();
+    for (CrashlyticsReport report : reportsToSend) {
+      reportsSender
+          .sendReport(report.withOrganizationId(appSettingsData.organizationId))
+          .addOnCompleteListener(this::onReportSendComplete);
+    }
+  }
+
+  private void onReportSendComplete(Task<CrashlyticsReport> task) {
+    if (task.isSuccessful()) {
+      // TODO: if the report is fatal, send an analytics event.
+      final CrashlyticsReport report = task.getResult();
+      reportPersistence.deleteFinalizedReport(report.getSession().getIdentifier());
+    }
+
+    // TODO: Something went wrong. Log? Throw?
+  }
+}


### PR DESCRIPTION
Handles the interaction between Crashlytics lifecycle events and
crash reports (capture, persistence, and sending).