### PR TITLE
Include branch information in metrics uploading.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/MetricsReportUploader.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/MetricsReportUploader.java
@@ -38,11 +38,10 @@ public class MetricsReportUploader {
     String baseCommit = System.getenv("PULL_BASE_SHA");
     String headCommit = System.getenv("PULL_PULL_SHA");
     String baseRef = System.getenv("PULL_BASE_REF");
-    String pullRef = System.getenv("PULL_REFS");
     String pullRequest = System.getenv("PULL_NUMBER");
 
     String commit = headCommit != null && !headCommit.isEmpty() ? headCommit : baseCommit;
-    String branch = pullRef != null && !pullRef.isEmpty() ? pullRef : baseRef;
+    String branch = pullRequest != null && !pullRequest.isEmpty() ? "" : baseRef;
 
     post(project, report, owner, repo, commit, branch, baseCommit, pullRequest);
   }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/MetricsReportUploader.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/MetricsReportUploader.java
@@ -35,12 +35,14 @@ public class MetricsReportUploader {
 
     String owner = System.getenv("REPO_OWNER");
     String repo = System.getenv("REPO_NAME");
-    String branch = System.getenv("PULL_BASE_REF");
     String baseCommit = System.getenv("PULL_BASE_SHA");
     String headCommit = System.getenv("PULL_PULL_SHA");
+    String baseRef = System.getenv("PULL_BASE_REF");
+    String pullRef = System.getenv("PULL_REFS");
     String pullRequest = System.getenv("PULL_NUMBER");
 
     String commit = headCommit != null && !headCommit.isEmpty() ? headCommit : baseCommit;
+    String branch = pullRef != null && !pullRef.isEmpty() ? pullRef : baseRef;
 
     post(project, report, owner, repo, commit, branch, baseCommit, pullRequest);
   }

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/MetricsReportUploader.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/measurement/MetricsReportUploader.java
@@ -16,6 +16,7 @@ package com.google.firebase.gradle.plugins.measurement;
 
 import org.gradle.api.Project;
 
+// TODO(yifany): Move to fireci and reuse the metrics uploading code there.
 /** A helper class for uploading a metric report to the metrics service. */
 public class MetricsReportUploader {
   private static final String METRICS_SERVICE_URL = System.getenv("METRICS_SERVICE_URL");
@@ -34,13 +35,14 @@ public class MetricsReportUploader {
 
     String owner = System.getenv("REPO_OWNER");
     String repo = System.getenv("REPO_NAME");
+    String branch = System.getenv("PULL_BASE_REF");
     String baseCommit = System.getenv("PULL_BASE_SHA");
     String headCommit = System.getenv("PULL_PULL_SHA");
     String pullRequest = System.getenv("PULL_NUMBER");
 
     String commit = headCommit != null && !headCommit.isEmpty() ? headCommit : baseCommit;
 
-    post(project, report, owner, repo, commit, baseCommit, pullRequest);
+    post(project, report, owner, repo, commit, branch, baseCommit, pullRequest);
   }
 
   private static void post(
@@ -49,6 +51,7 @@ public class MetricsReportUploader {
       String owner,
       String repo,
       String commit,
+      String branch,
       String baseCommit,
       String pullRequest) {
     String post = "-X POST";
@@ -56,10 +59,10 @@ public class MetricsReportUploader {
     String headerContentType = "-H \"Content-Type: application/json\"";
     String body = String.format("-d @%s", report);
 
-    String template = "%s/repos/%s/%s/commits/%s/reports";
-    String endpoint = String.format(template, METRICS_SERVICE_URL, owner, repo, commit);
+    String template = "%s/repos/%s/%s/commits/%s/reports/?branch=%s";
+    String endpoint = String.format(template, METRICS_SERVICE_URL, owner, repo, commit, branch);
     if (pullRequest != null && !pullRequest.isEmpty()) {
-      endpoint += String.format("?base_commit=%s&pull_request=%s", baseCommit, pullRequest);
+      endpoint += String.format("&base_commit=%s&pull_request=%s", baseCommit, pullRequest);
     }
 
     String request =


### PR DESCRIPTION
The branch information is used by the binary size dashboard.

This was written before coverage upload in `fireci` is implemented. I'll move this part of the logic to `fireci` as well when I get a chance. Right now, I want to make the data flow for dashboard work first. 