### PR TITLE
Fix package name in Crashlytics NDK manifest

### DIFF
--- a/firebase-crashlytics-ndk/src/main/AndroidManifest.xml
+++ b/firebase-crashlytics-ndk/src/main/AndroidManifest.xml
@@ -20,8 +20,8 @@
   ~
   ~
 -->
-<manifest package="com.crashlytics.android.ndk"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.crashlytics.ndk" >
 
     <application>
         <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashlyticsNdkRegistrar.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashlyticsNdkRegistrar.java
@@ -15,7 +15,6 @@
 package com.google.firebase.crashlytics.ndk;
 
 import android.content.Context;
-import com.crashlytics.android.ndk.BuildConfig;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentContainer;
 import com.google.firebase.components.ComponentRegistrar;


### PR DESCRIPTION
Update to reflect new Firebase Crashlytics package name