### PR TITLE
Update spec tests from changes in the firebase-js-sdk respository

### DIFF
--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -992,7 +992,17 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
 
     // Validate that each active limbo doc has an expected active target
     for (Map.Entry<DocumentKey, Integer> limboDoc : actualLimboDocs.entrySet()) {
-      assertTrue("Found limbo doc " + limboDoc.getKey() + ", but its target ID " + limboDoc.getValue() + " was not in the set of expected active target IDs " + expectedActiveTargets.keySet().stream().sorted().map(String::valueOf).collect(Collectors.joining(", ")), expectedActiveTargets.containsKey(limboDoc.getValue()));
+      assertTrue(
+          "Found limbo doc "
+              + limboDoc.getKey()
+              + ", but its target ID "
+              + limboDoc.getValue()
+              + " was not in the set of expected active target IDs "
+              + expectedActiveTargets.keySet().stream()
+                  .sorted()
+                  .map(String::valueOf)
+                  .collect(Collectors.joining(", ")),
+          expectedActiveTargets.containsKey(limboDoc.getValue()));
     }
 
     for (DocumentKey expectedLimboDoc : expectedActiveLimboDocs) {

--- a/firebase-firestore/src/test/resources/json/collection_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/collection_spec_test.json
@@ -2,19 +2,22 @@
   "Events are raised after watch ack": {
     "describeName": "Collections:",
     "itName": "Events are raised after watch ack",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -22,9 +25,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -42,14 +47,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "foo": "bar"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -67,32 +72,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
@@ -101,19 +109,22 @@
   "Events are raised for local sets before watch ack": {
     "describeName": "Collections:",
     "itName": "Events are raised for local sets before watch ack",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -121,9 +132,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -140,27 +153,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }

--- a/firebase-firestore/src/test/resources/json/existence_filter_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/existence_filter_spec_test.json
@@ -740,7 +740,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/2"
           ],
           "activeTargets": {
@@ -786,7 +786,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -1061,7 +1061,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/2"
           ],
           "activeTargets": {
@@ -1107,7 +1107,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -1757,7 +1757,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/2"
           ],
           "activeTargets": {
@@ -1806,7 +1806,7 @@
               "resumeToken": ""
             }
           },
-          "limboDocs": []
+          "activeLimboDocs": []
         },
         "expectedSnapshotEvents": [
           {

--- a/firebase-firestore/src/test/resources/json/existence_filter_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/existence_filter_spec_test.json
@@ -1,20 +1,23 @@
 {
-  "Existence filter match": {
+  "Existence filter handled at global snapshot": {
     "describeName": "Existence Filters:",
-    "itName": "Existence filter match",
-    "tags": [],
+    "itName": "Existence filter handled at global snapshot",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -22,9 +25,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -42,14 +47,14 @@
           "docs": [
             {
               "key": "collection/1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -67,32 +72,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/1",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -101,33 +109,61 @@
           [
             2
           ],
-          "collection/1"
+          "collection/1",
+          "collection/2"
         ]
       },
       {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/3",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 3
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            2
+          ]
         }
-      }
-    ]
-  },
-  "Existence filter match after pending update": {
-    "describeName": "Existence Filters:",
-    "itName": "Existence filter match after pending update",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
+      },
       {
-        "userListen": [
-          2,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "added": [
+              {
+                "key": "collection/3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 3
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -135,9 +171,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -146,34 +184,15 @@
         }
       },
       {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
         "watchAck": [
           2
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
         ]
       },
       {
@@ -181,14 +200,36 @@
           "docs": [
             {
               "key": "collection/1",
-              "version": 2000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/2",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 2
               },
+              "version": 2000
+            },
+            {
+              "key": "collection/3",
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 3
+              },
+              "version": 3000
             }
           ],
           "targets": [
@@ -197,133 +238,44 @@
         }
       },
       {
-        "watchFilter": [
-          [
-            2
-          ],
-          "collection/1"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/1",
-                "version": 2000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Existence filter with empty target": {
-    "describeName": "Existence Filters:",
-    "itName": "Existence filter with empty target",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
         "watchCurrent": [
           [
             2
           ],
-          "resume-token-1000"
+          "resume-token-3000"
         ]
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 3000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "added": [
+              {
+                "key": "collection/2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchFilter": [
-          [
-            2
-          ],
-          "collection/1"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
@@ -332,19 +284,22 @@
   "Existence filter ignored with pending target": {
     "describeName": "Existence Filters:",
     "itName": "Existence filter ignored with pending target",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -352,9 +307,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -372,14 +329,14 @@
           "docs": [
             {
               "key": "collection/1",
-              "version": 2000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 2000
             }
           ],
           "targets": [
@@ -397,32 +354,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/1",
-                "version": 2000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 2000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -430,22 +390,54 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -453,40 +445,17 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "resume-token-1000"
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/1",
-                "version": 2000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchFilter": [
@@ -517,40 +486,46 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
     ]
   },
-  "Existence filter mismatch triggers re-run of query": {
+  "Existence filter limbo resolution is denied": {
     "describeName": "Existence Filters:",
-    "itName": "Existence filter mismatch triggers re-run of query",
-    "tags": [],
+    "itName": "Existence filter limbo resolution is denied",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -558,9 +533,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -578,25 +555,25 @@
           "docs": [
             {
               "key": "collection/1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/2",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -614,43 +591,46 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/1",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/2",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -664,19 +644,22 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -684,9 +667,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -711,14 +696,14 @@
           "docs": [
             {
               "key": "collection/1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -736,8 +721,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedState": {
           "activeLimboDocs": [
@@ -747,9 +733,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/2"
                 }
               ],
               "resumeToken": ""
@@ -757,9 +745,576 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "cause": {
+            "code": 7
+          },
+          "targetIds": [
+            1
+          ]
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Existence filter match": {
+    "describeName": "Existence Filters:",
+    "itName": "Existence filter match",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/1",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": [
+          [
+            2
+          ],
+          "collection/1"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      }
+    ]
+  },
+  "Existence filter match after pending update": {
+    "describeName": "Existence Filters:",
+    "itName": "Existence filter match after pending update",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/1",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchFilter": [
+          [
+            2
+          ],
+          "collection/1"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Existence filter mismatch triggers re-run of query": {
+    "describeName": "Existence Filters:",
+    "itName": "Existence filter mismatch triggers re-run of query",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/1",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/2",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchFilter": [
+          [
+            2
+          ],
+          "collection/1"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/1",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/2"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/2"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -782,68 +1337,77 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
         "expectedState": {
-          "activeLimboDocs": [],
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/2",
-                "version": 1000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
   "Existence filter mismatch will drop resume token": {
     "describeName": "Existence Filters:",
     "itName": "Existence filter mismatch will drop resume token",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -851,9 +1415,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -871,25 +1437,25 @@
           "docs": [
             {
               "key": "collection/1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/2",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -907,43 +1473,46 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/1",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/2",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -960,9 +1529,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "existence-filter-resume-token"
@@ -985,19 +1556,22 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -1005,9 +1579,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1032,14 +1608,14 @@
           "docs": [
             {
               "key": "collection/1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -1057,8 +1633,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedState": {
           "activeLimboDocs": [
@@ -1068,9 +1645,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/2"
                 }
               ],
               "resumeToken": ""
@@ -1078,9 +1657,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1103,334 +1684,77 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
             },
             "removed": [
               {
                 "key": "collection/2",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Existence filter handled at global snapshot": {
-    "describeName": "Existence Filters:",
-    "itName": "Existence filter handled at global snapshot",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            ]
           }
         ],
         "expectedState": {
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
         }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/1",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/1",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchFilter": [
-          [
-            2
-          ],
-          "collection/1",
-          "collection/2"
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/3",
-              "version": 3000,
-              "value": {
-                "v": 3
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/3",
-                "version": 3000,
-                "value": {
-                  "v": 3
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/1",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/2",
-              "version": 2000,
-              "value": {
-                "v": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/3",
-              "version": 3000,
-              "value": {
-                "v": 3
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-3000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/2",
-                "version": 2000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
       }
     ]
   },
   "Existence filter synthesizes deletes": {
     "describeName": "Existence Filters:",
     "itName": "Existence filter synthesizes deletes",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/a",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/a"
           }
         ],
         "expectedState": {
@@ -1438,9 +1762,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
                 }
               ],
               "resumeToken": ""
@@ -1458,14 +1784,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -1483,32 +1809,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
           }
         ]
       },
@@ -1521,53 +1850,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
             },
             "removed": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            ]
           }
         ]
       }
     ]
   },
-  "Existence filter limbo resolution is denied": {
+  "Existence filter with empty target": {
     "describeName": "Existence Filters:",
-    "itName": "Existence filter limbo resolution is denied",
-    "tags": [],
+    "itName": "Existence filter with empty target",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1575,9 +1910,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1591,37 +1928,6 @@
         ]
       },
       {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/1",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/2",
-              "version": 1000,
-              "value": {
-                "v": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
         "watchCurrent": [
           [
             2
@@ -1631,43 +1937,22 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/1",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/2",
-                "version": 1000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1681,156 +1966,22 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/1",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/2"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/2",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            1
-          ],
-          "cause": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          },
-          "activeLimboDocs": []
-        },
-        "expectedSnapshotEvents": [
-          {
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/2",
-                "version": 1000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }

--- a/firebase-firestore/src/test/resources/json/limbo_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/limbo_spec_test.json
@@ -1,20 +1,23 @@
 {
-  "Limbo documents are deleted without an existence filter": {
+  "Document remove message will cause docs to go in limbo": {
     "describeName": "Limbo Documents:",
-    "itName": "Limbo documents are deleted without an existence filter",
-    "tags": [],
+    "itName": "Document remove message will cause docs to go in limbo",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -22,9 +25,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -42,14 +47,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1001
             }
           ],
           "targets": [
@@ -62,69 +78,95 @@
           [
             2
           ],
-          "resume-token-1000"
+          "resume-token-1002"
         ]
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
-        "watchReset": [
-          2
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
+        "watchEntity": {
+          "key": "collection/b",
+          "removedTargets": [
             2
-          ],
-          "resume-token-1001"
-        ]
+          ]
+        }
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1003
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
-            "collection/a"
+            "collection/b"
           ],
           "activeTargets": {
             "1": {
               "queries": [
                 {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
                 }
               ],
               "resumeToken": ""
@@ -132,27 +174,17 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -164,73 +196,87 @@
           [
             1
           ],
-          "resume-token-2"
+          "resume-token-1004"
         ]
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1004
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ]
+          }
+        ],
         "expectedState": {
-          "activeLimboDocs": [],
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
-  "Limbo documents are deleted with an existence filter": {
+  "Failed limbo resolution removes document from view": {
     "describeName": "Limbo Documents:",
-    "itName": "Limbo documents are deleted with an existence filter",
-    "tags": [],
+    "itName": "Failed limbo resolution removes document from view",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+              [
+                "matches",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -238,9 +284,16 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                    [
+                      "matches",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -258,14 +311,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1000
             }
           ],
           "targets": [
@@ -283,32 +336,751 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "matches",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/a",
+          {
+            "modified": true
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "matches": true,
+                  "modified": true
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+                [
+                  "matches",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+              [
+                "matches",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "matches": true,
+                  "modified": true
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-1001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1001
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a"
+            ]
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "cause": {
+            "code": 7
+          },
+          "targetIds": [
+            1
+          ]
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Limbo docs are resolved by primary client": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo docs are resolved by primary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1001
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1002"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1002
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "key": "collection/b",
+          "removedTargets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1003
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-1004"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1004
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "Limbo documents are deleted with an existence filter": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo documents are deleted with an existence filter",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -327,9 +1099,24 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/a"
@@ -338,9 +1125,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
                 }
               ],
               "resumeToken": ""
@@ -348,27 +1137,17 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -392,74 +1171,77 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1002
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
         "expectedState": {
-          "activeLimboDocs": [],
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
-  "Limbo documents are resolved with updates": {
+  "Limbo documents are deleted without an existence filter": {
     "describeName": "Limbo Documents:",
-    "itName": "Limbo documents are resolved with updates",
-    "tags": [],
+    "itName": "Limbo documents are deleted without an existence filter",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
             "filters": [
-              [
-                "key",
-                "==",
-                "a"
-              ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -467,15 +1249,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
-                    [
-                      "key",
-                      "==",
-                      "a"
-                    ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -493,14 +1271,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -518,38 +1296,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "key",
-                  "==",
-                  "a"
-                ]
-              ],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -568,9 +1343,24 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/a"
@@ -579,9 +1369,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
                 }
               ],
               "resumeToken": ""
@@ -589,7 +1381,521 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-2"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1002
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Limbo documents are resolved after primary tab failover": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo documents are resolved after primary tab failover",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1001
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "key": "collection/b",
+          "removedTargets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000000
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-3000000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000000
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-4000000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 4000000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Limbo documents are resolved with updates": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo documents are resolved with updates",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+              [
+                "key",
+                "==",
+                "a"
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
                   "filters": [
                     [
                       "key",
@@ -597,17 +1903,74 @@
                       "a"
                     ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
               "filters": [
                 [
                   "key",
@@ -615,13 +1978,87 @@
                   "a"
                 ]
               ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
+      },
+      {
+        "watchReset": [
+          2
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1001
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "key",
+                  "==",
+                  "a"
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "key",
+                      "==",
+                      "a"
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       },
       {
         "watchAck": [
@@ -633,14 +2070,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1002,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1002
             }
           ],
           "targets": [
@@ -658,34 +2095,16 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "key",
-                      "==",
-                      "a"
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
               "filters": [
                 [
                   "key",
@@ -693,59 +2112,32 @@
                   "a"
                 ]
               ],
-              "orderBys": []
+              "orderBys": [
+              ],
+              "path": "collection"
             },
             "removed": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Limbo documents are resolved with updates in different snapshot than \"current\"": {
-    "describeName": "Limbo Documents:",
-    "itName": "Limbo documents are resolved with updates in different snapshot than \"current\"",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "key",
-                "==",
-                "a"
-              ]
-            ],
-            "orderBys": []
+            ]
           }
         ],
         "expectedState": {
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
                     [
                       "key",
@@ -753,7 +2145,59 @@
                       "a"
                     ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Limbo documents are resolved with updates in different snapshot than \"current\"": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo documents are resolved with updates in different snapshot than \"current\"",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+              [
+                "key",
+                "==",
+                "a"
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "key",
+                      "==",
+                      "a"
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -771,14 +2215,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -796,13 +2240,29 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
               "filters": [
                 [
                   "key",
@@ -810,24 +2270,10 @@
                   "a"
                 ]
               ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -835,7 +2281,6 @@
         "userListen": [
           4,
           {
-            "path": "collection",
             "filters": [
               [
                 "key",
@@ -843,7 +2288,9 @@
                 "b"
               ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -851,7 +2298,6 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
                     [
                       "key",
@@ -859,7 +2305,9 @@
                       "a"
                     ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -867,7 +2315,6 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
                     [
                       "key",
@@ -875,7 +2322,9 @@
                       "b"
                     ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -898,9 +2347,29 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "key",
+                  "==",
+                  "a"
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/a"
@@ -909,9 +2378,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
                 }
               ],
               "resumeToken": ""
@@ -919,7 +2390,6 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
                     [
                       "key",
@@ -927,7 +2397,9 @@
                       "a"
                     ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -935,7 +2407,6 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
                     [
                       "key",
@@ -943,31 +2414,15 @@
                       "b"
                     ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "key",
-                  "==",
-                  "a"
-                ]
-              ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -984,14 +2439,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1002,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1002
             }
           ],
           "targets": [
@@ -1010,50 +2465,16 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "key",
-                      "==",
-                      "a"
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "key",
-                      "==",
-                      "b"
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
               "filters": [
                 [
                   "key",
@@ -1061,28 +2482,42 @@
                   "a"
                 ]
               ],
-              "orderBys": []
+              "orderBys": [
+              ],
+              "path": "collection"
             },
             "removed": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
+                "version": 1000
+              }
+            ]
+          },
+          {
+            "added": [
+              {
+                "key": "collection/a",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1002
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
               "filters": [
                 [
                   "key",
@@ -1090,26 +2525,52 @@
                   "b"
                 ]
               ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1002,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
-        ]
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "key",
+                      "==",
+                      "a"
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "key",
+                      "==",
+                      "b"
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       },
       {
         "watchCurrent": [
@@ -1121,2843 +2582,21 @@
       },
       {
         "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
-        }
-      }
-    ]
-  },
-  "Document remove message will cause docs to go in limbo": {
-    "describeName": "Limbo Documents:",
-    "itName": "Document remove message will cause docs to go in limbo",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1001,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1002"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "key": "collection/b",
-          "removedTargets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/b"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          1
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-1004"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1004,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Limbo resolution handles snapshot before CURRENT": {
-    "describeName": "Limbo Documents:",
-    "itName": "Limbo resolution handles snapshot before CURRENT",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "key": "b",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "limit": 1,
-            "limitType": "LimitToFirst",
-            "filters": [
-              [
-                "include",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "include",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "include",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "include",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userPatch": [
-          "collection/a",
-          {
-            "include": false
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "include",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/b"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "include",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          1
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "key": "b",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            1
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-3000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "removedTargets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "key": "b",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 4000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "include",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "include",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      }
-    ]
-  },
-  "Limbo resolution handles snapshot before CURRENT [no document update]": {
-    "describeName": "Limbo Documents:",
-    "itName": "Limbo resolution handles snapshot before CURRENT [no document update]",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "key": "b",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "limit": 1,
-            "limitType": "LimitToFirst",
-            "filters": [
-              [
-                "include",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "include",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "include",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "include",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userPatch": [
-          "collection/a",
-          {
-            "include": false
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "include",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/b"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "include",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          1
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-3000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "include",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "include",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b",
-                  "include": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a",
-                "include": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "removedTargets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 4000,
-          "targetIds": []
-        }
-      }
-    ]
-  },
-  "Failed limbo resolution removes document from view": {
-    "describeName": "Limbo Documents:",
-    "itName": "Failed limbo resolution removes document from view",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "matches",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "matches": true
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userPatch": [
-          "collection/a",
-          {
-            "modified": true
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "matches": true,
-                  "modified": true
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "matches": true,
-                  "modified": true
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-1001"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a"
-            ]
-          },
-          "activeLimboDocs": [
-            "collection/a"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchRemove": {
           "targetIds": [
-            1
           ],
-          "cause": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          },
-          "activeLimboDocs": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Limbo docs are resolved by primary client": {
-    "describeName": "Limbo Documents:",
-    "itName": "Limbo docs are resolved by primary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1001,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1002"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "key": "collection/b",
-          "removedTargets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/b"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          1
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-1004"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1004,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Limbo documents are resolved after primary tab failover": {
-    "describeName": "Limbo Documents:",
-    "itName": "Limbo documents are resolved after primary tab failover",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1001,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "key": "collection/b",
-          "removedTargets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/b"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-3000000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/b"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          1
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-4000000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 4000000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Limbo documents survive primary state transitions": {
-    "describeName": "Limbo Documents:",
-    "itName": "Limbo documents survive primary state transitions",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1001,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1002,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1002,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "key": "collection/b",
-          "removedTargets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "key": "collection/c",
-          "removedTargets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/b",
-            "collection/c"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "3": {
-              "queries": [
-                {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": false,
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-3000000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/b",
-            "collection/c"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            },
-            "3": {
-              "queries": [
-                {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          1
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-3000000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/c"
-          ],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            },
-            "3": {
-              "queries": [
-                {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-5000000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 5000000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/c"
-          ],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            },
-            "5": {
-              "queries": [
-                {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          5
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            5
-          ],
-          "resume-token-6000000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 6000000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1002,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
+          "version": 1003
+        }
       }
     ]
   },
   "Limbo documents stay consistent between views": {
     "describeName": "Limbo Documents:",
     "itName": "Limbo documents stay consistent between views",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
@@ -3985,7 +2624,8 @@
             "acknowledgedDocs": [
               "collection/a"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -3998,7 +2638,8 @@
             "acknowledgedDocs": [
               "collection/b"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -4006,9 +2647,49 @@
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -4016,51 +2697,17 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -4072,14 +2719,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "matches": true
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -4097,8 +2744,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedState": {
           "activeLimboDocs": [
@@ -4108,9 +2756,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
                 }
               ],
               "resumeToken": ""
@@ -4118,9 +2768,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4132,7 +2784,6 @@
         "userListen": [
           4,
           {
-            "path": "collection",
             "filters": [
               [
                 "matches",
@@ -4140,53 +2791,41 @@
                 true
               ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
-        "expectedState": {
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "matches",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
               "filters": [
                 [
                   "matches",
@@ -4194,53 +2833,41 @@
                   true
                 ]
               ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
           "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
             "4": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
                     [
                       "matches",
@@ -4248,22 +2875,98 @@
                       true
                     ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
-          },
-          "activeLimboDocs": []
+          }
+        }
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "matches",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
         }
       },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -4271,9 +2974,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "resume-token-2000"
@@ -4281,7 +2986,6 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
                     [
                       "matches",
@@ -4289,800 +2993,58 @@
                       true
                     ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
-  "LimitToLast query from secondary results in no expected limbo doc": {
+  "Limbo documents survive primary state transitions": {
     "describeName": "Limbo Documents:",
-    "itName": "LimitToLast query from secondary results in no expected limbo doc",
+    "itName": "Limbo documents survive primary state transitions",
     "tags": [
       "multi-client"
     ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
+      "numClients": 2,
+      "useGarbageCollection": false
     },
     "steps": [
       {
+        "clientIndex": 0,
         "drainQueue": true,
-        "clientIndex": 0
+        "expectedState": {
+          "isPrimary": true
+        }
       },
       {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
+        "clientIndex": 0,
         "userListen": [
           2,
           {
-            "path": "collection",
-            "limit": 3,
-            "limitType": "LimitToLast",
-            "filters": [],
+            "filters": [
+            ],
             "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 3,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 3,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "val": 11
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "val": 12
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1000,
-              "value": {
-                "val": 13
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 3,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "val": 13
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 12
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 11
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "path": "collection"
           }
         ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchReset": [],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "val": 5
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "val": 6
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/d",
-              "version": 2000,
-              "value": {
-                "val": 7
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 3,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/d",
-                "version": 2000,
-                "value": {
-                  "val": 7
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "modified": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "val": 6
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "val": 5
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "val": 13
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
         "expectedState": {
-          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "limit": 3,
-                  "limitType": "LimitToLast",
-                  "filters": [],
+                  "filters": [
+                  ],
                   "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      }
-    ]
-  },
-  "LimitToLast query from secondary results in expected limbo doc": {
-    "describeName": "Limbo Documents:",
-    "itName": "LimitToLast query from secondary results in expected limbo doc",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 3,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 3,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 3,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "val": 11
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "val": 12
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1000,
-              "value": {
-                "val": 13
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 3,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "val": 13
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 12
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 11
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchReset": [],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "val": 11
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "val": 12
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/d",
-              "version": 2000,
-              "value": {
-                "val": 100
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/c"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 3,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 3,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Limbo resolution throttling with all results at once from watch": {
-    "describeName": "Limbo Documents:",
-    "itName": "Limbo resolution throttling with all results at once from watch",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1,
-      "maxConcurrentLimboResolutions": 2
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -5091,67 +3053,47 @@
         }
       },
       {
+        "clientIndex": 0,
         "watchAck": [
           2
         ]
       },
       {
+        "clientIndex": 0,
         "watchEntity": {
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             },
             {
               "key": "collection/c",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "c"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/d",
-              "version": 1000,
-              "value": {
-                "key": "d"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/e",
-              "version": 1000,
-              "value": {
-                "key": "e"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1002
             }
           ],
           "targets": [
@@ -5160,754 +3102,108 @@
         }
       },
       {
+        "clientIndex": 0,
         "watchCurrent": [
           [
             2
           ],
-          "resume-token-1000"
+          "resume-token-1000000"
         ]
       },
       {
+        "clientIndex": 0,
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/b",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1001
               },
               {
                 "key": "collection/c",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "c"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/d",
-                "version": 1000,
-                "value": {
-                  "key": "d"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/e",
-                "version": 1000,
-                "value": {
-                  "key": "e"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1002
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
-        "watchReset": [
-          2
-        ]
-      },
-      {
+        "clientIndex": 0,
         "watchEntity": {
-          "docs": [],
-          "targets": [
+          "key": "collection/b",
+          "removedTargets": [
             2
           ]
         }
       },
       {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/a",
-            "collection/b"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "3": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          },
-          "enqueuedLimboDocs": [
-            "collection/c",
-            "collection/d",
-            "collection/e"
-          ]
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          1
-        ]
-      },
-      {
-        "watchAck": [
-          3
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-2001"
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            3
-          ],
-          "resume-token-2001"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2001,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/c",
-            "collection/d"
-          ],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "5": {
-              "queries": [
-                {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "7": {
-              "queries": [
-                {
-                  "path": "collection/d",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          },
-          "enqueuedLimboDocs": [
-            "collection/e"
-          ]
-        }
-      },
-      {
-        "watchAck": [
-          5
-        ]
-      },
-      {
-        "watchAck": [
-          7
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            5
-          ],
-          "resume-token-2002"
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            7
-          ],
-          "resume-token-2002"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2002,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/d",
-                "version": 1000,
-                "value": {
-                  "key": "d"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/e"
-          ],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "9": {
-              "queries": [
-                {
-                  "path": "collection/e",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          },
-          "enqueuedLimboDocs": []
-        }
-      },
-      {
-        "watchAck": [
-          9
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            9
-          ],
-          "resume-token-2003"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2003,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/e",
-                "version": 1000,
-                "value": {
-                  "key": "e"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          },
-          "enqueuedLimboDocs": []
-        }
-      }
-    ]
-  },
-  "Limbo resolution throttling with results one at a time from watch": {
-    "describeName": "Limbo Documents:",
-    "itName": "Limbo resolution throttling with results one at a time from watch",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1,
-      "maxConcurrentLimboResolutions": 2
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
+        "clientIndex": 0,
         "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1000,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/d",
-              "version": 1000,
-              "value": {
-                "key": "d"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/e",
-              "version": 1000,
-              "value": {
-                "key": "e"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
+          "key": "collection/c",
+          "removedTargets": [
             2
           ]
         }
       },
       {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
+        "clientIndex": 0,
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/d",
-                "version": 1000,
-                "value": {
-                  "key": "d"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/e",
-                "version": 1000,
-                "value": {
-                  "key": "e"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
             "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchReset": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/a",
-            "collection/b"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
               ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
+              "orderBys": [
               ],
-              "resumeToken": ""
-            },
-            "3": {
-              "queries": [
-                {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
+              "path": "collection"
             }
-          },
-          "enqueuedLimboDocs": [
-            "collection/c",
-            "collection/d",
-            "collection/e"
-          ]
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          1
-        ]
-      },
-      {
-        "watchAck": [
-          3
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-2001"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2001,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
           }
         ],
         "expectedState": {
@@ -5916,12 +3212,26 @@
             "collection/c"
           ],
           "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -5929,323 +3239,1415 @@
             "3": {
               "queries": [
                 {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
                 }
               ],
               "resumeToken": ""
-            },
-            "5": {
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
               "queries": [
                 {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           },
-          "enqueuedLimboDocs": [
-            "collection/d",
-            "collection/e"
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
           ]
         }
       },
       {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-3000000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000000
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b",
+            "collection/c"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            },
+            "3": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-3000000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000000
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/c"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            },
+            "3": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 0,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-5000000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 5000000
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/c"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            },
+            "5": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
         "watchAck": [
           5
         ]
       },
       {
-        "watchCurrent": [
-          [
-            3
-          ],
-          "resume-token-2002"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2002,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/c",
-            "collection/d"
-          ],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "5": {
-              "queries": [
-                {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "7": {
-              "queries": [
-                {
-                  "path": "collection/d",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          },
-          "enqueuedLimboDocs": [
-            "collection/e"
-          ]
-        }
-      },
-      {
-        "watchAck": [
-          7
-        ]
-      },
-      {
+        "clientIndex": 0,
         "watchCurrent": [
           [
             5
           ],
-          "resume-token-2003"
+          "resume-token-6000000"
         ]
       },
       {
+        "clientIndex": 0,
         "watchSnapshot": {
-          "version": 2003,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 6000000
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
             },
             "removed": [
               {
                 "key": "collection/c",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "c"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1002
               }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+            ]
           }
         ],
         "expectedState": {
           "activeLimboDocs": [
-            "collection/d",
-            "collection/e"
           ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
-              "resumeToken": ""
-            },
-            "7": {
+              "resumeToken": "resume-token-1000000"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Limbo resolution handles snapshot before CURRENT": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution handles snapshot before CURRENT",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
               "queries": [
                 {
-                  "path": "collection/d",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "9": {
-              "queries": [
-                {
-                  "path": "collection/e",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
-          },
-          "enqueuedLimboDocs": []
+          }
         }
       },
       {
         "watchAck": [
-          9
+          2
         ]
       },
       {
-        "watchCurrent": [
-          [
-            7
-          ],
-          "resume-token-2004"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2004,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "a"
+              },
+              "version": 1000
             },
-            "removed": [
-              {
-                "key": "collection/d",
-                "version": 1000,
-                "value": {
-                  "key": "d"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/e"
-          ],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "9": {
-              "queries": [
-                {
-                  "path": "collection/e",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "b"
+              },
+              "version": 1000
             }
-          },
-          "enqueuedLimboDocs": []
+          ],
+          "targets": [
+            2
+          ]
         }
       },
       {
         "watchCurrent": [
           [
-            9
+            2
           ],
-          "resume-token-2005"
+          "resume-token-1000"
         ]
       },
       {
         "watchSnapshot": {
-          "version": 2005,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
+            "added": [
               {
-                "key": "collection/e",
-                "version": 1000,
-                "value": {
-                  "key": "e"
-                },
+                "key": "collection/a",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "b"
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeLimboDocs": [],
           "activeTargets": {
-            "2": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+              [
+                "include",
+                "==",
+                true
+              ]
+            ],
+            "limit": 1,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "include",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                    [
+                      "include",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
-          },
-          "enqueuedLimboDocs": []
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "include",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/a",
+          {
+            "include": false
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "include",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "include",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "b"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            1
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-3000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "removedTargets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "b"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 4000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "include",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "include",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Limbo resolution handles snapshot before CURRENT [no document update]": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution handles snapshot before CURRENT [no document update]",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "a"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "b"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+              [
+                "include",
+                "==",
+                true
+              ]
+            ],
+            "limit": 1,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "include",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "include",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "include",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/a",
+          {
+            "include": false
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "include",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "include",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-3000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "include",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "include": true,
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "include",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "include": true,
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "removedTargets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 4000
         }
       }
     ]
@@ -6258,18 +4660,20 @@
       "no-ios"
     ],
     "config": {
-      "useGarbageCollection": true,
+      "maxConcurrentLimboResolutions": 1,
       "numClients": 1,
-      "maxConcurrentLimboResolutions": 1
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -6277,9 +4681,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -6297,25 +4703,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -6333,43 +4739,46 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/b",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -6380,7 +4789,8 @@
       },
       {
         "watchEntity": {
-          "docs": [],
+          "docs": [
+          ],
           "targets": [
             2
           ]
@@ -6396,9 +4806,24 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/a"
@@ -6407,9 +4832,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
                 }
               ],
               "resumeToken": ""
@@ -6417,9 +4844,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -6428,37 +4857,57 @@
           "enqueuedLimboDocs": [
             "collection/b"
           ]
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchRemove": {
-          "targetIds": [
-            1
-          ],
           "cause": {
             "code": 8
-          }
+          },
+          "targetIds": [
+            1
+          ]
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
         "expectedState": {
+          "activeLimboDocs": [
+            "collection/b"
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -6466,95 +4915,655 @@
             "3": {
               "queries": [
                 {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
                 }
               ],
               "resumeToken": ""
             }
           },
-          "activeLimboDocs": [
-            "collection/b"
-          ],
-          "enqueuedLimboDocs": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+          "enqueuedLimboDocs": [
+          ]
+        }
       },
       {
         "watchRemove": {
-          "targetIds": [
-            3
-          ],
           "cause": {
             "code": 8
-          }
+          },
+          "targetIds": [
+            3
+          ]
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      }
+    ]
+  },
+  "Limbo resolution throttling with all results at once from watch": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution throttling with all results at once from watch",
+    "tags": [
+      "no-android",
+      "no-ios"
+    ],
+    "config": {
+      "maxConcurrentLimboResolutions": 2,
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
         "expectedState": {
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/d",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "d"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/e",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "e"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "d"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/e",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "e"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchReset": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a",
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
                 }
               ],
               "resumeToken": ""
             }
           },
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
+          "enqueuedLimboDocs": [
+            "collection/c",
+            "collection/d",
+            "collection/e"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchAck": [
+          3
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-2001"
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            3
+          ],
+          "resume-token-2001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2001
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
             },
             "removed": [
               {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
                 "key": "collection/b",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
-            ],
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/c",
+            "collection/d"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "5": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "7": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/d"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/e"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          5
+        ]
+      },
+      {
+        "watchAck": [
+          7
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            5
+          ],
+          "resume-token-2002"
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            7
+          ],
+          "resume-token-2002"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2002
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "d"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/e"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "9": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/e"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          9
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            9
+          ],
+          "resume-token-2003"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2003
+        },
+        "expectedSnapshotEvents": [
+          {
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/e",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "e"
+                },
+                "version": 1000
+              }
+            ]
           }
-        ]
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
       }
     ]
   },
@@ -6566,18 +5575,20 @@
       "no-ios"
     ],
     "config": {
-      "useGarbageCollection": true,
+      "maxConcurrentLimboResolutions": 2,
       "numClients": 1,
-      "maxConcurrentLimboResolutions": 2
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -6585,9 +5596,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -6605,36 +5618,36 @@
           "docs": [
             {
               "key": "collection/a1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a1"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/a2",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a2"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/a3",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a3"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -6652,76 +5665,84 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a1",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a1"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/a2",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a2"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/a3",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a3"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
         "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
-        ]
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
       },
       {
         "enableNetwork": true,
@@ -6730,9 +5751,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "resume-token-1000"
@@ -6750,36 +5773,36 @@
           "docs": [
             {
               "key": "collection/b1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b1"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b2",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b2"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b3",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b3"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -6799,54 +5822,57 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/b1",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b1"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/b2",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b2"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/b3",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b3"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -6854,9 +5880,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -6881,36 +5909,36 @@
           "docs": [
             {
               "key": "collection/b1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b1"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b2",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b2"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b3",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b3"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -6928,8 +5956,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedState": {
           "activeLimboDocs": [
@@ -6940,9 +5969,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/a1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a1"
                 }
               ],
               "resumeToken": ""
@@ -6950,9 +5981,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -6960,9 +5993,11 @@
             "3": {
               "queries": [
                 {
-                  "path": "collection/a2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a2"
                 }
               ],
               "resumeToken": ""
@@ -7001,43 +6036,46 @@
       },
       {
         "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1003
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
             },
             "removed": [
               {
                 "key": "collection/a1",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a1"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/a2",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a2"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+            ]
           }
         ],
         "expectedState": {
@@ -7048,9 +6086,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -7058,15 +6098,18 @@
             "5": {
               "queries": [
                 {
-                  "path": "collection/a3",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a3"
                 }
               ],
               "resumeToken": ""
             }
           },
-          "enqueuedLimboDocs": []
+          "enqueuedLimboDocs": [
+          ]
         }
       },
       {
@@ -7084,49 +6127,1514 @@
       },
       {
         "watchSnapshot": {
-          "version": 1004,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1004
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
             },
             "removed": [
               {
                 "key": "collection/a3",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a3"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            ]
           }
         ],
         "expectedState": {
-          "activeLimboDocs": [],
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           },
-          "enqueuedLimboDocs": []
+          "enqueuedLimboDocs": [
+          ]
+        }
+      }
+    ]
+  },
+  "Limbo resolution throttling with results one at a time from watch": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution throttling with results one at a time from watch",
+    "tags": [
+      "no-android",
+      "no-ios"
+    ],
+    "config": {
+      "maxConcurrentLimboResolutions": 2,
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/d",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "d"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/e",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "e"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "d"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/e",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "e"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchReset": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a",
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/c",
+            "collection/d",
+            "collection/e"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchAck": [
+          3
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-2001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2001
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b",
+            "collection/c"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "5": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/d",
+            "collection/e"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          5
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            3
+          ],
+          "resume-token-2002"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2002
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/c",
+            "collection/d"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "5": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "7": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/d"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/e"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          7
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            5
+          ],
+          "resume-token-2003"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2003
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/d",
+            "collection/e"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "7": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/d"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "9": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/e"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          9
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            7
+          ],
+          "resume-token-2004"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2004
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "d"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/e"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "9": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/e"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            9
+          ],
+          "resume-token-2005"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2005
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/e",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "e"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      }
+    ]
+  },
+  "LimitToLast query from secondary results in expected limbo doc": {
+    "describeName": "Limbo Documents:",
+    "itName": "LimitToLast query from secondary results in expected limbo doc",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 3,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 3,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 3,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 11
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 12
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 13
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 13
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 12
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 11
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 3,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchReset": [
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 11
+              },
+              "version": 2000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 12
+              },
+              "version": 2000
+            },
+            {
+              "key": "collection/d",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 100
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/c"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 3,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 3,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "LimitToLast query from secondary results in no expected limbo doc": {
+    "describeName": "Limbo Documents:",
+    "itName": "LimitToLast query from secondary results in no expected limbo doc",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 3,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 3,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 3,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 11
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 12
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 13
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 13
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 12
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 11
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 3,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchReset": [
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 5
+              },
+              "version": 2000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 6
+              },
+              "version": 2000
+            },
+            {
+              "key": "collection/d",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 7
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 7
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 6
+                },
+                "version": 2000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 5
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "limit": 3,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 13
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 3,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
         }
       }
     ]

--- a/firebase-firestore/src/test/resources/json/limbo_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/limbo_spec_test.json
@@ -115,7 +115,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -173,7 +173,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -331,7 +331,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -396,7 +396,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -572,7 +572,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -662,7 +662,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -902,7 +902,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -1014,7 +1014,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -1260,7 +1260,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b"
           ],
           "activeTargets": {
@@ -1318,7 +1318,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -1405,8 +1405,8 @@
               "key": "collection/a",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "a"
+                "key": "a",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -1417,8 +1417,8 @@
               "key": "collection/b",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "b"
+                "key": "b",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -1456,8 +1456,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "a"
+                  "key": "a",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -1468,8 +1468,8 @@
                 "key": "collection/b",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "b"
+                  "key": "b",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -1555,8 +1555,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "a"
+                  "key": "a",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -1582,8 +1582,8 @@
               "key": "collection/a",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "a"
+                "key": "a",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -1657,8 +1657,8 @@
                 "key": "collection/b",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "b"
+                  "key": "b",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -1671,8 +1671,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "a"
+                  "key": "a",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -1686,7 +1686,7 @@
           }
         ],
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b"
           ],
           "activeTargets": {
@@ -1733,8 +1733,8 @@
               "key": "collection/b",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "b"
+                "key": "b",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -1774,8 +1774,8 @@
               "key": "collection/a",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "a"
+                "key": "a",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -1795,8 +1795,8 @@
               "key": "collection/b",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "b"
+                "key": "b",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -1835,7 +1835,7 @@
           }
         ],
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "4": {
               "queries": [
@@ -1905,8 +1905,8 @@
               "key": "collection/a",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "a"
+                "key": "a",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -1917,8 +1917,8 @@
               "key": "collection/b",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "b"
+                "key": "b",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -1956,8 +1956,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "a"
+                  "key": "a",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -1968,8 +1968,8 @@
                 "key": "collection/b",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "b"
+                  "key": "b",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2055,8 +2055,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "a"
+                  "key": "a",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2082,8 +2082,8 @@
               "key": "collection/a",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "a"
+                "key": "a",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -2157,8 +2157,8 @@
                 "key": "collection/b",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "b"
+                  "key": "b",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2171,8 +2171,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "a"
+                  "key": "a",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2186,7 +2186,7 @@
           }
         ],
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b"
           ],
           "activeTargets": {
@@ -2246,7 +2246,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "4": {
               "queries": [
@@ -2288,8 +2288,8 @@
                 "key": "collection/b",
                 "version": 1000,
                 "value": {
-                  "include": true,
-                  "key": "b"
+                  "key": "b",
+                  "include": true
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2310,8 +2310,8 @@
               "key": "collection/a",
               "version": 1000,
               "value": {
-                "include": true,
-                "key": "a"
+                "key": "a",
+                "include": true
               },
               "options": {
                 "hasLocalMutations": false,
@@ -2608,7 +2608,7 @@
               "collection/a"
             ]
           },
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -2682,7 +2682,7 @@
               "resumeToken": ""
             }
           },
-          "limboDocs": []
+          "activeLimboDocs": []
         },
         "expectedSnapshotEvents": [
           {
@@ -2890,7 +2890,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b"
           ],
           "activeTargets": {
@@ -2959,7 +2959,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -3184,7 +3184,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b"
           ],
           "activeTargets": {
@@ -3216,7 +3216,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -3285,7 +3286,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b"
           ],
           "activeTargets": {
@@ -3334,7 +3335,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -3568,7 +3569,7 @@
           }
         ],
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b",
             "collection/c"
           ],
@@ -3616,7 +3617,19 @@
           "primary": true
         },
         "expectedState": {
-          "isPrimary": true
+          "isPrimary": true,
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": "resume-token-1000000"
+            }
+          }
         },
         "clientIndex": 1
       },
@@ -3628,7 +3641,7 @@
         "runTimer": "client_metadata_refresh",
         "expectedState": {
           "isPrimary": false,
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -3646,20 +3659,6 @@
       },
       {
         "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000000"
-            }
-          }
-        },
         "clientIndex": 1
       },
       {
@@ -3692,7 +3691,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b",
             "collection/c"
           ],
