### PR TITLE
Make Logging consistent across Crashlytics

### DIFF
--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/BreakpadController.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/BreakpadController.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -25,8 +26,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 class BreakpadController implements NativeComponentController {
 
@@ -56,8 +55,7 @@ class BreakpadController implements NativeComponentController {
         initSuccess = nativeApi.initialize(crashReportPath, context.getAssets());
       }
     } catch (IOException e) {
-      Logger.getLogger(FirebaseCrashlyticsNdk.TAG)
-          .log(Level.SEVERE, "Error initializing CrashlyticsNdk", e);
+      Logger.getLogger().e("Error initializing CrashlyticsNdk", e);
     }
     return initSuccess;
   }

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/FirebaseCrashlyticsNdk.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/FirebaseCrashlyticsNdk.java
@@ -15,20 +15,14 @@
 package com.google.firebase.crashlytics.ndk;
 
 import android.content.Context;
-import android.util.Log;
 import androidx.annotation.NonNull;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
+import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.NativeSessionFileProvider;
 import java.io.File;
 
 /** The Crashlytics NDK Kit provides crash reporting functionality for Android NDK users. */
 class FirebaseCrashlyticsNdk implements CrashlyticsNativeComponent {
-
-  /**
-   * Matches the non-NDK TAG in the Crashlytics Logger, so log levels for all of Crashlytics can be
-   * set with a single command.
-   */
-  static final String TAG = "FirebaseCrashlytics";
 
   /** Relative sub-path to use for storing files. */
   private static final String FILES_PATH = ".com.google.firebase.crashlytics-ndk";
@@ -55,8 +49,8 @@ class FirebaseCrashlyticsNdk implements CrashlyticsNativeComponent {
   @Override
   public boolean openSession(String sessionId) {
     final boolean initSuccess = controller.initialize(sessionId);
-    // TODO: Clean up logging
-    Log.i(TAG, "Crashlytics NDK initialization " + (initSuccess ? "successful" : "FAILED"));
+    Logger.getLogger()
+        .i("Crashlytics NDK initialization " + (initSuccess ? "successful" : "FAILED"));
     return initSuccess;
   }
 

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/JniNativeApi.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/JniNativeApi.java
@@ -15,7 +15,7 @@
 package com.google.firebase.crashlytics.ndk;
 
 import android.content.res.AssetManager;
-import android.util.Log;
+import com.google.firebase.crashlytics.internal.Logger;
 
 /** JNI implementation of the native API interface. */
 @SuppressWarnings("PMD.AvoidUsingNativeCode")
@@ -34,13 +34,13 @@ class JniNativeApi implements NativeApi {
       // This can happen if the APK doesn't contain the correct binary for this architecture,
       // most likely because the user sideloaded the APK that was intended for a different
       // architecture. We can't reasonably recover, and Crashlytics may not be
-      // initialized yet. So all we can do is write the error to LogCat.
-      Log.e(
-          FirebaseCrashlyticsNdk.TAG,
-          "libcrashlytics could not be loaded. "
-              + "This APK may not have been compiled for this device's architecture. "
-              + "NDK crashes will not be reported to Crashlytics:\n"
-              + e.getLocalizedMessage());
+      // initialized yet. So all we can do is write the error to logs
+      Logger.getLogger()
+          .e(
+              "libcrashlytics could not be loaded. "
+                  + "This APK may not have been compiled for this device's architecture. "
+                  + "NDK crashes will not be reported to Crashlytics:\n"
+                  + e.getLocalizedMessage());
     }
     LIB_CRASHLYTICS_LOADED = loadSuccessful;
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCallTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCallTest.java
@@ -183,7 +183,7 @@ public class DefaultSettingsSpiCallTest extends CrashlyticsTestCase {
 
     assertNull(defaultSettingsSpiCall.handleResponse(mockHttpResponse));
     // Verify failing to parse a JSON object does not result in an error log.
-    verify(mockLogger, never()).e(anyString(), anyString());
+    verify(mockLogger, never()).e(anyString());
   }
 
   public void testHandleResponse_requestNotSuccessful() throws IOException {
@@ -192,8 +192,7 @@ public class DefaultSettingsSpiCallTest extends CrashlyticsTestCase {
 
     assertNull(defaultSettingsSpiCall.handleResponse(mockHttpResponse));
     verify(mockHttpResponse, never()).body();
-    verify(mockLogger, times(1))
-        .e(eq(Logger.TAG), eq("Failed to retrieve settings from " + TEST_URL));
+    verify(mockLogger, times(1)).e(eq("Failed to retrieve settings from " + TEST_URL));
   }
 
   public void testRequestWasSuccessful_successfulStatusCodes() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -66,7 +66,7 @@ public class FirebaseCrashlytics {
         new CrashlyticsCore(app, idManager, nativeComponent, arbiter, analyticsConnector);
 
     if (!onboarding.onPreExecute()) {
-      Logger.getLogger().e(Logger.TAG, "Unable to start Crashlytics.");
+      Logger.getLogger().e("Unable to start Crashlytics.");
       return null;
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsController.java
@@ -383,7 +383,6 @@ class CrashlyticsController {
 
     Logger.getLogger()
         .d(
-            Logger.TAG,
             "Crashlytics is handling uncaught "
                 + "exception \""
                 + ex
@@ -464,13 +463,13 @@ class CrashlyticsController {
   //       should be sent or deleted, at which point the promise will be resolved with the action.
   private Task<Boolean> waitForReportAction() {
     if (dataCollectionArbiter.isAutomaticDataCollectionEnabled()) {
-      Logger.getLogger().d(Logger.TAG, "Automatic data collection is enabled. Allowing upload.");
+      Logger.getLogger().d("Automatic data collection is enabled. Allowing upload.");
       unsentReportsAvailable.trySetResult(false);
       return Tasks.forResult(true);
     }
 
-    Logger.getLogger().d(Logger.TAG, "Automatic data collection is disabled.");
-    Logger.getLogger().d(Logger.TAG, "Notifying that unsent reports are available.");
+    Logger.getLogger().d("Automatic data collection is disabled.");
+    Logger.getLogger().d("Notifying that unsent reports are available.");
     unsentReportsAvailable.trySetResult(true);
 
     // If data collection gets enabled while we are waiting for an action, go ahead and send the
@@ -487,7 +486,7 @@ class CrashlyticsController {
                   }
                 });
 
-    Logger.getLogger().d(Logger.TAG, "Waiting for send/deleteUnsentReports to be called.");
+    Logger.getLogger().d("Waiting for send/deleteUnsentReports to be called.");
     // Wait for either the processReports callback to be called, or data collection to be enabled.
     return Utils.race(collectionEnabled, reportActionProvided.getTask());
   }
@@ -501,7 +500,7 @@ class CrashlyticsController {
       return sessionId != null && nativeComponent.hasCrashDataForSession(sessionId);
     }
 
-    Logger.getLogger().d(Logger.TAG, "Found previous crash marker.");
+    Logger.getLogger().d("Found previous crash marker.");
     crashMarker.remove();
 
     return Boolean.TRUE;
@@ -514,8 +513,7 @@ class CrashlyticsController {
     // and 2) when there's a fatal crash. So no new reports will become available while the app is
     // running.
     if (!checkForUnsentReportsCalled.compareAndSet(false, true)) {
-      Logger.getLogger()
-          .d(Logger.TAG, "checkForUnsentReports should only be called once per execution.");
+      Logger.getLogger().d("checkForUnsentReports should only be called once per execution.");
       return Tasks.forResult(false);
     }
     return unsentReportsAvailable.getTask();
@@ -534,11 +532,11 @@ class CrashlyticsController {
   Task<Void> submitAllReports(float delay, Task<AppSettingsData> appSettingsDataTask) {
     if (!reportManager.areReportsAvailable()) {
       // Just notify the user that there are no reports and stop.
-      Logger.getLogger().d(Logger.TAG, "No reports are available.");
+      Logger.getLogger().d("No reports are available.");
       unsentReportsAvailable.trySetResult(false);
       return Tasks.forResult(null);
     }
-    Logger.getLogger().d(Logger.TAG, "Unsent reports are available.");
+    Logger.getLogger().d("Unsent reports are available.");
 
     return waitForReportAction()
         .onSuccessTask(
@@ -554,14 +552,14 @@ class CrashlyticsController {
                         List<Report> reports = reportManager.findReports();
 
                         if (!send) {
-                          Logger.getLogger().d(Logger.TAG, "Reports are being deleted.");
+                          Logger.getLogger().d("Reports are being deleted.");
                           reportManager.deleteReports(reports);
                           reportingCoordinator.removeAllReports();
                           unsentReportsHandled.trySetResult(null);
                           return Tasks.forResult(null);
                         }
 
-                        Logger.getLogger().d(Logger.TAG, "Reports are being sent.");
+                        Logger.getLogger().d("Reports are being sent.");
 
                         // waitForReportAction guarantees we got user permission.
                         boolean dataCollectionToken = send;
@@ -675,8 +673,7 @@ class CrashlyticsController {
       if (context != null && CommonUtils.isAppDebuggable(context)) {
         throw ex;
       } else {
-        Logger.getLogger()
-            .e(Logger.TAG, "Attempting to set custom attribute with null key, ignoring.", null);
+        Logger.getLogger().e("Attempting to set custom attribute with null key, ignoring.", null);
         return;
       }
     }
@@ -789,19 +786,18 @@ class CrashlyticsController {
     backgroundWorker.checkRunningOnThread();
 
     if (isHandlingException()) {
-      Logger.getLogger()
-          .d(Logger.TAG, "Skipping session finalization because a crash has already occurred.");
+      Logger.getLogger().d("Skipping session finalization because a crash has already occurred.");
       return Boolean.FALSE;
     }
 
-    Logger.getLogger().d(Logger.TAG, "Finalizing previously open sessions.");
+    Logger.getLogger().d("Finalizing previously open sessions.");
     try {
       doCloseSessions(maxCustomExceptionEvents, false);
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Unable to finalize previously open sessions.", e);
+      Logger.getLogger().e("Unable to finalize previously open sessions.", e);
       return false;
     }
-    Logger.getLogger().d(Logger.TAG, "Closed all previously open sessions");
+    Logger.getLogger().d("Closed all previously open sessions");
 
     return true;
   }
@@ -814,7 +810,7 @@ class CrashlyticsController {
     final long startedAtSeconds = new Date().getTime() / 1000;
     final String sessionIdentifier = new CLSUUID(idManager).toString();
 
-    Logger.getLogger().d(Logger.TAG, "Opening a new session with ID " + sessionIdentifier);
+    Logger.getLogger().d("Opening a new session with ID " + sessionIdentifier);
 
     nativeComponent.openSession(sessionIdentifier);
 
@@ -845,7 +841,7 @@ class CrashlyticsController {
     final File[] sessionBeginFiles = listSortedSessionBeginFiles();
 
     if (sessionBeginFiles.length <= offset) {
-      Logger.getLogger().d(Logger.TAG, "No open sessions to be closed.");
+      Logger.getLogger().d("No open sessions to be closed.");
       return;
     }
 
@@ -871,13 +867,13 @@ class CrashlyticsController {
    */
   private void closeOpenSessions(
       File[] sessionBeginFiles, int beginIndex, int maxLoggedExceptionsCount) {
-    Logger.getLogger().d(Logger.TAG, "Closing open sessions.");
+    Logger.getLogger().d("Closing open sessions.");
 
     for (int i = beginIndex; i < sessionBeginFiles.length; ++i) {
       final File sessionBeginFile = sessionBeginFiles[i];
       final String sessionIdentifier = getSessionIdFromSessionFile(sessionBeginFile);
 
-      Logger.getLogger().d(Logger.TAG, "Closing session: " + sessionIdentifier);
+      Logger.getLogger().d("Closing session: " + sessionIdentifier);
       writeSessionPartsToSessionFile(sessionBeginFile, sessionIdentifier, maxLoggedExceptionsCount);
     }
   }
@@ -900,8 +896,7 @@ class CrashlyticsController {
     try {
       fos.closeInProgressStream();
     } catch (IOException ex) {
-      Logger.getLogger()
-          .e(Logger.TAG, "Error closing session file stream in the presence of an exception", ex);
+      Logger.getLogger().e("Error closing session file stream in the presence of an exception", ex);
     }
   }
 
@@ -1018,14 +1013,14 @@ class CrashlyticsController {
       final Matcher matcher = SESSION_FILE_PATTERN.matcher(fileName);
 
       if (!matcher.matches()) {
-        Logger.getLogger().d(Logger.TAG, "Deleting unknown file: " + fileName);
+        Logger.getLogger().d("Deleting unknown file: " + fileName);
         sessionPartFile.delete();
         continue;
       }
 
       final String sessionId = matcher.group(1);
       if (!sessionIdsToKeep.contains(sessionId)) {
-        Logger.getLogger().d(Logger.TAG, "Trimming session file: " + fileName);
+        Logger.getLogger().d("Trimming session file: " + fileName);
         sessionPartFile.delete();
       }
     }
@@ -1042,7 +1037,6 @@ class CrashlyticsController {
     if (nonFatalFiles.length > maxLoggedExceptionsCount) {
       Logger.getLogger()
           .d(
-              Logger.TAG,
               String.format(
                   Locale.US, "Trimming down to %d logged exceptions.", maxLoggedExceptionsCount));
       trimSessionEventFiles(sessionId, maxLoggedExceptionsCount);
@@ -1080,7 +1074,7 @@ class CrashlyticsController {
     // to be opened properly and is now invalid. Clean it up by moving it to a quarantine
     // directory where it can be dealt with separately.
     for (File invalidFile : invalidFiles) {
-      Logger.getLogger().d(Logger.TAG, "Found invalid session part file: " + invalidFile);
+      Logger.getLogger().d("Found invalid session part file: " + invalidFile);
       invalidSessionIds.add(getSessionIdFromSessionFile(invalidFile));
     }
 
@@ -1100,7 +1094,7 @@ class CrashlyticsController {
         };
 
     for (File sessionFile : listFilesMatching(invalidSessionFilter)) {
-      Logger.getLogger().d(Logger.TAG, "Deleting invalid session file: " + sessionFile);
+      Logger.getLogger().d("Deleting invalid session file: " + sessionFile);
       sessionFile.delete();
     }
   }
@@ -1119,7 +1113,7 @@ class CrashlyticsController {
       finalizePreviousNativeSession(previousSessionId);
       return nativeComponent.finalizeSession(previousSessionId);
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Unable to finalize native crash " + previousSessionId, e);
+      Logger.getLogger().e("Unable to finalize native crash " + previousSessionId, e);
       return false;
     }
   }
@@ -1137,7 +1131,7 @@ class CrashlyticsController {
     final File sessionOs = nativeSessionFileProvider.getOsFile();
 
     if (minidump == null || !minidump.exists()) {
-      Logger.getLogger().w(Logger.TAG, "No minidump data found for session " + previousSessionId);
+      Logger.getLogger().w("No minidump data found for session " + previousSessionId);
       return;
     }
 
@@ -1153,7 +1147,7 @@ class CrashlyticsController {
     final File nativeSessionDirectory = new File(getNativeSessionFilesDir(), previousSessionId);
 
     if (!nativeSessionDirectory.mkdirs()) {
-      Logger.getLogger().d(Logger.TAG, "Couldn't create native sessions directory");
+      Logger.getLogger().d("Couldn't create native sessions directory");
       return;
     }
 
@@ -1239,8 +1233,7 @@ class CrashlyticsController {
       final String currentSessionId = getCurrentSessionId();
 
       if (currentSessionId == null) {
-        Logger.getLogger()
-            .e(Logger.TAG, "Tried to write a fatal exception while no session was open.", null);
+        Logger.getLogger().e("Tried to write a fatal exception while no session was open.", null);
         return;
       }
 
@@ -1248,7 +1241,7 @@ class CrashlyticsController {
       cos = CodedOutputStream.newInstance(fos);
       writeSessionEvent(cos, thread, ex, eventTime, EVENT_TYPE_CRASH, true);
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "An error occurred in the fatal exception logger", e);
+      Logger.getLogger().e("An error occurred in the fatal exception logger", e);
     } finally {
       CommonUtils.flushOrLog(cos, "Failed to flush to session begin file.");
       CommonUtils.closeOrLog(fos, "Failed to close fatal exception file output stream.");
@@ -1263,8 +1256,7 @@ class CrashlyticsController {
     final String currentSessionId = getCurrentSessionId();
 
     if (currentSessionId == null) {
-      Logger.getLogger()
-          .e(Logger.TAG, "Tried to write a non-fatal exception while no session was open.", null);
+      Logger.getLogger().e("Tried to write a non-fatal exception while no session was open.", null);
       return;
     }
 
@@ -1273,7 +1265,6 @@ class CrashlyticsController {
     try {
       Logger.getLogger()
           .d(
-              Logger.TAG,
               "Crashlytics is logging non-fatal exception \""
                   + ex
                   + "\" from thread "
@@ -1287,7 +1278,7 @@ class CrashlyticsController {
       cos = CodedOutputStream.newInstance(fos);
       writeSessionEvent(cos, thread, ex, eventTime, EVENT_TYPE_LOGGED, false);
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "An error occurred in the non-fatal exception logger", e);
+      Logger.getLogger().e("An error occurred in the non-fatal exception logger", e);
     } finally {
       CommonUtils.flushOrLog(cos, "Failed to flush to non-fatal file.");
       CommonUtils.closeOrLog(fos, "Failed to close non-fatal file output stream.");
@@ -1298,7 +1289,7 @@ class CrashlyticsController {
       // closed before we attempt to trim.
       trimSessionEventFiles(currentSessionId, MAX_LOCAL_LOGGED_EXCEPTIONS);
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "An error occurred when trimming non-fatal files.", e);
+      Logger.getLogger().e("An error occurred when trimming non-fatal files.", e);
     }
   }
 
@@ -1561,22 +1552,19 @@ class CrashlyticsController {
    */
   private void writeSessionPartsToSessionFile(
       File sessionBeginFile, String sessionId, int maxLoggedExceptionsCount) {
-    Logger.getLogger().d(Logger.TAG, "Collecting session parts for ID " + sessionId);
+    Logger.getLogger().d("Collecting session parts for ID " + sessionId);
 
     final File[] fatalFiles =
         listFilesMatching(new FileNameContainsFilter(sessionId + SESSION_FATAL_TAG));
     final boolean hasFatal = fatalFiles != null && fatalFiles.length > 0;
     Logger.getLogger()
-        .d(
-            Logger.TAG,
-            String.format(Locale.US, "Session %s has fatal exception: %s", sessionId, hasFatal));
+        .d(String.format(Locale.US, "Session %s has fatal exception: %s", sessionId, hasFatal));
 
     final File[] nonFatalFiles =
         listFilesMatching(new FileNameContainsFilter(sessionId + SESSION_NON_FATAL_TAG));
     final boolean hasNonFatal = nonFatalFiles != null && nonFatalFiles.length > 0;
     Logger.getLogger()
         .d(
-            Logger.TAG,
             String.format(
                 Locale.US, "Session %s has non-fatal exceptions: %s", sessionId, hasNonFatal));
 
@@ -1586,10 +1574,10 @@ class CrashlyticsController {
       final File fatalFile = hasFatal ? fatalFiles[0] : null;
       synthesizeSessionFile(sessionBeginFile, sessionId, trimmedNonFatalFiles, fatalFile);
     } else {
-      Logger.getLogger().d(Logger.TAG, "No events present for session ID " + sessionId);
+      Logger.getLogger().d("No events present for session ID " + sessionId);
     }
 
-    Logger.getLogger().d(Logger.TAG, "Removing session part files for ID " + sessionId);
+    Logger.getLogger().d("Removing session part files for ID " + sessionId);
     deleteSessionPartFilesFor(sessionId);
   }
 
@@ -1609,7 +1597,7 @@ class CrashlyticsController {
       fos = new ClsFileOutputStream(outputDir, sessionId);
       cos = CodedOutputStream.newInstance(fos);
 
-      Logger.getLogger().d(Logger.TAG, "Collecting SessionStart data for session ID " + sessionId);
+      Logger.getLogger().d("Collecting SessionStart data for session ID " + sessionId);
       writeToCosFromFile(cos, sessionBeginFile);
 
       cos.writeUInt64(4, new Date().getTime() / 1000);
@@ -1627,8 +1615,7 @@ class CrashlyticsController {
         writeToCosFromFile(cos, fatalFile);
       }
     } catch (Exception e) {
-      Logger.getLogger()
-          .e(Logger.TAG, "Failed to write session file for session ID: " + sessionId, e);
+      Logger.getLogger().e("Failed to write session file for session ID: " + sessionId, e);
       // Need to set this ugly flag because we can't close the CFOS before we flush the
       // COS.
       exceptionDuringWrite = true;
@@ -1660,7 +1647,6 @@ class CrashlyticsController {
       try {
         Logger.getLogger()
             .d(
-                Logger.TAG,
                 String.format(
                     Locale.US,
                     "Found Non Fatal for session ID %s in %s ",
@@ -1668,7 +1654,7 @@ class CrashlyticsController {
                     nonFatalFile.getName()));
         writeToCosFromFile(cos, nonFatalFile);
       } catch (Exception e) {
-        Logger.getLogger().e(Logger.TAG, "Error writting non-fatal to session.", e);
+        Logger.getLogger().e("Error writting non-fatal to session.", e);
       }
     }
   }
@@ -1679,10 +1665,9 @@ class CrashlyticsController {
           listFilesMatching(new FileNameContainsFilter(sessionId + tag + SESSION_FILE_EXTENSION));
 
       if (sessionPartFiles.length == 0) {
-        Logger.getLogger()
-            .e(Logger.TAG, "Can't find " + tag + " data for session ID " + sessionId, null);
+        Logger.getLogger().e("Can't find " + tag + " data for session ID " + sessionId, null);
       } else {
-        Logger.getLogger().d(Logger.TAG, "Collecting " + tag + " data for session ID " + sessionId);
+        Logger.getLogger().d("Collecting " + tag + " data for session ID " + sessionId);
         writeToCosFromFile(cos, sessionPartFiles[0]);
       }
     }
@@ -1706,8 +1691,7 @@ class CrashlyticsController {
    */
   private static void writeToCosFromFile(CodedOutputStream cos, File file) throws IOException {
     if (!file.exists()) {
-      Logger.getLogger()
-          .e(Logger.TAG, "Tried to include a file that doesn't exist: " + file.getName(), null);
+      Logger.getLogger().e("Tried to include a file that doesn't exist: " + file.getName(), null);
       return;
     }
 
@@ -1776,9 +1760,7 @@ class CrashlyticsController {
   void registerAnalyticsListener() {
     final boolean analyticsRegistered = analyticsReceiver.register();
     Logger.getLogger()
-        .d(
-            Logger.TAG,
-            "Registered Firebase Analytics event listener for breadcrumbs: " + analyticsRegistered);
+        .d("Registered Firebase Analytics event listener for breadcrumbs: " + analyticsRegistered);
   }
 
   private CreateReportSpiCall getCreateReportSpiCall(String reportsUrl, String ndkReportsUrl) {
@@ -1821,16 +1803,13 @@ class CrashlyticsController {
     private final CountDownLatch eventLatch = new CountDownLatch(1);
 
     public void awaitEvent() throws InterruptedException {
-      Logger.getLogger()
-          .d(Logger.TAG, "Background thread awaiting app exception callback from FA...");
+      Logger.getLogger().d("Background thread awaiting app exception callback from FA...");
 
       if (eventLatch.await(APP_EXCEPTION_CALLBACK_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-        Logger.getLogger().d(Logger.TAG, "App exception callback received from FA listener.");
+        Logger.getLogger().d("App exception callback received from FA listener.");
       } else {
         Logger.getLogger()
-            .d(
-                Logger.TAG,
-                "Timeout exceeded while awaiting app exception callback from FA listener.");
+            .d("Timeout exceeded while awaiting app exception callback from FA listener.");
       }
     }
 
@@ -1857,22 +1836,18 @@ class CrashlyticsController {
           public Void call() throws Exception {
             if (firebaseCrashExists()) {
               Logger.getLogger()
-                  .d(
-                      Logger.TAG,
-                      "Skipping logging Crashlytics event to Firebase, FirebaseCrash exists");
+                  .d("Skipping logging Crashlytics event to Firebase, FirebaseCrash exists");
               return null;
             }
             if (analyticsConnector == null) {
               Logger.getLogger()
-                  .d(
-                      Logger.TAG,
-                      "Skipping logging Crashlytics event to Firebase, no Firebase Analytics");
+                  .d("Skipping logging Crashlytics event to Firebase, no Firebase Analytics");
               return null;
             }
             final BlockingCrashEventListener blockingListener = new BlockingCrashEventListener();
             analyticsReceiver.setCrashlyticsOriginEventListener(blockingListener);
 
-            Logger.getLogger().d(Logger.TAG, "Logging Crashlytics event to Firebase");
+            Logger.getLogger().d("Logging Crashlytics event to Firebase");
             final Bundle params = new Bundle();
             params.putInt(FIREBASE_CRASH_TYPE, FIREBASE_CRASH_TYPE_FATAL);
             params.putLong(FIREBASE_TIMESTAMP, timestamp);
@@ -1942,7 +1917,7 @@ class CrashlyticsController {
         return;
       }
 
-      Logger.getLogger().d(Logger.TAG, "Attempting to send crash report at time of crash...");
+      Logger.getLogger().d("Attempting to send crash report at time of crash...");
 
       reportUploader.uploadReport(report, dataCollectionToken);
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsCore.java
@@ -129,7 +129,7 @@ public class CrashlyticsCore {
     // before starting the crash detector make sure that this was built with our build
     // tools.
     final String mappingFileId = CommonUtils.getMappingFileId(context);
-    Logger.getLogger().d(Logger.TAG, "Mapping file id is: " + mappingFileId);
+    Logger.getLogger().d("Mapping file ID is: " + mappingFileId);
 
     // Throw an exception and halt the app if the build ID is required and not present.
     // TODO: This flag is no longer supported and should be removed, as part of a larger refactor
@@ -144,7 +144,7 @@ public class CrashlyticsCore {
     final String googleAppId = app.getOptions().getApplicationId();
 
     try {
-      Logger.getLogger().i(Logger.TAG, "Initializing Crashlytics " + getVersion());
+      Logger.getLogger().i("Initializing Crashlytics " + getVersion());
 
       final FileStore fileStore = new FileStoreImpl(context);
       crashMarker = new CrashlyticsFileMarker(CRASH_MARKER_FILE_NAME, fileStore);
@@ -165,8 +165,7 @@ public class CrashlyticsCore {
                 }
               });
 
-      Logger.getLogger()
-          .d(Logger.TAG, "Installer package name is: " + appData.installerPackageName);
+      Logger.getLogger().d("Installer package name is: " + appData.installerPackageName);
 
       controller =
           new CrashlyticsController(
@@ -199,7 +198,6 @@ public class CrashlyticsCore {
       if (initializeSynchronously && CommonUtils.canTryConnection(context)) {
         Logger.getLogger()
             .d(
-                Logger.TAG,
                 "Crashlytics did not finish previous background "
                     + "initialization. Initializing synchronously.");
         // finishInitSynchronously blocks the UI thread while it finishes background init.
@@ -209,15 +207,12 @@ public class CrashlyticsCore {
       }
     } catch (Exception e) {
       Logger.getLogger()
-          .e(
-              Logger.TAG,
-              "Crashlytics was not started due to an exception during initialization",
-              e);
+          .e("Crashlytics was not started due to an exception during initialization", e);
       controller = null;
       return false;
     }
 
-    Logger.getLogger().d(Logger.TAG, "Exception handling initialization successful");
+    Logger.getLogger().d("Exception handling initialization successful");
     return true;
   }
 
@@ -246,8 +241,7 @@ public class CrashlyticsCore {
       final Settings settingsData = settingsProvider.getSettings();
 
       if (!settingsData.getFeaturesData().collectReports) {
-        Logger.getLogger()
-            .d(Logger.TAG, "Collection of crash reports disabled in Crashlytics settings.");
+        Logger.getLogger().d("Collection of crash reports disabled in Crashlytics settings.");
         // TODO: This isn't actually an error condition, so figure out the right way to
         // handle this case.
         return Tasks.forException(
@@ -255,11 +249,11 @@ public class CrashlyticsCore {
       }
 
       if (!controller.finalizeNativeSessions()) {
-        Logger.getLogger().d(Logger.TAG, "Could not finalize native sessions.");
+        Logger.getLogger().d("Could not finalize native sessions.");
       }
 
       if (!controller.finalizeSessions(settingsData.getSessionData().maxCustomExceptionEvents)) {
-        Logger.getLogger().d(Logger.TAG, "Could not finalize previous sessions.");
+        Logger.getLogger().d("Could not finalize previous sessions.");
       }
 
       // TODO: Move this call out of this method, so that the return value merely indicates
@@ -269,10 +263,7 @@ public class CrashlyticsCore {
           CLS_DEFAULT_PROCESS_DELAY, settingsProvider.getAppSettings());
     } catch (Exception e) {
       Logger.getLogger()
-          .e(
-              Logger.TAG,
-              "Crashlytics encountered a problem during asynchronous initialization.",
-              e);
+          .e("Crashlytics encountered a problem during asynchronous initialization.", e);
       return Tasks.forException(e);
     } finally {
       // The only thing that compels us to leave the marker and start synchronously next time
@@ -330,8 +321,7 @@ public class CrashlyticsCore {
    */
   public void logException(final Throwable throwable) {
     if (throwable == null) {
-      Logger.getLogger()
-          .log(Log.WARN, Logger.TAG, "Crashlytics is ignoring a request to log a null exception.");
+      Logger.getLogger().w("Crashlytics is ignoring a request to log a null exception.");
       return;
     }
 
@@ -400,18 +390,17 @@ public class CrashlyticsCore {
 
     Logger.getLogger()
         .d(
-            Logger.TAG,
             "Crashlytics detected incomplete initialization on previous app launch."
                 + " Will initialize synchronously.");
 
     try {
       future.get(DEFAULT_MAIN_HANDLER_TIMEOUT_SEC, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
-      Logger.getLogger().e(Logger.TAG, "Crashlytics was interrupted during initialization.", e);
+      Logger.getLogger().e("Crashlytics was interrupted during initialization.", e);
     } catch (ExecutionException e) {
-      Logger.getLogger().e(Logger.TAG, "Problem encountered during Crashlytics initialization.", e);
+      Logger.getLogger().e("Problem encountered during Crashlytics initialization.", e);
     } catch (TimeoutException e) {
-      Logger.getLogger().e(Logger.TAG, "Crashlytics timed out during initialization.", e);
+      Logger.getLogger().e("Crashlytics timed out during initialization.", e);
     }
   }
 
@@ -422,7 +411,7 @@ public class CrashlyticsCore {
     // Create the Crashlytics initialization marker file, which is used to determine
     // whether the app crashed before initialization could complete.
     initializationMarker.create();
-    Logger.getLogger().d(Logger.TAG, "Initialization marker file created.");
+    Logger.getLogger().d("Initialization marker file created.");
   }
 
   /** Enqueues a job to remove the Crashlytics initialization marker file */
@@ -433,14 +422,11 @@ public class CrashlyticsCore {
           public Boolean call() throws Exception {
             try {
               final boolean removed = initializationMarker.remove();
-              Logger.getLogger().d(Logger.TAG, "Initialization marker file removed: " + removed);
+              Logger.getLogger().d("Initialization marker file removed: " + removed);
               return removed;
             } catch (Exception e) {
               Logger.getLogger()
-                  .e(
-                      Logger.TAG,
-                      "Problem encountered deleting Crashlytics initialization marker.",
-                      e);
+                  .e("Problem encountered deleting Crashlytics initialization marker.", e);
               return false;
             }
           }
@@ -485,7 +471,7 @@ public class CrashlyticsCore {
 
   static boolean isBuildIdValid(String buildId, boolean requiresBuildId) {
     if (!requiresBuildId) {
-      Logger.getLogger().d(Logger.TAG, "Configured not to require a build ID.");
+      Logger.getLogger().d("Configured not to require a build ID.");
       return true;
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsFileMarker.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsFileMarker.java
@@ -50,7 +50,7 @@ class CrashlyticsFileMarker {
     try {
       wasCreated = getMarkerFile().createNewFile();
     } catch (IOException e) {
-      Logger.getLogger().e(Logger.TAG, "Error creating marker: " + markerName, e);
+      Logger.getLogger().e("Error creating marker: " + markerName, e);
     }
     return wasCreated;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsUncaughtExceptionHandler.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/CrashlyticsUncaughtExceptionHandler.java
@@ -48,11 +48,10 @@ class CrashlyticsUncaughtExceptionHandler implements Thread.UncaughtExceptionHan
     try {
       crashListener.onUncaughtException(settingsDataProvider, thread, ex);
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "An error occurred in the uncaught exception handler", e);
+      Logger.getLogger().e("An error occurred in the uncaught exception handler", e);
     } finally {
       Logger.getLogger()
           .d(
-              Logger.TAG,
               "Crashlytics completed exception processing."
                   + " Invoking default exception handler.");
       defaultHandler.uncaughtException(thread, ex);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/MetaDataStore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/MetaDataStore.java
@@ -60,7 +60,7 @@ class MetaDataStore {
       writer.write(userDataString);
       writer.flush();
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Error serializing user metadata.", e);
+      Logger.getLogger().e("Error serializing user metadata.", e);
     } finally {
       CommonUtils.closeOrLog(writer, "Failed to close user metadata file.");
     }
@@ -77,7 +77,7 @@ class MetaDataStore {
       is = new FileInputStream(f);
       return jsonToUserData(CommonUtils.streamToString(is));
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Error deserializing user metadata.", e);
+      Logger.getLogger().e("Error deserializing user metadata.", e);
     } finally {
       CommonUtils.closeOrLog(is, "Failed to close user metadata file.");
     }
@@ -93,7 +93,7 @@ class MetaDataStore {
       writer.write(keyDataString);
       writer.flush();
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Error serializing key/value metadata.", e);
+      Logger.getLogger().e("Error serializing key/value metadata.", e);
     } finally {
       CommonUtils.closeOrLog(writer, "Failed to close key/value metadata file.");
     }
@@ -110,7 +110,7 @@ class MetaDataStore {
       is = new FileInputStream(f);
       return jsonToKeysData(CommonUtils.streamToString(is));
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Error deserializing user metadata.", e);
+      Logger.getLogger().e("Error deserializing user metadata.", e);
     } finally {
       CommonUtils.closeOrLog(is, "Failed to close user metadata file.");
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/core/UserMetadata.java
@@ -53,8 +53,7 @@ public class UserMetadata {
     key = sanitizeAttribute(key);
 
     if (attributes.size() >= MAX_ATTRIBUTES && !attributes.containsKey(key)) {
-      Logger.getLogger()
-          .d(Logger.TAG, "Exceeded maximum number of custom attributes (" + MAX_ATTRIBUTES + ")");
+      Logger.getLogger().d("Exceeded maximum number of custom attributes (" + MAX_ATTRIBUTES + ")");
       return;
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/Logger.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/Logger.java
@@ -20,11 +20,13 @@ import android.util.Log;
 public class Logger {
   public static final String TAG = "FirebaseCrashlytics";
 
-  static final Logger DEFAULT_LOGGER = new Logger();
+  static final Logger DEFAULT_LOGGER = new Logger(TAG);
 
+  private final String tag;
   private int logLevel;
 
-  public Logger() {
+  public Logger(String tag) {
+    this.tag = tag;
     this.logLevel = Log.INFO;
   }
 
@@ -33,66 +35,66 @@ public class Logger {
     return DEFAULT_LOGGER;
   }
 
-  public boolean isLoggable(String tag, int level) {
+  private boolean canLog(int level) {
     return logLevel <= level || Log.isLoggable(tag, level);
   }
 
-  public void d(String tag, String text, Throwable throwable) {
-    if (isLoggable(tag, Log.DEBUG)) {
+  public void d(String text, Throwable throwable) {
+    if (canLog(Log.DEBUG)) {
       Log.d(tag, text, throwable);
     }
   }
 
-  public void v(String tag, String text, Throwable throwable) {
-    if (isLoggable(tag, Log.VERBOSE)) {
+  public void v(String text, Throwable throwable) {
+    if (canLog(Log.VERBOSE)) {
       Log.v(tag, text, throwable);
     }
   }
 
-  public void i(String tag, String text, Throwable throwable) {
-    if (isLoggable(tag, Log.INFO)) {
+  public void i(String text, Throwable throwable) {
+    if (canLog(Log.INFO)) {
       Log.i(tag, text, throwable);
     }
   }
 
-  public void w(String tag, String text, Throwable throwable) {
-    if (isLoggable(tag, Log.WARN)) {
+  public void w(String text, Throwable throwable) {
+    if (canLog(Log.WARN)) {
       Log.w(tag, text, throwable);
     }
   }
 
-  public void e(String tag, String text, Throwable throwable) {
-    if (isLoggable(tag, Log.ERROR)) {
+  public void e(String text, Throwable throwable) {
+    if (canLog(Log.ERROR)) {
       Log.e(tag, text, throwable);
     }
   }
 
-  public void d(String tag, String text) {
-    d(tag, text, null);
+  public void d(String text) {
+    d(text, null);
   }
 
-  public void v(String tag, String text) {
-    v(tag, text, null);
+  public void v(String text) {
+    v(text, null);
   }
 
-  public void i(String tag, String text) {
-    i(tag, text, null);
+  public void i(String text) {
+    i(text, null);
   }
 
-  public void w(String tag, String text) {
-    w(tag, text, null);
+  public void w(String text) {
+    w(text, null);
   }
 
-  public void e(String tag, String text) {
-    e(tag, text, null);
+  public void e(String text) {
+    e(text, null);
   }
 
-  public void log(int priority, String tag, String msg) {
-    log(priority, tag, msg, false);
+  public void log(int priority, String msg) {
+    log(priority, msg, false);
   }
 
-  public void log(int priority, String tag, String msg, boolean forceLog) {
-    if (forceLog || isLoggable(tag, priority)) {
+  public void log(int priority, String msg, boolean forceLog) {
+    if (forceLog || canLog(priority)) {
       Log.println(priority, tag, msg);
     }
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/Onboarding.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/Onboarding.java
@@ -92,7 +92,7 @@ public class Onboarding {
 
       return true;
     } catch (PackageManager.NameNotFoundException e) {
-      Logger.getLogger().e(Logger.TAG, "Failed init", e);
+      Logger.getLogger().e("Failed init", e);
     }
     return false;
   }
@@ -128,7 +128,7 @@ public class Onboarding {
                       backgroundExecutor,
                       dataCollectionToken);
                 } catch (Exception e) {
-                  Logger.getLogger().e(Logger.TAG, "Error performing auto configuration.", e);
+                  Logger.getLogger().e("Error performing auto configuration.", e);
                   throw e;
                 }
                 return null;
@@ -161,7 +161,7 @@ public class Onboarding {
               @Override
               public Object then(@NonNull Task<Void> task) throws Exception {
                 if (!task.isSuccessful()) {
-                  Logger.getLogger().e(Logger.TAG, "Error fetching settings.", task.getException());
+                  Logger.getLogger().e("Error fetching settings.", task.getException());
                 }
                 return null;
               }
@@ -185,7 +185,7 @@ public class Onboarding {
             SettingsCacheBehavior.SKIP_CACHE_LOOKUP, backgroundExecutor);
       } else {
         // Failed to create the app. We're not configured!
-        Logger.getLogger().e(Logger.TAG, "Failed to create app with Crashlytics service.", null);
+        Logger.getLogger().e("Failed to create app with Crashlytics service.", null);
       }
     } else if (AppSettingsData.STATUS_CONFIGURED.equals(appSettings.status)) {
       // Shouldn't be possible to see this status, but included for completeness.
@@ -194,8 +194,7 @@ public class Onboarding {
     } else if (appSettings.updateRequired) {
       // A non-critical update. We'll attempt it, but won't halt things if we fail, since
       // we're already well configured.
-      Logger.getLogger()
-          .d(Logger.TAG, "Server says an update is required - forcing a full App update.");
+      Logger.getLogger().d("Server says an update is required - forcing a full App update.");
       performUpdateApp(appSettings, googleAppId, dataCollectionToken);
     }
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/analytics/AnalyticsConnectorReceiver.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/analytics/AnalyticsConnectorReceiver.java
@@ -58,7 +58,6 @@ public class AnalyticsConnectorReceiver implements AnalyticsConnectorListener, A
       // unexpected states that will prevent the breadcrumbs feature from working.
       Logger.getLogger()
           .d(
-              Logger.TAG,
               "Firebase Analytics is not present; you will not see automatic logging of "
                   + "events before a crash occurs.");
       return false;
@@ -90,8 +89,7 @@ public class AnalyticsConnectorReceiver implements AnalyticsConnectorListener, A
   @Override
   public void onMessageTriggered(int id, @Nullable Bundle extras) {
 
-    Logger.getLogger()
-        .d(Logger.TAG, "AnalyticsConnectorReceiver received message: " + id + " " + extras);
+    Logger.getLogger().d("AnalyticsConnectorReceiver received message: " + id + " " + extras);
 
     if (extras == null) {
       return;
@@ -125,7 +123,7 @@ public class AnalyticsConnectorReceiver implements AnalyticsConnectorListener, A
       final String serializedEvent = BREADCRUMB_PREFIX + serializeEvent(name, params);
       breadcrumbHandler.dropBreadcrumb(serializedEvent);
     } catch (JSONException e) {
-      Logger.getLogger().w(Logger.TAG, "Unable to serialize Firebase Analytics event.");
+      Logger.getLogger().w("Unable to serialize Firebase Analytics event.");
     }
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -134,7 +134,7 @@ public class CommonUtils {
           }
         }
       } catch (Exception e) {
-        Logger.getLogger().e(Logger.TAG, "Error parsing " + file, e);
+        Logger.getLogger().e("Error parsing " + file, e);
       } finally {
         CommonUtils.closeOrLog(br, "Failed to close system file reader.");
       }
@@ -182,8 +182,7 @@ public class CommonUtils {
       String arch = Build.CPU_ABI;
 
       if (TextUtils.isEmpty(arch)) {
-        Logger.getLogger()
-            .d(Logger.TAG, "Architecture#getValue()::Build.CPU_ABI returned null or empty");
+        Logger.getLogger().d("Architecture#getValue()::Build.CPU_ABI returned null or empty");
         return UNKNOWN;
       }
 
@@ -220,12 +219,10 @@ public class CommonUtils {
             // leave in this handling since we don't know for certain it isn't.
             bytes = convertMemInfoToBytes(result, "GB", BYTES_IN_A_GIGABYTE);
           } else {
-            Logger.getLogger()
-                .d(Logger.TAG, "Unexpected meminfo format while computing RAM: " + result);
+            Logger.getLogger().d("Unexpected meminfo format while computing RAM: " + result);
           }
         } catch (NumberFormatException e) {
-          Logger.getLogger()
-              .e(Logger.TAG, "Unexpected meminfo format while computing RAM: " + result, e);
+          Logger.getLogger().e("Unexpected meminfo format while computing RAM: " + result, e);
         }
       }
       totalRamInBytes = bytes;
@@ -300,7 +297,7 @@ public class CommonUtils {
 
       return CommonUtils.hexify(digest.digest());
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Could not calculate hash for app icon.", e);
+      Logger.getLogger().e("Could not calculate hash for app icon.", e);
     }
 
     return "";
@@ -313,10 +310,7 @@ public class CommonUtils {
       digest = java.security.MessageDigest.getInstance(algorithm);
     } catch (NoSuchAlgorithmException e) {
       Logger.getLogger()
-          .e(
-              Logger.TAG,
-              "Could not create hashing algorithm: " + algorithm + ", returning empty string.",
-              e);
+          .e("Could not create hashing algorithm: " + algorithm + ", returning empty string.", e);
       return "";
     }
     // :TODO: Need to specify character encoding??
@@ -410,7 +404,7 @@ public class CommonUtils {
    */
   public static void logControlled(Context context, String msg) {
     if (isClsTrace(context)) {
-      Logger.getLogger().d(Logger.TAG, msg);
+      Logger.getLogger().d(msg);
     }
   }
 
@@ -420,7 +414,7 @@ public class CommonUtils {
    */
   public static void logControlledError(Context context, String msg, Throwable tr) {
     if (isClsTrace(context)) {
-      Logger.getLogger().e(Logger.TAG, msg);
+      Logger.getLogger().e(msg);
     }
   }
 
@@ -430,7 +424,7 @@ public class CommonUtils {
    */
   public static void logControlled(Context context, int level, String tag, String msg) {
     if (isClsTrace(context)) {
-      Logger.getLogger().log(level, Logger.TAG, msg);
+      Logger.getLogger().log(level, msg);
     }
   }
 
@@ -659,7 +653,7 @@ public class CommonUtils {
       try {
         c.close();
       } catch (IOException e) {
-        Logger.getLogger().e(Logger.TAG, message, e);
+        Logger.getLogger().e(message, e);
       }
     }
   }
@@ -669,7 +663,7 @@ public class CommonUtils {
       try {
         f.flush();
       } catch (IOException e) {
-        Logger.getLogger().e(Logger.TAG, message, e);
+        Logger.getLogger().e(message, e);
       }
     }
   }
@@ -791,7 +785,7 @@ public class CommonUtils {
       final String sha1 = CommonUtils.sha1(is);
       return CommonUtils.isNullOrEmpty(sha1) ? null : sha1;
     } catch (Exception e) {
-      Logger.getLogger().w(Logger.TAG, "Could not calculate hash for app icon:" + e.getMessage());
+      Logger.getLogger().w("Could not calculate hash for app icon:" + e.getMessage());
     } finally {
       CommonUtils.closeOrLog(is, "Failed to close icon input stream.");
     }
@@ -830,7 +824,7 @@ public class CommonUtils {
     final int id = CommonUtils.getResourcesIdentifier(context, UNITY_EDITOR_VERSION, "string");
     if (id != 0) {
       version = context.getResources().getString(id);
-      Logger.getLogger().d(Logger.TAG, "Unity Editor version is: " + version);
+      Logger.getLogger().d("Unity Editor version is: " + version);
     }
     return version;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
@@ -79,7 +79,7 @@ public class DataCollectionArbiter {
       } catch (PackageManager.NameNotFoundException e) {
         // This shouldn't happen since it's this app's package, but fall through to default
         // if so.
-        Logger.getLogger().d(Logger.TAG, "Unable to get PackageManager. Falling through", e);
+        Logger.getLogger().d("Unable to get PackageManager. Falling through", e);
       }
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/ExecutorUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/ExecutorUtils.java
@@ -83,13 +83,11 @@ public final class ExecutorUtils {
                   @Override
                   public void onRun() {
                     try {
-                      Logger.getLogger()
-                          .d(Logger.TAG, "Executing shutdown hook for " + serviceName);
+                      Logger.getLogger().d("Executing shutdown hook for " + serviceName);
                       service.shutdown();
                       if (!service.awaitTermination(terminationTimeout, timeUnit)) {
                         Logger.getLogger()
                             .d(
-                                Logger.TAG,
                                 serviceName
                                     + " did not shut down in the"
                                     + " allocated time. Requesting immediate shutdown.");
@@ -98,7 +96,6 @@ public final class ExecutorUtils {
                     } catch (InterruptedException e) {
                       Logger.getLogger()
                           .d(
-                              Logger.TAG,
                               String.format(
                                   Locale.US,
                                   "Interrupted while waiting for %s to shut down."

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
@@ -107,7 +107,7 @@ public class IdManager implements InstallIdProvider {
       // If it is a legacy upgrade, we'll migrate the legacy ID to the new pref store.
       final SharedPreferences legacyPrefs = CommonUtils.getLegacySharedPrefs(appContext);
       final String legacyId = legacyPrefs.getString(PREFKEY_LEGACY_INSTALLATION_UUID, null);
-      Logger.getLogger().d(Logger.TAG, "No cached FID; legacy id is " + legacyId);
+      Logger.getLogger().d("No cached FID; legacy id is " + legacyId);
 
       if (legacyId == null) {
         // if there's no legacy ID, this must be a new Crashlytics install.
@@ -121,8 +121,7 @@ public class IdManager implements InstallIdProvider {
       // we have a cached FID, so check if it has been changed since previous launch
       if (cachedFid.equals(currentFid)) {
         crashlyticsInstallId = prefs.getString(PREFKEY_INSTALLATION_UUID, null);
-        Logger.getLogger()
-            .d(Logger.TAG, "Found matching FID, using Crashlytics IID: " + crashlyticsInstallId);
+        Logger.getLogger().d("Found matching FID, using Crashlytics IID: " + crashlyticsInstallId);
         // Since we've cached an FID previously, the IID should always exist at this point.
         // But check just in case:
         if (crashlyticsInstallId == null) {
@@ -138,7 +137,7 @@ public class IdManager implements InstallIdProvider {
 
   private synchronized void migrateLegacyId(
       String legacyId, String fidToCache, SharedPreferences prefs, SharedPreferences legacyPrefs) {
-    Logger.getLogger().d(Logger.TAG, "Migrating legacy Crashlytics IID: " + legacyId);
+    Logger.getLogger().d("Migrating legacy Crashlytics IID: " + legacyId);
     prefs
         .edit()
         .putString(PREFKEY_INSTALLATION_UUID, legacyId)
@@ -153,7 +152,7 @@ public class IdManager implements InstallIdProvider {
 
   private synchronized String createAndStoreIid(String fidToCache, SharedPreferences prefs) {
     final String iid = formatId(UUID.randomUUID().toString());
-    Logger.getLogger().d(Logger.TAG, "Created new Crashlytics IID: " + iid);
+    Logger.getLogger().d("Created new Crashlytics IID: " + iid);
     prefs
         .edit()
         .putString(PREFKEY_INSTALLATION_UUID, iid)

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -160,7 +160,7 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
       Executor reportSendCompleteExecutor,
       SendReportPredicate sendReportPredicate) {
     if (!sendReportPredicate.shouldSendViaDataTransport()) {
-      Logger.getLogger().d(Logger.TAG, "Send via DataTransport disabled. Removing reports.");
+      Logger.getLogger().d("Send via DataTransport disabled. Removing reports.");
       reportPersistence.deleteAllReports();
       return;
     }
@@ -195,7 +195,7 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
       eventBuilder.setLog(
           CrashlyticsReport.Session.Event.Log.builder().setContent(content).build());
     } else {
-      Logger.getLogger().d(Logger.TAG, "No log data to include with this event.");
+      Logger.getLogger().d("No log data to include with this event.");
     }
 
     // TODO: Put this back once support for reports endpoint is removed.
@@ -221,7 +221,7 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
       // TODO: if the report is fatal, send an analytics event.
       final CrashlyticsReport report = task.getResult();
       final String reportId = report.getSession().getIdentifier();
-      Logger.getLogger().i(Logger.TAG, "Crashlytics report sent successfully: " + reportId);
+      Logger.getLogger().i("Crashlytics report sent successfully: " + reportId);
       reportPersistence.deleteFinalizedReport(reportId);
       return true;
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/log/LogFileManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/log/LogFileManager.java
@@ -72,8 +72,7 @@ public class LogFileManager {
         CommonUtils.getBooleanResourceValue(context, COLLECT_CUSTOM_LOGS, true);
 
     if (!isLoggingEnabled) {
-      Logger.getLogger()
-          .d(Logger.TAG, "Preferences requested no custom logs. Aborting log file creation.");
+      Logger.getLogger().d("Preferences requested no custom logs. Aborting log file creation.");
       return;
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/log/QueueFileLogStore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/log/QueueFileLogStore.java
@@ -105,8 +105,7 @@ class QueueFileLogStore implements FileLogStore {
             }
           });
     } catch (IOException e) {
-      Logger.getLogger()
-          .e(Logger.TAG, "A problem occurred while reading the Crashlytics log file.", e);
+      Logger.getLogger().e("A problem occurred while reading the Crashlytics log file.", e);
     }
 
     return new LogBytes(logBytes, offsetHolder[0]);
@@ -129,7 +128,7 @@ class QueueFileLogStore implements FileLogStore {
       try {
         logFile = new QueueFile(workingFile);
       } catch (IOException e) {
-        Logger.getLogger().e(Logger.TAG, "Could not open log file: " + workingFile, e);
+        Logger.getLogger().e("Could not open log file: " + workingFile, e);
       }
     }
   }
@@ -177,7 +176,7 @@ class QueueFileLogStore implements FileLogStore {
         logFile.remove();
       }
     } catch (IOException e) {
-      Logger.getLogger().e(Logger.TAG, "There was a problem writing to the Crashlytics log.", e);
+      Logger.getLogger().e("There was a problem writing to the Crashlytics log.", e);
     }
   }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/ndk/BinaryImagesConverter.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/ndk/BinaryImagesConverter.java
@@ -81,7 +81,7 @@ class BinaryImagesConverter {
       final JSONArray maps = rawObj.getJSONArray("maps");
       mapsString = joinMapsEntries(maps);
     } catch (JSONException e) {
-      Logger.getLogger().w(Logger.TAG, "Unable to parse proc maps string", e);
+      Logger.getLogger().w("Unable to parse proc maps string", e);
       return binaryImagesJson;
     }
 
@@ -113,14 +113,14 @@ class BinaryImagesConverter {
     try {
       uuid = fileIdStrategy.createId(binFile);
     } catch (IOException e) {
-      Logger.getLogger().d(Logger.TAG, "Could not generate ID for file " + mapInfo.path, e);
+      Logger.getLogger().d("Could not generate ID for file " + mapInfo.path, e);
       return null;
     }
 
     try {
       return createBinaryImageJson(uuid, mapInfo);
     } catch (JSONException e) {
-      Logger.getLogger().d(Logger.TAG, "Could not create a binary image json string", e);
+      Logger.getLogger().d("Could not create a binary image json string", e);
     }
 
     return null;
@@ -147,7 +147,7 @@ class BinaryImagesConverter {
             context.getPackageManager().getApplicationInfo(context.getPackageName(), 0);
         missingFile = new File(ai.nativeLibraryDir, missingFile.getName());
       } catch (PackageManager.NameNotFoundException e) {
-        Logger.getLogger().e(Logger.TAG, "Error getting ApplicationInfo", e);
+        Logger.getLogger().e("Error getting ApplicationInfo", e);
       }
     }
     return missingFile;
@@ -159,7 +159,7 @@ class BinaryImagesConverter {
     try {
       binaryImagesObject.put("binary_images", binaryImages);
     } catch (JSONException e) {
-      Logger.getLogger().w(Logger.TAG, "Binary images string is null", e);
+      Logger.getLogger().w("Binary images string is null", e);
       return new byte[] {};
     }
     return binaryImagesObject.toString().getBytes(Charset.forName("UTF-8"));

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/ndk/ProcMapEntryParser.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/ndk/ProcMapEntryParser.java
@@ -55,7 +55,7 @@ final class ProcMapEntryParser {
 
       return new ProcMapEntry(address, size, perms, path);
     } catch (Exception e) {
-      Logger.getLogger().d(Logger.TAG, "Could not parse map entry: " + mapEntry);
+      Logger.getLogger().d("Could not parse map entry: " + mapEntry);
       return null;
     }
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStoreImpl.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStoreImpl.java
@@ -43,10 +43,10 @@ public class FileStoreImpl implements FileStore {
       if (file.exists() || file.mkdirs()) {
         return file;
       } else {
-        Logger.getLogger().w(Logger.TAG, "Couldn't create file");
+        Logger.getLogger().w("Couldn't create file");
       }
     } else {
-      Logger.getLogger().d(Logger.TAG, "Null File");
+      Logger.getLogger().d("Null File");
     }
     return null;
   }
@@ -56,7 +56,6 @@ public class FileStoreImpl implements FileStore {
     if (!Environment.MEDIA_MOUNTED.equals(state)) {
       Logger.getLogger()
           .w(
-              Logger.TAG,
               "External Storage is not mounted and/or writable\n"
                   + "Have you declared android.permission.WRITE_EXTERNAL_STORAGE "
                   + "in the manifest?");

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/proto/SessionProtobufHelper.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/proto/SessionProtobufHelper.java
@@ -203,7 +203,7 @@ public class SessionProtobufHelper {
     if (logBytes != null) {
       logByteString = ByteString.copyFrom(logBytes);
     } else {
-      Logger.getLogger().d(Logger.TAG, "No log data to include with this event.");
+      Logger.getLogger().d("No log data to include with this event.");
     }
 
     cos.writeTag(10, WireFormat.WIRETYPE_LENGTH_DELIMITED);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/ReportManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/ReportManager.java
@@ -47,7 +47,7 @@ public class ReportManager {
   }
 
   public List<Report> findReports() {
-    Logger.getLogger().d(Logger.TAG, "Checking for crash reports...");
+    Logger.getLogger().d("Checking for crash reports...");
 
     File[] clsFiles = reportFilesProvider.getCompleteSessionFiles();
     File[] nativeReportFiles = reportFilesProvider.getNativeReportFiles();
@@ -55,7 +55,7 @@ public class ReportManager {
     final List<Report> reports = new LinkedList<>();
     if (clsFiles != null) {
       for (File file : clsFiles) {
-        Logger.getLogger().d(Logger.TAG, "Found crash report " + file.getPath());
+        Logger.getLogger().d("Found crash report " + file.getPath());
         reports.add(new SessionReport(file));
       }
     }
@@ -67,7 +67,7 @@ public class ReportManager {
     }
 
     if (reports.isEmpty()) {
-      Logger.getLogger().d(Logger.TAG, "No reports found.");
+      Logger.getLogger().d("No reports found.");
     }
 
     return reports;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/ReportUploader.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/ReportUploader.java
@@ -74,7 +74,7 @@ public class ReportUploader {
   public synchronized void uploadReportsAsync(
       List<Report> reports, boolean dataCollectionToken, float delay) {
     if (uploadThread != null) {
-      Logger.getLogger().d(Logger.TAG, "Report upload has already been started.");
+      Logger.getLogger().d("Report upload has already been started.");
       return;
     }
 
@@ -107,13 +107,12 @@ public class ReportUploader {
 
         Logger.getLogger()
             .i(
-                Logger.TAG,
                 "Crashlytics report upload "
                     + (sent ? "complete: " : "FAILED: ")
                     + report.getIdentifier());
         shouldDeleteReport = sent;
       } else {
-        Logger.getLogger().d(Logger.TAG, "Send to reports endpoint disabled. Removing report.");
+        Logger.getLogger().d("Send to reports endpoint disabled. Removing report.");
         shouldDeleteReport = true;
       }
 
@@ -122,7 +121,7 @@ public class ReportUploader {
         removed = true;
       }
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Error occurred sending report " + report, e);
+      Logger.getLogger().e("Error occurred sending report " + report, e);
     }
     return removed;
   }
@@ -144,16 +143,13 @@ public class ReportUploader {
         attemptUploadWithRetry(reports, dataCollectionToken);
       } catch (Exception e) {
         Logger.getLogger()
-            .e(
-                Logger.TAG,
-                "An unexpected error occurred while attempting to upload crash reports.",
-                e);
+            .e("An unexpected error occurred while attempting to upload crash reports.", e);
       }
       uploadThread = null;
     }
 
     private void attemptUploadWithRetry(List<Report> reports, boolean dataCollectionToken) {
-      Logger.getLogger().d(Logger.TAG, "Starting report processing in " + delay + " second(s)...");
+      Logger.getLogger().d("Starting report processing in " + delay + " second(s)...");
 
       if (delay > 0) {
         try {
@@ -186,7 +182,7 @@ public class ReportUploader {
           return;
         }
 
-        Logger.getLogger().d(Logger.TAG, "Attempting to send " + reports.size() + " report(s)");
+        Logger.getLogger().d("Attempting to send " + reports.size() + " report(s)");
         ArrayList<Report> remaining = new ArrayList<>();
         for (Report report : reports) {
           boolean removed = uploadReport(report, dataCollectionToken);
@@ -198,9 +194,7 @@ public class ReportUploader {
         if (reports.size() > 0) {
           final long interval = RETRY_INTERVALS[Math.min(retryCount++, RETRY_INTERVALS.length - 1)];
           Logger.getLogger()
-              .d(
-                  Logger.TAG,
-                  "Report submission: scheduling delayed retry in " + interval + " seconds");
+              .d("Report submission: scheduling delayed retry in " + interval + " seconds");
           try {
             Thread.sleep(interval * 1000);
           } catch (InterruptedException e) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/model/NativeSessionReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/model/NativeSessionReport.java
@@ -29,10 +29,10 @@ public class NativeSessionReport implements Report {
   @Override
   public void remove() {
     for (File file : getFiles()) {
-      Logger.getLogger().d(Logger.TAG, "Removing native report file at " + file.getPath());
+      Logger.getLogger().d("Removing native report file at " + file.getPath());
       file.delete();
     }
-    Logger.getLogger().d(Logger.TAG, "Removing native report directory at " + reportDirectory);
+    Logger.getLogger().d("Removing native report directory at " + reportDirectory);
     reportDirectory.delete();
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/model/SessionReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/model/SessionReport.java
@@ -63,7 +63,7 @@ public class SessionReport implements Report {
 
   @Override
   public void remove() {
-    Logger.getLogger().d(Logger.TAG, "Removing report at " + file.getPath());
+    Logger.getLogger().d("Removing report at " + file.getPath());
     file.delete();
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/network/DefaultCreateReportSpiCall.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/network/DefaultCreateReportSpiCall.java
@@ -84,20 +84,19 @@ public class DefaultCreateReportSpiCall extends AbstractSpiCall implements Creat
     httpRequest = applyHeadersTo(httpRequest, requestData);
     httpRequest = applyMultipartDataTo(httpRequest, requestData.report);
 
-    Logger.getLogger().d(Logger.TAG, "Sending report to: " + getUrl());
+    Logger.getLogger().d("Sending report to: " + getUrl());
 
     try {
       final HttpResponse httpResponse = httpRequest.execute();
 
       final int statusCode = httpResponse.code();
 
-      Logger.getLogger()
-          .d(Logger.TAG, "Create report request ID: " + httpResponse.header(HEADER_REQUEST_ID));
-      Logger.getLogger().d(Logger.TAG, "Result was: " + statusCode);
+      Logger.getLogger().d("Create report request ID: " + httpResponse.header(HEADER_REQUEST_ID));
+      Logger.getLogger().d("Result was: " + statusCode);
 
       return ResponseParser.ResponseActionDiscard == ResponseParser.parse(statusCode);
     } catch (IOException ioe) {
-      Logger.getLogger().e(Logger.TAG, "Create report HTTP request failed.", ioe);
+      Logger.getLogger().e("Create report HTTP request failed.", ioe);
       throw new RuntimeException(ioe);
     }
   }
@@ -123,19 +122,14 @@ public class DefaultCreateReportSpiCall extends AbstractSpiCall implements Creat
 
     if (report.getFiles().length == 1) {
       Logger.getLogger()
-          .d(
-              Logger.TAG,
-              "Adding single file "
-                  + report.getFileName()
-                  + " to report "
-                  + report.getIdentifier());
+          .d("Adding single file " + report.getFileName() + " to report " + report.getIdentifier());
       return request.part(FILE_PARAM, report.getFileName(), FILE_CONTENT_TYPE, report.getFile());
     }
 
     int i = 0;
     for (File file : report.getFiles()) {
       Logger.getLogger()
-          .d(Logger.TAG, "Adding file " + file.getName() + " to report " + report.getIdentifier());
+          .d("Adding file " + file.getName() + " to report " + report.getIdentifier());
       request = request.part(MULTI_FILE_PARAM + i + "]", file.getName(), FILE_CONTENT_TYPE, file);
       i++;
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/network/NativeCreateReportSpiCall.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/report/network/NativeCreateReportSpiCall.java
@@ -67,14 +67,14 @@ public class NativeCreateReportSpiCall extends AbstractSpiCall implements Create
     httpRequest = applyHeadersTo(httpRequest, requestData.googleAppId);
     httpRequest = applyMultipartDataTo(httpRequest, requestData.organizationId, requestData.report);
 
-    Logger.getLogger().d(Logger.TAG, "Sending report to: " + getUrl());
+    Logger.getLogger().d("Sending report to: " + getUrl());
 
     try {
       HttpResponse httpResponse = httpRequest.execute();
 
       final int statusCode = httpResponse.code();
 
-      Logger.getLogger().d(Logger.TAG, "Result was: " + statusCode);
+      Logger.getLogger().d("Result was: " + statusCode);
 
       return ResponseParser.ResponseActionDiscard == ResponseParser.parse(statusCode);
     } catch (IOException ioe) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/CachedSettingsIo.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/CachedSettingsIo.java
@@ -45,7 +45,7 @@ public class CachedSettingsIo {
    *     cached data could be found, or an error occurred.
    */
   public JSONObject readCachedSettings() {
-    Logger.getLogger().d(Logger.TAG, "Reading cached settings...");
+    Logger.getLogger().d("Reading cached settings...");
 
     FileInputStream fis = null;
     JSONObject toReturn = null;
@@ -59,10 +59,10 @@ public class CachedSettingsIo {
 
         toReturn = new JSONObject(settingsStr);
       } else {
-        Logger.getLogger().d(Logger.TAG, "No cached settings found.");
+        Logger.getLogger().d("No cached settings found.");
       }
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Failed to fetch cached settings", e);
+      Logger.getLogger().e("Failed to fetch cached settings", e);
     } finally {
       CommonUtils.closeOrLog(fis, "Error while closing settings cache file.");
     }
@@ -78,7 +78,7 @@ public class CachedSettingsIo {
    * @param settingsJson JSON data to write to the cache
    */
   public void writeCachedSettings(long expiresAtMillis, JSONObject settingsJson) {
-    Logger.getLogger().d(Logger.TAG, "Writing settings to cache file...");
+    Logger.getLogger().d("Writing settings to cache file...");
 
     if (settingsJson != null) {
       FileWriter writer = null;
@@ -90,7 +90,7 @@ public class CachedSettingsIo {
         writer.write(settingsJson.toString());
         writer.flush();
       } catch (Exception e) {
-        Logger.getLogger().e(Logger.TAG, "Failed to cache settings", e);
+        Logger.getLogger().e("Failed to cache settings", e);
       } finally {
         CommonUtils.closeOrLog(writer, "Failed to close settings writer.");
       }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsController.java
@@ -244,26 +244,26 @@ public class SettingsController implements SettingsDataProvider {
             if (SettingsCacheBehavior.IGNORE_CACHE_EXPIRATION.equals(cacheBehavior)
                 || !settingsData.isExpired(currentTimeMillis)) {
               toReturn = settingsData;
-              Logger.getLogger().d(Logger.TAG, "Returning cached settings.");
+              Logger.getLogger().d("Returning cached settings.");
             } else {
-              Logger.getLogger().d(Logger.TAG, "Cached settings have expired.");
+              Logger.getLogger().d("Cached settings have expired.");
             }
           } else {
-            Logger.getLogger().e(Logger.TAG, "Failed to parse cached settings data.", null);
+            Logger.getLogger().e("Failed to parse cached settings data.", null);
           }
         } else {
-          Logger.getLogger().d(Logger.TAG, "No cached settings data found.");
+          Logger.getLogger().d("No cached settings data found.");
         }
       }
     } catch (Exception e) {
-      Logger.getLogger().e(Logger.TAG, "Failed to get cached settings", e);
+      Logger.getLogger().e("Failed to get cached settings", e);
     }
 
     return toReturn;
   }
 
   private void logSettings(JSONObject json, String message) throws JSONException {
-    Logger.getLogger().d(Logger.TAG, message + json.toString());
+    Logger.getLogger().d(message + json.toString());
   }
 
   private String getStoredBuildInstanceIdentifier() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/network/AbstractAppSpiCall.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/network/AbstractAppSpiCall.java
@@ -62,7 +62,7 @@ abstract class AbstractAppSpiCall extends AbstractSpiCall implements AppSpiCall 
     httpRequest = applyHeadersTo(httpRequest, requestData);
     httpRequest = applyMultipartDataTo(httpRequest, requestData);
 
-    Logger.getLogger().d(Logger.TAG, "Sending app info to " + getUrl());
+    Logger.getLogger().d("Sending app info to " + getUrl());
 
     try {
       final HttpResponse httpResponse = httpRequest.execute();
@@ -71,14 +71,12 @@ abstract class AbstractAppSpiCall extends AbstractSpiCall implements AppSpiCall 
       final String kind = "POST".equalsIgnoreCase(httpRequest.method()) ? "Create" : "Update";
 
       Logger.getLogger()
-          .d(
-              Logger.TAG,
-              kind + " app request ID: " + httpResponse.header(AbstractSpiCall.HEADER_REQUEST_ID));
-      Logger.getLogger().d(Logger.TAG, "Result was " + statusCode);
+          .d(kind + " app request ID: " + httpResponse.header(AbstractSpiCall.HEADER_REQUEST_ID));
+      Logger.getLogger().d("Result was " + statusCode);
 
       return ResponseParser.ResponseActionDiscard == ResponseParser.parse(statusCode);
     } catch (IOException ioe) {
-      Logger.getLogger().e(Logger.TAG, "HTTP request failed.", ioe);
+      Logger.getLogger().e("HTTP request failed.", ioe);
       throw new RuntimeException(ioe);
     }
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCall.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCall.java
@@ -80,17 +80,15 @@ public class DefaultSettingsSpiCall extends AbstractSpiCall implements SettingsS
       HttpRequest httpRequest = getHttpRequest(queryParams);
       httpRequest = applyHeadersTo(httpRequest, requestData);
 
-      logger.d(Logger.TAG, "Requesting settings from " + getUrl());
-      logger.d(Logger.TAG, "Settings query params were: " + queryParams);
+      logger.d("Requesting settings from " + getUrl());
+      logger.d("Settings query params were: " + queryParams);
 
       final HttpResponse httpResponse = httpRequest.execute();
-      logger.d(
-          Logger.TAG,
-          "Settings request ID: " + httpResponse.header(AbstractSpiCall.HEADER_REQUEST_ID));
+      logger.d("Settings request ID: " + httpResponse.header(AbstractSpiCall.HEADER_REQUEST_ID));
 
       toReturn = handleResponse(httpResponse);
     } catch (IOException e) {
-      logger.e(Logger.TAG, "Settings request failed.", e);
+      logger.e("Settings request failed.", e);
       toReturn = null;
     }
 
@@ -100,13 +98,13 @@ public class DefaultSettingsSpiCall extends AbstractSpiCall implements SettingsS
   /** package private for testing */
   JSONObject handleResponse(HttpResponse httpResponse) {
     final int statusCode = httpResponse.code();
-    logger.d(Logger.TAG, "Settings result was: " + statusCode);
+    logger.d("Settings result was: " + statusCode);
 
     final JSONObject toReturn;
     if (requestWasSuccessful(statusCode)) {
       toReturn = getJsonObjectFrom(httpResponse.body());
     } else {
-      logger.e(Logger.TAG, "Failed to retrieve settings from " + getUrl());
+      logger.e("Failed to retrieve settings from " + getUrl());
       toReturn = null;
     }
     return toReturn;
@@ -128,8 +126,8 @@ public class DefaultSettingsSpiCall extends AbstractSpiCall implements SettingsS
     try {
       return new JSONObject(httpRequestBody);
     } catch (Exception e) {
-      logger.d(Logger.TAG, "Failed to parse settings JSON from " + getUrl(), e);
-      logger.d(Logger.TAG, "Settings response " + httpRequestBody);
+      logger.d("Failed to parse settings JSON from " + getUrl(), e);
+      logger.d("Settings response " + httpRequestBody);
       return null;
     }
   }


### PR DESCRIPTION
- Remove tags from internal logger, all tags are FirebaseCrashlytics, and we don't want to accidentally use something else.
- Make NDK use this internal logger