### PR TITLE
Nudge customers to update if on an old Firebase Analytics

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/analytics/AnalyticsConnectorReceiver.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/analytics/AnalyticsConnectorReceiver.java
@@ -69,11 +69,7 @@ public class AnalyticsConnectorReceiver implements AnalyticsConnectorListener, A
 
     if (analyticsConnectorHandle == null) {
       Logger.getLogger()
-          .d(
-              "Could not register AnalyticsConnectorListener with origin "
-                  + "\""
-                  + CRASHLYTICS_ORIGIN
-                  + "\"");
+          .d("Could not register AnalyticsConnectorListener with Crashlytics origin.");
       // Older versions of FA don't support CRASHLYTICS_ORIGIN. We can try using the old Firebase
       // Crash Reporting origin
       analyticsConnectorHandle =
@@ -84,9 +80,9 @@ public class AnalyticsConnectorReceiver implements AnalyticsConnectorListener, A
       if (analyticsConnectorHandle != null) {
         Logger.getLogger()
             .w(
-                "Outdated version of Firebase Analytics detected. For improved "
-                    + "performance and compatibility with Crashlytics, please update to the latest "
-                    + "version of Firebase Analytics.");
+                "A new version of the Google Analytics for Firebase SDK is now available. "
+                    + "For improved performance and compatibility with Crashlytics, please "
+                    + "update to the latest version.");
       }
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/analytics/AnalyticsConnectorReceiver.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/analytics/AnalyticsConnectorReceiver.java
@@ -31,6 +31,7 @@ public class AnalyticsConnectorReceiver implements AnalyticsConnectorListener, A
   }
 
   static final String CRASHLYTICS_ORIGIN = "clx";
+  static final String LEGACY_CRASH_ORIGIN = "crash";
   public static final String EVENT_NAME_KEY = "name";
   public static final String APP_EXCEPTION_EVENT_NAME = "_ae";
   private static final String EVENT_ORIGIN_KEY = "_o";
@@ -65,6 +66,29 @@ public class AnalyticsConnectorReceiver implements AnalyticsConnectorListener, A
 
     analyticsConnectorHandle =
         analyticsConnector.registerAnalyticsConnectorListener(CRASHLYTICS_ORIGIN, this);
+
+    if (analyticsConnectorHandle == null) {
+      Logger.getLogger()
+          .d(
+              "Could not register AnalyticsConnectorListener with origin "
+                  + "\""
+                  + CRASHLYTICS_ORIGIN
+                  + "\"");
+      // Older versions of FA don't support CRASHLYTICS_ORIGIN. We can try using the old Firebase
+      // Crash Reporting origin
+      analyticsConnectorHandle =
+          analyticsConnector.registerAnalyticsConnectorListener(LEGACY_CRASH_ORIGIN, this);
+
+      // If FA allows us to connect with the legacy origin, but not the new one, nudge customers
+      // to update their FA version.
+      if (analyticsConnectorHandle != null) {
+        Logger.getLogger()
+            .w(
+                "Outdated version of Firebase Analytics detected. For improved "
+                    + "performance and compatibility with Crashlytics, please update to the latest "
+                    + "version of Firebase Analytics.");
+      }
+    }
 
     return analyticsConnectorHandle != null;
   }


### PR DESCRIPTION
We can infer the customer is on an outdated version of FA
if we cannot attach a listener with the "clx" origin. If
that is the case, use the old "crash" origin and write a
logcat warning with a nudge to upgrade.