### PR TITLE
Make CrossProcessLock resilient to disk issues

### DIFF
--- a/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/internal/ShortDynamicLinkImpl.java
+++ b/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/internal/ShortDynamicLinkImpl.java
@@ -44,7 +44,7 @@ public final class ShortDynamicLinkImpl extends AbstractSafeParcelable implement
       @Param(id = 3) List<WarningImpl> warnings) {
     this.shortLink = shortLink;
     this.previewLink = previewLink;
-    this.warnings = warnings == null ? Collections.<>emptyList() : warnings;
+    this.warnings = warnings == null ? Collections.emptyList() : warnings;
   }
 
   @Override

--- a/firebase-installations/src/main/java/com/google/firebase/installations/CrossProcessLock.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/CrossProcessLock.java
@@ -15,6 +15,7 @@
 package com.google.firebase.installations;
 
 import android.content.Context;
+import android.util.Log;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -23,6 +24,7 @@ import java.nio.channels.FileLock;
 
 /** Use file locking to acquire a lock that will also block other processes. */
 class CrossProcessLock {
+  private final static String TAG = "CrossProcessLock";
   private final FileChannel channel;
   private final FileLock lock;
 
@@ -31,16 +33,45 @@ class CrossProcessLock {
     this.lock = lock;
   }
 
+  /**
+   * Create and return a lock that is exclusive across processes. If another process
+   * has the lock then this call will block until it is released.
+   * @param lockName the lockname is global across all processes of an app
+   * @return a CrossProcessLock if success. If the lock failed to acquire (maybe due to disk full
+   * or other unexpected and unsupported permissions) then null will be returned.
+   */
   static CrossProcessLock acquire(Context appContext, String lockName) {
+    FileChannel channel = null;
+    FileLock lock = null;
     try {
       File file = new File(appContext.getFilesDir(), lockName);
-      FileChannel channel = new RandomAccessFile(file, "rw").getChannel();
+      channel = new RandomAccessFile(file, "rw").getChannel();
       // Use the file channel to create a lock on the file.
       // This method blocks until it can retrieve the lock.
-      FileLock lock = channel.lock();
+      lock = channel.lock();
       return new CrossProcessLock(channel, lock);
     } catch (IOException e) {
-      throw new IllegalStateException("exception while using file locks, should never happen", e);
+      // Certain conditions can cause file locking to fail, such as out of disk or bad permissions.
+      // In any case, the acquire will fail and return null instead of a held lock.
+      Log.e(TAG, "encountered error while creating and acquiring the lock, ignoring", e);
+
+      // Clean up any dangling resources
+      if (lock != null) {
+        try {
+          lock.release();
+        } catch (IOException e2) {
+          // nothing to do here
+        }
+      }
+      if (channel != null) {
+        try {
+          channel.close();
+        } catch (IOException e3) {
+          // nothing to do here
+        }
+      }
+
+      return null;
     }
   }
 
@@ -50,7 +81,8 @@ class CrossProcessLock {
       lock.release();
       channel.close();
     } catch (IOException e) {
-      throw new IllegalStateException("exception while using file locks, should never happen", e);
+      // nothing to do here
+      Log.e(TAG, "encountered error while releasing, ignoring", e);
     }
   }
 }

--- a/firebase-installations/src/main/java/com/google/firebase/installations/FirebaseInstallations.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/FirebaseInstallations.java
@@ -375,7 +375,12 @@ public class FirebaseInstallations implements FirebaseInstallationsApi {
         return prefs;
 
       } finally {
-        lock.releaseAndClose();
+        // It is possible that the lock acquisition failed, resulting in lock being null.
+        // We handle this case by going on with our business even if the acquisition failed
+        // but we need to be sure to only release if we got a lock.
+        if (lock != null) {
+          lock.releaseAndClose();
+        }
       }
     }
   }


### PR DESCRIPTION
If the CrossProcessLock fails due to disk issues it will fail instead of throwing an exception.

As this should only happen due to issues like disk full or messed up permissions the FirebaseInstallations code will log and ignore any failure to get the log and move forward.