@@ -3752,7 +3751,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/c"
           ],
           "activeTargets": {
@@ -3860,7 +3859,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/c"
           ],
           "activeTargets": {
@@ -3909,7 +3908,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -4102,7 +4101,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b"
           ],
           "activeTargets": {
@@ -4255,7 +4254,7 @@
               "resumeToken": ""
             }
           },
-          "limboDocs": []
+          "activeLimboDocs": []
         }
       },
       {
@@ -4691,7 +4690,7 @@
       {
         "drainQueue": true,
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -4994,7 +4993,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/c"
           ],
           "activeTargets": {
@@ -5051,6 +5050,2084 @@
           }
         ],
         "clientIndex": 1
+      }
+    ]
+  },
+  "Limbo resolution throttling with all results at once from watch": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution throttling with all results at once from watch",
+    "tags": [
+      "no-android",
+      "no-ios"
+    ],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1,
+      "maxConcurrentLimboResolutions": 2
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
+                "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
+                "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/c",
+              "version": 1000,
+              "value": {
+                "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/d",
+              "version": 1000,
+              "value": {
+                "key": "d"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/e",
+              "version": 1000,
+              "value": {
+                "key": "e"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/c",
+                "version": 1000,
+                "value": {
+                  "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/d",
+                "version": 1000,
+                "value": {
+                  "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/e",
+                "version": 1000,
+                "value": {
+                  "key": "e"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchReset": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a",
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "path": "collection/a",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "path": "collection/b",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/c",
+            "collection/d",
+            "collection/e"
+          ]
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchAck": [
+          3
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-2001"
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            3
+          ],
+          "resume-token-2001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2001,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/c",
+            "collection/d"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "5": {
+              "queries": [
+                {
+                  "path": "collection/c",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "7": {
+              "queries": [
+                {
+                  "path": "collection/d",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/e"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          5
+        ]
+      },
+      {
+        "watchAck": [
+          7
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            5
+          ],
+          "resume-token-2002"
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            7
+          ],
+          "resume-token-2002"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2002,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "version": 1000,
+                "value": {
+                  "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/d",
+                "version": 1000,
+                "value": {
+                  "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/e"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "9": {
+              "queries": [
+                {
+                  "path": "collection/e",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": []
+        }
+      },
+      {
+        "watchAck": [
+          9
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            9
+          ],
+          "resume-token-2003"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2003,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/e",
+                "version": 1000,
+                "value": {
+                  "key": "e"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": []
+        }
+      }
+    ]
+  },
+  "Limbo resolution throttling with results one at a time from watch": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution throttling with results one at a time from watch",
+    "tags": [
+      "no-android",
+      "no-ios"
+    ],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1,
+      "maxConcurrentLimboResolutions": 2
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
+                "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
+                "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/c",
+              "version": 1000,
+              "value": {
+                "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/d",
+              "version": 1000,
+              "value": {
+                "key": "d"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/e",
+              "version": 1000,
+              "value": {
+                "key": "e"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/c",
+                "version": 1000,
+                "value": {
+                  "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/d",
+                "version": 1000,
+                "value": {
+                  "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/e",
+                "version": 1000,
+                "value": {
+                  "key": "e"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchReset": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a",
+            "collection/b"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "path": "collection/a",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "path": "collection/b",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/c",
+            "collection/d",
+            "collection/e"
+          ]
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchAck": [
+          3
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-2001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2001,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/b",
+            "collection/c"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "path": "collection/b",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "5": {
+              "queries": [
+                {
+                  "path": "collection/c",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/d",
+            "collection/e"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          5
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            3
+          ],
+          "resume-token-2002"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2002,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/c",
+            "collection/d"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "5": {
+              "queries": [
+                {
+                  "path": "collection/c",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "7": {
+              "queries": [
+                {
+                  "path": "collection/d",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/e"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          7
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            5
+          ],
+          "resume-token-2003"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2003,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "version": 1000,
+                "value": {
+                  "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/d",
+            "collection/e"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "7": {
+              "queries": [
+                {
+                  "path": "collection/d",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "9": {
+              "queries": [
+                {
+                  "path": "collection/e",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": []
+        }
+      },
+      {
+        "watchAck": [
+          9
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            7
+          ],
+          "resume-token-2004"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2004,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/d",
+                "version": 1000,
+                "value": {
+                  "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/e"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "9": {
+              "queries": [
+                {
+                  "path": "collection/e",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": []
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            9
+          ],
+          "resume-token-2005"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2005,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/e",
+                "version": 1000,
+                "value": {
+                  "key": "e"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": []
+        }
+      }
+    ]
+  },
+  "Limbo resolution throttling when a limbo listen is rejected.": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution throttling when a limbo listen is rejected.",
+    "tags": [
+      "no-android",
+      "no-ios"
+    ],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1,
+      "maxConcurrentLimboResolutions": 1
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
+                "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
+                "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchReset": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "path": "collection/a",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/b"
+          ]
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            1
+          ],
+          "cause": {
+            "code": 8
+          }
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "path": "collection/b",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "activeLimboDocs": [
+            "collection/b"
+          ],
+          "enqueuedLimboDocs": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            3
+          ],
+          "cause": {
+            "code": 8
+          }
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      }
+    ]
+  },
+  "Limbo resolution throttling with existence filter mismatch": {
+    "describeName": "Limbo Documents:",
+    "itName": "Limbo resolution throttling with existence filter mismatch",
+    "tags": [
+      "no-android",
+      "no-ios"
+    ],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1,
+      "maxConcurrentLimboResolutions": 2
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a1",
+              "version": 1000,
+              "value": {
+                "key": "a1"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/a2",
+              "version": 1000,
+              "value": {
+                "key": "a2"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/a3",
+              "version": 1000,
+              "value": {
+                "key": "a3"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a1",
+                "version": 1000,
+                "value": {
+                  "key": "a1"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/a2",
+                "version": 1000,
+                "value": {
+                  "key": "a2"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/a3",
+                "version": 1000,
+                "value": {
+                  "key": "a3"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "enableNetwork": false,
+        "expectedState": {
+          "activeTargets": {},
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "enableNetwork": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b1",
+              "version": 1000,
+              "value": {
+                "key": "b1"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/b2",
+              "version": 1000,
+              "value": {
+                "key": "b2"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/b3",
+              "version": 1000,
+              "value": {
+                "key": "b3"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchFilter": [
+          [
+            2
+          ],
+          "collection/b1",
+          "collection/b2",
+          "collection/b3"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/b1",
+                "version": 1000,
+                "value": {
+                  "key": "b1"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b2",
+                "version": 1000,
+                "value": {
+                  "key": "b2"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b3",
+                "version": 1000,
+                "value": {
+                  "key": "b3"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b1",
+              "version": 1000,
+              "value": {
+                "key": "b1"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/b2",
+              "version": 1000,
+              "value": {
+                "key": "b2"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/b3",
+              "version": 1000,
+              "value": {
+                "key": "b3"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1002"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002,
+          "targetIds": []
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a1",
+            "collection/a2"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "path": "collection/a1",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "3": {
+              "queries": [
+                {
+                  "path": "collection/a2",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": [
+            "collection/a3"
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchAck": [
+          3
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-1003"
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            3
+          ],
+          "resume-token-1003"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1003,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/a1",
+                "version": 1000,
+                "value": {
+                  "key": "a1"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/a2",
+                "version": 1000,
+                "value": {
+                  "key": "a2"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a3"
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            },
+            "5": {
+              "queries": [
+                {
+                  "path": "collection/a3",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": []
+        }
+      },
+      {
+        "watchAck": [
+          5
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            5
+          ],
+          "resume-token-1004"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1004,
+          "targetIds": []
+        },
+        "expectedSnapshotEvents": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/a3",
+                "version": 1000,
+                "value": {
+                  "key": "a3"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "path": "collection",
+                  "filters": [],
+                  "orderBys": []
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "enqueuedLimboDocs": []
+        }
       }
     ]
   }

--- a/firebase-firestore/src/test/resources/json/limit_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/limit_spec_test.json
@@ -1,451 +1,25 @@
 {
-  "Documents in limit are replaced by remote event": {
-    "describeName": "Limits:",
-    "itName": "Documents in limit are replaced by remote event",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1001,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1001"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1001,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 1002,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 1001,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "removedTargets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1001,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Documents outside of limit don't raise hasPendingWrites": {
-    "describeName": "Limits:",
-    "itName": "Documents outside of limit don't raise hasPendingWrites",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "userSet": [
-          "collection/c",
-          {
-            "key": "c"
-          }
-        ]
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
   "Deleted Document in limbo in full limit query": {
     "describeName": "Limits:",
     "itName": "Deleted Document in limbo in full limit query",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -453,11 +27,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -475,25 +51,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             }
           ],
           "targets": [
@@ -511,45 +87,48 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/b",
-                "version": 1001,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -563,25 +142,25 @@
           "docs": [
             {
               "key": "collection/b",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             },
             {
               "key": "collection/c",
-              "version": 1002,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "c"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1002
             }
           ],
           "targets": [
@@ -599,9 +178,26 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/a"
@@ -610,9 +206,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
                 }
               ],
               "resumeToken": ""
@@ -620,31 +218,19 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -661,305 +247,96 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/c",
-                "version": 1002,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "c"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1002
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Documents in limit can handle removed messages": {
-    "describeName": "Limits:",
-    "itName": "Documents in limit can handle removed messages",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
           }
         ],
         "expectedState": {
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
         }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1001,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1001"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1001,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 1002,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchEntity": {
-          "key": "collection/c",
-          "removedTargets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1001,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
       }
     ]
   },
   "Documents in limit are can handle removed messages for only one of many query": {
     "describeName": "Limits:",
     "itName": "Documents in limit are can handle removed messages for only one of many query",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -967,11 +344,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -983,11 +362,13 @@
         "userListen": [
           4,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 3,
             "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -995,11 +376,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1007,11 +390,13 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 3,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1034,25 +419,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/c",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "c"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             }
           ],
           "targets": [
@@ -1065,25 +450,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/c",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "c"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             }
           ],
           "targets": [
@@ -1109,81 +494,86 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
+              "filters": [
+              ],
               "limit": 2,
               "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1001,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           },
           {
-            "query": {
-              "path": "collection",
-              "limit": 3,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/c",
-                "version": 1001,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "c"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 3,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1192,14 +582,14 @@
           "docs": [
             {
               "key": "collection/b",
-              "version": 1002,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1002
             }
           ],
           "targets": [
@@ -1218,128 +608,137 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 3,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/b",
-                "version": 1002,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1002
               }
             ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
             "removed": [
               {
                 "key": "collection/c",
-                "version": 1001,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "c"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1001
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            ]
           },
           {
-            "query": {
-              "path": "collection",
-              "limit": 3,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/b",
-                "version": 1002,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1002
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 3,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
-        ]
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 3,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       }
     ]
   },
-  "Limits are re-filled from cache": {
+  "Documents in limit are replaced by remote event": {
     "describeName": "Limits:",
-    "itName": "Limits are re-filled from cache",
-    "tags": [],
+    "itName": "Documents in limit are replaced by remote event",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
             "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
             ],
-            "orderBys": []
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1347,15 +746,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
-                    [
-                      "matches",
-                      "==",
-                      true
-                    ]
                   ],
-                  "orderBys": []
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1373,36 +770,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1001,
-              "value": {
-                "matches": true
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1002,
-              "value": {
-                "matches": true
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
             },
             {
               "key": "collection/c",
-              "version": 1000,
-              "value": {
-                "matches": true
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 1001
             }
           ],
           "targets": [
@@ -1415,249 +801,168 @@
           [
             2
           ],
-          "resume-token-1002"
+          "resume-token-1001"
         ]
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "matches": true
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "matches": true
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
               },
               {
                 "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "matches": true
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1002
+            }
+          ],
+          "targets": [
+            2
+          ]
         }
       },
       {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "matches",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 1001
             }
-          }
+          ],
+          "removedTargets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
             "added": [
               {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
                 "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "matches": true
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1002
               }
             ],
             "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "matches": false
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
+              "filters": [
+              ],
               "limit": 2,
               "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
+              "orderBys": [
               ],
-              "orderBys": []
+              "path": "collection"
             },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
             "removed": [
               {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "matches": true
-                },
+                "key": "collection/c",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1001
               }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+            ]
           }
         ]
       }
     ]
   },
-  "Initial snapshots for limit queries are re-filled from cache (with removal)": {
+  "Documents in limit can handle removed messages": {
     "describeName": "Limits:",
-    "itName": "Initial snapshots for limit queries are re-filled from cache (with removal)",
-    "tags": [],
+    "itName": "Documents in limit can handle removed messages",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
             "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
             ],
-            "orderBys": []
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1665,15 +970,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
-                    [
-                      "matches",
-                      "==",
-                      true
-                    ]
                   ],
-                  "orderBys": []
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1691,36 +994,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1001,
-              "value": {
-                "matches": true
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1002,
-              "value": {
-                "matches": true
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
             },
             {
               "key": "collection/c",
-              "version": 1003,
-              "value": {
-                "matches": true
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 1001
             }
           ],
           "targets": [
@@ -1733,174 +1025,200 @@
           [
             2
           ],
-          "resume-token-1003"
+          "resume-token-1001"
         ]
       },
       {
         "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "matches": true
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "matches": true
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
               },
               {
                 "key": "collection/c",
-                "version": 1003,
-                "value": {
-                  "matches": true
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1002
+            }
+          ],
+          "targets": [
+            2
+          ]
         }
       },
       {
-        "userListen": [
-          4,
+        "watchEntity": {
+          "key": "collection/c",
+          "removedTargets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1002
+        },
+        "expectedSnapshotEvents": [
           {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1002
+              }
             ],
-            "orderBys": []
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1001
+              }
+            ]
           }
         ],
         "expectedState": {
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
-            "4": {
+            "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "matches",
-                      "==",
-                      true
-                    ]
+                  "orderBys": [
                   ],
-                  "orderBys": []
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
+        }
+      }
+    ]
+  },
+  "Documents outside of limit don't raise hasPendingWrites": {
+    "describeName": "Limits:",
+    "itName": "Documents outside of limit don't raise hasPendingWrites",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "matches": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
+            "filters": [
             ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+            ],
+            "path": "collection"
           }
-        ]
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       },
       {
         "watchAck": [
-          4
+          2
         ]
       },
       {
@@ -1908,204 +1226,206 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1001,
-              "value": {
-                "matches": true
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
             },
             {
               "key": "collection/b",
-              "version": 1002,
-              "value": {
-                "matches": true
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1000
             }
           ],
           "targets": [
-            4
+            2
           ]
         }
       },
       {
         "watchCurrent": [
           [
-            4
+            2
           ],
-          "resume-token-1004"
+          "resume-token-1000"
         ]
       },
       {
         "watchSnapshot": {
-          "version": 1004,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1000
+              }
+            ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
         "userUnlisten": [
-          4,
+          2,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
+            "orderBys": [
             ],
-            "orderBys": []
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            4
-          ]
+          "activeTargets": {
+          }
         }
       },
       {
         "userSet": [
-          "collection/a",
+          "collection/c",
           {
-            "matches": false
+            "key": "c"
           }
         ]
       },
       {
         "userListen": [
-          4,
+          2,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [
-              [
-                "matches",
-                "==",
-                true
-              ]
+            "orderBys": [
             ],
-            "orderBys": []
+            "path": "collection"
           }
         ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [
-                    [
-                      "matches",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1004"
-            }
-          }
-        },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [
-                [
-                  "matches",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
             "added": [
               {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "matches": true
-                },
+                "key": "collection/a",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
               },
               {
-                "key": "collection/c",
-                "version": 1003,
-                "value": {
-                  "matches": true
-                },
+                "key": "collection/b",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
-        ]
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
       }
     ]
   },
   "Initial snapshots for limit queries are re-filled from cache (with latency-compensated edit)": {
     "describeName": "Limits:",
     "itName": "Initial snapshots for limit queries are re-filled from cache (with latency-compensated edit)",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -2113,9 +1433,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -2133,36 +1455,36 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "pos": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             },
             {
               "key": "collection/b",
-              "version": 1002,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "pos": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1002
             },
             {
               "key": "collection/c",
-              "version": 1003,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "pos": 3
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1003
             }
           ],
           "targets": [
@@ -2180,54 +1502,57 @@
       },
       {
         "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1003
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1001,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "pos": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1001
               },
               {
                 "key": "collection/b",
-                "version": 1002,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "pos": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1002
               },
               {
                 "key": "collection/c",
-                "version": 1003,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "pos": 3
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1003
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2235,13 +1560,16 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
@@ -2255,16 +1583,61 @@
         "userListen": [
           4,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
             "orderBys": [
               [
                 "pos",
                 "asc"
               ]
-            ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 1
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 2
+                },
+                "version": 1002
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "pos",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -2272,65 +1645,23 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
                   "orderBys": [
                     [
                       "pos",
                       "asc"
                     ]
-                  ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "pos",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "pos": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "pos": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -2342,25 +1673,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "pos": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             },
             {
               "key": "collection/b",
-              "version": 1002,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "pos": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1002
             }
           ],
           "targets": [
@@ -2378,26 +1709,28 @@
       },
       {
         "watchSnapshot": {
-          "version": 1004,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1004
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
+              "filters": [
+              ],
               "limit": 2,
               "limitType": "LimitToFirst",
-              "filters": [],
               "orderBys": [
                 [
                   "pos",
                   "asc"
                 ]
-              ]
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2405,20 +1738,22 @@
         "userUnlisten": [
           4,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
             "orderBys": [
               [
                 "pos",
                 "asc"
               ]
-            ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
@@ -2440,16 +1775,61 @@
         "userListen": [
           4,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
             "orderBys": [
               [
                 "pos",
                 "asc"
               ]
-            ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 2
+                },
+                "version": 1002
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 3
+                },
+                "version": 1003
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "pos",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -2457,84 +1837,50 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
                   "orderBys": [
                     [
                       "pos",
                       "asc"
                     ]
-                  ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "resume-token-1004"
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "pos",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "pos": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1003,
-                "value": {
-                  "pos": 3
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
-  "Initial snapshots for limit queries are re-filled from cache (with update from backend)": {
+  "Initial snapshots for limit queries are re-filled from cache (with removal)": {
     "describeName": "Limits:",
-    "itName": "Initial snapshots for limit queries are re-filled from cache (with update from backend)",
-    "tags": [],
+    "itName": "Initial snapshots for limit queries are re-filled from cache (with removal)",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+              [
+                "matches",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -2542,9 +1888,16 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                    [
+                      "matches",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -2562,36 +1915,36 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1001,
-              "value": {
-                "pos": 1
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1001
             },
             {
               "key": "collection/b",
-              "version": 1002,
-              "value": {
-                "pos": 2
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1002
             },
             {
               "key": "collection/c",
-              "version": 1003,
-              "value": {
-                "pos": 3
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1003
             }
           ],
           "targets": [
@@ -2609,54 +1962,62 @@
       },
       {
         "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1003
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "pos": 1
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1001
               },
               {
                 "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "pos": 2
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1002
               },
               {
                 "key": "collection/c",
-                "version": 1003,
-                "value": {
-                  "pos": 3
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1003
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "matches",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2664,36 +2025,84 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+              [
+                "matches",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           4,
           {
-            "path": "collection",
+            "filters": [
+              [
+                "matches",
+                "==",
+                true
+              ]
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
             "orderBys": [
-              [
-                "pos",
-                "asc"
-              ]
-            ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1002
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "matches",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -2701,65 +2110,24 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                    [
+                      "matches",
+                      "==",
+                      true
+                    ]
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
                   "orderBys": [
-                    [
-                      "pos",
-                      "asc"
-                    ]
-                  ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "pos",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "pos": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "pos": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -2771,25 +2139,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1001,
-              "value": {
-                "pos": 1
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1001
             },
             {
               "key": "collection/b",
-              "version": 1002,
-              "value": {
-                "pos": 2
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1002
             }
           ],
           "targets": [
@@ -2807,26 +2175,29 @@
       },
       {
         "watchSnapshot": {
-          "version": 1004,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1004
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "pos",
-                  "asc"
-                ]
-              ]
-            },
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "matches",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2834,20 +2205,23 @@
         "userUnlisten": [
           4,
           {
-            "path": "collection",
+            "filters": [
+              [
+                "matches",
+                "==",
+                true
+              ]
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
             "orderBys": [
-              [
-                "pos",
-                "asc"
-              ]
-            ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
@@ -2858,137 +2232,10 @@
         }
       },
       {
-        "userListen": [
-          2,
+        "userSet": [
+          "collection/a",
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1003"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "pos": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "pos": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1003,
-                "value": {
-                  "pos": 3
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1005,
-              "value": {
-                "pos": 4
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1005"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1005,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 1005,
-                "value": {
-                  "pos": 4
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "matches": false
           }
         ]
       },
@@ -2996,120 +2243,110 @@
         "userListen": [
           4,
           {
-            "path": "collection",
+            "filters": [
+              [
+                "matches",
+                "==",
+                true
+              ]
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
             "orderBys": [
-              [
-                "pos",
-                "asc"
-              ]
-            ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1002
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1003
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "matches",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
           "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1003"
-            },
             "4": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                    [
+                      "matches",
+                      "==",
+                      true
+                    ]
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
                   "orderBys": [
-                    [
-                      "pos",
-                      "asc"
-                    ]
-                  ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "resume-token-1004"
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "pos",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "pos": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1003,
-                "value": {
-                  "pos": 3
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
-  "Resumed limit queries exclude deleted documents ": {
+  "Initial snapshots for limit queries are re-filled from cache (with update from backend)": {
     "describeName": "Limits:",
-    "itName": "Resumed limit queries exclude deleted documents ",
+    "itName": "Initial snapshots for limit queries are re-filled from cache (with update from backend)",
     "tags": [
-      "durable-persistence"
     ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "limit": 1,
-            "limitType": "LimitToFirst",
-            "filters": [],
+            "filters": [
+            ],
             "orderBys": [
-              [
-                "a",
-                "asc"
-              ]
-            ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -3117,16 +2354,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
+                  "filters": [
+                  ],
                   "orderBys": [
-                    [
-                      "a",
-                      "asc"
-                    ]
-                  ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -3144,14 +2376,36 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1001,
-              "value": {
-                "a": 1
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "pos": 1
+              },
+              "version": 1001
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "pos": 2
+              },
+              "version": 1002
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "pos": 3
+              },
+              "version": 1003
             }
           ],
           "targets": [
@@ -3160,6 +2414,984 @@
         }
       },
       {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1003"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1003
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 1
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 2
+                },
+                "version": 1002
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 3
+                },
+                "version": 1003
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "pos",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 1
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 2
+                },
+                "version": 1002
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "pos",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "pos",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "pos": 1
+              },
+              "version": 1001
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "pos": 2
+              },
+              "version": 1002
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-1004"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1004
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "pos",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          4,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "pos",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            4
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 1
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 2
+                },
+                "version": 1002
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 3
+                },
+                "version": 1003
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1003"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "pos": 4
+              },
+              "version": 1005
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1005"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1005
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 4
+                },
+                "version": 1005
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "pos",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 2
+                },
+                "version": 1002
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "pos": 3
+                },
+                "version": 1003
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "pos",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1003"
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "pos",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1004"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Limit query includes write from secondary client ": {
+    "describeName": "Limits:",
+    "itName": "Limit query includes write from secondary client ",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1001
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 1002
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1002"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1002
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1002
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "userSet": [
+          "collection/a",
+          {
+            "key": "a"
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1002
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 1003
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1003
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 1002
+            }
+          ],
+          "removedTargets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1003
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1003
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Limit query is refilled by primary client": {
+    "describeName": "Limits:",
+    "itName": "Limit query is refilled by primary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 1001
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
         "watchCurrent": [
           [
             2
@@ -3168,632 +3400,183 @@
         ]
       },
       {
+        "clientIndex": 0,
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
-        },
+          "targetIds": [
+          ],
+          "version": 1001
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "a": 1
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 1,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "a",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
+        "clientIndex": 0,
+        "drainQueue": true
       },
       {
-        "watchRemove": {
-          "targetIds": [
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 1002
+            }
+          ],
+          "targets": [
             2
           ]
         }
       },
       {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": [
-              [
-                "a",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "a",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "a": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
+        "clientIndex": 0,
         "watchEntity": {
           "docs": [
             {
-              "key": "collection/a",
-              "version": 1001,
-              "value": {
-                "a": 1
-              },
+              "key": "collection/c",
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "a": 2
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "value": {
+                "key": "c"
+              },
+              "version": 1001
             }
           ],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-1002"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "a": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "key": "collection/a",
           "removedTargets": [
-            4
+            2
           ]
         }
       },
       {
+        "clientIndex": 0,
         "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/a"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "a",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userUnlisten": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": [
-              [
-                "a",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": []
-        }
-      },
-      {
-        "watchRemove": {
           "targetIds": [
-            4
-          ]
+          ],
+          "version": 1002
         }
       },
       {
-        "restart": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 1,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "a",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "a",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": "resume-token-1001"
-            }
-          }
-        },
+        "clientIndex": 1,
+        "drainQueue": true,
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "a": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "a": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchFilter": [
-          [
-            2
-          ],
-          "collection/b"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1004,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "a",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "a": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1005"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1005,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/a"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "a",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          1
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-1006"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1006,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "a",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
-            },
             "added": [
               {
                 "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "a": 2
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1002
               }
             ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
             "removed": [
               {
-                "key": "collection/a",
-                "version": 1001,
-                "value": {
-                  "a": 1
-                },
+                "key": "collection/c",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1001
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            ]
           }
         ]
       }
     ]
   },
-  "Resumed limit queries use updated documents ": {
+  "Limits are re-filled from cache": {
     "describeName": "Limits:",
-    "itName": "Resumed limit queries use updated documents ",
-    "tags": [],
+    "itName": "Limits are re-filled from cache",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "limit": 1,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
+            "filters": [
               [
-                "a",
-                "asc"
+                "matches",
+                "==",
+                true
               ]
-            ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -3801,16 +3584,16 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
+                  "filters": [
                     [
-                      "a",
-                      "asc"
+                      "matches",
+                      "==",
+                      true
                     ]
-                  ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -3828,14 +3611,36 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 2001,
-              "value": {
-                "a": 1
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1001
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1002
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "matches": true
+              },
+              "version": 1000
             }
           ],
           "targets": [
@@ -3848,44 +3653,67 @@
           [
             2
           ],
-          "resume-token-2001"
+          "resume-token-1002"
         ]
       },
       {
         "watchSnapshot": {
-          "version": 2001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 1,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 2001,
-                "value": {
-                  "a": 1
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1002
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "matches",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -3893,41 +3721,84 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "limit": 1,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
+            "filters": [
               [
-                "a",
-                "asc"
+                "matches",
+                "==",
+                true
               ]
-            ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           4,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": [
+            "filters": [
               [
-                "a",
-                "asc"
+                "matches",
+                "==",
+                true
               ]
-            ]
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1002
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "matches",
+                  "==",
+                  true
+                ]
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -3935,236 +3806,77 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": [
+                  "filters": [
                     [
-                      "a",
-                      "asc"
+                      "matches",
+                      "==",
+                      true
                     ]
-                  ]
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
+        }
+      },
+      {
+        "userSet": [
+          "collection/a",
+          {
+            "matches": false
+          }
+        ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
-            },
             "added": [
               {
-                "key": "collection/a",
-                "version": 2001,
-                "value": {
-                  "a": 1
-                },
+                "key": "collection/c",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2003,
-              "value": {
-                "a": 3
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1000,
-              "value": {
-                "a": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-2003"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2003,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": [
+              "filters": [
                 [
-                  "a",
-                  "asc"
+                  "matches",
+                  "==",
+                  true
                 ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "a": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 2003,
-                "value": {
-                  "a": 3
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": [
-              [
-                "a",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            4
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 1,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "a",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 1,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "a",
-                      "asc"
-                    ]
-                  ]
-                }
               ],
-              "resumeToken": "resume-token-2001"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 1,
+              "limit": 2,
               "limitType": "LimitToFirst",
-              "filters": [],
               "orderBys": [
-                [
-                  "a",
-                  "asc"
-                ]
-              ]
+              ],
+              "path": "collection"
             },
-            "added": [
+            "removed": [
               {
-                "key": "collection/c",
-                "version": 1000,
-                "value": {
-                  "a": 2
-                },
+                "key": "collection/a",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "matches": true
+                },
+                "version": 1001
               }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+            ]
           }
         ]
       }
@@ -4173,21 +3885,24 @@
   "Multiple docs in limbo in full limit query": {
     "describeName": "Limits:",
     "itName": "Multiple docs in limbo in full limit query",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 2,
             "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -4195,11 +3910,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4217,25 +3934,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             }
           ],
           "targets": [
@@ -4253,45 +3970,48 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               },
               {
                 "key": "collection/b",
-                "version": 1001,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -4299,9 +4019,49 @@
         "userListen": [
           4,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -4309,11 +4069,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4321,51 +4083,17 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -4377,69 +4105,69 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             },
             {
               "key": "collection/c",
-              "version": 1002,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "c"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1002
             },
             {
               "key": "collection/d",
-              "version": 1003,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "d"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1003
             },
             {
               "key": "collection/e",
-              "version": 1004,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "e"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1004
             },
             {
               "key": "collection/f",
-              "version": 1005,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "f"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1005
             }
           ],
           "targets": [
@@ -4457,65 +4185,68 @@
       },
       {
         "watchSnapshot": {
-          "version": 1005,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1005
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/c",
-                "version": 1002,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "c"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1002
               },
               {
                 "key": "collection/d",
-                "version": 1003,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "d"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1003
               },
               {
                 "key": "collection/e",
-                "version": 1004,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "e"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1004
               },
               {
                 "key": "collection/f",
-                "version": 1005,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "f"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1005
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -4529,25 +4260,25 @@
           "docs": [
             {
               "key": "collection/e",
-              "version": 1004,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "e"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1004
             },
             {
               "key": "collection/f",
-              "version": 1005,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "f"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1005
             }
           ],
           "targets": [
@@ -4565,9 +4296,26 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/a",
@@ -4577,9 +4325,11 @@
             "1": {
               "queries": [
                 {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
                 }
               ],
               "resumeToken": ""
@@ -4587,11 +4337,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4599,9 +4351,11 @@
             "3": {
               "queries": [
                 {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
                 }
               ],
               "resumeToken": ""
@@ -4609,29 +4363,17 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -4648,9 +4390,77 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          },
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1002
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/b",
@@ -4660,11 +4470,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4672,9 +4484,11 @@
             "3": {
               "queries": [
                 {
-                  "path": "collection/b",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/b"
                 }
               ],
               "resumeToken": ""
@@ -4682,9 +4496,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4692,78 +4508,17 @@
             "5": {
               "queries": [
                 {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 1002,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchRemove": {
@@ -4787,9 +4542,77 @@
       },
       {
         "watchSnapshot": {
-          "version": 2001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2001
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ]
+          },
+          {
+            "added": [
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "d"
+                },
+                "version": 1003
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 1001
+              }
+            ]
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/c",
@@ -4799,11 +4622,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4811,9 +4636,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4821,9 +4648,11 @@
             "5": {
               "queries": [
                 {
-                  "path": "collection/c",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/c"
                 }
               ],
               "resumeToken": ""
@@ -4831,78 +4660,17 @@
             "7": {
               "queries": [
                 {
-                  "path": "collection/d",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/d"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/d",
-                "version": 1003,
-                "value": {
-                  "key": "d"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchRemove": {
@@ -4926,9 +4694,77 @@
       },
       {
         "watchSnapshot": {
-          "version": 2002,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2002
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1002
+              }
+            ]
+          },
+          {
+            "added": [
+              {
+                "key": "collection/e",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "e"
+                },
+                "version": 1004
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 1002
+              }
+            ]
+          }
+        ],
         "expectedState": {
           "activeLimboDocs": [
             "collection/d"
@@ -4937,11 +4773,13 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4949,9 +4787,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4959,78 +4799,17 @@
             "7": {
               "queries": [
                 {
-                  "path": "collection/d",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/d"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1002,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/e",
-                "version": 1004,
-                "value": {
-                  "key": "e"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1002,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchRemove": {
@@ -5054,20 +4833,91 @@
       },
       {
         "watchSnapshot": {
-          "version": 2003,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2003
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "d"
+                },
+                "version": 1003
+              }
+            ]
+          },
+          {
+            "added": [
+              {
+                "key": "collection/f",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "f"
+                },
+                "version": 1005
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "d"
+                },
+                "version": 1003
+              }
+            ]
+          }
+        ],
         "expectedState": {
-          "activeLimboDocs": [],
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 2,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -5075,78 +4925,17 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/d",
-                "version": 1003,
-                "value": {
-                  "key": "d"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/f",
-                "version": 1005,
-                "value": {
-                  "key": "f"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/d",
-                "version": 1003,
-                "value": {
-                  "key": "d"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchRemove": {
@@ -5157,40 +4946,32 @@
       }
     ]
   },
-  "Limit query is refilled by primary client": {
+  "Resumed limit queries exclude deleted documents ": {
     "describeName": "Limits:",
-    "itName": "Limit query is refilled by primary client",
+    "itName": "Resumed limit queries exclude deleted documents ",
     "tags": [
-      "multi-client"
+      "durable-persistence"
     ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "limit": 2,
+            "filters": [
+            ],
+            "limit": 1,
             "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -5198,76 +4979,48 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "limit": 2,
+                  "filters": [
+                  ],
+                  "limit": 1,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
+        }
       },
       {
         "watchAck": [
           2
-        ],
-        "clientIndex": 0
+        ]
       },
       {
         "watchEntity": {
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1001,
-              "value": {
-                "key": "c"
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "value": {
+                "a": 1
+              },
+              "version": 1001
             }
           ],
           "targets": [
             2
           ]
-        },
-        "clientIndex": 0
+        }
       },
       {
         "watchCurrent": [
@@ -5275,485 +5028,1058 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "clientIndex": 0
+        ]
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1001,
-                "value": {
-                  "key": "c"
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "value": {
+                  "a": 1
+                },
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 1002,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 1001,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "removedTargets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "limit": 2,
+              "filters": [
+              ],
+              "limit": 1,
               "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1002,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
             ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1001,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
+            "limit": 1,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "path": "collection"
           }
         ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Limit query includes write from secondary client ": {
-    "describeName": "Limits:",
-    "itName": "Limit query includes write from secondary client ",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
       },
       {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "userListen": [
-          2,
+          4,
           {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 1001,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/c",
-              "version": 1002,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1002"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 1002,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
+            "filters": [
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
           }
         ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "key": "a"
-          }
-        ],
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "key": "a"
-                },
                 "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 1002,
-                "value": {
-                  "key": "c"
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "value": {
+                  "a": 1
+                },
+                "version": 1001
               }
             ],
             "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
           }
         ],
-        "clientIndex": 1
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       },
       {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 1003
-        },
-        "clientIndex": 0
+        "watchAck": [
+          4
+        ]
       },
       {
         "watchEntity": {
           "docs": [
             {
               "key": "collection/a",
-              "version": 1003,
-              "value": {
-                "key": "a"
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": 1
+              },
+              "version": 1001
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": 2
+              },
+              "version": 1000
             }
           ],
           "targets": [
-            2
+            4
           ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-1002"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1002
         },
-        "clientIndex": 0
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "key": "collection/a",
+          "removedTargets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1003
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userUnlisten": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            4
+          ]
+        }
+      },
+      {
+        "restart": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 1,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 1
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1001"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
       },
       {
         "watchEntity": {
           "docs": [
             {
-              "key": "collection/c",
-              "version": 1002,
-              "value": {
-                "key": "c"
-              },
+              "key": "collection/b",
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": 2
+              },
+              "version": 1000
             }
           ],
-          "removedTargets": [
+          "targets": [
             2
           ]
-        },
-        "clientIndex": 0
+        }
+      },
+      {
+        "watchFilter": [
+          [
+            2
+          ],
+          "collection/b"
+        ]
       },
       {
         "watchSnapshot": {
-          "version": 1003,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1004
         },
-        "clientIndex": 0
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       },
       {
-        "drainQueue": true,
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": 2
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1005"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1005
+        },
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-1006"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1006
+        },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
+            "added": [
               {
-                "key": "collection/a",
-                "version": 1003,
-                "value": {
-                  "key": "a"
-                },
+                "key": "collection/b",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 2
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 1
+                },
+                "version": 1001
+              }
+            ]
           }
         ],
-        "clientIndex": 1
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Resumed limit queries use updated documents ": {
+    "describeName": "Limits:",
+    "itName": "Resumed limit queries use updated documents ",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 1,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       },
       {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": 1
+              },
+              "version": 2001
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2001
         },
-        "clientIndex": 2
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 1
+                },
+                "version": 2001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 1,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 1
+                },
+                "version": 2001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": 3
+              },
+              "version": 2003
+            },
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": 2
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-2003"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2003
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 3
+                },
+                "version": 2003
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            4
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 1,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "a",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 1,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "a",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 1,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "a",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-2001"
+            }
+          }
+        }
       }
     ]
   }

--- a/firebase-firestore/src/test/resources/json/limit_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/limit_spec_test.json
@@ -603,7 +603,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -665,7 +665,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -883,7 +883,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -1222,7 +1222,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -3407,7 +3407,7 @@
           }
         ],
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -3455,7 +3455,7 @@
         ],
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": []
         }
       },
       {
@@ -3469,7 +3469,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         }
       },
       {
@@ -3648,7 +3649,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -3701,7 +3702,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -4568,7 +4569,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a",
             "collection/b"
           ],
@@ -4651,7 +4652,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/b",
             "collection/c"
           ],
@@ -4790,7 +4791,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/c",
             "collection/d"
           ],
@@ -4929,7 +4930,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/d"
           ],
           "activeTargets": {
@@ -5057,7 +5058,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [

--- a/firebase-firestore/src/test/resources/json/listen_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/listen_spec_test.json
@@ -1,23 +1,28 @@
 {
-  "Contents of query are cleared when listen is removed.": {
+  "Array-contains queries support resuming": {
     "describeName": "Listens:",
-    "itName": "Contents of query are cleared when listen is removed.",
+    "itName": "Array-contains queries support resuming",
     "tags": [
-      "eager-gc"
     ],
-    "comment": "Explicitly tests eager GC behavior",
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+              [
+                "array",
+                "array-contains",
+                42
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -25,9 +30,398 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                    [
+                      "array",
+                      "array-contains",
+                      42
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "array",
+                  "array-contains",
+                  42
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "array": [
+                  1,
+                  42,
+                  3
+                ],
+                "foo": "bar"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "resumeToken": "resume-token-2000",
+          "targetIds": [
+            2
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "array": [
+                    1,
+                    42,
+                    3
+                  ],
+                  "foo": "bar"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "array",
+                  "array-contains",
+                  42
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+              [
+                "array",
+                "array-contains",
+                42
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+              [
+                "array",
+                "array-contains",
+                42
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "array": [
+                    1,
+                    42,
+                    3
+                  ],
+                  "foo": "bar"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "array",
+                  "array-contains",
+                  42
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "array",
+                      "array-contains",
+                      42
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-2000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-3000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "array",
+                  "array-contains",
+                  42
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Can listen/unlisten to mirror queries.": {
+    "describeName": "Listens:",
+    "itName": "Can listen/unlisten to mirror queries.",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "val",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                },
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -45,14 +439,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 0
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 1
+              },
+              "version": 1000
             }
           ],
           "targets": [
@@ -70,32 +475,94 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "val",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          },
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -103,22 +570,406 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 0
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "val",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 2000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                },
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "cause": {
+            "code": 8
+          },
+          "targetIds": [
+            2
+          ]
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 8,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "val",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          },
+          {
+            "errorCode": 8,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      }
+    ]
+  },
+  "Contents of query are cleared when listen is removed.": {
+    "comment": "Explicitly tests eager GC behavior",
+    "describeName": "Listens:",
+    "itName": "Contents of query are cleared when listen is removed.",
+    "tags": [
+      "eager-gc"
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           4,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -126,9 +977,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -141,19 +994,22 @@
   "Contents of query update when new data is received.": {
     "describeName": "Listens:",
     "itName": "Contents of query update when new data is received.",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -161,9 +1017,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -181,14 +1039,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -206,32 +1064,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -240,14 +1101,14 @@
           "docs": [
             {
               "key": "collection/b",
-              "version": 2000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 2000
             }
           ],
           "targets": [
@@ -257,53 +1118,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/b",
-                "version": 2000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "b"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 2000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
     ]
   },
-  "Doesn't raise events for empty target": {
+  "Does not raise event for initial document delete": {
     "describeName": "Listens:",
-    "itName": "Doesn't raise events for empty target",
-    "tags": [],
+    "itName": "Does not raise event for initial document delete",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection1",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -311,87 +1178,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection1",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection2",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection1",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection2",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userListen": [
-          6,
-          {
-            "path": "collection3",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection1",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection2",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "6": {
-              "queries": [
-                {
-                  "path": "collection3",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -405,93 +1196,264 @@
         ]
       },
       {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "value": null,
+              "version": 1000
+            }
+          ],
+          "removedTargets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
         "watchCurrent": [
           [
             2
           ],
-          "resume-token-1000"
+          "resume-token-2000"
         ]
       },
       {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Does not synthesize deletes for previously acked documents": {
+    "describeName": "Listens:",
+    "itName": "Does not synthesize deletes for previously acked documents",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/a"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
         "watchAck": [
-          4
+          2
         ]
       },
       {
         "watchEntity": {
           "docs": [
             {
-              "key": "collection2/a",
-              "version": 1000,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
-            4
+            2
           ]
         }
       },
       {
-        "watchAck": [
-          6
-        ]
-      },
-      {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection1",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection2",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
-                "key": "collection2/a",
-                "version": 1000,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
           }
         ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/a"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/a"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": "resume-token-2000"
+            }
+          }
+        }
       }
     ]
   },
   "Doesn't include unknown documents in cached result": {
     "describeName": "Listens:",
     "itName": "Doesn't include unknown documents in cached result",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
@@ -514,9 +1476,38 @@
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/exists",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -524,59 +1515,39 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/exists",
-                "version": 0,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
+        }
       }
     ]
   },
   "Doesn't raise 'hasPendingWrites' for deletes": {
     "describeName": "Listens:",
     "itName": "Doesn't raise 'hasPendingWrites' for deletes",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -584,9 +1555,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -604,14 +1577,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -629,32 +1602,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -662,27 +1638,29 @@
         "userDelete": "collection/a",
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
             },
             "removed": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            ]
           }
         ]
       },
