### PR TITLE
Add proguard.txt for firebase-crashlytics-ndk

### DIFF
--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk-proguard.txt
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk-proguard.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Prevent FirebaseCrashlytics from being obfuscated because the Crashlytics native libs call
-# FirebaseCrashlytics public methods dynamically via JNI.
+# Prevent FirebaseCrashlytics from being obfuscated, because the Crashlytics
+# native libraries call FirebaseCrashlytics public methods dynamically via JNI.
 -keep public class com.google.firebase.crashlytics.FirebaseCrashlytics { public *; }

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -34,7 +34,7 @@ android {
         targetSdkVersion androidVersion
         versionName version
 
-        consumerProguardFiles 'proguard.txt'
+        consumerProguardFiles 'firebase-crashlytics-ndk-proguard.txt'
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -34,6 +34,7 @@ android {
         targetSdkVersion androidVersion
         versionName version
 
+        consumerProguardFiles 'proguard.txt'
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/firebase-crashlytics-ndk/proguard.txt
+++ b/firebase-crashlytics-ndk/proguard.txt
@@ -1,0 +1,17 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prevent FirebaseCrashlytics from being obfuscated because the Crashlytics native libs call
+# FirebaseCrashlytics public methods dynamically via JNI.
+-keep public class com.google.firebase.crashlytics.FirebaseCrashlytics { public *; }


### PR DESCRIPTION
Obfuscated apps which use Crashlytics NDK could experience a crash
on launch if the FirebaseCrashlytics class has been obfuscated. This
commit adds a proguard rule that gets packaged with the Crashlytics
NDK AAR, which prevents obfuscation of FirebaseCrashlytics.