### PR TITLE
Catching NPE and throwing IOE instead.

### DIFF
--- a/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
@@ -179,7 +179,7 @@ public class FirebaseInstallationServiceClient {
       throws IOException {
     OutputStream outputStream = httpURLConnection.getOutputStream();
     if (outputStream == null) {
-      throw new ObjectStreamException("Cannot send request to FIS. No OutputStream available.");
+      throw new ObjectStreamException("Cannot send CreateInstallation request to FIS. No OutputStream available.");
     }
     
     GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);
@@ -207,7 +207,7 @@ public class FirebaseInstallationServiceClient {
       throws IOException {
     OutputStream outputStream = httpURLConnection.getOutputStream();
     if (outputStream == null) {
-      throw new ObjectStreamException("Cannot send request to FIS. No OutputStream available.");
+      throw new ObjectStreamException("Cannot send GenerateAuthToken request to FIS. No OutputStream available.");
     }
     
     GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);

--- a/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
@@ -36,6 +36,8 @@ import com.google.firebase.installations.remote.InstallationResponse.ResponseCod
 import com.google.firebase.platforminfo.UserAgentPublisher;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.ObjectStreamException
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -175,7 +177,12 @@ public class FirebaseInstallationServiceClient {
   private void writeFIDCreateRequestBodyToOutputStream(
       HttpURLConnection httpURLConnection, @NonNull String fid, @NonNull String appId)
       throws IOException {
-    GZIPOutputStream gzipOutputStream = new GZIPOutputStream(httpURLConnection.getOutputStream());
+    OutputStream outputStream = httpURLConnection.getOutputStream();
+    if (outputStream == null) {
+      throw new ObjectStreamException("Cannot send request to FIS. No OutputStream available.");
+    }
+    
+    GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);
     try {
       gzipOutputStream.write(
           buildCreateFirebaseInstallationRequestBody(fid, appId).toString().getBytes("UTF-8"));
@@ -198,7 +205,12 @@ public class FirebaseInstallationServiceClient {
 
   private void writeGenerateAuthTokenRequestBodyToOutputStream(HttpURLConnection httpURLConnection)
       throws IOException {
-    GZIPOutputStream gzipOutputStream = new GZIPOutputStream(httpURLConnection.getOutputStream());
+    OutputStream outputStream = httpURLConnection.getOutputStream();
+    if (outputStream == null) {
+      throw new ObjectStreamException("Cannot send request to FIS. No OutputStream available.");
+    }
+    
+    GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);
     try {
       gzipOutputStream.write(buildGenerateAuthTokenRequestBody().toString().getBytes("UTF-8"));
     } catch (JSONException e) {


### PR DESCRIPTION
Youtube observed this error on some devices when rolling out a new version. b/150526702
We were not able to reproduce this Exception, but found implementations of (Http)URLConnection that might return NULL for #getOutputStream.
The new code is preventing NPE and following the default error scenario that a connection to the FIS server API can not be established.