@@ -695,7 +1673,8 @@
             "acknowledgedDocs": [
               "collection/a"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -704,8 +1683,8 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 2000,
-              "value": null
+              "value": null,
+              "version": 2000
             }
           ],
           "targets": [
@@ -715,19 +1694,242 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         }
+      }
+    ]
+  },
+  "Doesn't raise events for empty target": {
+    "describeName": "Listens:",
+    "itName": "Doesn't raise events for empty target",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection1"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection1"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection2"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection1"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection2"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userListen": [
+          6,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection3"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection1"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection2"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "6": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection3"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection2/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchAck": [
+          6
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection1"
+            }
+          },
+          {
+            "added": [
+              {
+                "key": "collection2/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection2"
+            }
+          }
+        ]
       }
     ]
   },
   "Ensure correct query results with latency-compensated deletes": {
     "describeName": "Listens:",
     "itName": "Ensure correct query results with latency-compensated deletes",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
@@ -737,9 +1939,11 @@
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -747,9 +1951,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -767,25 +1973,25 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "a": true
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "b": true
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -803,32 +2009,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "a": true
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -836,11 +2045,42 @@
         "userListen": [
           4,
           {
-            "path": "collection",
+            "filters": [
+            ],
             "limit": 10,
             "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": true
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 10,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -848,9 +2088,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -858,63 +2100,41 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
+                  "filters": [
+                  ],
                   "limit": 10,
                   "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 10,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "a": true
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
-  "Does not raise event for initial document delete": {
+  "Ignores update from inactive target": {
     "describeName": "Listens:",
-    "itName": "Does not raise event for initial document delete",
-    "tags": [],
+    "itName": "Ignores update from inactive target",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -922,9 +2142,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -942,8 +2164,518 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
-              "value": null
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Individual (deleted) documents cannot revert": {
+    "describeName": "Listens:",
+    "itName": "Individual (deleted) documents cannot revert",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+              [
+                "visible",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "visible",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v1000",
+                "visible": true
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v1000",
+                  "visible": true
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "visible",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+              [
+                "visible",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v1000",
+                  "visible": true
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "value": null,
+              "version": 3000
+            }
+          ],
+          "removedTargets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-4000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 4000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v1000",
+                  "visible": true
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            4
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+              [
+                "visible",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "visible",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v2000",
+                "visible": false
+              },
+              "version": 2000
             }
           ],
           "removedTargets": [
@@ -952,9 +2684,1750 @@
         }
       },
       {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-5000"
+        ]
+      },
+      {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 5000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "visible",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+              [
+                "visible",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-4000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-6000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 6000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Individual documents cannot revert": {
+    "describeName": "Listens:",
+    "itName": "Individual documents cannot revert",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+              [
+                "visible",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "visible",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v1000",
+                "visible": true
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v1000",
+                  "visible": true
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "visible",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+              [
+                "visible",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v1000",
+                  "visible": true
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v3000",
+                "visible": false
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-4000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 4000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v3000",
+                  "visible": false
+                },
+                "version": 3000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            4
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+              [
+                "visible",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "visible",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v2000",
+                "visible": false
+              },
+              "version": 2000
+            }
+          ],
+          "removedTargets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-5000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 5000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "visible",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+              [
+                "visible",
+                "==",
+                true
+              ]
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v3000",
+                  "visible": false
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-4000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-6000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 6000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Listen is established in new primary tab": {
+    "describeName": "Listens:",
+    "itName": "Listen is established in new primary tab",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Listen is established in newly started primary": {
+    "describeName": "Listens:",
+    "itName": "Listen is established in newly started primary",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 2,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 2,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Listen is re-listened to after primary tab failover": {
+    "describeName": "Listens:",
+    "itName": "Listen is re-listened to after primary tab failover",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Listens are reestablished after network disconnect": {
+    "describeName": "Listens:",
+    "itName": "Listens are reestablished after network disconnect",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          },
+          "watchStreamRequestCount": 1
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "enableNetwork": false,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "enableNetwork": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "watchStreamRequestCount": 2
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
         }
       },
       {
@@ -967,40 +4440,81 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
     ]
   },
