### PR TITLE
Remove D/FirebaseCrashlytics prefix from logs

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsCore.java
@@ -347,32 +347,8 @@ public class CrashlyticsCore {
    * @see #logException(Throwable)
    */
   public void log(final String msg) {
-    doLog(Log.DEBUG, Logger.TAG, msg);
-  }
-
-  private void doLog(int priority, String tag, String msg) {
     final long timestamp = System.currentTimeMillis() - startTime;
-    controller.writeToLog(timestamp, formatLogMessage(priority, tag, msg));
-  }
-
-  /**
-   * Add text logging that will be sent with your next report, using {@link
-   * CrashlyticsCore#log(String)}. The message will also be printed to LogCat using
-   * android.util.Log.println(priority, tag, msg).
-   *
-   * @param priority The priority/type constant of this log message, as defined in android.util.Log.
-   *     One of: ERROR, WARN, INFO, DEBUG, VERBOSE.
-   * @param tag Used to identify the source of a log message. It usually identifies the class or
-   *     activity where the log call occurs.
-   * @param msg The message you would like logged.
-   * @see #log(String)
-   * @see android.util.Log#println(int, String, String)
-   */
-  public void log(int priority, String tag, String msg) {
-    doLog(priority, tag, msg);
-
-    // concatenate after "" to avoid NullPointerException if either String is null.
-    Logger.getLogger().log(priority, "" + tag, "" + msg, true);
+    controller.writeToLog(timestamp, msg);
   }
 
   public void setUserId(String identifier) {
@@ -504,10 +480,6 @@ public class CrashlyticsCore {
   // endregion
 
   // region Static utilities
-
-  private static String formatLogMessage(int priority, String tag, String msg) {
-    return CommonUtils.logPriorityToString(priority) + "/" + tag + " " + msg;
-  }
 
   static boolean isBuildIdValid(String buildId, boolean requiresBuildId) {
     if (!requiresBuildId) {


### PR DESCRIPTION
Previously, this could be overridden by end users, but the
override has been removed, rendering this prefix superfluous.