### PR TITLE
Add new version of setAutomaticDataCollectionEnabled api

### DIFF
--- a/firebase-inappmessaging/api.txt
+++ b/firebase-inappmessaging/api.txt
@@ -14,6 +14,7 @@ package com.google.firebase.inappmessaging {
     method public void removeClickListener(@NonNull com.google.firebase.inappmessaging.FirebaseInAppMessagingClickListener);
     method public void removeDisplayErrorListener(@NonNull com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplayErrorListener);
     method public void removeImpressionListener(@NonNull com.google.firebase.inappmessaging.FirebaseInAppMessagingImpressionListener);
+    method @Keep public void setAutomaticDataCollectionEnabled(@Nullable Boolean);
     method @Keep public void setAutomaticDataCollectionEnabled(boolean);
     method @Keep public void setMessageDisplayComponent(@NonNull com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplay);
     method @Keep public void setMessagesSuppressed(@NonNull Boolean);

--- a/firebase-inappmessaging/gradle.properties
+++ b/firebase-inappmessaging/gradle.properties
@@ -1,2 +1,2 @@
-version=19.0.4
+version=19.1.0
 latestReleasedVersion=19.0.3

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
@@ -109,6 +109,12 @@ public class FirebaseInAppMessaging {
     return dataCollectionHelper.isAutomaticDataCollectionEnabled();
   }
 
+  // TODO: Add public api docs
+  @Keep
+  public void setAutomaticDataCollectionEnabled(Boolean isAutomaticCollectionEnabled) {
+    dataCollectionHelper.setAutomaticDataCollectionEnabled(isAutomaticCollectionEnabled);
+  }
+
   /**
    * Enable or disable automatic data collection for Firebase In-App Messaging.
    *

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
@@ -16,6 +16,8 @@ package com.google.firebase.inappmessaging;
 
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.android.gms.common.annotation.KeepForSdk;
 import com.google.android.gms.common.util.VisibleForTesting;
 import com.google.firebase.FirebaseApp;
@@ -111,7 +113,7 @@ public class FirebaseInAppMessaging {
 
   // TODO: Add public api docs
   @Keep
-  public void setAutomaticDataCollectionEnabled(Boolean isAutomaticCollectionEnabled) {
+  public void setAutomaticDataCollectionEnabled(@Nullable Boolean isAutomaticCollectionEnabled) {
     dataCollectionHelper.setAutomaticDataCollectionEnabled(isAutomaticCollectionEnabled);
   }
 

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
@@ -124,7 +124,8 @@ public class FirebaseInAppMessaging {
    * enabled by default.
    *
    * <p>If you need to change the default, (for example, because you want to prompt the user before
-   * generates/refreshes a registration token on app startup), add to your application’s manifest:
+   * generates/refreshes a registration token on app startup), add the following
+   * to your application’s manifest:
    *
    * <pre>{@code
    * <meta-data android:name="firebase_inapp_messaging_auto_init_enabled" android:value="false" />

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
@@ -110,7 +110,37 @@ public class FirebaseInAppMessaging {
     return dataCollectionHelper.isAutomaticDataCollectionEnabled();
   }
 
-  // TODO: Add public api docs
+  /**
+   * Enable, disable or clear automatic data collection for Firebase In-App Messaging.
+   *
+   * <p>When enabled, generates a registration token on app startup if there is no valid one and
+   * generates a new token when it is deleted (which prevents {@link
+   * com.google.firebase.iid.FirebaseInstanceId#deleteInstanceId} from stopping the periodic sending
+   * of data). This setting is persisted across app restarts and overrides the setting specified in
+   * your manifest.
+   *
+   * <p>When null, the enablement of the auto-initialization depends on the manifest and then on the
+   * global enablement setting in this order. If none of these settings are present then it is
+   * enabled by default.
+   *
+   * <p>If you need to change the default, (for example, because you want to prompt the user before
+   * generates/refreshes a registration token on app startup), add to your application’s manifest:
+   *
+   * <pre>{@code
+   * <meta-data android:name="firebase_inapp_messaging_auto_init_enabled" android:value="false" />
+   * }</pre>
+   *
+   * <p>Note, this will require you to manually initialize Firebase In-App Messaging, via:
+   *
+   * <pre>{@code FirebaseInAppMessaging.getInstance().setAutomaticDataCollectionEnabled(true)}</pre>
+   *
+   * <p>Manual initialization will also be required in order to clear these settings and fall back
+   * on other settings, via:
+   *
+   * <pre>{@code FirebaseInAppMessaging.getInstance().setAutomaticDataCollectionEnabled(null)}</pre>
+   *
+   * @param isAutomaticCollectionEnabled Whether isEnabled
+   */
   @Keep
   public void setAutomaticDataCollectionEnabled(@Nullable Boolean isAutomaticCollectionEnabled) {
     dataCollectionHelper.setAutomaticDataCollectionEnabled(isAutomaticCollectionEnabled);

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
@@ -124,8 +124,8 @@ public class FirebaseInAppMessaging {
    * enabled by default.
    *
    * <p>If you need to change the default, (for example, because you want to prompt the user before
-   * generates/refreshes a registration token on app startup), add the following
-   * to your application’s manifest:
+   * generates/refreshes a registration token on app startup), add the following to your
+   * application’s manifest:
    *
    * <pre>{@code
    * <meta-data android:name="firebase_inapp_messaging_auto_init_enabled" android:value="false" />

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
@@ -17,7 +17,6 @@ package com.google.firebase.inappmessaging;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.android.gms.common.annotation.KeepForSdk;
 import com.google.android.gms.common.util.VisibleForTesting;
 import com.google.firebase.FirebaseApp;

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DataCollectionHelper.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DataCollectionHelper.java
@@ -135,7 +135,8 @@ public class DataCollectionHelper {
    * enabled by default.
    *
    * <p>If you need to change the default, (for example, because you want to prompt the user before
-   * generates/refreshes a registration token on app startup), add to your application’s manifest:
+   * generates/refreshes a registration token on app startup), add the following
+   * to your application’s manifest:
    *
    * <pre>{@code
    * <meta-data android:name="firebase_inapp_messaging_auto_init_enabled" android:value="false" />

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DataCollectionHelper.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DataCollectionHelper.java
@@ -121,7 +121,37 @@ public class DataCollectionHelper {
     sharedPreferencesUtils.setBooleanPreference(AUTO_INIT_PREFERENCES, isEnabled);
   }
 
-  // TODO: Add docs similar to the function present in FirebaseInAppMessaging.java
+  /**
+   * Enable, disable or clear automatic data collection for Firebase In-App Messaging.
+   *
+   * <p>When enabled, generates a registration token on app startup if there is no valid one and
+   * generates a new token when it is deleted (which prevents {@link
+   * com.google.firebase.iid.FirebaseInstanceId#deleteInstanceId} from stopping the periodic sending
+   * of data). This setting is persisted across app restarts and overrides the setting specified in
+   * your manifest.
+   *
+   * <p>When null, the enablement of the auto-initialization depends on the manifest and then on the
+   * global enablement setting in this order. If none of these settings are present then it is
+   * enabled by default.
+   *
+   * <p>If you need to change the default, (for example, because you want to prompt the user before
+   * generates/refreshes a registration token on app startup), add to your application’s manifest:
+   *
+   * <pre>{@code
+   * <meta-data android:name="firebase_inapp_messaging_auto_init_enabled" android:value="false" />
+   * }</pre>
+   *
+   * <p>Note, this will require you to manually initialize Firebase In-App Messaging, via:
+   *
+   * <pre>{@code FirebaseInAppMessaging.getInstance().setAutomaticDataCollectionEnabled(true)}</pre>
+   *
+   * <p>Manual initialization will also be required in order to clear these settings and fall back
+   * on other settings, via:
+   *
+   * <pre>{@code FirebaseInAppMessaging.getInstance().setAutomaticDataCollectionEnabled(null)}</pre>
+   *
+   * @param isAutomaticCollectionEnabled Whether isEnabled
+   */
   public void setAutomaticDataCollectionEnabled(Boolean isEnabled) {
     // Update SharedPreferences, so that we preserve state across app restarts
     if (isEnabled == null) {

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DataCollectionHelper.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DataCollectionHelper.java
@@ -135,8 +135,8 @@ public class DataCollectionHelper {
    * enabled by default.
    *
    * <p>If you need to change the default, (for example, because you want to prompt the user before
-   * generates/refreshes a registration token on app startup), add the following
-   * to your application’s manifest:
+   * generates/refreshes a registration token on app startup), add the following to your
+   * application’s manifest:
    *
    * <pre>{@code
    * <meta-data android:name="firebase_inapp_messaging_auto_init_enabled" android:value="false" />

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DataCollectionHelper.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DataCollectionHelper.java
@@ -121,6 +121,17 @@ public class DataCollectionHelper {
     sharedPreferencesUtils.setBooleanPreference(AUTO_INIT_PREFERENCES, isEnabled);
   }
 
+  // TODO: Add docs similar to the function present in FirebaseInAppMessaging.java
+  public void setAutomaticDataCollectionEnabled(Boolean isEnabled) {
+    // Update SharedPreferences, so that we preserve state across app restarts
+    if (isEnabled == null) {
+      sharedPreferencesUtils.clearPreference(AUTO_INIT_PREFERENCES);
+    } else {
+      sharedPreferencesUtils.setBooleanPreference(
+          AUTO_INIT_PREFERENCES, Boolean.TRUE.equals(isEnabled));
+    }
+  }
+
   private boolean readAutomaticDataCollectionEnabledFromPreferences() {
     return sharedPreferencesUtils.getBooleanPreference(AUTO_INIT_PREFERENCES, true);
   }

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/SharedPreferencesUtils.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/SharedPreferencesUtils.java
@@ -51,6 +51,19 @@ public class SharedPreferencesUtils {
   }
 
   /**
+   * Helper method for clearing the value in the apps stored preferences.
+   *
+   * @param preference the preference key.
+   */
+  public void clearPreference(String preference) {
+    Application application = (Application) firebaseApp.getApplicationContext();
+    SharedPreferences.Editor preferencesEditor =
+        application.getSharedPreferences(PREFERENCES_PACKAGE_NAME, Context.MODE_PRIVATE).edit();
+    preferencesEditor.remove(preference);
+    preferencesEditor.apply();
+  }
+
+  /**
    * Helper method for getting a boolean value from the apps stored preferences.
    *
    * @param preference the preference key.

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/SharedPreferencesUtils.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/SharedPreferencesUtils.java
@@ -51,7 +51,7 @@ public class SharedPreferencesUtils {
   }
 
   /**
-   * Helper method for clearing the value in the apps stored preferences.
+   * Helper method for clearing the value in the app's stored preferences.
    *
    * @param preference the preference key.
    */

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/FirebaseInAppMessagingTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/FirebaseInAppMessagingTest.java
@@ -239,8 +239,8 @@ public class FirebaseInAppMessagingTest {
             displayCallbacksFactory,
             listenerScheduler);
 
-    firebaseInAppMessaging.setAutomaticDataCollectionEnabled(true);
-    verify(dataCollectionHelper).setAutomaticDataCollectionEnabled(true);
+    firebaseInAppMessaging.setAutomaticDataCollectionEnabled(Boolean.TRUE);
+    verify(dataCollectionHelper).setAutomaticDataCollectionEnabled(Boolean.TRUE);
     assertThat(firebaseInAppMessaging.isAutomaticDataCollectionEnabled()).isTrue();
   }
 
@@ -254,8 +254,23 @@ public class FirebaseInAppMessagingTest {
             displayCallbacksFactory,
             listenerScheduler);
 
-    firebaseInAppMessaging.setAutomaticDataCollectionEnabled(false);
-    verify(dataCollectionHelper).setAutomaticDataCollectionEnabled(false);
+    firebaseInAppMessaging.setAutomaticDataCollectionEnabled(Boolean.FALSE);
+    verify(dataCollectionHelper).setAutomaticDataCollectionEnabled(Boolean.FALSE);
+    assertThat(firebaseInAppMessaging.isAutomaticDataCollectionEnabled()).isTrue();
+  }
+
+  @Test
+  public void automaticDataCollectionDisabling_clearsInDataCollectionHelper() {
+    firebaseInAppMessaging =
+        new FirebaseInAppMessaging(
+            inAppMessageStreamManager,
+            programaticContextualTriggers,
+            dataCollectionHelper,
+            displayCallbacksFactory,
+            listenerScheduler);
+
+    firebaseInAppMessaging.setAutomaticDataCollectionEnabled(null);
+    verify(dataCollectionHelper).setAutomaticDataCollectionEnabled(null);
   }
 
   @Test

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DataCollectionHelperTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DataCollectionHelperTest.java
@@ -92,7 +92,8 @@ public final class DataCollectionHelperTest {
     verify(sharedPreferencesUtils, times(1))
         .setBooleanPreference(DataCollectionHelper.AUTO_INIT_PREFERENCES, false);
     dataCollectionHelper.setAutomaticDataCollectionEnabled(null);
-    verify(sharedPreferencesUtils, times(1)).clearPreference(DataCollectionHelper.AUTO_INIT_PREFERENCES);
+    verify(sharedPreferencesUtils, times(1))
+        .clearPreference(DataCollectionHelper.AUTO_INIT_PREFERENCES);
   }
 
   @Test

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DataCollectionHelperTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DataCollectionHelperTest.java
@@ -88,9 +88,11 @@ public final class DataCollectionHelperTest {
     dataCollectionHelper =
         new DataCollectionHelper(
             firebaseApp, sharedPreferencesUtils, firebaseInstanceId, subscriber);
-    dataCollectionHelper.setAutomaticDataCollectionEnabled(false);
+    dataCollectionHelper.setAutomaticDataCollectionEnabled(Boolean.FALSE);
     verify(sharedPreferencesUtils, times(1))
         .setBooleanPreference(DataCollectionHelper.AUTO_INIT_PREFERENCES, false);
+    dataCollectionHelper.setAutomaticDataCollectionEnabled(null);
+    verify(sharedPreferencesUtils, times(1)).clearPreference(DataCollectionHelper.AUTO_INIT_PREFERENCES);
   }
 
   @Test

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/SharedPreferencesUtilsTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/SharedPreferencesUtilsTest.java
@@ -16,6 +16,7 @@ package com.google.firebase.inappmessaging.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -161,5 +162,14 @@ public class SharedPreferencesUtilsTest {
 
     verify(editor).putBoolean(TEST_PREFERENCE, false);
     verify(editor).apply();
+  }
+
+  @Test
+  public void getBooleanPreference_correctlyRemovesPreference() throws Exception {
+    sharedPreferencesUtils.setBooleanPreference(TEST_PREFERENCE, false);
+    verify(editor).putBoolean(TEST_PREFERENCE, false);
+    sharedPreferencesUtils.clearPreference(TEST_PREFERENCE);
+    verify(editor).remove(TEST_PREFERENCE);
+    verify(editor, times(2)).apply();
   }
 }


### PR DESCRIPTION
The new apis will be named as the existing setters are named and have a nullable Boolean.
The non-tri state api's is planned to be removed in the next breaking change release.