-  "Will process removals without waiting for a consistent snapshot": {
+  "Mirror queries from different secondary client": {
     "describeName": "Listens:",
-    "itName": "Will process removals without waiting for a consistent snapshot",
-    "tags": [],
+    "itName": "Mirror queries from different secondary client",
+    "tags": [
+      "multi-client"
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 3,
+      "useGarbageCollection": false
     },
     "steps": [
       {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "val",
+                "asc"
+              ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1008,9 +4522,17 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1019,53 +4541,25 @@
         }
       },
       {
-        "watchAck": [
-          2
-        ]
+        "clientIndex": 2,
+        "drainQueue": true
       },
       {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ],
-          "cause": {
-            "code": 8
-          }
-        },
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 8,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Will re-issue listen for errored target": {
-    "describeName": "Listens:",
-    "itName": "Will re-issue listen for errored target",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
+        "clientIndex": 2,
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1073,9 +4567,17 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1084,42 +4586,362 @@
         }
       },
       {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                },
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
         "watchAck": [
           2
         ]
       },
       {
-        "watchRemove": {
-          "targetIds": [
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 0
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
             2
           ],
-          "cause": {
-            "code": 8
-          }
-        },
-        "expectedState": {
-          "activeTargets": {}
-        },
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 8,
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "val",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 0
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "val",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "Mirror queries from primary and secondary client": {
+    "describeName": "Listens:",
+    "itName": "Mirror queries from primary and secondary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 0,
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "val",
+                "asc"
+              ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1127,9 +4949,1842 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                },
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 0
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "val",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 0
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "val",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 2000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                },
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "val",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/d",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": -1
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/d",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": -1
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 2000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      }
+    ]
+  },
+  "Mirror queries from same secondary client": {
+    "describeName": "Listens:",
+    "itName": "Mirror queries from same secondary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "val",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                },
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                },
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToFirst",
+                  "orderBys": [
+                    [
+                      "val",
+                      "asc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 0
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToFirst",
+              "orderBys": [
+                [
+                  "val",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
+          },
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToFirst",
+            "orderBys": [
+              [
+                "val",
+                "asc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "limit": 2,
+                  "limitType": "LimitToLast",
+                  "orderBys": [
+                    [
+                      "val",
+                      "desc"
+                    ]
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "val": 0
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 0
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "limit": 2,
+              "limitType": "LimitToLast",
+              "orderBys": [
+                [
+                  "val",
+                  "desc"
+                ]
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "limit": 2,
+            "limitType": "LimitToLast",
+            "orderBys": [
+              [
+                "val",
+                "desc"
+              ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      }
+    ]
+  },
+  "New client becomes primary if no client has its network enabled": {
+    "describeName": "Listens:",
+    "itName": "New client becomes primary if no client has its network enabled",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "enableNetwork": false,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 2,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 2,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "New client uses existing online state": {
+    "describeName": "Listens:",
+    "itName": "New client uses existing online state",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "enableNetwork": false,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "enableNetwork": false,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 2,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Offline state doesn't persist if primary is shut down": {
+    "describeName": "Listens:",
+    "itName": "Offline state doesn't persist if primary is shut down",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "enableNetwork": false,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Omits global resume tokens for a short while": {
+    "describeName": "Listens:",
+    "itName": "Omits global resume tokens for a short while",
+    "tags": [
+      "durable-persistence"
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1144,7 +6799,19 @@
       },
       {
         "watchEntity": {
-          "docs": [],
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
           "targets": [
             2
           ]
@@ -1160,19 +6827,6314 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "resumeToken": "resume-token-2000",
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "restart": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-3000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Persists global resume tokens if the snapshot is old enough": {
+    "describeName": "Listens:",
+    "itName": "Persists global resume tokens if the snapshot is old enough",
+    "tags": [
+      "durable-persistence"
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "resumeToken": "resume-token-minutes-later",
+          "targetIds": [
+          ],
+          "version": 300001000
+        }
+      },
+      {
+        "restart": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-minutes-later"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-even-later"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 300002000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Persists global resume tokens on unlisten": {
+    "describeName": "Listens:",
+    "itName": "Persists global resume tokens on unlisten",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "resumeToken": "resume-token-2000",
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-2000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-3000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Persists resume token sent with target": {
+    "describeName": "Listens:",
+    "itName": "Persists resume token sent with target",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "resumeToken": "resume-token-2000",
+          "targetIds": [
+            2
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-2000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-3000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Previous primary immediately regains primary lease": {
+    "describeName": "Listens:",
+    "itName": "Previous primary immediately regains primary lease",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "runTimer": "client_metadata_refresh",
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-2000"
+            }
+          },
+          "isPrimary": true
+        }
+      }
+    ]
+  },
+  "Query bounces between primaries": {
+    "describeName": "Listens:",
+    "itName": "Query bounces between primaries",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 2,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 2,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-2000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-3000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query is executed by primary client": {
+    "describeName": "Listens:",
+    "itName": "Query is executed by primary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query is joined by primary client": {
+    "describeName": "Listens:",
+    "itName": "Query is joined by primary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-100"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 100
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          },
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query is rejected and re-listened to": {
+    "describeName": "Listens:",
+    "itName": "Query is rejected and re-listened to",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "cause": {
+            "code": 8
+          },
+          "targetIds": [
+            2
+          ]
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 8,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query is rejected and re-listened to by secondary client": {
+    "describeName": "Listens:",
+    "itName": "Query is rejected and re-listened to by secondary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchRemove": {
+          "cause": {
+            "code": 8
+          },
+          "targetIds": [
+            2
+          ]
+        },
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 8,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query is rejected by primary client": {
+    "describeName": "Listens:",
+    "itName": "Query is rejected by primary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchRemove": {
+          "cause": {
+            "code": 8
+          },
+          "targetIds": [
+            2
+          ]
+        },
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 8,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query is resumed by secondary client": {
+    "describeName": "Listens:",
+    "itName": "Query is resumed by secondary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query is shared between primary and secondary client": {
+    "describeName": "Listens:",
+    "itName": "Query is shared between primary and secondary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query is unlistened to by primary client": {
+    "describeName": "Listens:",
+    "itName": "Query is unlistened to by primary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      }
+    ]
+  },
+  "Query only raises events in participating clients": {
+    "describeName": "Listens:",
+    "itName": "Query only raises events in participating clients",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 4,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 3,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 3,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 3,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Query recovers after primary takeover": {
+    "describeName": "Listens:",
+    "itName": "Query recovers after primary takeover",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "b"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "c"
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "runTimer": "client_metadata_refresh",
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b"
+                },
+                "version": 2000
+              },
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "c"
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "isPrimary": false
+        }
+      }
+    ]
+  },
+  "Re-opens target without existence filter": {
+    "describeName": "Listens:",
+    "itName": "Re-opens target without existence filter",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "value": null,
+              "version": 2000
+            }
+          ],
+          "removedTargets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "Secondary client uses primary client's online state": {
+    "describeName": "Listens:",
+    "itName": "Secondary client uses primary client's online state",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "enableNetwork": false,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "enableNetwork": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Secondary client's online state is ignored": {
+    "describeName": "Listens:",
+    "itName": "Secondary client's online state is ignored",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "enableNetwork": false,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "enableNetwork": false,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ],
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "isPrimary": false
+        }
+      }
+    ]
+  },
+  "Synthesizes deletes for missing document": {
+    "describeName": "Listens:",
+    "itName": "Synthesizes deletes for missing document",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/a"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/a"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            4
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Unresponsive primary ignores watch update": {
+    "describeName": "Listens:",
+    "itName": "Unresponsive primary ignores watch update",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Waits until Watch catches up to local deletes ": {
+    "describeName": "Listens:",
+    "itName": "Waits until Watch catches up to local deletes ",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "1"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "1"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userDelete": "collection/a",
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "1"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "2"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "writeAck": {
+          "version": 4000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "3"
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "5"
+              },
+              "version": 5000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 5000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "5"
+                },
+                "version": 5000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Will gracefully handle watch stream reverting snapshots": {
+    "describeName": "Listens:",
+    "itName": "Will gracefully handle watch stream reverting snapshots",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v1000"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v1000"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v2000"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v2000"
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v2000"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v1000"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v2000"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Will gracefully handle watch stream reverting snapshots (with restart)": {
+    "describeName": "Listens:",
+    "itName": "Will gracefully handle watch stream reverting snapshots (with restart)",
+    "tags": [
+      "durable-persistence"
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v1000"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v1000"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v2000"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v2000"
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "restart": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": "v2000"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v1000"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": "v2000"
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
@@ -1181,19 +13143,22 @@
   "Will gracefully process failed targets": {
     "describeName": "Listens:",
     "itName": "Will gracefully process failed targets",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection1",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection1"
           }
         ],
         "expectedState": {
@@ -1201,9 +13166,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection1"
                 }
               ],
               "resumeToken": ""
@@ -1215,9 +13182,11 @@
         "userListen": [
           4,
           {
-            "path": "collection2",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection2"
           }
         ],
         "expectedState": {
@@ -1225,9 +13194,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection1"
                 }
               ],
               "resumeToken": ""
@@ -1235,9 +13206,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection2"
                 }
               ],
               "resumeToken": ""
@@ -1260,14 +13233,14 @@
           "docs": [
             {
               "key": "collection1/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "a": true
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -1280,14 +13253,14 @@
           "docs": [
             {
               "key": "collection2/a",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "b": true
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             }
           ],
           "targets": [
@@ -1297,39 +13270,43 @@
       },
       {
         "watchRemove": {
-          "targetIds": [
-            2
-          ],
           "cause": {
             "code": 8
-          }
+          },
+          "targetIds": [
+            2
+          ]
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 8,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection1"
+            }
+          }
+        ],
         "expectedState": {
           "activeTargets": {
             "4": {
               "queries": [
                 {
-                  "path": "collection2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection2"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection1",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 8,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchCurrent": [
@@ -1341,641 +13318,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection2",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection2/a",
-                "version": 1001,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "b": true
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1001
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection2"
+            }
           }
         ]
       }
     ]
   },
-  "Will gracefully handle watch stream reverting snapshots": {
+  "Will process removals without waiting for a consistent snapshot": {
     "describeName": "Listens:",
-    "itName": "Will gracefully handle watch stream reverting snapshots",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": "v1000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": "v1000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "v": "v2000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "v": "v2000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "v": "v2000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": "v1000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "v": "v2000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Will gracefully handle watch stream reverting snapshots (with restart)": {
-    "describeName": "Listens:",
-    "itName": "Will gracefully handle watch stream reverting snapshots (with restart)",
+    "itName": "Will process removals without waiting for a consistent snapshot",
     "tags": [
-      "durable-persistence"
     ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": "v1000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": "v1000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "v": "v2000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "v": "v2000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "restart": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "v": "v2000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": "v1000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "v": "v2000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Individual documents cannot revert": {
-    "describeName": "Listens:",
-    "itName": "Individual documents cannot revert",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
             "filters": [
-              [
-                "visible",
-                "==",
-                true
-              ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1983,288 +13378,14 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
-                    [
-                      "visible",
-                      "==",
-                      true
-                    ]
                   ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "visible": true,
-                "v": "v1000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "visible",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "visible": true,
-                  "v": "v1000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "visible",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "visible": true,
-                  "v": "v1000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 3000,
-              "value": {
-                "visible": false,
-                "v": "v3000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-4000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 4000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 3000,
-                "value": {
-                  "visible": false,
-                  "v": "v3000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            4
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "visible",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "visible",
-                      "==",
-                      true
-                    ]
+                  "orderBys": [
                   ],
-                  "orderBys": []
+                  "path": "collection"
                 }
               ],
-              "resumeToken": "resume-token-1000"
+              "resumeToken": ""
             }
           }
         }
@@ -2273,2441 +13394,56 @@
         "watchAck": [
           2
         ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "visible": false,
-                "v": "v2000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "removedTargets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-5000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 5000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "visible",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "visible",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
       },
       {
         "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-4000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 3000,
-                "value": {
-                  "visible": false,
-                  "v": "v3000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-6000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 6000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Individual (deleted) documents cannot revert": {
-    "describeName": "Listens:",
-    "itName": "Individual (deleted) documents cannot revert",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "visible",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "visible",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "visible": true,
-                "v": "v1000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "visible",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "visible": true,
-                  "v": "v1000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "visible",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "visible": true,
-                  "v": "v1000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 3000,
-              "value": null
-            }
-          ],
-          "removedTargets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-4000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 4000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "visible": true,
-                  "v": "v1000"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            4
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "visible",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "visible",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "visible": false,
-                "v": "v2000"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "removedTargets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-5000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 5000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "visible",
-                  "==",
-                  true
-                ]
-              ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "visible",
-                "==",
-                true
-              ]
-            ],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-4000"
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-6000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 6000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Waits until Watch catches up to local deletes ": {
-    "describeName": "Listens:",
-    "itName": "Waits until Watch catches up to local deletes ",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": "1"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": "1"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userDelete": "collection/a",
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": "1"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "v": "2"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        }
-      },
-      {
-        "writeAck": {
-          "version": 4000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 3000,
-              "value": {
-                "v": "3"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 5000,
-              "value": {
-                "v": "5"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 5000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 5000,
-                "value": {
-                  "v": "5"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Listens are reestablished after network disconnect": {
-    "describeName": "Listens:",
-    "itName": "Listens are reestablished after network disconnect",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          },
-          "watchStreamRequestCount": 1
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "enableNetwork": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          },
-          "watchStreamRequestCount": 2
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Synthesizes deletes for missing document": {
-    "describeName": "Listens:",
-    "itName": "Synthesizes deletes for missing document",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection/a",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          4,
-          {
-            "path": "collection/a",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            4
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Re-opens target without existence filter": {
-    "describeName": "Listens:",
-    "itName": "Re-opens target without existence filter",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": null
-            }
-          ],
-          "removedTargets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Ignores update from inactive target": {
-    "describeName": "Listens:",
-    "itName": "Ignores update from inactive target",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Does not synthesize deletes for previously acked documents": {
-    "describeName": "Listens:",
-    "itName": "Does not synthesize deletes for previously acked documents",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/a",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection/a",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/a",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-2000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Query is rejected and re-listened to": {
-    "describeName": "Listens:",
-    "itName": "Query is rejected and re-listened to",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ],
           "cause": {
             "code": 8
-          }
-        },
-        "expectedState": {
-          "activeTargets": {}
+          },
+          "targetIds": [
+            2
+          ]
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 8,
             "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
           "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
           }
         }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
       }
     ]
   },
