### PR TITLE
Cap events-per-session in Crashlytics persistence

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManagerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManagerTest.java
@@ -74,7 +74,7 @@ public class FirebaseCrashlyticsReportManagerTest {
   }
 
   @Test
-  public void testOnFatalEvent_persistsFatalEventForSessionId() {
+  public void testOnFatalEvent_persistsHighPriorityEventForSessionId() {
     final String eventType = "crash";
     final Exception exceptionEvent = new Exception("fatal");
     final Thread eventThread = Thread.currentThread();
@@ -99,11 +99,11 @@ public class FirebaseCrashlyticsReportManagerTest {
 
     verify(dataCapture)
         .captureEventData(exceptionEvent, eventThread, eventType, timestampSeconds, 4, 8, true);
-    verify(reportPersistence).persistEvent(mockEvent, sessionId);
+    verify(reportPersistence).persistEvent(mockEvent, sessionId, true);
   }
 
   @Test
-  public void testOnNonFatalEvent_persistsNonFatalEventForSessionId() {
+  public void testOnNonFatalEvent_persistsNormalPriorityEventForSessionId() {
     final String eventType = "error";
     final Exception exceptionEvent = new Exception("nonfatal");
     final Thread eventThread = Thread.currentThread();
@@ -128,7 +128,7 @@ public class FirebaseCrashlyticsReportManagerTest {
 
     verify(dataCapture)
         .captureEventData(exceptionEvent, eventThread, eventType, timestampSeconds, 4, 8, false);
-    verify(reportPersistence).persistEvent(mockEvent, sessionId);
+    verify(reportPersistence).persistEvent(mockEvent, sessionId, false);
   }
 
   @Test
@@ -142,7 +142,7 @@ public class FirebaseCrashlyticsReportManagerTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void onReportSend_successfulReportsAreDeleted() throws InterruptedException {
+  public void onReportSend_successfulReportsAreDeleted() {
     final String orgId = "testOrgId";
     final String sessionId1 = "sessionId1";
     final String sessionId2 = "sessionId2";

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/FirebaseCrashlyticsReportManager.java
@@ -109,7 +109,9 @@ public class FirebaseCrashlyticsReportManager implements CrashlyticsLifecycleEve
             MAX_CHAINED_EXCEPTION_DEPTH,
             includeAllThreads);
 
-    reportPersistence.persistEvent(capturedEvent, currentSessionId);
+    final boolean isHighPriority = eventType.equals(EVENT_TYPE_CRASH);
+
+    reportPersistence.persistEvent(capturedEvent, currentSessionId, isHighPriority);
   }
 
   private boolean onReportSendComplete(Task<CrashlyticsReport> task) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
@@ -43,17 +43,19 @@ public class CrashlyticsReportPersistence {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-  private static final String WORKING_DIRECTORY_NAME = "fl";
+  private static final String WORKING_DIRECTORY_NAME = "report-persistence";
   private static final String OPEN_SESSIONS_DIRECTORY_NAME = "sessions";
-  private static final String FATAL_DIRECTORY_NAME = "fatal";
-  private static final String NON_FATAL_DIRECTORY_NAME = "non-fatal";
+  private static final String PRIORITY_REPORTS_DIRECTORY = "priority-reports";
+  private static final String REPORTS_DIRECTORY = "reports";
 
-  private static final String REPORT_FILE_NAME = "report.json";
+  private static final String REPORT_FILE_NAME = "report";
   private static final String EVENT_FILE_NAME_PREFIX = "event";
-  private static final String EVENT_FILE_NAME_FORMAT = EVENT_FILE_NAME_PREFIX + "%s.json";
-  private static final String EVENT_COUNTER_FORMAT = "%010d";
-
-  private static final String EVENT_TYPE_FATAL = "crash";
+  private static final int EVENT_COUNTER_WIDTH = 10; // String width of maximum positive int value
+  private static final String EVENT_COUNTER_FORMAT = "%0" + EVENT_COUNTER_WIDTH + "d";
+  private static final int EVENT_NAME_LENGTH =
+      EVENT_FILE_NAME_PREFIX.length() + EVENT_COUNTER_WIDTH;
+  private static final String PRIORITY_EVENT_SUFFIX = "_";
+  private static final String NORMAL_EVENT_SUFFIX = "";
 
   private static final CrashlyticsReportJsonTransform TRANSFORM =
       new CrashlyticsReportJsonTransform();
@@ -61,18 +63,21 @@ public class CrashlyticsReportPersistence {
   private final AtomicInteger eventCounter = new AtomicInteger(0);
 
   // Storage for sessions that are still being written to
-  private File openSessionsDirectory;
+  private final File openSessionsDirectory;
 
   // Storage for finalized reports
-  // Keep finalized reports organized by whether or not they contain a fatal event.
-  private File fatalReportsDirectory;
-  private File nonFatalReportsDirectory;
+  private final File priorityReportsDirectory;
+  private final File reportsDirectory;
 
-  public CrashlyticsReportPersistence(File rootDirectory) {
+  // TODO: Add settings override
+  private final int defaultMaxEventsToKeep;
+
+  public CrashlyticsReportPersistence(File rootDirectory, int defaultMaxEventsToKeep) {
     final File workingDirectory = new File(rootDirectory, WORKING_DIRECTORY_NAME);
     openSessionsDirectory = new File(workingDirectory, OPEN_SESSIONS_DIRECTORY_NAME);
-    fatalReportsDirectory = new File(workingDirectory, FATAL_DIRECTORY_NAME);
-    nonFatalReportsDirectory = new File(workingDirectory, NON_FATAL_DIRECTORY_NAME);
+    priorityReportsDirectory = new File(workingDirectory, PRIORITY_REPORTS_DIRECTORY);
+    reportsDirectory = new File(workingDirectory, REPORTS_DIRECTORY);
+    this.defaultMaxEventsToKeep = defaultMaxEventsToKeep;
   }
 
   public void persistReport(CrashlyticsReport report) {
@@ -82,7 +87,31 @@ public class CrashlyticsReportPersistence {
     writeTextFile(new File(sessionDirectory, REPORT_FILE_NAME), json);
   }
 
+  /**
+   * Persist an event for a given session with normal priority.
+   *
+   * <p>Only a certain number of normal priority events are stored per-session. When this maximum is
+   * reached, the oldest events will be dropped.
+   *
+   * @param event
+   * @param sessionId
+   */
   public void persistEvent(CrashlyticsReport.Session.Event event, String sessionId) {
+    persistEvent(event, sessionId, false);
+  }
+
+  /**
+   * Persist an event for a given session, specifying whether or not it is high priority.
+   *
+   * <p>Only a certain number of normal priority events are stored per-session. When this maximum is
+   * reached, the oldest events will be dropped. High priority events are not subject to this limit.
+   *
+   * @param event
+   * @param sessionId
+   * @param isHighPriority
+   */
+  public void persistEvent(
+      CrashlyticsReport.Session.Event event, String sessionId, boolean isHighPriority) {
     final File sessionDirectory = getSessionDirectoryById(sessionId);
     if (!sessionDirectory.isDirectory()) {
       // No open session for this ID
@@ -90,18 +119,16 @@ public class CrashlyticsReportPersistence {
       return;
     }
     final String json = TRANSFORM.eventToJson(event);
-    final String eventNumber =
-        String.format(Locale.US, EVENT_COUNTER_FORMAT, eventCounter.getAndIncrement());
-    final String fileName = String.format(EVENT_FILE_NAME_FORMAT, eventNumber);
+    final String fileName = generateEventFilename(isHighPriority);
     writeTextFile(new File(sessionDirectory, fileName), json);
+    trimEvents(sessionDirectory, defaultMaxEventsToKeep);
   }
 
   public void deleteFinalizedReport(String sessionId) {
     final List<File> reportFiles = new ArrayList<>();
     final FilenameFilter filter = (d, f) -> f.startsWith(sessionId);
-    // Could be in either fatal reports or non-fatal reports
-    reportFiles.addAll(getFilesInDirectory(fatalReportsDirectory, filter));
-    reportFiles.addAll(getFilesInDirectory(nonFatalReportsDirectory, filter));
+    reportFiles.addAll(getFilesInDirectory(priorityReportsDirectory, filter));
+    reportFiles.addAll(getFilesInDirectory(reportsDirectory, filter));
     for (File reportFile : reportFiles) {
       reportFile.delete();
     }
@@ -133,15 +160,15 @@ public class CrashlyticsReportPersistence {
             TRANSFORM.reportFromJson(readTextFile(new File(sessionDirectory, REPORT_FILE_NAME)));
         final String sessionId = report.getSession().getIdentifier();
         final List<Event> events = new ArrayList<>();
-        boolean hasFatal = false;
+        boolean isHighPriorityReport = false;
         for (File eventFile : eventFiles) {
           final Event event = TRANSFORM.eventFromJson(readTextFile(eventFile));
-          hasFatal = hasFatal || event.getType().equals(EVENT_TYPE_FATAL);
+          isHighPriorityReport = isHighPriorityReport || isHighPriorityEvent(eventFile.getName());
           events.add(event);
         }
         // FIXME: If we fail to parse the events, we'll need to bail.
         final File outputDirectory =
-            prepareDirectory(hasFatal ? fatalReportsDirectory : nonFatalReportsDirectory);
+            prepareDirectory(isHighPriorityReport ? priorityReportsDirectory : reportsDirectory);
         writeTextFile(
             new File(outputDirectory, sessionId),
             TRANSFORM.reportToJson(report.withEvents(ImmutableList.from(events))));
@@ -151,20 +178,53 @@ public class CrashlyticsReportPersistence {
   }
 
   public List<CrashlyticsReport> loadFinalizedReports() {
-    final List<CrashlyticsReport> reports = new ArrayList<>();
-    final List<File> fatalReports = getAllFilesInDirectory(fatalReportsDirectory);
-    for (File reportFile : fatalReports) {
-      reports.add(TRANSFORM.reportFromJson(readTextFile(reportFile)));
+    final List<CrashlyticsReport> allReports = new ArrayList<>();
+    final List<File> priorityReports = getAllFilesInDirectory(priorityReportsDirectory);
+    for (File reportFile : priorityReports) {
+      allReports.add(TRANSFORM.reportFromJson(readTextFile(reportFile)));
     }
-    final List<File> nonFatalReports = getAllFilesInDirectory(nonFatalReportsDirectory);
-    for (File reportFile : nonFatalReports) {
-      reports.add(TRANSFORM.reportFromJson(readTextFile(reportFile)));
+    final List<File> reports = getAllFilesInDirectory(reportsDirectory);
+    for (File reportFile : reports) {
+      allReports.add(TRANSFORM.reportFromJson(readTextFile(reportFile)));
     }
-    return reports;
+    return allReports;
+  }
+
+  private static boolean isHighPriorityEvent(String eventFileName) {
+    return eventFileName.endsWith(PRIORITY_EVENT_SUFFIX);
+  }
+
+  private String generateEventFilename(boolean isHighPriority) {
+    final String eventNumber =
+        String.format(Locale.US, EVENT_COUNTER_FORMAT, eventCounter.getAndIncrement());
+    final String prioritySuffix = isHighPriority ? PRIORITY_EVENT_SUFFIX : NORMAL_EVENT_SUFFIX;
+    return EVENT_FILE_NAME_PREFIX + eventNumber + prioritySuffix;
   }
 
   private File getSessionDirectoryById(String sessionId) {
     return new File(openSessionsDirectory, sessionId);
+  }
+
+  private static int trimEvents(File sessionDirectory, int maximum) {
+    final List<File> normalPriorityEventFiles =
+        getFilesInDirectory(
+            sessionDirectory, CrashlyticsReportPersistence::isNormalPriorityEventFile);
+    Collections.sort(normalPriorityEventFiles, CrashlyticsReportPersistence::oldestEventFileFirst);
+    return capFilesCount(normalPriorityEventFiles, maximum);
+  }
+
+  private static String eventNameOnly(String eventFileName) {
+    return eventFileName.substring(0, EVENT_NAME_LENGTH);
+  }
+
+  private static boolean isNormalPriorityEventFile(File dir, String name) {
+    return name.startsWith(EVENT_FILE_NAME_PREFIX) && !isHighPriorityEvent(name);
+  }
+
+  private static int oldestEventFileFirst(File f1, File f2) {
+    final String name1 = eventNameOnly(f1.getName());
+    final String name2 = eventNameOnly(f2.getName());
+    return name1.compareTo(name2);
   }
 
   private static List<File> getAllFilesInDirectory(File directory) {
@@ -220,6 +280,25 @@ public class CrashlyticsReportPersistence {
     } catch (IOException e) {
       return null;
     }
+  }
+
+  /**
+   * Deletes files from the list until the list size is equal to the maximum. If list is already
+   * correctly sized, no files are deleted. List should be sorted in the order in which files should
+   * be deleted.
+   *
+   * @return the number of files retained on disk
+   */
+  private static int capFilesCount(List<File> files, int maximum) {
+    int numRetained = files.size();
+    for (File f : files) {
+      if (numRetained <= maximum) {
+        return numRetained;
+      }
+      recursiveDelete(f);
+      numRetained--;
+    }
+    return numRetained;
   }
 
   private static void recursiveDelete(File file) {


### PR DESCRIPTION
Replaces the concept of fatal/nonfatal in the persistence layer
with a persistence-specific concept of normal/high priority events.

This will be used to implement keeping a maximum number of logged
exceptions per session, without leaking information about specific
event types into the persistence layer.