### PR TITLE
Add 'generator type' to CrashlyticsReport

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransformTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransformTest.java
@@ -78,6 +78,7 @@ public class CrashlyticsReportJsonTransformTest {
         .setCrashed(true)
         .setApp(makeTestApplication())
         .setUser(User.builder().setIdentifier("user").build())
+        .setGeneratorType(3)
         .build();
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistenceTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistenceTest.java
@@ -581,6 +581,7 @@ public class CrashlyticsReportPersistenceTest {
         .setIdentifier(sessionId)
         .setStartedAt(0)
         .setApp(makeTestApplication())
+        .setGeneratorType(3)
         .build();
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
@@ -46,6 +46,9 @@ public class CrashlyticsReportDataCapture {
   private static final String GENERATOR =
       String.format(Locale.US, "Crashlytics Android SDK/%s", BuildConfig.VERSION_NAME);
 
+  // GeneratorType ANDROID_SDK = 3;
+  private static final int GENERATOR_TYPE = 3;
+
   private static final int REPORT_ANDROID_PLATFORM = 4;
   private static final int SESSION_ANDROID_PLATFORM = 3;
   private static final String SIGNAL_DEFAULT = "0";
@@ -123,6 +126,7 @@ public class CrashlyticsReportDataCapture {
         .setApp(populateSessionApplicationData())
         .setOs(populateSessionOperatingSystemData())
         .setDevice(populateSessionDeviceData())
+        .setGeneratorType(GENERATOR_TYPE)
         .build();
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -211,6 +211,8 @@ public abstract class CrashlyticsReport {
     @Nullable
     public abstract ImmutableList<Event> getEvents();
 
+    public abstract int getGeneratorType();
+
     @NonNull
     public abstract Builder toBuilder();
 
@@ -279,6 +281,9 @@ public abstract class CrashlyticsReport {
 
       @NonNull
       public abstract Builder setEvents(@NonNull ImmutableList<Event> value);
+
+      @NonNull
+      public abstract Builder setGeneratorType(int generatorType);
 
       @NonNull
       public abstract Session build();

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
@@ -144,6 +144,9 @@ public class CrashlyticsReportJsonTransform {
         case "events":
           builder.setEvents(parseArray(jsonReader, CrashlyticsReportJsonTransform::parseEvent));
           break;
+        case "generatorType":
+          builder.setGeneratorType(jsonReader.nextInt());
+          break;
         default:
           jsonReader.skipValue();
           break;

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReportTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReportTest.java
@@ -202,6 +202,7 @@ public class CrashlyticsReportTest {
         .setIdentifier("identifier")
         .setStartedAt(0)
         .setApp(makeTestApplication())
+        .setGeneratorType(3)
         .build();
   }
 


### PR DESCRIPTION
Enum value which should always be set to "3" for the Android SDK.