-  "Persists resume token sent with target": {
+  "Will re-issue listen for errored target": {
     "describeName": "Listens:",
-    "itName": "Persists resume token sent with target",
-    "tags": [],
+    "itName": "Will re-issue listen for errored target",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": [
-            2
-          ],
-          "resumeToken": "resume-token-2000"
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-2000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-3000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Array-contains queries support resuming": {
-    "describeName": "Listens:",
-    "itName": "Array-contains queries support resuming",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
             "filters": [
-              [
-                "array",
-                "array-contains",
-                42
-              ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -4715,15 +13451,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
-                    [
-                      "array",
-                      "array-contains",
-                      42
-                    ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -4737,160 +13469,42 @@
         ]
       },
       {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "array",
-                  "array-contains",
-                  42
-                ]
-              ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "foo": "bar",
-                "array": [
-                  1,
-                  42,
-                  3
-                ]
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
+        "watchRemove": {
+          "cause": {
+            "code": 8
+          },
           "targetIds": [
             2
-          ],
-          "resumeToken": "resume-token-2000"
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          ]
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "array",
-                  "array-contains",
-                  42
-                ]
-              ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "foo": "bar",
-                  "array": [
-                    1,
-                    42,
-                    3
-                  ]
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
+            "errorCode": 8,
             "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [
-              [
-                "array",
-                "array-contains",
-                42
-              ]
-            ],
-            "orderBys": []
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
             "filters": [
-              [
-                "array",
-                "array-contains",
-                42
-              ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -4898,7751 +13512,82 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
                   "filters": [
-                    [
-                      "array",
-                      "array-contains",
-                      42
-                    ]
                   ],
-                  "orderBys": []
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
-              "resumeToken": "resume-token-2000"
+              "resumeToken": ""
             }
           }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
               "filters": [
-                [
-                  "array",
-                  "array-contains",
-                  42
-                ]
               ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "foo": "bar",
-                  "array": [
-                    1,
-                    42,
-                    3
-                  ]
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-3000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [
-                [
-                  "array",
-                  "array-contains",
-                  42
-                ]
-              ],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Persists global resume tokens on unlisten": {
-    "describeName": "Listens:",
-    "itName": "Persists global resume tokens on unlisten",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": [],
-          "resumeToken": "resume-token-2000"
-        }
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-2000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-3000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Omits global resume tokens for a short while": {
-    "describeName": "Listens:",
-    "itName": "Omits global resume tokens for a short while",
-    "tags": [
-      "durable-persistence"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": [],
-          "resumeToken": "resume-token-2000"
-        }
-      },
-      {
-        "restart": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-3000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Persists global resume tokens if the snapshot is old enough": {
-    "describeName": "Listens:",
-    "itName": "Persists global resume tokens if the snapshot is old enough",
-    "tags": [
-      "durable-persistence"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 300001000,
-          "targetIds": [],
-          "resumeToken": "resume-token-minutes-later"
-        }
-      },
-      {
-        "restart": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-minutes-later"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-even-later"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 300002000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Query is executed by primary client": {
-    "describeName": "Listens:",
-    "itName": "Query is executed by primary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Query is shared between primary and secondary client": {
-    "describeName": "Listens:",
-    "itName": "Query is shared between primary and secondary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      }
-    ]
-  },
-  "Query is joined by primary client": {
-    "describeName": "Listens:",
-    "itName": "Query is joined by primary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-100"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 100,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 3000,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 3000,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 3000,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Query only raises events in participating clients": {
-    "describeName": "Listens:",
-    "itName": "Query only raises events in participating clients",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 4
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 3
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 3
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 3
-      }
-    ]
-  },
-  "Query is unlistened to by primary client": {
-    "describeName": "Listens:",
-    "itName": "Query is unlistened to by primary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Query is resumed by secondary client": {
-    "describeName": "Listens:",
-    "itName": "Query is resumed by secondary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Query is rejected by primary client": {
-    "describeName": "Listens:",
-    "itName": "Query is rejected by primary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ],
-          "cause": {
-            "code": 8
-          }
-        },
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 8,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Query is rejected and re-listened to by secondary client": {
-    "describeName": "Listens:",
-    "itName": "Query is rejected and re-listened to by secondary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ],
-          "cause": {
-            "code": 8
-          }
-        },
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 8,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Mirror queries from same secondary client": {
-    "describeName": "Listens:",
-    "itName": "Mirror queries from same secondary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                },
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                },
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "val": 0
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "val": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
               "orderBys": [
-                [
-                  "val",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
               ],
-              "resumeToken": ""
+              "path": "collection"
             }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 2000,
-              "value": {
-                "val": 0
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 2000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Mirror queries from different secondary client": {
-    "describeName": "Listens:",
-    "itName": "Mirror queries from different secondary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                },
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "val": 0
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "val": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 2000,
-              "value": {
-                "val": 0
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 2000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Mirror queries from primary and secondary client": {
-    "describeName": "Listens:",
-    "itName": "Mirror queries from primary and secondary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                },
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "val": 0
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "val": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 2000,
-              "value": {
-                "val": 0
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 2000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 2000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                },
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/d",
-              "version": 3000,
-              "value": {
-                "val": -1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/d",
-                "version": 3000,
-                "value": {
-                  "val": -1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 2000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Can listen/unlisten to mirror queries.": {
-    "describeName": "Listens:",
-    "itName": "Can listen/unlisten to mirror queries.",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToFirst",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "asc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                },
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "val": 0
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 1000,
-              "value": {
-                "val": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
           }
         ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 2000,
-              "value": {
-                "val": 0
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 2000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/b",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "limit": 2,
-            "limitType": "LimitToLast",
-            "filters": [],
-            "orderBys": [
-              [
-                "val",
-                "desc"
-              ]
-            ]
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToLast",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "desc"
-                    ]
-                  ]
-                },
-                {
-                  "path": "collection",
-                  "limit": 2,
-                  "limitType": "LimitToFirst",
-                  "filters": [],
-                  "orderBys": [
-                    [
-                      "val",
-                      "asc"
-                    ]
-                  ]
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 2000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "val": 0
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ],
-          "cause": {
-            "code": 8
-          }
-        },
-        "expectedState": {
-          "activeTargets": {}
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToFirst",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "asc"
-                ]
-              ]
-            },
-            "errorCode": 8,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection",
-              "limit": 2,
-              "limitType": "LimitToLast",
-              "filters": [],
-              "orderBys": [
-                [
-                  "val",
-                  "desc"
-                ]
-              ]
-            },
-            "errorCode": 8,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Secondary client uses primary client's online state": {
-    "describeName": "Listens:",
-    "itName": "Secondary client uses primary client's online state",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "enableNetwork": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "New client uses existing online state": {
-    "describeName": "Listens:",
-    "itName": "New client uses existing online state",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      }
-    ]
-  },
-  "New client becomes primary if no client has its network enabled": {
-    "describeName": "Listens:",
-    "itName": "New client becomes primary if no client has its network enabled",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          },
-          "isPrimary": true
-        },
-        "clientIndex": 2
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 2
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 2
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 2
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Secondary client's online state is ignored": {
-    "describeName": "Listens:",
-    "itName": "Secondary client's online state is ignored",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": [],
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Offline state doesn't persist if primary is shut down": {
-    "describeName": "Listens:",
-    "itName": "Offline state doesn't persist if primary is shut down",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Listen is re-listened to after primary tab failover": {
-    "describeName": "Listens:",
-    "itName": "Listen is re-listened to after primary tab failover",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      }
-    ]
-  },
-  "Listen is established in new primary tab": {
-    "describeName": "Listens:",
-    "itName": "Listen is established in new primary tab",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 2
-      }
-    ]
-  },
-  "Query recovers after primary takeover": {
-    "describeName": "Listens:",
-    "itName": "Query recovers after primary takeover",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 3000,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 3000,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": false
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/c",
-                "version": 3000,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Query bounces between primaries": {
-    "describeName": "Listens:",
-    "itName": "Query bounces between primaries",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 2
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 2
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 2
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-2000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/c",
-              "version": 3000,
-              "value": {
-                "key": "c"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-3000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 3000,
-                "value": {
-                  "key": "c"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Unresponsive primary ignores watch update": {
-    "describeName": "Listens:",
-    "itName": "Unresponsive primary ignores watch update",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Listen is established in newly started primary": {
-    "describeName": "Listens:",
-    "itName": "Listen is established in newly started primary",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 2
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 2
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "key": "b"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 2
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 2
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "key": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Previous primary immediately regains primary lease": {
-    "describeName": "Listens:",
-    "itName": "Previous primary immediately regains primary lease",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "clientIndex": 1
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-2000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      }
-    ]
-  },
-  "onSnapshotsInSync should not fire for doc changes if there are no listeners": {
-    "describeName": "Listens:",
-    "itName": "onSnapshotsInSync should not fire for doc changes if there are no listeners",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "addSnapshotsInSyncListener": true,
-        "expectedSnapshotsInSyncEvents": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 2
-          }
-        ]
-      }
-    ]
-  },
-  "onSnapshotsInSync fires when called even if there are no local listeners": {
-    "describeName": "Listens:",
-    "itName": "onSnapshotsInSync fires when called even if there are no local listeners",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "addSnapshotsInSyncListener": true,
-        "expectedSnapshotsInSyncEvents": 1
-      },
-      {
-        "addSnapshotsInSyncListener": true,
-        "expectedSnapshotsInSyncEvents": 1
       }
     ]
   },
   "onSnapshotsInSync fires for metadata changes": {
     "describeName": "Listens:",
     "itName": "onSnapshotsInSync fires for metadata changes",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -12650,9 +13595,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -12670,14 +13617,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -12695,32 +13642,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -12737,27 +13687,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "modified": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedSnapshotsInSyncEvents": 1
@@ -12767,14 +13719,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 2000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 2000
             }
           ],
           "targets": [
@@ -12784,426 +13736,74 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         }
       },
       {
         "writeAck": {
           "version": 2000
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedSnapshotsInSyncEvents": 1,
         "expectedState": {
           "userCallbacks": {
             "acknowledgedDocs": [
               "collection/a"
             ],
-            "rejectedDocs": []
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedSnapshotsInSyncEvents": 1
-      }
-    ]
-  },
-  "onSnapshotsInSync fires once for multiple event snapshots": {
-    "describeName": "Listens:",
-    "itName": "onSnapshotsInSync fires once for multiple event snapshots",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
+            "rejectedDocs": [
+            ]
           }
         }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection/a",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          4
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            4
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "addSnapshotsInSyncListener": true,
-        "expectedSnapshotsInSyncEvents": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 2
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          },
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "expectedSnapshotsInSyncEvents": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "v": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2,
-            4
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        }
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          },
-          {
-            "query": {
-              "path": "collection/a",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedSnapshotsInSyncEvents": 1
       }
     ]
   },
   "onSnapshotsInSync fires for multiple listeners": {
     "describeName": "Listens:",
     "itName": "onSnapshotsInSync fires for multiple listeners",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -13211,9 +13811,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -13231,14 +13833,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -13256,32 +13858,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -13298,27 +13903,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "modified": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedSnapshotsInSyncEvents": 1
@@ -13340,27 +13947,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "modified": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 3
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedSnapshotsInSyncEvents": 3
@@ -13377,30 +13986,464 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "modified": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 4
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedSnapshotsInSyncEvents": 2
+      }
+    ]
+  },
+  "onSnapshotsInSync fires once for multiple event snapshots": {
+    "describeName": "Listens:",
+    "itName": "onSnapshotsInSync fires once for multiple event snapshots",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": true
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/a"
           }
         ],
-        "expectedSnapshotsInSyncEvents": 2
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            4
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
+          }
+        ]
+      },
+      {
+        "addSnapshotsInSyncListener": true,
+        "expectedSnapshotsInSyncEvents": 1
+      },
+      {
+        "userSet": [
+          "collection/a",
+          {
+            "v": 2
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          },
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
+          }
+        ],
+        "expectedSnapshotsInSyncEvents": 1
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2,
+            4
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          },
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/a"
+            }
+          }
+        ],
+        "expectedSnapshotsInSyncEvents": 1,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "onSnapshotsInSync fires when called even if there are no local listeners": {
+    "describeName": "Listens:",
+    "itName": "onSnapshotsInSync fires when called even if there are no local listeners",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "addSnapshotsInSyncListener": true,
+        "expectedSnapshotsInSyncEvents": 1
+      },
+      {
+        "addSnapshotsInSyncListener": true,
+        "expectedSnapshotsInSyncEvents": 1
+      }
+    ]
+  },
+  "onSnapshotsInSync should not fire for doc changes if there are no listeners": {
+    "describeName": "Listens:",
+    "itName": "onSnapshotsInSync should not fire for doc changes if there are no listeners",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "addSnapshotsInSyncListener": true,
+        "expectedSnapshotsInSyncEvents": 1
+      },
+      {
+        "userSet": [
+          "collection/a",
+          {
+            "v": 2
+          }
+        ]
       }
     ]
   }

--- a/firebase-firestore/src/test/resources/json/listen_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/listen_spec_test.json
@@ -1822,7 +1822,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         }
       },
       {
@@ -2010,8 +2011,8 @@
               "key": "collection/a",
               "version": 1000,
               "value": {
-                "v": "v1000",
-                "visible": true
+                "visible": true,
+                "v": "v1000"
               },
               "options": {
                 "hasLocalMutations": false,
@@ -2055,8 +2056,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "v": "v1000",
-                  "visible": true
+                  "visible": true,
+                  "v": "v1000"
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2131,8 +2132,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "v": "v1000",
-                  "visible": true
+                  "visible": true,
+                  "v": "v1000"
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2158,8 +2159,8 @@
               "key": "collection/a",
               "version": 3000,
               "value": {
-                "v": "v3000",
-                "visible": false
+                "visible": false,
+                "v": "v3000"
               },
               "options": {
                 "hasLocalMutations": false,
@@ -2197,8 +2198,8 @@
                 "key": "collection/a",
                 "version": 3000,
                 "value": {
-                  "v": "v3000",
-                  "visible": false
+                  "visible": false,
+                  "v": "v3000"
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2280,8 +2281,8 @@
               "key": "collection/a",
               "version": 2000,
               "value": {
-                "v": "v2000",
-                "visible": false
+                "visible": false,
+                "v": "v2000"
               },
               "options": {
                 "hasLocalMutations": false,
@@ -2387,8 +2388,8 @@
                 "key": "collection/a",
                 "version": 3000,
                 "value": {
-                  "v": "v3000",
-                  "visible": false
+                  "visible": false,
+                  "v": "v3000"
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2500,8 +2501,8 @@
               "key": "collection/a",
               "version": 1000,
               "value": {
-                "v": "v1000",
-                "visible": true
+                "visible": true,
+                "v": "v1000"
               },
               "options": {
                 "hasLocalMutations": false,
@@ -2545,8 +2546,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "v": "v1000",
-                  "visible": true
+                  "visible": true,
+                  "v": "v1000"
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2621,8 +2622,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "v": "v1000",
-                  "visible": true
+                  "visible": true,
+                  "v": "v1000"
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2680,8 +2681,8 @@
                 "key": "collection/a",
                 "version": 1000,
                 "value": {
-                  "v": "v1000",
-                  "visible": true
+                  "visible": true,
+                  "v": "v1000"
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -2763,8 +2764,8 @@
               "key": "collection/a",
               "version": 2000,
               "value": {
-                "v": "v2000",
-                "visible": false
+                "visible": false,
+                "v": "v2000"
               },
               "options": {
                 "hasLocalMutations": false,
@@ -3245,7 +3246,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "expectedSnapshotEvents": [
           {
@@ -4781,12 +4783,12 @@
               "key": "collection/a",
               "version": 2000,
               "value": {
+                "foo": "bar",
                 "array": [
                   1,
                   42,
                   3
-                ],
-                "foo": "bar"
+                ]
               },
               "options": {
                 "hasLocalMutations": false,
@@ -4831,12 +4833,12 @@
                 "key": "collection/a",
                 "version": 2000,
                 "value": {
+                  "foo": "bar",
                   "array": [
                     1,
                     42,
                     3
-                  ],
-                  "foo": "bar"
+                  ]
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -4929,12 +4931,12 @@
                 "key": "collection/a",
                 "version": 2000,
                 "value": {
+                  "foo": "bar",
                   "array": [
                     1,
                     42,
                     3
-                  ],
-                  "foo": "bar"
+                  ]
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -5311,7 +5313,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         }
       },
       {
@@ -5506,7 +5509,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         }
       },
       {
@@ -9695,7 +9699,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -9877,7 +9882,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 1
       },
@@ -9926,7 +9932,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "expectedSnapshotEvents": [
           {
@@ -10154,7 +10161,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "expectedSnapshotEvents": [
           {
@@ -10389,7 +10397,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 1
       },
@@ -10462,7 +10471,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": [],
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": [],
           "isPrimary": true
         },
         "clientIndex": 0
@@ -10532,7 +10542,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "expectedSnapshotEvents": [
           {
@@ -10552,7 +10563,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -10786,7 +10798,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -11089,7 +11102,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -12260,7 +12274,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -12512,7 +12527,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 1
       },

--- a/firebase-firestore/src/test/resources/json/offline_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/offline_spec_test.json
@@ -585,7 +585,7 @@
           "targetIds": []
         },
         "expectedState": {
-          "limboDocs": [
+          "activeLimboDocs": [
             "collection/a"
           ],
           "activeTargets": {
@@ -745,7 +745,7 @@
           }
         ],
         "expectedState": {
-          "limboDocs": [],
+          "activeLimboDocs": [],
           "activeTargets": {
             "2": {
               "queries": [
@@ -1148,7 +1148,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         }
       },
       {

--- a/firebase-firestore/src/test/resources/json/offline_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/offline_spec_test.json
@@ -1,490 +1,23 @@
 {
-  "Empty queries are resolved if client goes offline": {
-    "describeName": "Offline:",
-    "itName": "Empty queries are resolved if client goes offline",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
-      }
-    ]
-  },
   "A successful message delays offline status": {
     "describeName": "Offline:",
     "itName": "A successful message delays offline status",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
-      }
-    ]
-  },
-  "Removing all listeners delays \"Offline\" status on next listen": {
-    "describeName": "Offline:",
-    "itName": "Removing all listeners delays \"Offline\" status on next listen",
     "tags": [
-      "eager-gc"
     ],
-    "comment": "Marked as no-lru because when a listen is re-added, it gets a new target id rather than reusing one",
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Queries revert to fromCache=true when offline.": {
-    "describeName": "Offline:",
-    "itName": "Queries revert to fromCache=true when offline.",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
+            "filters": [
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        },
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Queries with limbo documents handle going offline.": {
-    "describeName": "Offline:",
-    "itName": "Queries with limbo documents handle going offline.",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -492,9 +25,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -508,276 +43,76 @@
         ]
       },
       {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
         }
       },
       {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchReset": [
-          2
-        ]
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1001"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
-        },
-        "expectedState": {
-          "activeLimboDocs": [
-            "collection/a"
-          ],
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        },
-        "expectedState": {
-          "activeTargets": {
-            "1": {
-              "queries": [
-                {
-                  "path": "collection/a",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1001"
-            }
-          }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1001"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
-        }
-      },
-      {
-        "watchAck": [
-          1
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            1
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            1
-          ],
-          "resume-token-1001"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeLimboDocs": [],
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
+              "filters": [
               ],
-              "resumeToken": "resume-token-1001"
+              "orderBys": [
+              ],
+              "path": "collection"
             }
           }
+        ]
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
         }
       }
     ]
   },
-  "OnlineState timeout triggers offline behavior": {
+  "Empty queries are resolved if client goes offline": {
     "describeName": "Offline:",
-    "itName": "OnlineState timeout triggers offline behavior",
-    "tags": [],
+    "itName": "Empty queries are resolved if client goes offline",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -785,9 +120,92 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        }
+      }
+    ]
+  },
+  "New queries return immediately with fromCache=true when offline due to OnlineState timeout.": {
+    "describeName": "Offline:",
+    "itName": "New queries return immediately with fromCache=true when offline due to OnlineState timeout.",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -799,14 +217,244 @@
         "runTimer": "online_state_timeout",
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection2"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection2"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection2"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "New queries return immediately with fromCache=true when offline due to stream failures.": {
+    "describeName": "Offline:",
+    "itName": "New queries return immediately with fromCache=true when offline due to stream failures.",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection2"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection2"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection2"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "OnlineState timeout triggers offline behavior": {
+    "describeName": "Offline:",
+    "itName": "OnlineState timeout triggers offline behavior",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "runTimer": "online_state_timeout",
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -838,14 +486,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -863,32 +511,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -908,9 +559,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "resume-token-1000"
@@ -922,35 +575,66 @@
         "runTimer": "online_state_timeout",
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
     ]
   },
-  "New queries return immediately with fromCache=true when offline due to stream failures.": {
+  "Queries return from cache when network disabled": {
     "describeName": "Offline:",
-    "itName": "New queries return immediately with fromCache=true when offline due to stream failures.",
-    "tags": [],
+    "itName": "Queries return from cache when network disabled",
+    "tags": [
+      "eager-gc"
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
+      {
+        "enableNetwork": false,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -958,9 +642,646 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userUnlisten": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      }
+    ]
+  },
+  "Queries revert to fromCache=true when offline.": {
+    "describeName": "Offline:",
+    "itName": "Queries revert to fromCache=true when offline.",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Queries with limbo documents handle going offline.": {
+    "describeName": "Offline:",
+    "itName": "Queries with limbo documents handle going offline.",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchReset": [
+          2
+        ]
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1001
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+            "collection/a"
+          ],
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        },
+        "expectedState": {
+          "activeTargets": {
+            "1": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/a"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1001"
+            }
+          }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1001
+        }
+      },
+      {
+        "watchAck": [
+          1
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            1
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            1
+          ],
+          "resume-token-1001"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1001
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1001"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Removing all listeners delays \"Offline\" status on next listen": {
+    "comment": "Marked as no-lru because when a listen is re-added, it gets a new target id rather than reusing one",
+    "describeName": "Offline:",
+    "itName": "Removing all listeners delays \"Offline\" status on next listen",
+    "tags": [
+      "eager-gc"
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -978,213 +1299,16 @@
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection2",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
               ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection2",
-                  "filters": [],
-                  "orderBys": []
-                }
+              "orderBys": [
               ],
-              "resumeToken": ""
+              "path": "collection"
             }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection2",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "New queries return immediately with fromCache=true when offline due to OnlineState timeout.": {
-    "describeName": "Offline:",
-    "itName": "New queries return immediately with fromCache=true when offline due to OnlineState timeout.",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "runTimer": "online_state_timeout",
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection2",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection2",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection2",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Queries return from cache when network disabled": {
-    "describeName": "Offline:",
-    "itName": "Queries return from cache when network disabled",
-    "tags": [
-      "eager-gc"
-    ],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
           }
         ]
       },
@@ -1192,22 +1316,36 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
         }
       },
       {
         "userListen": [
           4,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1215,40 +1353,40 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
-      },
-      {
-        "userUnlisten": [
-          4,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
       }
     ]
   }

--- a/firebase-firestore/src/test/resources/json/orderby_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/orderby_spec_test.json
@@ -2,10 +2,11 @@
   "orderBy applies filtering based on local state": {
     "describeName": "OrderBy:",
     "itName": "orderBy applies filtering based on local state",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
@@ -37,14 +38,47 @@
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
+            "filters": [
+            ],
             "orderBys": [
               [
                 "sort",
                 "asc"
               ]
-            ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "key": "a",
+                  "sort": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+                [
+                  "sort",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -52,51 +86,21 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
+                  "filters": [
+                  ],
                   "orderBys": [
                     [
                       "sort",
                       "asc"
                     ]
-                  ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": [
-                [
-                  "sort",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "key": "a",
-                  "sort": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -108,14 +112,14 @@
           "docs": [
             {
               "key": "collection/b",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             }
           ],
           "targets": [
@@ -133,38 +137,40 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "key": "b",
+                  "sort": 2
+                },
+                "version": 1001
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "query": {
-              "path": "collection",
-              "filters": [],
+              "filters": [
+              ],
               "orderBys": [
                 [
                   "sort",
                   "asc"
                 ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b",
-                  "sort": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
@@ -173,24 +179,26 @@
   "orderBy applies to existing documents": {
     "describeName": "OrderBy:",
     "itName": "orderBy applies to existing documents",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
+            "filters": [
+            ],
             "orderBys": [
               [
                 "sort",
                 "asc"
               ]
-            ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -198,14 +206,15 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
+                  "filters": [
+                  ],
                   "orderBys": [
                     [
                       "sort",
                       "asc"
                     ]
-                  ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -223,27 +232,27 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a",
                 "sort": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             },
             {
               "key": "collection/b",
-              "version": 1001,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b",
                 "sort": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1001
             }
           ],
           "targets": [
@@ -261,50 +270,52 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b",
+                  "sort": 1
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a",
+                  "sort": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
+              "filters": [
+              ],
               "orderBys": [
                 [
                   "sort",
                   "asc"
                 ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b",
-                  "sort": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a",
-                  "sort": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -312,18 +323,20 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
+            "filters": [
+            ],
             "orderBys": [
               [
                 "sort",
                 "asc"
               ]
-            ]
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
@@ -337,14 +350,59 @@
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
+            "filters": [
+            ],
             "orderBys": [
               [
                 "sort",
                 "asc"
               ]
-            ]
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "b",
+                  "sort": 1
+                },
+                "version": 1001
+              },
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a",
+                  "sort": 2
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+                [
+                  "sort",
+                  "asc"
+                ]
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -352,63 +410,21 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
+                  "filters": [
+                  ],
                   "orderBys": [
                     [
                       "sort",
                       "asc"
                     ]
-                  ]
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "resume-token-1002"
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": [
-                [
-                  "sort",
-                  "asc"
-                ]
-              ]
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 1001,
-                "value": {
-                  "key": "b",
-                  "sort": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a",
-                  "sort": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -417,7 +433,8 @@
       },
       {
         "watchEntity": {
-          "docs": [],
+          "docs": [
+          ],
           "targets": [
             2
           ]
@@ -433,24 +450,26 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1002
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection",
-              "filters": [],
+              "filters": [
+              ],
               "orderBys": [
                 [
                   "sort",
                   "asc"
                 ]
-              ]
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+              ],
+              "path": "collection"
+            }
           }
         ]
       }

--- a/firebase-firestore/src/test/resources/json/persistence_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/persistence_spec_test.json
@@ -1,4 +1,133 @@
 {
+  "Detects all active clients": {
+    "describeName": "Persistence:",
+    "itName": "Detects all active clients",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "hidden"
+        },
+        "clientIndex": 0,
+        "expectedState": {
+          "numActiveClients": 1
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "numActiveClients": 2
+        }
+      }
+    ]
+  },
+  "Foreground tab acquires primary lease": {
+    "describeName": "Persistence:",
+    "itName": "Foreground tab acquires primary lease",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "hidden"
+        },
+        "clientIndex": 0,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "hidden"
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 2,
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": true
+        }
+      }
+    ]
+  },
   "Local mutations are persisted and re-sent": {
     "describeName": "Persistence:",
     "itName": "Local mutations are persisted and re-sent",
@@ -6,8 +135,8 @@
       "durable-persistence"
     ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
@@ -29,9 +158,12 @@
       {
         "restart": true,
         "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": [],
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ],
           "numOutstandingWrites": 2
         }
       },
@@ -50,6 +182,192 @@
       }
     ]
   },
