### PR TITLE
Backport ServerTimestamp type order changes

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataWriter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataWriter.java
@@ -17,6 +17,18 @@ package com.google.firebase.firestore;
 import static com.google.firebase.firestore.model.ServerTimestamps.getLocalWriteTime;
 import static com.google.firebase.firestore.model.ServerTimestamps.getPreviousValue;
 import static com.google.firebase.firestore.model.ServerTimestamps.isServerTimestamp;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_ARRAY;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_BLOB;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_BOOLEAN;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_GEOPOINT;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_MAP;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_NULL;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_NUMBER;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_REFERENCE;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_SERVER_TIMESTAMP;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_STRING;
+import static com.google.firebase.firestore.model.Values.TYPE_ORDER_TIMESTAMP;
+import static com.google.firebase.firestore.model.Values.typeOrder;
 import static com.google.firebase.firestore.util.Assert.fail;
 
 import androidx.annotation.RestrictTo;
@@ -52,31 +64,28 @@ public class UserDataWriter {
   }
 
   Object convertValue(Value value) {
-    switch (value.getValueTypeCase()) {
-      case MAP_VALUE:
-        if (isServerTimestamp(value)) {
-          return convertServerTimestamp(value);
-        }
+    switch (typeOrder(value)) {
+      case TYPE_ORDER_MAP:
         return convertObject(value.getMapValue().getFieldsMap());
-      case ARRAY_VALUE:
+      case TYPE_ORDER_ARRAY:
         return convertArray(value.getArrayValue());
-      case REFERENCE_VALUE:
+      case TYPE_ORDER_REFERENCE:
         return convertReference(value);
-      case TIMESTAMP_VALUE:
+      case TYPE_ORDER_TIMESTAMP:
         return convertTimestamp(value.getTimestampValue());
-      case NULL_VALUE:
+      case TYPE_ORDER_SERVER_TIMESTAMP:
+        return convertServerTimestamp(value);
+      case TYPE_ORDER_NULL:
         return null;
-      case BOOLEAN_VALUE:
+      case TYPE_ORDER_BOOLEAN:
         return value.getBooleanValue();
-      case INTEGER_VALUE:
-        return value.getIntegerValue();
-      case DOUBLE_VALUE:
-        return value.getDoubleValue();
-      case STRING_VALUE:
+      case TYPE_ORDER_NUMBER:
+        return value.getValueTypeCase().equals(Value.ValueTypeCase.INTEGER_VALUE) ? value.getIntegerValue() : value.getDoubleValue();
+      case TYPE_ORDER_STRING:
         return value.getStringValue();
-      case BYTES_VALUE:
+      case TYPE_ORDER_BLOB:
         return Blob.fromByteString(value.getBytesValue());
-      case GEO_POINT_VALUE:
+      case TYPE_ORDER_GEOPOINT:
         return new GeoPoint(
             value.getGeoPointValue().getLatitude(), value.getGeoPointValue().getLongitude());
       default:

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataWriter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataWriter.java
@@ -16,7 +16,6 @@ package com.google.firebase.firestore;
 
 import static com.google.firebase.firestore.model.ServerTimestamps.getLocalWriteTime;
 import static com.google.firebase.firestore.model.ServerTimestamps.getPreviousValue;
-import static com.google.firebase.firestore.model.ServerTimestamps.isServerTimestamp;
 import static com.google.firebase.firestore.model.Values.TYPE_ORDER_ARRAY;
 import static com.google.firebase.firestore.model.Values.TYPE_ORDER_BLOB;
 import static com.google.firebase.firestore.model.Values.TYPE_ORDER_BOOLEAN;
@@ -80,7 +79,9 @@ public class UserDataWriter {
       case TYPE_ORDER_BOOLEAN:
         return value.getBooleanValue();
       case TYPE_ORDER_NUMBER:
-        return value.getValueTypeCase().equals(Value.ValueTypeCase.INTEGER_VALUE) ? value.getIntegerValue() : value.getDoubleValue();
+        return value.getValueTypeCase().equals(Value.ValueTypeCase.INTEGER_VALUE)
+            ? (Object) value.getIntegerValue() // Cast to Object to prevent type coercion to double
+            : (Object) value.getDoubleValue();
       case TYPE_ORDER_STRING:
         return value.getStringValue();
       case TYPE_ORDER_BLOB:

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
@@ -40,18 +40,21 @@ public class Values {
   public static final Value NULL_VALUE =
       Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
 
-  /** The order of types in Firestore; this order is defined by the backend. */
+  /**
+   * The order of types in Firestore. This order is based on the backend's ordering,
+   * but modified to support server timestamps.
+   */
   public static final int TYPE_ORDER_NULL = 0;
-
   public static final int TYPE_ORDER_BOOLEAN = 1;
   public static final int TYPE_ORDER_NUMBER = 2;
   public static final int TYPE_ORDER_TIMESTAMP = 3;
-  public static final int TYPE_ORDER_STRING = 4;
-  public static final int TYPE_ORDER_BLOB = 5;
-  public static final int TYPE_ORDER_REFERENCE = 6;
-  public static final int TYPE_ORDER_GEOPOINT = 7;
-  public static final int TYPE_ORDER_ARRAY = 8;
-  public static final int TYPE_ORDER_MAP = 9;
+  public static final int TYPE_ORDER_SERVER_TIMESTAMP = 4;
+  public static final int TYPE_ORDER_STRING = 5;
+  public static final int TYPE_ORDER_BLOB = 6;
+  public static final int TYPE_ORDER_REFERENCE = 7;
+  public static final int TYPE_ORDER_GEOPOINT = 8;
+  public static final int TYPE_ORDER_ARRAY = 9;
+  public static final int TYPE_ORDER_MAP = 10;
 
   /** Returns the backend's type order of the given Value type. */
   public static int typeOrder(Value value) {
@@ -78,7 +81,7 @@ public class Values {
         return TYPE_ORDER_ARRAY;
       case MAP_VALUE:
         if (isServerTimestamp(value)) {
-          return TYPE_ORDER_TIMESTAMP;
+          return TYPE_ORDER_SERVER_TIMESTAMP;
         }
         return TYPE_ORDER_MAP;
       default:
@@ -106,21 +109,11 @@ public class Values {
         return arrayEquals(left, right);
       case TYPE_ORDER_MAP:
         return objectEquals(left, right);
-      case TYPE_ORDER_TIMESTAMP:
-        return timestampEquals(left, right);
+      case TYPE_ORDER_SERVER_TIMESTAMP:
+        return getLocalWriteTime(left).equals(getLocalWriteTime(right));
       default:
         return left.equals(right);
     }
-  }
-
-  private static boolean timestampEquals(Value left, Value right) {
-    if (isServerTimestamp(left) && isServerTimestamp(right)) {
-      return getLocalWriteTime(left).equals(getLocalWriteTime(right));
-    } else if (isServerTimestamp(left) || isServerTimestamp(right)) {
-      return false;
-    }
-
-    return left.getTimestampValue().equals(right.getTimestampValue());
   }
 
   private static boolean numberEquals(Value left, Value right) {
@@ -197,7 +190,9 @@ public class Values {
       case TYPE_ORDER_NUMBER:
         return compareNumbers(left, right);
       case TYPE_ORDER_TIMESTAMP:
-        return compareTimestamps(left, right);
+        return compareTimestamps(left.getTimestampValue(), right.getTimestampValue());
+      case TYPE_ORDER_SERVER_TIMESTAMP:
+        return compareTimestamps(getLocalWriteTime(left), getLocalWriteTime(right));
       case TYPE_ORDER_STRING:
         return left.getStringValue().compareTo(right.getStringValue());
       case TYPE_ORDER_BLOB:
@@ -235,30 +230,11 @@ public class Values {
     throw fail("Unexpected values: %s vs %s", left, right);
   }
 
-  private static int compareTimestamps(Value left, Value right) {
-    if (isServerTimestamp(left)) {
-      if (isServerTimestamp(right)) {
-        return compareTimestamps(getLocalWriteTime(left), getLocalWriteTime(right));
-      } else {
-        // Server timestamps come after all concrete timestamps.
-        return 1;
-      }
-    } else {
-      if (isServerTimestamp(right)) {
-        // Server timestamps come after all concrete timestamps.
-        return -1;
-      } else {
-        return compareTimestamps(left.getTimestampValue(), right.getTimestampValue());
-      }
-    }
-  }
-
   private static int compareTimestamps(Timestamp left, Timestamp right) {
     int cmp = Util.compareLongs(left.getSeconds(), right.getSeconds());
     if (cmp != 0) {
       return cmp;
     }
-
     return Util.compareIntegers(left.getNanos(), right.getNanos());
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
@@ -41,8 +41,8 @@ public class Values {
       Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
 
   /**
-   * The order of types in Firestore. This order is based on the backend's ordering,
-   * but modified to support server timestamps.
+   * The order of types in Firestore. This order is based on the backend's ordering, but modified to
+   * support server timestamps.
    */
   public static final int TYPE_ORDER_NULL = 0;
   public static final int TYPE_ORDER_BOOLEAN = 1;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Values.java
@@ -45,6 +45,7 @@ public class Values {
    * support server timestamps.
    */
   public static final int TYPE_ORDER_NULL = 0;
+
   public static final int TYPE_ORDER_BOOLEAN = 1;
   public static final int TYPE_ORDER_NUMBER = 2;
   public static final int TYPE_ORDER_TIMESTAMP = 3;


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-js-sdk/pull/2766/commits/985d51491f0b5322f0c1139cb0f5f59d4ad7dc49

This PR has two versions: One without enums, and one with enums. Not sure how strongly we feel about avoiding them.