### PR TITLE
Support AGP 3.6+ in the iid compatibility check.

### DIFF
--- a/firebase-installations/customer-lint-checks/customer-lint-checks.gradle
+++ b/firebase-installations/customer-lint-checks/customer-lint-checks.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation "com.android.tools.lint:lint:$lintVersion"
     testImplementation "com.android.tools.lint:lint-tests:$lintVersion"
     testImplementation "com.android.tools:testutils:$lintVersion"
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
 }
 
 compileKotlin.kotlinOptions.apiVersion = '1.2'

--- a/firebase-installations/customer-lint-checks/src/main/java/com/google/firebase/installations/lint/Checks.kt
+++ b/firebase-installations/customer-lint-checks/src/main/java/com/google/firebase/installations/lint/Checks.kt
@@ -20,7 +20,10 @@ import com.android.tools.lint.detector.api.Issue
 
 class Checks : IssueRegistry() {
     override val issues: List<Issue>
-        get() = listOf(IncompatibleIidVersionDetector.INCOMPATIBLE_IID_VERSION)
+        get() = listOf(
+                IncompatibleIidVersionDetector.INCOMPATIBLE_IID_VERSION,
+                IncompatibleIidVersionDetector.IID_COMPATIBILITY_CHECK_FAILURE
+        )
 
     override val api: Int
         get() = CURRENT_API

--- a/firebase-installations/customer-lint-checks/src/main/java/com/google/firebase/installations/lint/IncompatibleIidVersionDetector.kt
+++ b/firebase-installations/customer-lint-checks/src/main/java/com/google/firebase/installations/lint/IncompatibleIidVersionDetector.kt
@@ -14,7 +14,6 @@
 
 package com.google.firebase.installations.lint
 
-import com.android.builder.model.MavenCoordinates
 import com.android.builder.model.Variant
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Context
@@ -70,7 +69,7 @@ class IncompatibleIidVersionDetector : Detector() {
             for (lib in variant.mainArtifact.dependencies.libraries) {
                 val coordinates = lib.resolvedCoordinates
                 if (coordinates.groupId == "com.google.firebase" && coordinates.artifactId == "firebase-iid") {
-                    if (!isCompatibleVersion(coordinates)) {
+                    if (!isCompatibleVersion(coordinates.version)) {
                         context.report(INCOMPATIBLE_IID_VERSION,
                                 Location.create(context.file),
                                 "Incompatible IID version found in variant ${variant.name}: ${lib.name.removeSuffix("@aar")}.\n" +
@@ -96,8 +95,8 @@ class IncompatibleIidVersionDetector : Detector() {
         return variantsMethod.invoke(model) as List<Variant>
     }
 
-    private fun isCompatibleVersion(coordinates: MavenCoordinates): Boolean {
-        val versionComponents = coordinates.version.split('.', limit = 3).toTypedArray()
+    internal fun isCompatibleVersion(version: String): Boolean {
+        val versionComponents = version.split('.', limit = 3).toTypedArray()
 
         // Incompatible if major version is before v20
         if (20 > versionComponents[0].toInt()) {

--- a/firebase-installations/customer-lint-checks/src/main/java/com/google/firebase/installations/lint/IncompatibleIidVersionDetector.kt
+++ b/firebase-installations/customer-lint-checks/src/main/java/com/google/firebase/installations/lint/IncompatibleIidVersionDetector.kt
@@ -15,12 +15,14 @@
 package com.google.firebase.installations.lint
 
 import com.android.builder.model.MavenCoordinates
+import com.android.builder.model.Variant
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Context
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.Location
+import com.android.tools.lint.detector.api.Project
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.Scope
 import java.util.EnumSet
@@ -46,14 +48,25 @@ class IncompatibleIidVersionDetector : Detector() {
                 severity = Severity.ERROR,
                 implementation = IMPLEMENTATION
         )
+
+        @JvmField
+        val IID_COMPATIBILITY_CHECK_FAILURE = Issue.create(
+                id = "IidCompatibilityCheckFailure",
+                briefDescription = "Firebase IID Compatibility Check Unable To Run",
+                explanation = """
+                    The check failed to run as it encountered unknown failure.
+                    This is most likely caused by a new version of Android Gradle Plugin that this check does not support.
+                    Please make sure your build does not depend on firebase-iid version earlier than 20.1.1 as it will cause issues.
+                    """,
+                category = Category.LINT,
+                priority = 1,
+                severity = Severity.INFORMATIONAL,
+                implementation = IMPLEMENTATION
+        )
     }
 
-    override fun beforeCheckEachProject(context: Context) {
-        if (!context.project.isGradleProject) {
-            return
-        }
-
-        for (variant in context.project.gradleProjectModel.variants) {
+    override fun beforeCheckEachProject(context: Context) = catching(context) {
+        for (variant in getVariants(context.project)) {
             for (lib in variant.mainArtifact.dependencies.libraries) {
                 val coordinates = lib.resolvedCoordinates
                 if (coordinates.groupId == "com.google.firebase" && coordinates.artifactId == "firebase-iid") {
@@ -68,18 +81,45 @@ class IncompatibleIidVersionDetector : Detector() {
         }
     }
 
+    private fun getVariants(project: Project): List<Variant> {
+        if (!project.isGradleProject) {
+            return listOf()
+        }
+
+        // using reflection here due to breaking change in lint-api 26.6.0 that changed the return type
+        // of getGradleProject()
+        val method = project.javaClass.getMethod("getGradleProjectModel")
+        method.isAccessible = true
+        val model = method.invoke(project)
+        val variantsMethod = model.javaClass.getMethod("getVariants")
+        variantsMethod.isAccessible = true
+        return variantsMethod.invoke(model) as List<Variant>
+    }
+
     private fun isCompatibleVersion(coordinates: MavenCoordinates): Boolean {
         val versionComponents = coordinates.version.split('.', limit = 3).toTypedArray()
 
         // Incompatible if major version is before v20
-        if (20 > versionComponents.get(0).toInt()) {
+        if (20 > versionComponents[0].toInt()) {
             return false
         }
         // Compatible if major version is after v21
-        if (21 <= versionComponents.get(0).toInt()) {
+        if (21 <= versionComponents[0].toInt()) {
             return true
         }
         // Its compatible if major version is v20 and minor version is after v20.1
-        return 1 <= versionComponents.get(1).toInt()
+        return 1 <= versionComponents[1].toInt()
+    }
+
+    private inline fun catching(context: Context, block: () -> Unit) {
+        try {
+            block()
+        } catch (ex: Throwable) {
+            context.report(
+                    IID_COMPATIBILITY_CHECK_FAILURE,
+                    Location.create(context.file),
+                    "Check failed with exception: $ex"
+            )
+        }
     }
 }

--- a/firebase-installations/customer-lint-checks/src/test/java/com/google/firebase/installations/lint/VersionTests.kt
+++ b/firebase-installations/customer-lint-checks/src/test/java/com/google/firebase/installations/lint/VersionTests.kt
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.installations.lint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class VersionTests {
+    companion object Detector {
+        val detector = IncompatibleIidVersionDetector()
+    }
+
+    @Test
+    fun `isCompatibleVersion with 19_0_0 should be false`() {
+        assertThat(detector.isCompatibleVersion("19.0.0")).isFalse()
+    }
+
+    @Test
+    fun `isCompatibleVersion with 20_0_0 should be false`() {
+        assertThat(detector.isCompatibleVersion("20.0.0")).isFalse()
+    }
+
+    @Test
+    fun `isCompatibleVersion with 20_1_0 should be true`() {
+        assertThat(detector.isCompatibleVersion("20.1.0")).isTrue()
+    }
+
+    @Test
+    fun `isCompatibleVersion with 20_1_1 should be true`() {
+        assertThat(detector.isCompatibleVersion("20.1.1")).isTrue()
+    }
+
+    @Test
+    fun `isCompatibleVersion with 21_0_0 should be true`() {
+        assertThat(detector.isCompatibleVersion("21.0.0")).isTrue()
+    }
+}


### PR DESCRIPTION
AGP 3.6 introduced a breaking change to lint-api making the check fail.
The change switch to use reflection to support both versions of the api.

Additionally the change makes the check failures more developer friendly
to make sure this check does not cause failures in upcoming AGP
versions.

Versions tested: 3.2 through 4.1.0-alpha04

Fixes #1407