+  "Mutation Queue is persisted across uid switches": {
+    "describeName": "Persistence:",
+    "itName": "Mutation Queue is persisted across uid switches",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userSet": [
+          "users/anon",
+          {
+            "uid": "anon"
+          }
+        ]
+      },
+      {
+        "changeUser": "user1",
+        "expectedState": {
+          "numOutstandingWrites": 0
+        }
+      },
+      {
+        "userSet": [
+          "users/user1",
+          {
+            "uid": "user1"
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "users/user1",
+          {
+            "extra": true,
+            "uid": "user1"
+          }
+        ]
+      },
+      {
+        "changeUser": null,
+        "expectedState": {
+          "numOutstandingWrites": 1
+        }
+      },
+      {
+        "writeAck": {
+          "version": 1000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "users/anon"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "changeUser": "user1",
+        "expectedState": {
+          "numOutstandingWrites": 2
+        }
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "users/user1"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "writeAck": {
+          "version": 3000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "users/user1"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Mutation Queue is persisted across uid switches (with restarts)": {
+    "describeName": "Persistence:",
+    "itName": "Mutation Queue is persisted across uid switches (with restarts)",
+    "tags": [
+      "durable-persistence"
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userSet": [
+          "users/anon",
+          {
+            "uid": "anon"
+          }
+        ]
+      },
+      {
+        "changeUser": "user1",
+        "expectedState": {
+          "numOutstandingWrites": 0
+        }
+      },
+      {
+        "userSet": [
+          "users/user1",
+          {
+            "uid": "user1"
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "users/user1",
+          {
+            "extra": true,
+            "uid": "user1"
+          }
+        ]
+      },
+      {
+        "changeUser": null
+      },
+      {
+        "restart": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ],
+          "numOutstandingWrites": 1
+        }
+      },
+      {
+        "writeAck": {
+          "version": 1000
+        }
+      },
+      {
+        "changeUser": "user1"
+      },
+      {
+        "restart": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ],
+          "numOutstandingWrites": 2
+        }
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        }
+      },
+      {
+        "writeAck": {
+          "version": 3000
+        }
+      }
+    ]
+  },
   "Persisted local mutations are visible to listeners": {
     "describeName": "Persistence:",
     "itName": "Persisted local mutations are visible to listeners",
@@ -57,8 +375,8 @@
       "durable-persistence"
     ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
@@ -80,18 +398,61 @@
       {
         "restart": true,
         "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
         }
       },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              },
+              {
+                "key": "collection/key2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "baz": "quu"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -99,51 +460,125 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key1",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/key2",
-                "version": 0,
-                "value": {
-                  "baz": "quu"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
+        }
+      }
+    ]
+  },
+  "Primary lease bound to network state": {
+    "describeName": "Persistence:",
+    "itName": "Primary lease bound to network state",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "enableNetwork": false,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ],
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "enableNetwork": false,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ],
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "enableNetwork": true,
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": true
+        }
       }
     ]
   },
@@ -154,17 +589,19 @@
       "durable-persistence"
     ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -172,9 +609,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -192,14 +631,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "foo": "bar"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -217,211 +656,85 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
         "restart": true,
         "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 1000,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Remote documents from watch are not GC'd": {
-    "describeName": "Persistence:",
-    "itName": "Remote documents from watch are not GC'd",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/key",
-              "version": 1000,
-              "value": {
-                "foo": "bar"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
+          "activeLimboDocs": [
           ],
-          "targets": [
-            2
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
           ]
         }
       },
       {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 1000,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -429,50 +742,28 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "resume-token-1000"
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 1000,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
   "Remote documents from user sets are not GC'd": {
     "describeName": "Persistence:",
     "itName": "Remote documents from user sets are not GC'd",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
@@ -492,7 +783,8 @@
             "acknowledgedDocs": [
               "collection/key"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -500,9 +792,38 @@
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -510,215 +831,260 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
+        }
+      }
+    ]
+  },
+  "Remote documents from watch are not GC'd": {
+    "describeName": "Persistence:",
+    "itName": "Remote documents from watch are not GC'd",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/key",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "foo": "bar"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "foo": "bar"
                 },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
-        ]
-      }
-    ]
-  },
-  "Mutation Queue is persisted across uid switches": {
-    "describeName": "Persistence:",
-    "itName": "Mutation Queue is persisted across uid switches",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userSet": [
-          "users/anon",
-          {
-            "uid": "anon"
-          }
-        ]
-      },
-      {
-        "changeUser": "user1",
+        ],
         "expectedState": {
-          "numOutstandingWrites": 0
-        }
-      },
-      {
-        "userSet": [
-          "users/user1",
-          {
-            "uid": "user1"
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "users/user1",
-          {
-            "uid": "user1",
-            "extra": true
-          }
-        ]
-      },
-      {
-        "changeUser": null,
-        "expectedState": {
-          "numOutstandingWrites": 1
-        }
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "users/anon"
-            ],
-            "rejectedDocs": []
-          }
-        }
-      },
-      {
-        "changeUser": "user1",
-        "expectedState": {
-          "numOutstandingWrites": 2
-        }
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "users/user1"
-            ],
-            "rejectedDocs": []
-          }
-        }
-      },
-      {
-        "writeAck": {
-          "version": 3000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "users/user1"
-            ],
-            "rejectedDocs": []
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
           }
         }
       }
     ]
   },
-  "Mutation Queue is persisted across uid switches (with restarts)": {
+  "Single tab acquires primary lease": {
     "describeName": "Persistence:",
-    "itName": "Mutation Queue is persisted across uid switches (with restarts)",
+    "itName": "Single tab acquires primary lease",
     "tags": [
-      "durable-persistence"
+      "multi-client"
     ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 2,
+      "useGarbageCollection": false
     },
     "steps": [
       {
-        "userSet": [
-          "users/anon",
-          {
-            "uid": "anon"
-          }
-        ]
+        "clientIndex": 0,
+        "drainQueue": true
       },
       {
-        "changeUser": "user1",
+        "applyClientState": {
+          "visibility": "hidden"
+        },
+        "clientIndex": 0,
         "expectedState": {
-          "numOutstandingWrites": 0
+          "isPrimary": true
         }
       },
       {
-        "userSet": [
-          "users/user1",
-          {
-            "uid": "user1"
-          }
-        ]
+        "clientIndex": 1,
+        "drainQueue": true
       },
       {
-        "userSet": [
-          "users/user1",
-          {
-            "uid": "user1",
-            "extra": true
-          }
-        ]
-      },
-      {
-        "changeUser": null
-      },
-      {
-        "restart": true,
+        "applyClientState": {
+          "visibility": "hidden"
+        },
+        "clientIndex": 1,
         "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": [],
-          "numOutstandingWrites": 1
+          "isPrimary": false
         }
       },
       {
-        "writeAck": {
-          "version": 1000
-        }
+        "clientIndex": 0,
+        "drainQueue": true
       },
       {
-        "changeUser": "user1"
-      },
-      {
-        "restart": true,
+        "clientIndex": 0,
+        "shutdown": true,
         "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": [],
-          "numOutstandingWrites": 2
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
         }
       },
       {
-        "writeAck": {
-          "version": 2000
-        }
+        "clientIndex": 1,
+        "drainQueue": true
       },
       {
-        "writeAck": {
-          "version": 3000
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": true
         }
       }
     ]
@@ -726,19 +1092,22 @@
   "Visible mutations reflect uid switches": {
     "describeName": "Persistence:",
     "itName": "Visible mutations reflect uid switches",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "users",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "users"
           }
         ],
         "expectedState": {
@@ -746,9 +1115,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "users",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "users"
                 }
               ],
               "resumeToken": ""
@@ -766,14 +1137,14 @@
           "docs": [
             {
               "key": "users/existing",
-              "version": 0,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "uid": "existing"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 0
             }
           ],
           "targets": [
@@ -791,32 +1162,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 500
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "users",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "users/existing",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "uid": "existing"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "users"
+            }
           }
         ]
       },
@@ -829,71 +1203,77 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "users",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "users/anon",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "uid": "anon"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "users"
+            }
           }
         ]
       },
       {
         "changeUser": "user1",
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "users"
+            },
+            "removed": [
+              {
+                "key": "users/anon",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "uid": "anon"
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
         "expectedState": {
           "activeTargets": {
             "2": {
               "queries": [
                 {
-                  "path": "users",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "users"
                 }
               ],
               "resumeToken": "resume-token-500"
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "users",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "users/anon",
-                "version": 0,
-                "value": {
-                  "uid": "anon"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "userSet": [
@@ -904,27 +1284,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "users",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "users/user1",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "uid": "user1"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "users"
+            }
           }
         ]
       },
@@ -932,333 +1314,44 @@
         "changeUser": null,
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "users",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "users/anon",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "uid": "anon"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "users/user1",
-                "version": 0,
-                "value": {
-                  "uid": "user1"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "users"
+            },
+            "removed": [
+              {
+                "key": "users/user1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "uid": "user1"
+                },
+                "version": 0
+              }
+            ]
           }
         ]
-      }
-    ]
-  },
-  "Detects all active clients": {
-    "describeName": "Persistence:",
-    "itName": "Detects all active clients",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "hidden"
-        },
-        "expectedState": {
-          "numActiveClients": 1
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "expectedState": {
-          "numActiveClients": 2
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Single tab acquires primary lease": {
-    "describeName": "Persistence:",
-    "itName": "Single tab acquires primary lease",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "hidden"
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "visibility": "hidden"
-        },
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Foreground tab acquires primary lease": {
-    "describeName": "Persistence:",
-    "itName": "Foreground tab acquires primary lease",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "hidden"
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "visibility": "hidden"
-        },
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 2
-      }
-    ]
-  },
-  "Primary lease bound to network state": {
-    "describeName": "Persistence:",
-    "itName": "Primary lease bound to network state",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": [],
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 1
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": [],
-          "isPrimary": true
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "enableNetwork": true,
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
       }
     ]
   },
@@ -1269,13 +1362,13 @@
       "multi-client"
     ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
+      "numClients": 3,
+      "useGarbageCollection": false
     },
     "steps": [
       {
-        "drainQueue": true,
-        "clientIndex": 0
+        "clientIndex": 0,
+        "drainQueue": true
       },
       {
         "applyClientState": {
@@ -1284,43 +1377,46 @@
         "clientIndex": 0
       },
       {
-        "drainQueue": true,
-        "clientIndex": 1
+        "clientIndex": 1,
+        "drainQueue": true
       },
       {
-        "drainQueue": true,
-        "clientIndex": 2
+        "clientIndex": 2,
+        "drainQueue": true
       },
       {
-        "drainQueue": true,
-        "clientIndex": 0
+        "clientIndex": 0,
+        "drainQueue": true
       },
       {
+        "clientIndex": 0,
         "shutdown": true,
         "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
       },
       {
         "clearPersistence": true,
         "clientIndex": 0
       },
       {
+        "clientIndex": 1,
         "drainQueue": true,
         "expectedState": {
           "isShutdown": true
-        },
-        "clientIndex": 1
+        }
       },
       {
+        "clientIndex": 2,
         "drainQueue": true,
         "expectedState": {
           "isShutdown": true
-        },
-        "clientIndex": 2
+        }
       }
     ]
   }

--- a/firebase-firestore/src/test/resources/json/persistence_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/persistence_spec_test.json
@@ -30,7 +30,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": [],
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": [],
           "numOutstandingWrites": 2
         }
       },
@@ -80,7 +81,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         }
       },
       {
@@ -248,7 +250,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         }
       },
       {
@@ -686,7 +689,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": [],
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": [],
           "numOutstandingWrites": 1
         }
       },
@@ -702,7 +706,8 @@
         "restart": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": [],
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": [],
           "numOutstandingWrites": 2
         }
       },
@@ -1050,7 +1055,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -1125,7 +1131,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -1175,7 +1182,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": [],
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": [],
           "isPrimary": true
         },
         "clientIndex": 0
@@ -1213,7 +1221,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": [],
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": [],
           "isPrimary": true
         },
         "clientIndex": 1
@@ -1290,7 +1299,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },

--- a/firebase-firestore/src/test/resources/json/query_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/query_spec_test.json
@@ -2,19 +2,22 @@
   "Collection Group query": {
     "describeName": "Queries:",
     "itName": "Collection Group query",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "cg/1",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "cg/1"
           }
         ],
         "expectedState": {
@@ -22,9 +25,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
                 }
               ],
               "resumeToken": ""
@@ -42,14 +47,14 @@
           "docs": [
             {
               "key": "cg/1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "val": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -67,32 +72,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "cg/1",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "cg/1",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "val": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "cg/1"
+            }
           }
         ]
       },
@@ -100,9 +108,11 @@
         "userListen": [
           4,
           {
-            "path": "cg/2",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "cg/2"
           }
         ],
         "expectedState": {
@@ -110,9 +120,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
                 }
               ],
               "resumeToken": ""
@@ -120,9 +132,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "cg/2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/2"
                 }
               ],
               "resumeToken": ""
@@ -140,14 +154,14 @@
           "docs": [
             {
               "key": "cg/2",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "val": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -165,32 +179,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "cg/2",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "cg/2",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "val": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "cg/2"
+            }
           }
         ]
       },
@@ -198,9 +215,11 @@
         "userListen": [
           6,
           {
-            "path": "not-cg/nope/cg/3",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "not-cg/nope/cg/3"
           }
         ],
         "expectedState": {
@@ -208,9 +227,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
                 }
               ],
               "resumeToken": ""
@@ -218,9 +239,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "cg/2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/2"
                 }
               ],
               "resumeToken": ""
@@ -228,9 +251,11 @@
             "6": {
               "queries": [
                 {
-                  "path": "not-cg/nope/cg/3",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope/cg/3"
                 }
               ],
               "resumeToken": ""
@@ -248,14 +273,14 @@
           "docs": [
             {
               "key": "not-cg/nope/cg/3",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "val": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -273,32 +298,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "not-cg/nope/cg/3",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "not-cg/nope/cg/3",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "val": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "not-cg/nope/cg/3"
+            }
           }
         ]
       },
@@ -306,9 +334,11 @@
         "userListen": [
           8,
           {
-            "path": "not-cg/nope",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "not-cg/nope"
           }
         ],
         "expectedState": {
@@ -316,9 +346,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
                 }
               ],
               "resumeToken": ""
@@ -326,9 +358,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "cg/2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/2"
                 }
               ],
               "resumeToken": ""
@@ -336,9 +370,11 @@
             "6": {
               "queries": [
                 {
-                  "path": "not-cg/nope/cg/3",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope/cg/3"
                 }
               ],
               "resumeToken": ""
@@ -346,9 +382,11 @@
             "8": {
               "queries": [
                 {
-                  "path": "not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope"
                 }
               ],
               "resumeToken": ""
@@ -366,14 +404,14 @@
           "docs": [
             {
               "key": "not-cg/nope",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "val": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -391,32 +429,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "not-cg/nope",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "not-cg/nope",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "val": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "not-cg/nope"
+            }
           }
         ]
       },
@@ -424,19 +465,35 @@
         "userListen": [
           10,
           {
-            "path": "cg/1/not-cg/nope",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "cg/1/not-cg/nope"
           }
         ],
         "expectedState": {
           "activeTargets": {
+            "10": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1/not-cg/nope"
+                }
+              ],
+              "resumeToken": ""
+            },
             "2": {
               "queries": [
                 {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
                 }
               ],
               "resumeToken": ""
@@ -444,9 +501,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "cg/2",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/2"
                 }
               ],
               "resumeToken": ""
