### PR TITLE
fix(iam): check if message body is not empty string

### DIFF
--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/ProtoMarshallerClient.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/ProtoMarshallerClient.java
@@ -55,7 +55,9 @@ public class ProtoMarshallerClient {
     }
 
     if (in.hasBody()) {
-      builder.setBody(decode(in.getBody()));
+      if (!in.getBody().getText().isEmpty()) {
+        builder.setBody(decode(in.getBody()));
+      }
     }
 
     if (in.hasTitle()) {
@@ -97,7 +99,9 @@ public class ProtoMarshallerClient {
     }
 
     if (in.hasBody()) {
-      builder.setBody(decode(in.getBody()));
+      if (!in.getBody().getText().isEmpty()) {
+        builder.setBody(decode(in.getBody()));
+      }
     }
 
     if (in.hasTitle()) {
@@ -116,7 +120,9 @@ public class ProtoMarshallerClient {
     }
 
     if (in.hasBody()) {
-      builder.setBody(decode(in.getBody()));
+      if (!in.getBody().getText().isEmpty()) {
+        builder.setBody(decode(in.getBody()));
+      }
     }
 
     if (!TextUtils.isEmpty(in.getBackgroundHexColor())) {

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/ProtoMarshallerClient.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/ProtoMarshallerClient.java
@@ -55,9 +55,7 @@ public class ProtoMarshallerClient {
     }
 
     if (in.hasBody()) {
-      if (!in.getBody().getText().isEmpty()) {
-        builder.setBody(decode(in.getBody()));
-      }
+      builder.setBody(decode(in.getBody()));
     }
 
     if (in.hasTitle()) {
@@ -99,9 +97,7 @@ public class ProtoMarshallerClient {
     }
 
     if (in.hasBody()) {
-      if (!in.getBody().getText().isEmpty()) {
-        builder.setBody(decode(in.getBody()));
-      }
+      builder.setBody(decode(in.getBody()));
     }
 
     if (in.hasTitle()) {
@@ -120,9 +116,7 @@ public class ProtoMarshallerClient {
     }
 
     if (in.hasBody()) {
-      if (!in.getBody().getText().isEmpty()) {
-        builder.setBody(decode(in.getBody()));
-      }
+      builder.setBody(decode(in.getBody()));
     }
 
     if (!TextUtils.isEmpty(in.getBackgroundHexColor())) {
@@ -198,15 +192,18 @@ public class ProtoMarshallerClient {
   }
 
   private static Text decode(MessagesProto.Text in) {
+    if (TextUtils.isEmpty(in.getText())) {
+      return null;
+    }
+
     Text.Builder builder = Text.builder();
 
     if (!TextUtils.isEmpty(in.getHexColor())) {
       builder.setHexColor(in.getHexColor());
     }
 
-    if (!TextUtils.isEmpty(in.getText())) {
-      builder.setText(in.getText());
-    }
+    // We know the text is not empty here
+    builder.setText(in.getText());
 
     return builder.build();
   }


### PR DESCRIPTION
Should fix #1362 

In proto3, if a String value has not been set, it will default to empty String. (See https://developers.google.com/protocol-buffers/docs/proto3#default)

Unfortunately, proto3 doesn't allow us to explicitly specify a default value. To work around that, we could check if the body is an empty String when decoding the message.