### PR TITLE
Pass executor into Crashlytics report manager

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManagerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManagerTest.java
@@ -55,7 +55,7 @@ public class FirebaseCrashlyticsReportManagerTest {
 
     reportManager =
         new FirebaseCrashlyticsReportManager(
-            dataCapture, reportPersistence, reportSender, mockCurrentTimeProvider);
+            dataCapture, reportPersistence, reportSender, mockCurrentTimeProvider, Runnable::run);
   }
 
   @Test

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManager.java
@@ -21,8 +21,7 @@ import com.google.firebase.crashlytics.internal.persistence.CrashlyticsReportPer
 import com.google.firebase.crashlytics.internal.send.DataTransportCrashlyticsReportSender;
 import com.google.firebase.crashlytics.internal.settings.model.AppSettingsData;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 
 /**
  * This class handles Crashlytics lifecycle events and manages capture, persistence, and sending of
@@ -39,21 +38,21 @@ public class FirebaseCrashlyticsReportManager implements CrashlyticsLifecycleEve
   private final CrashlyticsReportPersistence reportPersistence;
   private final DataTransportCrashlyticsReportSender reportsSender;
   private final CurrentTimeProvider currentTimeProvider;
-
-  // TODO: Use the shared executor from Crashlytics
-  private final ExecutorService executor = Executors.newCachedThreadPool();
+  private final Executor executor;
 
   private String currentSessionId;
 
-  public FirebaseCrashlyticsReportManager(
+  FirebaseCrashlyticsReportManager(
       CrashlyticsReportDataCapture dataCapture,
       CrashlyticsReportPersistence reportPersistence,
       DataTransportCrashlyticsReportSender reportsSender,
-      CurrentTimeProvider currentTimeProvider) {
+      CurrentTimeProvider currentTimeProvider,
+      Executor executor) {
     this.dataCapture = dataCapture;
     this.reportPersistence = reportPersistence;
     this.reportsSender = reportsSender;
     this.currentTimeProvider = currentTimeProvider;
+    this.executor = executor;
   }
 
   @Override


### PR DESCRIPTION
Also fix flaky test by passing a "same thread" executor