@@ -454,9 +513,11 @@
             "6": {
               "queries": [
                 {
-                  "path": "not-cg/nope/cg/3",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope/cg/3"
                 }
               ],
               "resumeToken": ""
@@ -464,19 +525,11 @@
             "8": {
               "queries": [
                 {
-                  "path": "not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "10": {
-              "queries": [
-                {
-                  "path": "cg/1/not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope"
                 }
               ],
               "resumeToken": ""
@@ -494,14 +547,14 @@
           "docs": [
             {
               "key": "cg/1/not-cg/nope",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "val": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -519,32 +572,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "cg/1/not-cg/nope",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "cg/1/not-cg/nope",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "val": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "cg/1/not-cg/nope"
+            }
           }
         ]
       },
@@ -552,60 +608,74 @@
         "userListen": [
           12,
           {
-            "path": "",
             "collectionGroup": "cg",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": ""
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "cg/1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "cg/2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 2
+                },
+                "version": 1000
+              },
+              {
+                "key": "not-cg/nope/cg/3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "collectionGroup": "cg",
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": ""
+            }
           }
         ],
         "expectedState": {
           "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "cg/2",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "6": {
-              "queries": [
-                {
-                  "path": "not-cg/nope/cg/3",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "8": {
-              "queries": [
-                {
-                  "path": "not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
             "10": {
               "queries": [
                 {
-                  "path": "cg/1/not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1/not-cg/nope"
                 }
               ],
               "resumeToken": ""
@@ -613,70 +683,71 @@
             "12": {
               "queries": [
                 {
-                  "path": "",
                   "collectionGroup": "cg",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": ""
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/2"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "6": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope/cg/3"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "8": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "",
-              "collectionGroup": "cg",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "cg/1",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "cg/2",
-                "version": 1000,
-                "value": {
-                  "val": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "not-cg/nope/cg/3",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "userListen": [
           14,
           {
-            "path": "",
             "collectionGroup": "cg",
             "filters": [
               [
@@ -685,95 +756,41 @@
                 1
               ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": ""
           }
         ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "cg/2",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "6": {
-              "queries": [
-                {
-                  "path": "not-cg/nope/cg/3",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "8": {
-              "queries": [
-                {
-                  "path": "not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "10": {
-              "queries": [
-                {
-                  "path": "cg/1/not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "12": {
-              "queries": [
-                {
-                  "path": "",
-                  "collectionGroup": "cg",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "14": {
-              "queries": [
-                {
-                  "path": "",
-                  "collectionGroup": "cg",
-                  "filters": [
-                    [
-                      "val",
-                      "==",
-                      1
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "cg/1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "not-cg/nope/cg/3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
             "query": {
-              "path": "",
               "collectionGroup": "cg",
               "filters": [
                 [
@@ -782,56 +799,129 @@
                   1
                 ]
               ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "cg/1",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "not-cg/nope/cg/3",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+              "orderBys": [
+              ],
+              "path": ""
+            }
           }
-        ]
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "10": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1/not-cg/nope"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "12": {
+              "queries": [
+                {
+                  "collectionGroup": "cg",
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": ""
+                }
+              ],
+              "resumeToken": ""
+            },
+            "14": {
+              "queries": [
+                {
+                  "collectionGroup": "cg",
+                  "filters": [
+                    [
+                      "val",
+                      "==",
+                      1
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": ""
+                }
+              ],
+              "resumeToken": ""
+            },
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/2"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "6": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope/cg/3"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "8": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       }
     ]
   },
   "Collection Group query with mutations": {
     "describeName": "Queries:",
     "itName": "Collection Group query with mutations",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "cg/1",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "cg/1"
           }
         ],
         "expectedState": {
@@ -839,9 +929,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
                 }
               ],
               "resumeToken": ""
@@ -859,14 +951,14 @@
           "docs": [
             {
               "key": "cg/1",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "val": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -884,32 +976,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "cg/1",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "cg/1",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "val": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "cg/1"
+            }
           }
         ]
       },
@@ -917,9 +1012,11 @@
         "userListen": [
           4,
           {
-            "path": "not-cg/nope",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "not-cg/nope"
           }
         ],
         "expectedState": {
@@ -927,9 +1024,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
                 }
               ],
               "resumeToken": ""
@@ -937,9 +1036,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope"
                 }
               ],
               "resumeToken": ""
@@ -957,14 +1058,14 @@
           "docs": [
             {
               "key": "not-cg/nope",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "val": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -982,32 +1083,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "not-cg/nope",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "not-cg/nope",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "val": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "not-cg/nope"
+            }
           }
         ]
       },
@@ -1039,10 +1143,62 @@
         "userListen": [
           6,
           {
-            "path": "",
             "collectionGroup": "cg",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": ""
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "cg/1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "cg/2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "val": 2
+                },
+                "version": 0
+              },
+              {
+                "key": "not-cg/nope/cg/3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "collectionGroup": "cg",
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": ""
+            }
           }
         ],
         "expectedState": {
@@ -1050,9 +1206,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
                 }
               ],
               "resumeToken": ""
@@ -1060,9 +1218,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope"
                 }
               ],
               "resumeToken": ""
@@ -1070,70 +1230,23 @@
             "6": {
               "queries": [
                 {
-                  "path": "",
                   "collectionGroup": "cg",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": ""
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "",
-              "collectionGroup": "cg",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "cg/1",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "cg/2",
-                "version": 0,
-                "value": {
-                  "val": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "not-cg/nope/cg/3",
-                "version": 0,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
+        }
       },
       {
         "userListen": [
           8,
           {
-            "path": "",
             "collectionGroup": "cg",
             "filters": [
               [
@@ -1142,65 +1255,41 @@
                 1
               ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": ""
           }
         ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "cg/1",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "not-cg/nope",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "6": {
-              "queries": [
-                {
-                  "path": "",
-                  "collectionGroup": "cg",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "8": {
-              "queries": [
-                {
-                  "path": "",
-                  "collectionGroup": "cg",
-                  "filters": [
-                    [
-                      "val",
-                      "==",
-                      1
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "cg/1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "not-cg/nope/cg/3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "val": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
             "query": {
-              "path": "",
               "collectionGroup": "cg",
               "filters": [
                 [
@@ -1209,56 +1298,10 @@
                   1
                 ]
               ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "cg/1",
-                "version": 1000,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "not-cg/nope/cg/3",
-                "version": 0,
-                "value": {
-                  "val": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      }
-    ]
-  },
-  "Latency-compensated updates are included in query results": {
-    "describeName": "Queries:",
-    "itName": "Latency-compensated updates are included in query results",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+              "orderBys": [
+              ],
+              "path": ""
+            }
           }
         ],
         "expectedState": {
@@ -1266,9 +1309,94 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "cg/1"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "not-cg/nope"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "6": {
+              "queries": [
+                {
+                  "collectionGroup": "cg",
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": ""
+                }
+              ],
+              "resumeToken": ""
+            },
+            "8": {
+              "queries": [
+                {
+                  "collectionGroup": "cg",
+                  "filters": [
+                    [
+                      "val",
+                      "==",
+                      1
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": ""
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Latency-compensated updates are included in query results": {
+    "describeName": "Queries:",
+    "itName": "Latency-compensated updates are included in query results",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1286,14 +1414,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "match": false
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -1311,32 +1439,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "match": false
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1349,27 +1480,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "modified": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "match": true
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1377,7 +1510,6 @@
         "userListen": [
           4,
           {
-            "path": "collection",
             "filters": [
               [
                 "match",
@@ -1385,43 +1517,30 @@
                 true
               ]
             ],
-            "orderBys": []
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [
-                    [
-                      "match",
-                      "==",
-                      true
-                    ]
-                  ],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
         "expectedSnapshotEvents": [
           {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "match": true
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
             "query": {
-              "path": "collection",
               "filters": [
                 [
                   "match",
@@ -1429,26 +1548,45 @@
                   true
                 ]
               ],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "match": true
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
-        ]
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                    [
+                      "match",
+                      "==",
+                      true
+                    ]
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       }
     ]
   }

--- a/firebase-firestore/src/test/resources/json/remote_store_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/remote_store_spec_test.json
@@ -1,20 +1,23 @@
 {
-  "Waits for watch to remove targets": {
+  "Cleans up watch state correctly": {
     "describeName": "Remote store:",
-    "itName": "Waits for watch to remove targets",
-    "tags": [],
+    "itName": "Cleans up watch state correctly",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -22,9 +25,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -33,87 +38,27 @@
         }
       },
       {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "userUnlisten": [
-          2,
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        },
+        "expectedSnapshotEvents": [
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
               ],
-              "resumeToken": ""
+              "orderBys": [
+              ],
+              "path": "collection"
             }
           }
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "key": "a"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token"
         ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        }
-      },
-      {
-        "watchRemove": {
-          "targetIds": [
-            2
-          ]
-        }
       },
       {
         "watchAck": [
@@ -125,14 +70,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -150,53 +95,61 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
     ]
   },
-  "Waits for watch to ack last target add": {
+  "Handles user changes while offline (b/74749605).": {
     "describeName": "Remote store:",
-    "itName": "Waits for watch to ack last target add",
-    "tags": [],
+    "itName": "Handles user changes while offline (b/74749605).",
+    "tags": [
+      "no-android",
+      "no-ios"
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -204,9 +157,106 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": false
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "changeUser": "abc",
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchStreamClose": {
+          "error": {
+            "code": 14,
+            "message": "Simulated Backend Error"
+          },
+          "runBackoffTimer": true
+        }
+      }
+    ]
+  },
+  "Waits for watch to ack last target add": {
+    "describeName": "Remote store:",
+    "itName": "Waits for watch to ack last target add",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -223,22 +273,27 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -246,9 +301,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -260,22 +317,27 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -283,9 +345,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -297,22 +361,27 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -320,9 +389,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -335,14 +406,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -360,8 +431,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         }
       },
       {
@@ -381,14 +453,14 @@
           "docs": [
             {
               "key": "collection/b",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "b"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -406,8 +478,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         }
       },
       {
@@ -427,14 +500,14 @@
           "docs": [
             {
               "key": "collection/c",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "c"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -452,8 +525,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         }
       },
       {
@@ -473,14 +547,14 @@
           "docs": [
             {
               "key": "collection/d",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "d"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -498,53 +572,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/d",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "d"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
     ]
   },
-  "Cleans up watch state correctly": {
+  "Waits for watch to remove targets": {
     "describeName": "Remote store:",
-    "itName": "Cleans up watch state correctly",
-    "tags": [],
+    "itName": "Waits for watch to remove targets",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -552,9 +632,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -563,25 +645,95 @@
         }
       },
       {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
+        "watchAck": [
+          2
         ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
       },
       {
         "watchAck": [
@@ -593,14 +745,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -618,122 +770,37 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
-      }
-    ]
-  },
-  "Handles user changes while offline (b/74749605).": {
-    "describeName": "Remote store:",
-    "itName": "Handles user changes while offline (b/74749605).",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": false
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {}
-        }
-      },
-      {
-        "changeUser": "abc",
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
       }
     ]
   }

--- a/firebase-firestore/src/test/resources/json/resume_token_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/resume_token_spec_test.json
@@ -2,19 +2,22 @@
   "Resume tokens are sent after watch stream restarts": {
     "describeName": "Resume tokens:",
     "itName": "Resume tokens are sent after watch stream restarts",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -22,9 +25,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -42,14 +47,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -67,32 +72,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -109,9 +117,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "custom-query-resume-token"
@@ -124,19 +134,22 @@
   "Resume tokens are used across new listens": {
     "describeName": "Resume tokens:",
     "itName": "Resume tokens are used across new listens",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -144,9 +157,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -164,14 +179,14 @@
           "docs": [
             {
               "key": "collection/a",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "key": "a"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -189,32 +204,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "key": "a"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -222,22 +240,54 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -245,40 +295,17 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": "custom-query-resume-token"
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "key": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       },
       {
         "watchAck": [
@@ -287,8 +314,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1001
         }
       }
     ]

--- a/firebase-firestore/src/test/resources/json/write_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/write_spec_test.json
@@ -5041,7 +5041,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": [],
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": [],
           "writeStreamRequestCount": 3
         },
         "expectedSnapshotEvents": [
@@ -7357,10 +7358,10 @@
               "key": "collection/doc",
               "version": 1000,
               "value": {
+                "v": 1,
                 "a": {
                   "b": 2
-                },
-                "v": 1
+                }
               },
               "options": {
                 "hasLocalMutations": false,
@@ -7398,10 +7399,10 @@
                 "key": "collection/doc",
                 "version": 1000,
                 "value": {
+                  "v": 1,
                   "a": {
                     "b": 2
-                  },
-                  "v": 1
+                  }
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -7435,10 +7436,10 @@
                 "key": "collection/doc",
                 "version": 1000,
                 "value": {
+                  "v": 2,
                   "a": {
                     "b": 2
-                  },
-                  "v": 2
+                  }
                 },
                 "options": {
                   "hasLocalMutations": true,
@@ -7459,10 +7460,10 @@
               "key": "collection/doc",
               "version": 2000,
               "value": {
+                "v": 2,
                 "a": {
                   "b": 2
-                },
-                "v": 2
+                }
               },
               "options": {
                 "hasLocalMutations": false,
@@ -7505,10 +7506,10 @@
                 "key": "collection/doc",
                 "version": 2000,
                 "value": {
+                  "v": 2,
                   "a": {
                     "b": 2
-                  },
-                  "v": 2
+                  }
                 },
                 "options": {
                   "hasLocalMutations": false,
@@ -7548,7 +7549,8 @@
         "enableNetwork": false,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": [],
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": [],
           "writeStreamRequestCount": 3
         }
       },
@@ -9550,7 +9552,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },
@@ -10428,7 +10431,8 @@
         "shutdown": true,
         "expectedState": {
           "activeTargets": {},
-          "limboDocs": []
+          "activeLimboDocs": [],
+          "enqueuedLimboDocs": []
         },
         "clientIndex": 0
       },

--- a/firebase-firestore/src/test/resources/json/write_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/write_spec_test.json
@@ -1,20 +1,23 @@
 {
-  "Two sequential writes to different documents smoke test.": {
+  "Cache raises correct event if write is acked before watch delivers it": {
     "describeName": "Writes:",
-    "itName": "Two sequential writes to different documents smoke test.",
-    "tags": [],
+    "itName": "Cache raises correct event if write is acked before watch delivers it",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -22,324 +25,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 500,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 500,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 2
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 2000,
-              "value": {
-                "v": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        }
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 2000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/b",
-          {
-            "v": 2
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/b",
-                "version": 500,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2500,
-              "value": {
-                "v": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
-        }
-      },
-      {
-        "writeAck": {
-          "version": 2500
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/b"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/b",
-                "version": 2500,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Event is raised for a local set before and after the write ack": {
-    "describeName": "Writes:",
-    "itName": "Event is raised for a local set before and after the write ack",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -357,14 +47,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -382,32 +72,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       },
@@ -420,55 +113,31 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "modified": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/key",
-              "version": 2000,
-              "value": {
-                "v": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        }
       },
       {
         "writeAck": {
@@ -479,61 +148,86 @@
             "acknowledgedDocs": [
               "collection/key"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/key",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/key",
-                "version": 2000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 2000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       }
     ]
   },
-  "Raises snapshot with 'hasPendingWrites' for unacknowledged write": {
+  "Cache will hold local write until watch catches up": {
     "describeName": "Writes:",
-    "itName": "Raises snapshot with 'hasPendingWrites' for unacknowledged write",
-    "tags": [],
+    "itName": "Cache will hold local write until watch catches up",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
-      {
-        "userSet": [
-          "collection/doc",
-          {
-            "v": 1
-          }
-        ]
-      },
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -541,50 +235,459 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/key",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
-                "key": "collection/doc",
-                "version": 0,
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "v": 3
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 3
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 3000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/key"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/key",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "doc": "b"
+              },
+              "version": 3000
+            },
+            {
+              "key": "collection/key",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 3
+              },
+              "version": 3000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "doc": "b"
+                },
+                "version": 3000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 3
+                },
+                "version": 3000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Cache will not keep data for an outdated write ack": {
+    "describeName": "Writes:",
+    "itName": "Cache will not keep data for an outdated write ack",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/key",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "v": 2
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/key",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 3
+              },
+              "version": 10000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 10000
+        }
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "modified": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 3
+                },
+                "version": 10000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/key"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
       }
     ]
   },
   "Doesn't raise 'hasPendingWrites' for committed write and new listen": {
     "describeName": "Writes:",
     "itName": "Doesn't raise 'hasPendingWrites' for committed write and new listen",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
@@ -604,7 +707,8 @@
             "acknowledgedDocs": [
               "collection/doc"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -612,9 +716,38 @@
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -622,59 +755,39 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/doc",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
+        }
       }
     ]
   },
   "Doesn't raise event for document with pending patch": {
     "describeName": "Writes:",
     "itName": "Doesn't raise event for document with pending patch",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -682,9 +795,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -699,7 +814,8 @@
       },
       {
         "watchEntity": {
-          "docs": [],
+          "docs": [
+          ],
           "targets": [
             2
           ]
@@ -715,19 +831,22 @@
       },
       {
         "watchSnapshot": {
-          "version": 250,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 250
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -748,7 +867,8 @@
             "acknowledgedDocs": [
               "collection/doc"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -757,14 +877,14 @@
           "docs": [
             {
               "key": "collection/doc",
-              "version": 500,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 500
             }
           ],
           "targets": [
@@ -774,8 +894,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 500
         }
       },
       {
@@ -783,14 +904,14 @@
           "docs": [
             {
               "key": "collection/doc",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -800,53 +921,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/doc",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
     ]
   },
-  "Cache will not keep data for an outdated write ack": {
+  "Ensure correct events after patching a doc (including a delete) and getting watcher events.": {
     "describeName": "Writes:",
-    "itName": "Cache will not keep data for an outdated write ack",
-    "tags": [],
+    "itName": "Ensure correct events after patching a doc (including a delete) and getting watcher events.",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/doc"
           }
         ],
         "expectedState": {
@@ -854,9 +981,237 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": {
+                  "b": 2
+                },
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-500"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 500
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": {
+                    "b": 2
+                  },
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/doc",
+          {
+            "a.c": "<DELETE>",
+            "v": 2
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "a": {
+                    "b": 2
+                  },
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "a": {
+                  "b": 2
+                },
+                "v": 2
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "a": {
+                    "b": 2
+                  },
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Event is raised for a local set before and after the write ack": {
+    "describeName": "Writes:",
+    "itName": "Event is raised for a local set before and after the write ack",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -874,14 +1229,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -899,228 +1254,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "v": 2
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/key",
-                "version": 1000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/key",
-              "version": 10000,
-              "value": {
-                "v": 3
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 10000,
-          "targetIds": []
-        }
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/key"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/key",
-                "version": 10000,
-                "value": {
-                  "v": 3
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Cache raises correct event if write is acked before watch delivers it": {
-    "describeName": "Writes:",
-    "itName": "Cache raises correct event if write is acked before watch delivers it",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
+              "filters": [
               ],
-              "resumeToken": ""
+              "orderBys": [
+              ],
+              "path": "collection/key"
             }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/key",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
           }
         ]
       },
@@ -1133,56 +1295,45 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "modified": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/key"
-            ],
-            "rejectedDocs": []
-          }
-        }
       },
       {
         "watchEntity": {
           "docs": [
             {
               "key": "collection/key",
-              "version": 2000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 2000
             }
           ],
           "targets": [
@@ -1192,53 +1343,73 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "writeAck": {
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/key",
-                "version": 2000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 2000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
-        ]
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/key"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
       }
     ]
   },
-  "Cache will hold local write until watch catches up": {
+  "Failed writes are released immediately.": {
     "describeName": "Writes:",
-    "itName": "Cache will hold local write until watch catches up",
-    "tags": [],
+    "itName": "Failed writes are released immediately.",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1246,9 +1417,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1265,15 +1438,15 @@
         "watchEntity": {
           "docs": [
             {
-              "key": "collection/key",
-              "version": 1000,
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -1291,105 +1464,163 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
-                "key": "collection/key",
-                "version": 1000,
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
         "userSet": [
-          "collection/key",
+          "collection/b",
           {
-            "v": 3
+            "v": 1
           }
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
+            "added": [
               {
-                "key": "collection/key",
-                "version": 1000,
-                "value": {
-                  "v": 3
-                },
+                "key": "collection/b",
                 "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
         "writeAck": {
-          "version": 3000
+          "version": 2000
         },
         "expectedState": {
           "userCallbacks": {
             "acknowledgedDocs": [
-              "collection/key"
+              "collection/b"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
       {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/key",
-              "version": 2000,
-              "value": {
-                "v": 2
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
+        "userSet": [
+          "collection/a",
+          {
+            "v": 2
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
               }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
             }
-          ],
-          "targets": [
-            2
-          ]
-        }
+          }
+        ]
       },
       {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a"
+            ]
+          }
         }
       },
       {
@@ -1397,25 +1628,14 @@
           "docs": [
             {
               "key": "collection/b",
-              "version": 3000,
-              "value": {
-                "doc": "b"
-              },
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/key",
-              "version": 3000,
-              "value": {
-                "v": 3
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "value": {
+                "v": 1
+              },
+              "version": 2000
             }
           ],
           "targets": [
@@ -1425,45 +1645,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 3000,
-                "value": {
-                  "doc": "b"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "metadata": [
-              {
-                "key": "collection/key",
-                "version": 3000,
-                "value": {
-                  "v": 3
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
@@ -1472,10 +1682,11 @@
   "Local patch is applied to query until watch catches up": {
     "describeName": "Writes:",
     "itName": "Local patch is applied to query until watch catches up",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": false
     },
     "steps": [
       {
@@ -1490,9 +1701,38 @@
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "local": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -1500,40 +1740,17 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
             }
           }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/doc",
-                "version": 0,
-                "value": {
-                  "local": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
+        }
       },
       {
         "writeAck": {
@@ -1544,7 +1761,8 @@
             "acknowledgedDocs": [
               "collection/doc"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -1558,15 +1776,15 @@
           "docs": [
             {
               "key": "collection/doc",
-              "version": 2000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "local": 1,
                 "remote": 2
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 2000
             }
           ],
           "targets": [
@@ -1584,33 +1802,36 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "modified": [
               {
                 "key": "collection/doc",
-                "version": 2000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "local": 1,
                   "remote": 2
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 2000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1623,28 +1844,30 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "modified": [
               {
                 "key": "collection/doc",
-                "version": 2000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "local": 5,
                   "remote": 2
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 2000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1657,7 +1880,8 @@
             "acknowledgedDocs": [
               "collection/doc"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -1666,15 +1890,15 @@
           "docs": [
             {
               "key": "collection/doc",
-              "version": 3000,
+              "options": {
+                "hasCommittedMutations": true,
+                "hasLocalMutations": false
+              },
               "value": {
                 "local": 1,
                 "remote": 3
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": true
-              }
+              "version": 3000
             }
           ],
           "targets": [
@@ -1684,8 +1908,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 3000
         }
       },
       {
@@ -1693,15 +1918,15 @@
           "docs": [
             {
               "key": "collection/doc",
-              "version": 4000,
+              "options": {
+                "hasCommittedMutations": true,
+                "hasLocalMutations": false
+              },
               "value": {
                 "local": 1,
                 "remote": 4
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": true
-              }
+              "version": 4000
             }
           ],
           "targets": [
@@ -1711,8 +1936,9 @@
       },
       {
         "watchSnapshot": {
-          "version": 4000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 4000
         }
       },
       {
@@ -1720,15 +1946,15 @@
           "docs": [
             {
               "key": "collection/doc",
-              "version": 5000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "local": 5,
                 "remote": 5
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 5000
             }
           ],
           "targets": [
@@ -1738,33 +1964,5394 @@
       },
       {
         "watchSnapshot": {
-          "version": 5000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 5000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "modified": [
               {
                 "key": "collection/doc",
-                "version": 5000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "local": 5,
                   "remote": 5
                 },
+                "version": 5000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Mutation are not sent twice after primary failover": {
+    "describeName": "Writes:",
+    "itName": "Mutation are not sent twice after primary failover",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "k": "a"
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/b",
+          {
+            "k": "b"
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "writeAck": {
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 0,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/b"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "k": "a"
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "k": "b"
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Mutation recovers after primary takeover": {
+    "describeName": "Writes:",
+    "itName": "Mutation recovers after primary takeover",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "k": "a"
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "k": "a"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "writeAck": {
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "k": "a"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "k": "a"
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Mutations are scoped by user": {
+    "describeName": "Writes:",
+    "itName": "Mutations are scoped by user",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "changeUser": "user1",
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "changeUser": "user2",
+        "clientIndex": 1
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/b",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "New writes are sent after write failure": {
+    "describeName": "Writes:",
+    "itName": "New writes are sent after write failure",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a"
+            ]
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/b",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/b"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Pending write is acknowledged by primary client": {
+    "describeName": "Writes:",
+    "itName": "Pending write is acknowledged by primary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-500"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 500
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Pending write is rejected by primary client": {
+    "describeName": "Writes:",
+    "itName": "Pending write is rejected by primary client",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-500"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 500
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Pending writes are shared between clients": {
+    "describeName": "Writes:",
+    "itName": "Pending writes are shared between clients",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-500"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 500
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 2
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 0
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 0
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 3
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 3
+                },
+                "version": 0
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 3
+                },
+                "version": 0
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Pipelined writes can fail": {
+    "describeName": "Writes:",
+    "itName": "Pipelined writes can fail",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/a0",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a0",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a1",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a2",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a3",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a4",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a4",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a5",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a5",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a6",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a6",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a7",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a7",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a8",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a8",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a9",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a9",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a10",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a10",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a11",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a11",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a12",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a12",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a13",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a13",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a14",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a14",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "numOutstandingWrites": 10
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a0",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a0"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a1",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a1"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a2",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a2"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a3",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a3"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a4",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a4"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a5",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a5"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a6",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a6"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a7",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a7"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a8",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a8"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a9",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a9"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a10",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a10"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a11",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a11"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a12",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a12"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a13",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a13"
+            ]
+          }
+        }
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a14",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "numOutstandingWrites": 0,
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a14"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Primary client acknowledges write": {
+    "describeName": "Writes:",
+    "itName": "Primary client acknowledges write",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Primary client rejects write": {
+    "describeName": "Writes:",
+    "itName": "Primary client rejects write",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/a"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Raises snapshot with 'hasPendingWrites' for unacknowledged write": {
+    "describeName": "Writes:",
+    "itName": "Raises snapshot with 'hasPendingWrites' for unacknowledged write",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userSet": [
+          "collection/doc",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Secondary tabs handle user change": {
+    "describeName": "Writes:",
+    "itName": "Secondary tabs handle user change",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "changeUser": "user1",
+        "clientIndex": 0
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "changeUser": "user1",
+        "clientIndex": 1
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/b",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "changeUser": "user2",
+        "clientIndex": 0,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/c",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "changeUser": "user2",
+        "clientIndex": 1,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "changeUser": "user1",
+        "clientIndex": 1,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "changeUser": "user1",
+        "clientIndex": 0,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/c",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "Two sequential writes to different documents smoke test.": {
+    "describeName": "Writes:",
+    "itName": "Two sequential writes to different documents smoke test.",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 500
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 500
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a",
+          {
+            "v": 2
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/b",
+          {
+            "v": 2
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 500
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 2
+              },
+              "version": 2500
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 3000
+        }
+      },
+      {
+        "writeAck": {
+          "version": 2500
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 2
+                },
+                "version": 2500
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/b"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Unresponsive primary ignores acknowledged write": {
+    "describeName": "Writes:",
+    "itName": "Unresponsive primary ignores acknowledged write",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "k": "a"
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 1000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/b",
+          {
+            "k": "b"
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 2,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "keepInQueue": true,
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "writeAck": {
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/b"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Unresponsive primary ignores rejected write": {
+    "describeName": "Writes:",
+    "itName": "Unresponsive primary ignores rejected write",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "k": "a"
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 1000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/b",
+          {
+            "k": "b"
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 2,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "failWrite": {
+          "error": {
+            "code": 9
+          },
+          "keepInQueue": true
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/b"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Write are sequenced by multiple clients": {
+    "describeName": "Writes:",
+    "itName": "Write are sequenced by multiple clients",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 4,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/b",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "userSet": [
+          "collection/c",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 3,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 3,
+        "userSet": [
+          "collection/d",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 1000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 3000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/b"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/c"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 3,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/d"
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/f",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/g",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 2,
+        "userSet": [
+          "collection/h",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 3,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 3,
+        "userSet": [
+          "collection/i",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 4000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/f"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 5000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 6000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/g"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/h"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 3,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/i"
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 3,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 3,
+        "userSet": [
+          "collection/j",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 3,
+        "userSet": [
+          "collection/k",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 3,
+        "userSet": [
+          "collection/l",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 7000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 8000
+        }
+      },
+      {
+        "clientIndex": 3,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/j",
+              "collection/l"
+            ],
+            "rejectedDocs": [
+              "collection/k"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Write is executed after primary tab failover": {
+    "describeName": "Writes:",
+    "itName": "Write is executed after primary tab failover",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/b",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 0,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "runTimer": "client_metadata_refresh",
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/b"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Write is sent by newly started primary": {
+    "describeName": "Writes:",
+    "itName": "Write is sent by newly started primary",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 3,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": false
+        }
+      },
+      {
+        "clientIndex": 1,
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "shutdown": true,
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ]
+        }
+      },
+      {
+        "clientIndex": 2,
+        "drainQueue": true,
+        "expectedState": {
+          "isPrimary": true,
+          "numOutstandingWrites": 1
+        }
+      },
+      {
+        "clientIndex": 2,
+        "writeAck": {
+          "version": 1000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Writes are held during primary failover": {
+    "describeName": "Writes:",
+    "itName": "Writes are held during primary failover",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/doc",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "clientIndex": 1,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          },
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 1,
+        "userListen": [
+          4,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/doc"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": true,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 2000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchAck": [
+          4
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2,
+            4
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/doc"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            },
+            "4": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/doc"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "runTimer": "client_metadata_refresh",
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/doc",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "isPrimary": false
+        }
+      }
+    ]
+  },
+  "Writes are not re-sent after disable/enable network.": {
+    "describeName": "Writes:",
+    "itName": "Writes are not re-sent after disable/enable network.",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-500"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 500
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 1000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          },
+          "writeStreamRequestCount": 2
+        }
+      },
+      {
+        "enableNetwork": false,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeLimboDocs": [
+          ],
+          "activeTargets": {
+          },
+          "enqueuedLimboDocs": [
+          ],
+          "writeStreamRequestCount": 3
+        }
+      },
+      {
+        "enableNetwork": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-500"
+            }
+          },
+          "writeStreamRequestCount": 3
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Writes are not re-sent.": {
+    "describeName": "Writes:",
+    "itName": "Writes are not re-sent.",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-500"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 500
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userSet": [
+          "collection/a",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 1000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/b",
+          {
+            "v": 1
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/b"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            },
+            {
+              "key": "collection/b",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "metadata": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              },
+              {
+                "key": "collection/b",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 2000
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
@@ -1773,19 +7360,22 @@
   "Writes are pipelined": {
     "describeName": "Writes:",
     "itName": "Writes are pipelined",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -1793,9 +7383,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -1825,27 +7417,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a0",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1858,27 +7452,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a1",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1891,27 +7487,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a2",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1924,27 +7522,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a3",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1957,27 +7557,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a4",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -1990,27 +7592,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a5",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2023,27 +7627,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a6",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2056,27 +7662,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a7",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2089,27 +7697,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a8",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2122,27 +7732,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a9",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2155,27 +7767,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a10",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2188,27 +7802,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a11",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2221,27 +7837,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a12",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2254,27 +7872,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a13",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2287,27 +7907,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a14",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ],
         "expectedState": {
@@ -2323,7 +7945,8 @@
             "acknowledgedDocs": [
               "collection/a0"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2332,14 +7955,14 @@
           "docs": [
             {
               "key": "collection/a0",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -2349,32 +7972,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a0",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2387,7 +8013,8 @@
             "acknowledgedDocs": [
               "collection/a1"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2396,14 +8023,14 @@
           "docs": [
             {
               "key": "collection/a1",
-              "version": 2000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 2000
             }
           ],
           "targets": [
@@ -2413,32 +8040,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 2000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a1",
-                "version": 2000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 2000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2451,7 +8081,8 @@
             "acknowledgedDocs": [
               "collection/a2"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2460,14 +8091,14 @@
           "docs": [
             {
               "key": "collection/a2",
-              "version": 3000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 3000
             }
           ],
           "targets": [
@@ -2477,32 +8108,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 3000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a2",
-                "version": 3000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 3000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2515,7 +8149,8 @@
             "acknowledgedDocs": [
               "collection/a3"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2524,14 +8159,14 @@
           "docs": [
             {
               "key": "collection/a3",
-              "version": 4000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 4000
             }
           ],
           "targets": [
@@ -2541,32 +8176,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 4000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 4000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a3",
-                "version": 4000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 4000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2579,7 +8217,8 @@
             "acknowledgedDocs": [
               "collection/a4"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2588,14 +8227,14 @@
           "docs": [
             {
               "key": "collection/a4",
-              "version": 5000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 5000
             }
           ],
           "targets": [
@@ -2605,32 +8244,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 5000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 5000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a4",
-                "version": 5000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 5000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2643,7 +8285,8 @@
             "acknowledgedDocs": [
               "collection/a5"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2652,14 +8295,14 @@
           "docs": [
             {
               "key": "collection/a5",
-              "version": 6000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 6000
             }
           ],
           "targets": [
@@ -2669,32 +8312,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 6000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 6000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a5",
-                "version": 6000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 6000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2707,7 +8353,8 @@
             "acknowledgedDocs": [
               "collection/a6"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2716,14 +8363,14 @@
           "docs": [
             {
               "key": "collection/a6",
-              "version": 7000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 7000
             }
           ],
           "targets": [
@@ -2733,32 +8380,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 7000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 7000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a6",
-                "version": 7000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 7000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2771,7 +8421,8 @@
             "acknowledgedDocs": [
               "collection/a7"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2780,14 +8431,14 @@
           "docs": [
             {
               "key": "collection/a7",
-              "version": 8000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 8000
             }
           ],
           "targets": [
@@ -2797,32 +8448,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 8000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 8000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a7",
-                "version": 8000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 8000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2835,7 +8489,8 @@
             "acknowledgedDocs": [
               "collection/a8"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2844,14 +8499,14 @@
           "docs": [
             {
               "key": "collection/a8",
-              "version": 9000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 9000
             }
           ],
           "targets": [
@@ -2861,32 +8516,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 9000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 9000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a8",
-                "version": 9000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 9000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2899,7 +8557,8 @@
             "acknowledgedDocs": [
               "collection/a9"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2908,14 +8567,14 @@
           "docs": [
             {
               "key": "collection/a9",
-              "version": 10000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 10000
             }
           ],
           "targets": [
@@ -2925,32 +8584,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 10000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 10000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a9",
-                "version": 10000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 10000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -2963,7 +8625,8 @@
             "acknowledgedDocs": [
               "collection/a10"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -2972,14 +8635,14 @@
           "docs": [
             {
               "key": "collection/a10",
-              "version": 11000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 11000
             }
           ],
           "targets": [
@@ -2989,32 +8652,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 11000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 11000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a10",
-                "version": 11000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 11000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -3027,7 +8693,8 @@
             "acknowledgedDocs": [
               "collection/a11"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -3036,14 +8703,14 @@
           "docs": [
             {
               "key": "collection/a11",
-              "version": 12000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 12000
             }
           ],
           "targets": [
@@ -3053,32 +8720,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 12000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 12000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a11",
-                "version": 12000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 12000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -3091,7 +8761,8 @@
             "acknowledgedDocs": [
               "collection/a12"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -3100,14 +8771,14 @@
           "docs": [
             {
               "key": "collection/a12",
-              "version": 13000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 13000
             }
           ],
           "targets": [
@@ -3117,32 +8788,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 13000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 13000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a12",
-                "version": 13000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 13000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -3155,7 +8829,8 @@
             "acknowledgedDocs": [
               "collection/a13"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -3164,14 +8839,14 @@
           "docs": [
             {
               "key": "collection/a13",
-              "version": 14000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 14000
             }
           ],
           "targets": [
@@ -3181,32 +8856,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 14000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 14000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
             "metadata": [
               {
                 "key": "collection/a13",
-                "version": 14000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 14000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -3219,7 +8897,8 @@
             "acknowledgedDocs": [
               "collection/a14"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -3228,14 +8907,14 @@
           "docs": [
             {
               "key": "collection/a14",
-              "version": 15000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "v": 1
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 15000
             }
           ],
           "targets": [
@@ -3245,53 +8924,65 @@
       },
       {
         "watchSnapshot": {
-          "version": 15000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 15000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/a14",
-                "version": 15000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 15000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       }
     ]
   },
-  "Pipelined writes can fail": {
+  "Writes are released by primary client": {
     "describeName": "Writes:",
-    "itName": "Pipelined writes can fail",
-    "tags": [],
+    "itName": "Writes are released by primary client",
+    "tags": [
+      "multi-client"
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 2,
+      "useGarbageCollection": false
     },
     "steps": [
       {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -3299,9 +8990,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -3310,1158 +9003,15 @@
         }
       },
       {
-        "userSet": [
-          "collection/a0",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a0",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a1",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a1",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a2",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a2",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a3",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a3",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a4",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a4",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a5",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a5",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a6",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a6",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a7",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a7",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a8",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a8",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a9",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a9",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a10",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a10",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a11",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a11",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a12",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a12",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a13",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a13",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a14",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a14",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "expectedState": {
-          "numOutstandingWrites": 10
-        }
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a0"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a0",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a1"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a1",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a2"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a2",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a3"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a3",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a4"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a4",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a5"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a5",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a6"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a6",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a7"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a7",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a8"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a8",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a9"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a9",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a10"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a10",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a11"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a11",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a12"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a12",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a13"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a13",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a14"
-            ]
-          },
-          "numOutstandingWrites": 0
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a14",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Failed writes are released immediately.": {
-    "describeName": "Writes:",
-    "itName": "Failed writes are released immediately.",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
+        "clientIndex": 0,
         "watchAck": [
           2
         ]
       },
       {
+        "clientIndex": 0,
         "watchEntity": {
           "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
           ],
           "targets": [
             2
@@ -4469,263 +9019,7 @@
         }
       },
       {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/b",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/b"
-            ],
-            "rejectedDocs": []
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 2
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes are not re-sent.": {
-    "describeName": "Writes:",
-    "itName": "Writes are not re-sent.",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
+        "clientIndex": 0,
         "watchCurrent": [
           [
             2
@@ -4734,433 +9028,173 @@
         ]
       },
       {
+        "clientIndex": 0,
         "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 500
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
         "userSet": [
           "collection/a",
           {
             "v": 1
           }
-        ],
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
       {
+        "clientIndex": 0,
         "writeAck": {
           "version": 1000
-        },
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
         "expectedState": {
           "userCallbacks": {
             "acknowledgedDocs": [
               "collection/a"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
       {
-        "userSet": [
-          "collection/b",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
+        "clientIndex": 0,
+        "drainQueue": true
       },
       {
-        "writeAck": {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
           "version": 2000
         },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/b"
-            ],
-            "rejectedDocs": []
-          }
-        }
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            },
-            {
-              "key": "collection/b",
-              "version": 2000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/a",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes are not re-sent after disable/enable network.": {
-    "describeName": "Writes:",
-    "itName": "Writes are not re-sent after disable/enable network.",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
+            "query": {
+              "filters": [
               ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-500"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          },
-          "writeStreamRequestCount": 2
-        }
-      },
-      {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": [],
-          "writeStreamRequestCount": 3
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "enableNetwork": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
+              "orderBys": [
               ],
-              "resumeToken": "resume-token-500"
+              "path": "collection"
             }
-          },
-          "writeStreamRequestCount": 3
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
           }
         ]
       }
     ]
   },
   "Writes are released when there are no queries left": {
+    "comment": "This test verifies that committed mutations are eligible for garbage collection on target removal",
     "describeName": "Writes:",
     "itName": "Writes are released when there are no queries left",
     "tags": [
       "eager-gc"
     ],
-    "comment": "This test verifies that committed mutations are eligible for garbage collection on target removal",
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -5168,9 +9202,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -5185,7 +9221,8 @@
       },
       {
         "watchEntity": {
-          "docs": [],
+          "docs": [
+          ],
           "targets": [
             2
           ]
@@ -5201,19 +9238,22 @@
       },
       {
         "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 500
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -5226,27 +9266,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/a",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "v": 1
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
           }
         ]
       },
@@ -5259,7 +9301,8 @@
             "acknowledgedDocs": [
               "collection/a"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -5267,22 +9310,27 @@
         "userUnlisten": [
           2,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
-          "activeTargets": {}
+          "activeTargets": {
+          }
         }
       },
       {
         "userListen": [
           4,
           {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
           }
         ],
         "expectedState": {
@@ -5290,9 +9338,11 @@
             "4": {
               "queries": [
                 {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
                 }
               ],
               "resumeToken": ""
@@ -5302,39 +9352,16 @@
       }
     ]
   },
-  "Writes that fail with code invalid-argument are rejected": {
+  "Writes are resent after network disconnect": {
     "describeName": "Writes:",
-    "itName": "Writes that fail with code invalid-argument are rejected",
-    "tags": [],
+    "itName": "Writes are resent after network disconnect",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
       {
         "userSet": [
           "collection/key",
@@ -5342,902 +9369,42 @@
             "foo": "bar"
           }
         ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 3
-          }
-        },
         "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes that fail with code not-found are rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code not-found are rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
+          "numOutstandingWrites": 1
         }
       },
       {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 5
-          }
-        },
+        "enableNetwork": false,
         "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes that fail with code already-exists are rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code already-exists are rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
+          "activeLimboDocs": [
+          ],
           "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 6
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes that fail with code permission-denied are rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code permission-denied are rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 7
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes that fail with code failed-precondition are rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code failed-precondition are rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes that fail with code out-of-range are rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code out-of-range are rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 11
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes that fail with code unimplemented are rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code unimplemented are rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 12
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes that fail with code data-loss are rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code data-loss are rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 15
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes that fail with code resource_exhausted are not rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code resource_exhausted are not rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 8
           },
-          "keepInQueue": true
+          "enqueuedLimboDocs": [
+          ],
+          "writeStreamRequestCount": 3
+        }
+      },
+      {
+        "enableNetwork": true,
+        "expectedState": {
+          "numOutstandingWrites": 1,
+          "writeStreamRequestCount": 5
+        }
+      },
+      {
+        "writeAck": {
+          "version": 1
+        },
+        "expectedState": {
+          "numOutstandingWrites": 0,
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/key"
+            ],
+            "rejectedDocs": [
+            ]
+          }
         }
       }
     ]
@@ -6245,19 +9412,22 @@
   "Writes that fail with code aborted are retried": {
     "describeName": "Writes:",
     "itName": "Writes that fail with code aborted are retried",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -6265,9 +9435,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -6284,27 +9456,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       },
@@ -6325,7 +9499,8 @@
             "acknowledgedDocs": [
               "collection/key"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -6339,14 +9514,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "foo": "bar"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -6364,53 +9539,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       }
     ]
   },
-  "Writes that fail with code cancelled are retried": {
+  "Writes that fail with code already-exists are rejected": {
     "describeName": "Writes:",
-    "itName": "Writes that fail with code cancelled are retried",
-    "tags": [],
+    "itName": "Writes that fail with code already-exists are rejected",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -6418,9 +9599,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -6437,27 +9620,147 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 6
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            },
+            "removed": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/key"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Writes that fail with code cancelled are retried": {
+    "describeName": "Writes:",
+    "itName": "Writes that fail with code cancelled are retried",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "foo": "bar"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       },
@@ -6478,7 +9781,8 @@
             "acknowledgedDocs": [
               "collection/key"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -6492,14 +9796,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "foo": "bar"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -6517,53 +9821,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       }
     ]
   },
-  "Writes that fail with code unknown are retried": {
+  "Writes that fail with code data-loss are rejected": {
     "describeName": "Writes:",
-    "itName": "Writes that fail with code unknown are retried",
-    "tags": [],
+    "itName": "Writes that fail with code data-loss are rejected",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -6571,9 +9881,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -6590,133 +9902,96 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       },
       {
         "failWrite": {
           "error": {
-            "code": 2
-          },
-          "keepInQueue": true
-        }
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/key"
-            ],
-            "rejectedDocs": []
+            "code": 15
           }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/key",
-              "version": 1000,
-              "value": {
-                "foo": "bar"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
             },
-            "metadata": [
+            "removed": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            ]
           }
-        ]
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/key"
+            ]
+          }
+        }
       }
     ]
   },
   "Writes that fail with code deadline-exceeded are retried": {
     "describeName": "Writes:",
     "itName": "Writes that fail with code deadline-exceeded are retried",
-    "tags": [],
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -6724,9 +9999,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -6743,27 +10020,29 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       },
@@ -6784,7 +10063,8 @@
             "acknowledgedDocs": [
               "collection/key"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -6798,14 +10078,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "foo": "bar"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -6823,53 +10103,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       }
     ]
   },
-  "Writes that fail with code internal are retried": {
+  "Writes that fail with code failed-precondition are rejected": {
     "describeName": "Writes:",
-    "itName": "Writes that fail with code internal are retried",
-    "tags": [],
+    "itName": "Writes that fail with code failed-precondition are rejected",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -6877,9 +10163,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -6896,27 +10184,147 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 9
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            },
+            "removed": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/key"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Writes that fail with code internal are retried": {
+    "describeName": "Writes:",
+    "itName": "Writes that fail with code internal are retried",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "foo": "bar"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       },
@@ -6937,7 +10345,8 @@
             "acknowledgedDocs": [
               "collection/key"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -6951,14 +10360,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "foo": "bar"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -6976,53 +10385,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       }
     ]
   },
-  "Writes that fail with code unavailable are retried": {
+  "Writes that fail with code invalid-argument are rejected": {
     "describeName": "Writes:",
-    "itName": "Writes that fail with code unavailable are retried",
-    "tags": [],
+    "itName": "Writes that fail with code invalid-argument are rejected",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -7030,9 +10445,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -7049,133 +10466,96 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       },
       {
         "failWrite": {
           "error": {
-            "code": 14
-          },
-          "keepInQueue": true
-        }
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/key"
-            ],
-            "rejectedDocs": []
+            "code": 3
           }
-        }
-      },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/key",
-              "version": 1000,
-              "value": {
-                "foo": "bar"
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-1000"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
         },
         "expectedSnapshotEvents": [
           {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
             "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
             },
-            "metadata": [
+            "removed": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            ]
           }
-        ]
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/key"
+            ]
+          }
+        }
       }
     ]
   },
-  "Writes that fail with code unauthenticated are retried": {
+  "Writes that fail with code not-found are rejected": {
     "describeName": "Writes:",
-    "itName": "Writes that fail with code unauthenticated are retried",
-    "tags": [],
+    "itName": "Writes that fail with code not-found are rejected",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -7183,9 +10563,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/key",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -7202,27 +10584,466 @@
         ],
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
             "added": [
               {
                 "key": "collection/key",
-                "version": 0,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
+                "version": 0
               }
             ],
             "errorCode": 0,
             "fromCache": true,
-            "hasPendingWrites": true
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 5
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            },
+            "removed": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/key"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Writes that fail with code out-of-range are rejected": {
+    "describeName": "Writes:",
+    "itName": "Writes that fail with code out-of-range are rejected",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "foo": "bar"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 11
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            },
+            "removed": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/key"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Writes that fail with code permission-denied are rejected": {
+    "describeName": "Writes:",
+    "itName": "Writes that fail with code permission-denied are rejected",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "foo": "bar"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 7
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            },
+            "removed": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/key"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Writes that fail with code resource_exhausted are not rejected": {
+    "describeName": "Writes:",
+    "itName": "Writes that fail with code resource_exhausted are not rejected",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "foo": "bar"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 8
+          },
+          "keepInQueue": true
+        }
+      }
+    ]
+  },
+  "Writes that fail with code unauthenticated are retried": {
+    "describeName": "Writes:",
+    "itName": "Writes that fail with code unauthenticated are retried",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "foo": "bar"
+          }
+        ],
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       },
@@ -7243,7 +11064,8 @@
             "acknowledgedDocs": [
               "collection/key"
             ],
-            "rejectedDocs": []
+            "rejectedDocs": [
+            ]
           }
         }
       },
@@ -7257,14 +11079,14 @@
           "docs": [
             {
               "key": "collection/key",
-              "version": 1000,
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
               "value": {
                 "foo": "bar"
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "version": 1000
             }
           ],
           "targets": [
@@ -7282,53 +11104,59 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
             "metadata": [
               {
                 "key": "collection/key",
-                "version": 1000,
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
                 "value": {
                   "foo": "bar"
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
         ]
       }
     ]
   },
-  "Ensure correct events after patching a doc (including a delete) and getting watcher events.": {
+  "Writes that fail with code unavailable are retried": {
     "describeName": "Writes:",
-    "itName": "Ensure correct events after patching a doc (including a delete) and getting watcher events.",
-    "tags": [],
+    "itName": "Writes that fail with code unavailable are retried",
+    "tags": [
+    ],
     "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
         "userListen": [
           2,
           {
-            "path": "collection/doc",
-            "filters": [],
-            "orderBys": []
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
           }
         ],
         "expectedState": {
@@ -7336,9 +11164,11 @@
             "2": {
               "queries": [
                 {
-                  "path": "collection/doc",
-                  "filters": [],
-                  "orderBys": []
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
                 }
               ],
               "resumeToken": ""
@@ -7346,194 +11176,6 @@
           }
         }
       },
-      {
-        "watchAck": [
-          2
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/doc",
-              "version": 1000,
-              "value": {
-                "v": 1,
-                "a": {
-                  "b": 2
-                }
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-500"
-        ]
-      },
-      {
-        "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/doc",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/doc",
-                "version": 1000,
-                "value": {
-                  "v": 1,
-                  "a": {
-                    "b": 2
-                  }
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      },
-      {
-        "userPatch": [
-          "collection/doc",
-          {
-            "v": 2,
-            "a.c": "<DELETE>"
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/doc",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/doc",
-                "version": 1000,
-                "value": {
-                  "v": 2,
-                  "a": {
-                    "b": 2
-                  }
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/doc",
-              "version": 2000,
-              "value": {
-                "v": 2,
-                "a": {
-                  "b": 2
-                }
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        }
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        }
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/doc"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/doc",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/doc",
-                "version": 2000,
-                "value": {
-                  "v": 2,
-                  "a": {
-                    "b": 2
-                  }
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
-  "Writes are resent after network disconnect": {
-    "describeName": "Writes:",
-    "itName": "Writes are resent after network disconnect",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
       {
         "userSet": [
           "collection/key",
@@ -7541,1358 +11183,80 @@
             "foo": "bar"
           }
         ],
-        "expectedState": {
-          "numOutstandingWrites": 1
-        }
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
       },
       {
-        "enableNetwork": false,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": [],
-          "writeStreamRequestCount": 3
-        }
-      },
-      {
-        "enableNetwork": true,
-        "expectedState": {
-          "writeStreamRequestCount": 5,
-          "numOutstandingWrites": 1
+        "failWrite": {
+          "error": {
+            "code": 14
+          },
+          "keepInQueue": true
         }
       },
       {
         "writeAck": {
-          "version": 1
+          "version": 1000
         },
         "expectedState": {
           "userCallbacks": {
             "acknowledgedDocs": [
               "collection/key"
             ],
-            "rejectedDocs": []
-          },
-          "numOutstandingWrites": 0
-        }
-      }
-    ]
-  },
-  "New writes are sent after write failure": {
-    "describeName": "Writes:",
-    "itName": "New writes are sent after write failure",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
             "rejectedDocs": [
-              "collection/a"
             ]
           }
         }
       },
       {
-        "userSet": [
-          "collection/b",
-          {
-            "v": 1
-          }
+        "watchAck": [
+          2
         ]
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/b"
-            ],
-            "rejectedDocs": []
-          }
-        }
-      }
-    ]
-  },
-  "Primary client acknowledges write": {
-    "describeName": "Writes:",
-    "itName": "Primary client acknowledges write",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Primary client rejects write": {
-    "describeName": "Writes:",
-    "itName": "Primary client rejects write",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a"
-            ]
-          }
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Pending writes are shared between clients": {
-    "describeName": "Writes:",
-    "itName": "Pending writes are shared between clients",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-500"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 2
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 2
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 3
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 3
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "modified": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 3
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Pending write is acknowledged by primary client": {
-    "describeName": "Writes:",
-    "itName": "Pending write is acknowledged by primary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-500"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "clientIndex": 0
       },
       {
         "watchEntity": {
           "docs": [
             {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": 1
-              },
+              "key": "collection/key",
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Pending write is rejected by primary client": {
-    "describeName": "Writes:",
-    "itName": "Pending write is rejected by primary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-500"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/a"
-            ]
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Writes are released by primary client": {
-    "describeName": "Writes:",
-    "itName": "Writes are released by primary client",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-500"
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 500,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "v": 1
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
               },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+              "value": {
+                "foo": "bar"
+              },
+              "version": 1000
             }
           ],
           "targets": [
             2
           ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Writes are held during primary failover": {
-    "describeName": "Writes:",
-    "itName": "Writes are held during primary failover",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/doc",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/doc",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
+        }
       },
       {
         "watchCurrent": [
@@ -8900,326 +11264,242 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "clientIndex": 0
+        ]
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/doc"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true,
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            }
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          4,
-          {
-            "path": "collection/doc",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": "resume-token-1000"
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection/doc",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/doc",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/doc",
-                "version": 2000,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          2
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchAck": [
-          4
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            {
-              "key": "collection/doc",
-              "version": 2000,
-              "value": {
-                "v": 1
-              },
-              "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
-            }
-          ],
-          "targets": [
-            2,
-            4
-          ]
-        },
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            2
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchCurrent": [
-          [
-            4
-          ],
-          "resume-token-2000"
-        ],
-        "clientIndex": 1
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000,
-          "targetIds": []
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection/doc",
-              "filters": [],
-              "orderBys": []
-            },
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            },
-            "4": {
-              "queries": [
-                {
-                  "path": "collection/doc",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": false
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
+            "hasPendingWrites": false,
             "metadata": [
               {
-                "key": "collection/doc",
-                "version": 2000,
-                "value": {
-                  "v": 1
-                },
+                "key": "collection/key",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
-        ],
-        "clientIndex": 0
+        ]
       }
     ]
   },
-  "Write are sequenced by multiple clients": {
+  "Writes that fail with code unimplemented are rejected": {
     "describeName": "Writes:",
-    "itName": "Write are sequenced by multiple clients",
+    "itName": "Writes that fail with code unimplemented are rejected",
     "tags": [
-      "multi-client"
     ],
     "config": {
-      "useGarbageCollection": false,
-      "numClients": 4
+      "numClients": 1,
+      "useGarbageCollection": true
     },
     "steps": [
       {
-        "drainQueue": true,
-        "clientIndex": 0
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       },
       {
         "userSet": [
-          "collection/a",
+          "collection/key",
           {
-            "v": 1
+            "foo": "bar"
           }
         ],
-        "clientIndex": 0
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
+          }
+        ]
       },
       {
-        "drainQueue": true,
-        "clientIndex": 1
+        "failWrite": {
+          "error": {
+            "code": 12
+          }
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            },
+            "removed": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ]
+          }
+        ],
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+            ],
+            "rejectedDocs": [
+              "collection/key"
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "Writes that fail with code unknown are retried": {
+    "describeName": "Writes:",
+    "itName": "Writes that fail with code unknown are retried",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": true
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection/key"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection/key"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
       },
       {
         "userSet": [
-          "collection/b",
+          "collection/key",
           {
-            "v": 1
+            "foo": "bar"
           }
         ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userSet": [
-          "collection/c",
+        "expectedSnapshotEvents": [
           {
-            "v": 1
+            "added": [
+              {
+                "key": "collection/key",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
-        ],
-        "clientIndex": 2
+        ]
       },
       {
-        "drainQueue": true,
-        "clientIndex": 3
-      },
-      {
-        "userSet": [
-          "collection/d",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 3
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
+        "failWrite": {
+          "error": {
+            "code": 2
+          },
+          "keepInQueue": true
+        }
       },
       {
         "writeAck": {
@@ -9228,1111 +11508,37 @@
         "expectedState": {
           "userCallbacks": {
             "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 3000
-        },
-        "clientIndex": 0
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/b"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/c"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/d"
-            ]
-          }
-        },
-        "clientIndex": 3
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/f",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/g",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "userSet": [
-          "collection/h",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 3
-      },
-      {
-        "userSet": [
-          "collection/i",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 3
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 4000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/f"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 5000
-        },
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 6000
-        },
-        "clientIndex": 0
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/g"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/h"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/i"
-            ]
-          }
-        },
-        "clientIndex": 3
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 3
-      },
-      {
-        "userSet": [
-          "collection/j",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 3
-      },
-      {
-        "userSet": [
-          "collection/k",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 3
-      },
-      {
-        "userSet": [
-          "collection/l",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 3
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 7000
-        },
-        "clientIndex": 0
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 8000
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/j",
-              "collection/l"
+              "collection/key"
             ],
             "rejectedDocs": [
-              "collection/k"
             ]
           }
-        },
-        "clientIndex": 3
-      }
-    ]
-  },
-  "Write is executed after primary tab failover": {
-    "describeName": "Writes:",
-    "itName": "Write is executed after primary tab failover",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "visibility": "visible"
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/b",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 1
-      },
-      {
-        "runTimer": "client_metadata_refresh",
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 1
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/b"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Secondary tabs handle user change": {
-    "describeName": "Writes:",
-    "itName": "Secondary tabs handle user change",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "changeUser": "user1",
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "changeUser": "user1",
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/b",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "changeUser": "user2",
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/c",
-          {
-            "v": 1
-          }
-        ],
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "changeUser": "user2",
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/c",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "changeUser": "user1",
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "changeUser": "user1",
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "removed": [
-              {
-                "key": "collection/c",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Mutations are scoped by user": {
-    "describeName": "Writes:",
-    "itName": "Mutations are scoped by user",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "changeUser": "user1",
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "changeUser": "user2",
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/b",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/b",
-                "version": 0,
-                "value": {
-                  "v": 1
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Mutation recovers after primary takeover": {
-    "describeName": "Writes:",
-    "itName": "Mutation recovers after primary takeover",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "k": "a"
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/a",
-                "version": 0,
-                "value": {
-                  "k": "a"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 1
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "clientIndex": 1
+        }
       },
       {
         "watchAck": [
           2
-        ],
-        "clientIndex": 1
+        ]
       },
       {
         "watchEntity": {
           "docs": [
             {
-              "key": "collection/a",
-              "version": 1000,
-              "value": {
-                "k": "a"
-              },
+              "key": "collection/key",
               "options": {
-                "hasLocalMutations": false,
-                "hasCommittedMutations": false
-              }
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "foo": "bar"
+              },
+              "version": 1000
             }
           ],
           "targets": [
             2
           ]
-        },
-        "clientIndex": 1
+        }
       },
       {
         "watchCurrent": [
@@ -10340,488 +11546,41 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "clientIndex": 1
+        ]
       },
       {
         "watchSnapshot": {
-          "version": 1000,
-          "targetIds": []
+          "targetIds": [
+          ],
+          "version": 1000
         },
         "expectedSnapshotEvents": [
           {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "k": "a"
-                },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
             "errorCode": 0,
             "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 0
-      }
-    ]
-  },
-  "Write is sent by newly started primary": {
-    "describeName": "Writes:",
-    "itName": "Write is sent by newly started primary",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": false
-        },
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "v": 1
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "shutdown": true,
-        "expectedState": {
-          "activeTargets": {},
-          "activeLimboDocs": [],
-          "enqueuedLimboDocs": []
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true,
-          "numOutstandingWrites": 1
-        },
-        "clientIndex": 2
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Unresponsive primary ignores acknowledged write": {
-    "describeName": "Writes:",
-    "itName": "Unresponsive primary ignores acknowledged write",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "k": "a"
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/b",
-          {
-            "k": "b"
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 2000,
-          "keepInQueue": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/b"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Unresponsive primary ignores rejected write": {
-    "describeName": "Writes:",
-    "itName": "Unresponsive primary ignores rejected write",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 3
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "k": "a"
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "userSet": [
-          "collection/b",
-          {
-            "k": "b"
-          }
-        ],
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          },
-          "keepInQueue": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 2
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 9
-          }
-        },
-        "clientIndex": 2
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/b"
-            ]
-          }
-        },
-        "clientIndex": 1
-      }
-    ]
-  },
-  "Mutation are not sent twice after primary failover": {
-    "describeName": "Writes:",
-    "itName": "Mutation are not sent twice after primary failover",
-    "tags": [
-      "multi-client"
-    ],
-    "config": {
-      "useGarbageCollection": false,
-      "numClients": 2
-    },
-    "steps": [
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/a",
-          {
-            "k": "a"
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "userSet": [
-          "collection/b",
-          {
-            "k": "b"
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 1
-      },
-      {
-        "writeAck": {
-          "version": 1000
-        },
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/a"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "applyClientState": {
-          "primary": true
-        },
-        "expectedState": {
-          "isPrimary": true
-        },
-        "clientIndex": 0
-      },
-      {
-        "writeAck": {
-          "version": 2000
-        },
-        "expectedState": {
-          "userCallbacks": {
-            "acknowledgedDocs": [
-              "collection/b"
-            ],
-            "rejectedDocs": []
-          }
-        },
-        "clientIndex": 0
-      },
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "expectedState": {
-          "activeTargets": {
-            "2": {
-              "queries": [
-                {
-                  "path": "collection",
-                  "filters": [],
-                  "orderBys": []
-                }
-              ],
-              "resumeToken": ""
-            }
-          }
-        },
-        "expectedSnapshotEvents": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
+            "hasPendingWrites": false,
+            "metadata": [
               {
-                "key": "collection/a",
-                "version": 1000,
-                "value": {
-                  "k": "a"
-                },
+                "key": "collection/key",
                 "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
-              },
-              {
-                "key": "collection/b",
-                "version": 2000,
-                "value": {
-                  "k": "b"
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
                 },
-                "options": {
-                  "hasLocalMutations": false,
-                  "hasCommittedMutations": true
-                }
+                "value": {
+                  "foo": "bar"
+                },
+                "version": 1000
               }
             ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection/key"
+            }
           }
-        ],
-        "clientIndex": 0
+        ]
       }
     ]
   }


### PR DESCRIPTION
This change picks up changes to the spec tests, especially https://github.com/firebase/firebase-js-sdk/pull/2790, which renamed the "limboDocs" key in the JSON objects to "activeLimboDocs".