### PR TITLE
Use Locale#toLanguageTag to properly encode IETF BCP 47 language tags.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -294,7 +294,8 @@ public class ConfigFetchHttpClient {
     requestBodyMap.put(COUNTRY_CODE, locale.getCountry());
 
     // Locale#toLanguageTag() was added in API level 21 (Lollipop)
-    String languageCode = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+    String languageCode =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
             ? locale.toLanguageTag()
             : locale.toString();
     requestBodyMap.put(LANGUAGE_CODE, languageCode);

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -291,7 +291,7 @@ public class ConfigFetchHttpClient {
 
     Locale locale = context.getResources().getConfiguration().locale;
     requestBodyMap.put(COUNTRY_CODE, locale.getCountry());
-    requestBodyMap.put(LANGUAGE_CODE, locale.toString());
+    requestBodyMap.put(LANGUAGE_CODE, locale.toLanguageTag());
 
     requestBodyMap.put(PLATFORM_VERSION, Integer.toString(android.os.Build.VERSION.SDK_INT));
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -36,6 +36,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Build;
 import android.util.Log;
 import androidx.annotation.Keep;
 import androidx.annotation.VisibleForTesting;
@@ -291,7 +292,12 @@ public class ConfigFetchHttpClient {
 
     Locale locale = context.getResources().getConfiguration().locale;
     requestBodyMap.put(COUNTRY_CODE, locale.getCountry());
-    requestBodyMap.put(LANGUAGE_CODE, locale.toLanguageTag());
+
+    // Locale#toLanguageTag() was added in API level 21 (Lollipop)
+    String languageCode = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+            ? locale.toLanguageTag()
+            : locale.toString();
+    requestBodyMap.put(LANGUAGE_CODE, languageCode);
 
     requestBodyMap.put(PLATFORM_VERSION, Integer.toString(android.os.Build.VERSION.SDK_INT));
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -199,13 +199,27 @@ public class ConfigFetchHttpClientTest {
     assertThat(requestBody.get(APP_ID)).isEqualTo(FAKE_APP_ID);
     Locale locale = context.getResources().getConfiguration().locale;
     assertThat(requestBody.get(COUNTRY_CODE)).isEqualTo(locale.getCountry());
-    assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(locale.toString());
+    assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(locale.toLanguageTag());
     assertThat(requestBody.getInt(PLATFORM_VERSION)).isEqualTo(android.os.Build.VERSION.SDK_INT);
     assertThat(requestBody.get(TIME_ZONE)).isEqualTo(TimeZone.getDefault().getID());
     assertThat(requestBody.get(PACKAGE_NAME)).isEqualTo(context.getPackageName());
     assertThat(requestBody.get(SDK_VERSION)).isEqualTo(BuildConfig.VERSION_NAME);
     assertThat(requestBody.getJSONObject(ANALYTICS_USER_PROPERTIES).toString())
         .isEqualTo(new JSONObject(userProperties).toString());
+  }
+
+  @Test
+  public void fetch_requestEncodesLanguageSubtags() throws Exception {
+    String languageTag = "zh-TW_#Hant";  // Taiwan Chinese in traditional script
+    context.getResources().getConfiguration().setLocale(Locale.forLanguageTag(languageTag));
+
+    setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
+
+    Map<String, String> userProperties = ImmutableMap.of("up1", "hello", "up2", "world");
+    fetch(FIRST_ETAG, userProperties);
+
+    JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
+    assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(languageTag);
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -36,6 +36,8 @@ import static com.google.firebase.remoteconfig.testutil.Assert.assertThrows;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import android.content.Context;
+import android.os.Build;
+
 import com.google.android.gms.common.util.MockClock;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -221,6 +223,23 @@ public class ConfigFetchHttpClientTest {
     JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
     assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(languageTag);
   }
+
+  @Test
+  @Config(sdk = Build.VERSION_CODES.KITKAT /* 19 */)
+  public void fetch_localeUsesToStringBelowLollipop() throws Exception {
+    String languageTag = "zh-Hant-TW";  // Taiwan Chinese in traditional script
+    String languageString = "zh_TW_#Hant";
+    context.getResources().getConfiguration().setLocale(Locale.forLanguageTag(languageTag));
+
+    setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
+
+    Map<String, String> userProperties = ImmutableMap.of("up1", "hello", "up2", "world");
+    fetch(FIRST_ETAG, userProperties);
+
+    JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
+    assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(languageString);
+  }
+
 
   @Test
   public void fetch_instanceIdIsNull_throwsFRCClientException() throws Exception {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -210,7 +210,7 @@ public class ConfigFetchHttpClientTest {
 
   @Test
   public void fetch_requestEncodesLanguageSubtags() throws Exception {
-    String languageTag = "zh-TW_#Hant";  // Taiwan Chinese in traditional script
+    String languageTag = "zh-Hant-TW";  // Taiwan Chinese in traditional script
     context.getResources().getConfiguration().setLocale(Locale.forLanguageTag(languageTag));
 
     setServerResponseTo(noChangeResponseBody, SECOND_ETAG);

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -37,7 +37,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import android.content.Context;
 import android.os.Build;
-
 import com.google.android.gms.common.util.MockClock;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -212,7 +211,7 @@ public class ConfigFetchHttpClientTest {
 
   @Test
   public void fetch_requestEncodesLanguageSubtags() throws Exception {
-    String languageTag = "zh-Hant-TW";  // Taiwan Chinese in traditional script
+    String languageTag = "zh-Hant-TW"; // Taiwan Chinese in traditional script
     context.getResources().getConfiguration().setLocale(Locale.forLanguageTag(languageTag));
 
     setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
@@ -227,7 +226,7 @@ public class ConfigFetchHttpClientTest {
   @Test
   @Config(sdk = Build.VERSION_CODES.KITKAT /* 19 */)
   public void fetch_localeUsesToStringBelowLollipop() throws Exception {
-    String languageTag = "zh-Hant-TW";  // Taiwan Chinese in traditional script
+    String languageTag = "zh-Hant-TW"; // Taiwan Chinese in traditional script
     String languageString = "zh_TW_#Hant";
     context.getResources().getConfiguration().setLocale(Locale.forLanguageTag(languageTag));
 
@@ -239,7 +238,6 @@ public class ConfigFetchHttpClientTest {
     JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
     assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(languageString);
   }
-
 
   @Test
   public void fetch_instanceIdIsNull_throwsFRCClientException() throws Exception {


### PR DESCRIPTION
[`Locale#toLanguageTag`](https://developer.android.com/reference/java/util/Locale#toLanguageTag()) is preferred to [`Locale#toString`](https://developer.android.com/reference/java/util/Locale#toString()) for interchange purposes.

The Firebase backends expect a BCP-47 encoded language tag, which is produced by `Locale#toLanguageTag`, and not in all cases by `Locale#toString`.