### PR TITLE
Add large payload support to datatransport.

### DIFF
--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SpyEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SpyEventStoreModule.java
@@ -54,4 +54,10 @@ public abstract class SpyEventStoreModule {
   static int schemaVersion() {
     return SchemaManager.SCHEMA_VERSION;
   }
+
+  @Provides
+  @Named("SQLITE_DB_NAME")
+  static String dbName() {
+    return SchemaManager.DB_NAME;
+  }
 }

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
@@ -35,6 +35,7 @@ public abstract class TestEventStoreModule {
         .setLoadBatchSize(LOAD_BATCH_SIZE)
         .setCriticalSectionEnterTimeoutMs(LOCK_TIME_OUT_MS)
         .setEventCleanUpAge(60 * 1000)
+        .setMaxBlobSizePerRow(80 * 1000)
         .build();
   }
 

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
@@ -33,7 +33,7 @@ public abstract class TestEventStoreModule {
         .setLoadBatchSize(LOAD_BATCH_SIZE)
         .setCriticalSectionEnterTimeoutMs(LOCK_TIME_OUT_MS)
         .setEventCleanUpAge(60 * 1000)
-        .setMaxBlobSizePerRow(80 * 1000)
+        .setMaxBlobByteSizePerRow(80 * 1000)
         .build();
   }
 

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
@@ -14,8 +14,6 @@
 
 package com.google.android.datatransport.runtime.scheduling.persistence;
 
-import static com.google.android.datatransport.runtime.scheduling.persistence.SchemaManager.SCHEMA_VERSION;
-
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
 import dagger.Binds;
 import dagger.Module;
@@ -48,6 +46,12 @@ public abstract class TestEventStoreModule {
   @Provides
   @Named("SCHEMA_VERSION")
   static int schemaVersion() {
-    return SCHEMA_VERSION;
+    return SchemaManager.SCHEMA_VERSION;
+  }
+
+  @Provides
+  @Named("SQLITE_DB_NAME")
+  static String dbName() {
+    return SchemaManager.DB_NAME;
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreConfig.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreConfig.java
@@ -22,6 +22,7 @@ abstract class EventStoreConfig {
   private static final int LOAD_BATCH_SIZE = 200;
   private static final int LOCK_TIME_OUT_MS = 10000;
   private static final long DURATION_ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  private static final int MAX_BLOB_SIZE_PER_ROW = 80 * 1024;
 
   static final EventStoreConfig DEFAULT =
       EventStoreConfig.builder()
@@ -29,6 +30,7 @@ abstract class EventStoreConfig {
           .setLoadBatchSize(LOAD_BATCH_SIZE)
           .setCriticalSectionEnterTimeoutMs(LOCK_TIME_OUT_MS)
           .setEventCleanUpAge(DURATION_ONE_WEEK_MS)
+          .setMaxBlobSizePerRow(MAX_BLOB_SIZE_PER_ROW)
           .build();
 
   abstract long getMaxStorageSizeInBytes();
@@ -39,6 +41,8 @@ abstract class EventStoreConfig {
 
   abstract long getEventCleanUpAge();
 
+  abstract int getMaxBlobSizePerRow();
+
   static EventStoreConfig.Builder builder() {
     return new AutoValue_EventStoreConfig.Builder();
   }
@@ -48,7 +52,8 @@ abstract class EventStoreConfig {
         .setMaxStorageSizeInBytes(getMaxStorageSizeInBytes())
         .setLoadBatchSize(getLoadBatchSize())
         .setCriticalSectionEnterTimeoutMs(getCriticalSectionEnterTimeoutMs())
-        .setEventCleanUpAge(getEventCleanUpAge());
+        .setEventCleanUpAge(getEventCleanUpAge())
+        .setMaxBlobSizePerRow(getMaxBlobSizePerRow());
   }
 
   @AutoValue.Builder
@@ -60,6 +65,8 @@ abstract class EventStoreConfig {
     abstract Builder setCriticalSectionEnterTimeoutMs(int value);
 
     abstract Builder setEventCleanUpAge(long value);
+
+    abstract Builder setMaxBlobSizePerRow(int value);
 
     abstract EventStoreConfig build();
   }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreConfig.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreConfig.java
@@ -22,7 +22,7 @@ abstract class EventStoreConfig {
   private static final int LOAD_BATCH_SIZE = 200;
   private static final int LOCK_TIME_OUT_MS = 10000;
   private static final long DURATION_ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-  private static final int MAX_BLOB_SIZE_PER_ROW = 80 * 1024;
+  private static final int MAX_BLOB_BYTE_SIZE_PER_ROW = 80 * 1024;
 
   static final EventStoreConfig DEFAULT =
       EventStoreConfig.builder()
@@ -30,7 +30,7 @@ abstract class EventStoreConfig {
           .setLoadBatchSize(LOAD_BATCH_SIZE)
           .setCriticalSectionEnterTimeoutMs(LOCK_TIME_OUT_MS)
           .setEventCleanUpAge(DURATION_ONE_WEEK_MS)
-          .setMaxBlobSizePerRow(MAX_BLOB_SIZE_PER_ROW)
+          .setMaxBlobByteSizePerRow(MAX_BLOB_BYTE_SIZE_PER_ROW)
           .build();
 
   abstract long getMaxStorageSizeInBytes();
@@ -41,7 +41,7 @@ abstract class EventStoreConfig {
 
   abstract long getEventCleanUpAge();
 
-  abstract int getMaxBlobSizePerRow();
+  abstract int getMaxBlobByteSizePerRow();
 
   static EventStoreConfig.Builder builder() {
     return new AutoValue_EventStoreConfig.Builder();
@@ -53,7 +53,7 @@ abstract class EventStoreConfig {
         .setLoadBatchSize(getLoadBatchSize())
         .setCriticalSectionEnterTimeoutMs(getCriticalSectionEnterTimeoutMs())
         .setEventCleanUpAge(getEventCleanUpAge())
-        .setMaxBlobSizePerRow(getMaxBlobSizePerRow());
+        .setMaxBlobByteSizePerRow(getMaxBlobByteSizePerRow());
   }
 
   @AutoValue.Builder
@@ -66,7 +66,7 @@ abstract class EventStoreConfig {
 
     abstract Builder setEventCleanUpAge(long value);
 
-    abstract Builder setMaxBlobSizePerRow(int value);
+    abstract Builder setMaxBlobByteSizePerRow(int value);
 
     abstract EventStoreConfig build();
   }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreModule.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreModule.java
@@ -14,8 +14,6 @@
 
 package com.google.android.datatransport.runtime.scheduling.persistence;
 
-import static com.google.android.datatransport.runtime.scheduling.persistence.SchemaManager.SCHEMA_VERSION;
-
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
 import dagger.Binds;
 import dagger.Module;
@@ -39,6 +37,12 @@ public abstract class EventStoreModule {
   @Provides
   @Named("SCHEMA_VERSION")
   static int schemaVersion() {
-    return SCHEMA_VERSION;
+    return SchemaManager.SCHEMA_VERSION;
+  }
+
+  @Provides
+  @Named("SQLITE_DB_NAME")
+  static String dbName() {
+    return SchemaManager.DB_NAME;
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -77,7 +77,8 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
     this.config = config;
   }
 
-  private SQLiteDatabase getDb() {
+  @VisibleForTesting
+  SQLiteDatabase getDb() {
     return retryIfDbLocked(
         schemaManager::getWritableDatabase,
         ex -> {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -51,6 +51,7 @@ import javax.inject.Singleton;
 @Singleton
 @WorkerThread
 public class SQLiteEventStore implements EventStore, SynchronizationGuard {
+
   private static final String LOG_TAG = "SQLiteEventStore";
 
   static final int MAX_RETRIES = 10;
@@ -104,16 +105,39 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
               }
 
               long contextId = ensureTransportContext(db, transportContext);
+              int maxBlobSizePerRow = config.getMaxBlobSizePerRow();
+
+              byte[] payloadBytes = event.getEncodedPayload().getBytes();
+              boolean inline = payloadBytes.length <= maxBlobSizePerRow;
               ContentValues values = new ContentValues();
               values.put("context_id", contextId);
               values.put("transport_name", event.getTransportName());
               values.put("timestamp_ms", event.getEventMillis());
               values.put("uptime_ms", event.getUptimeMillis());
               values.put("payload_encoding", event.getEncodedPayload().getEncoding().getName());
-              values.put("payload", event.getEncodedPayload().getBytes());
               values.put("code", event.getCode());
               values.put("num_attempts", 0);
+              values.put("inline", inline);
+              values.put("payload", inline ? payloadBytes : new byte[0]);
               long newEventId = db.insert("events", null, values);
+              if (!inline) {
+                int numChunks = payloadBytes.length / maxBlobSizePerRow;
+                if (payloadBytes.length % maxBlobSizePerRow != 0) {
+                  numChunks += 1;
+                }
+                for (int chunk = 1; chunk <= numChunks; chunk++) {
+                  byte[] chunkBytes =
+                      Arrays.copyOfRange(
+                          payloadBytes,
+                          (chunk - 1) * maxBlobSizePerRow,
+                          Math.min((chunk) * maxBlobSizePerRow, payloadBytes.length));
+                  ContentValues payloadValues = new ContentValues();
+                  payloadValues.put("event_id", newEventId);
+                  payloadValues.put("sequence_num", chunk);
+                  payloadValues.put("bytes", chunkBytes);
+                  db.insert("event_payloads", null, payloadValues);
+                }
+              }
 
               // TODO: insert all with one sql query.
               for (Map.Entry<String, String> entry : event.getMetadata().entrySet()) {
@@ -358,7 +382,8 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
               "uptime_ms",
               "payload_encoding",
               "payload",
-              "code"
+              "code",
+              "inline",
             },
             "context_id = ?",
             new String[] {contextId.toString()},
@@ -369,13 +394,19 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
         cursor -> {
           while (cursor.moveToNext()) {
             long id = cursor.getLong(0);
+            boolean inline = cursor.getInt(7) != 0;
             EventInternal.Builder event =
                 EventInternal.builder()
                     .setTransportName(cursor.getString(1))
                     .setEventMillis(cursor.getLong(2))
-                    .setUptimeMillis(cursor.getLong(3))
-                    .setEncodedPayload(
-                        new EncodedPayload(toEncoding(cursor.getString(4)), cursor.getBlob(5)));
+                    .setUptimeMillis(cursor.getLong(3));
+            if (inline) {
+              event.setEncodedPayload(
+                  new EncodedPayload(toEncoding(cursor.getString(4)), cursor.getBlob(5)));
+            } else {
+              event.setEncodedPayload(
+                  new EncodedPayload(toEncoding(cursor.getString(4)), readPayload(id)));
+            }
             if (!cursor.isNull(6)) {
               event.setCode(cursor.getInt(6));
             }
@@ -384,6 +415,37 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
           return null;
         });
     return events;
+  }
+
+  private byte[] readPayload(long eventId) {
+    return tryWithCursor(
+        getDb()
+            .query(
+                "event_payloads",
+                new String[] {"bytes"},
+                "event_id = ?",
+                new String[] {String.valueOf(eventId)},
+                null,
+                null,
+                "sequence_num"),
+        cursor -> {
+          List<byte[]> chunks = new ArrayList<>();
+          while (cursor.moveToNext()) {
+            chunks.add(cursor.getBlob(0));
+          }
+          int totalLength = 0;
+          for (byte[] chunk : chunks) {
+            totalLength += chunk.length;
+          }
+          byte[] payloadBytes = new byte[totalLength];
+          int offset = 0;
+          for (int i = 0; i < chunks.size(); i++) {
+            byte[] chunk = chunks.get(i);
+            System.arraycopy(chunk, 0, payloadBytes, offset, chunk.length);
+            offset += chunk.length;
+          }
+          return payloadBytes;
+        });
   }
 
   private static Encoding toEncoding(@Nullable String value) {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.google.android.datatransport.runtime.scheduling.persistence;
 
-import android.content.ContentValues;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
@@ -106,10 +105,7 @@ final class SchemaManager extends SQLiteOpenHelper {
 
   private static final SchemaManager.Migration MIGRATE_TO_V4 =
       db -> {
-        db.execSQL("ALTER TABLE events ADD COLUMN inline BOOLEAN DEFAULT 1");
-        ContentValues values = new ContentValues();
-        values.put("inline", 1);
-        db.update("events", values, null, new String[0]);
+        db.execSQL("ALTER TABLE events ADD COLUMN inline BOOLEAN NOT NULL DEFAULT 1");
         db.execSQL(CREATE_PAYLOADS_TABLE_V4);
       };
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -26,7 +26,7 @@ import javax.inject.Named;
 final class SchemaManager extends SQLiteOpenHelper {
   // TODO: when we do schema upgrades in the future we need to make sure both downgrades and
   // upgrades work as expected, e.g. `up+down+up` is equivalent to `up`.
-  private static final String DB_NAME = "com.google.android.datatransport.events";
+  static final String DB_NAME = "com.google.android.datatransport.events";
   private final int schemaVersion;
   private boolean configured = false;
 
@@ -117,8 +117,11 @@ final class SchemaManager extends SQLiteOpenHelper {
       Arrays.asList(MIGRATE_TO_V1, MIGRATE_TO_V2, MIGRATE_TO_V3, MIGRATE_TO_V4);
 
   @Inject
-  SchemaManager(Context context, @Named("SCHEMA_VERSION") int schemaVersion) {
-    super(context, DB_NAME, null, schemaVersion);
+  SchemaManager(
+      Context context,
+      @Named("SQLITE_DB_NAME") String dbName,
+      @Named("SCHEMA_VERSION") int schemaVersion) {
+    super(context, dbName, null, schemaVersion);
     this.schemaVersion = schemaVersion;
   }
 

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
@@ -130,8 +130,14 @@ public class SchemaManagerTest {
 
     // Upgrade to V4
     schemaManager.onUpgrade(schemaManager.getWritableDatabase(), oldVersion, newVersion);
-
     assertThat(store.loadBatch(CONTEXT1)).containsExactly(event1);
+
+    long inlineRows =
+        store
+            .getDb()
+            .compileStatement("SELECT COUNT(*) from events where inline = 1")
+            .simpleQueryForLong();
+    assertThat(inlineRows).isEqualTo(1);
   }
 
   @Test

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -69,7 +69,7 @@ dependencies {
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
-    testImplementation 'org.robolectric:robolectric:4.1'
+    testImplementation 'org.robolectric:robolectric:4.2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
 
     androidTestImplementation 'junit:junit:4.13-beta-3'

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -62,18 +62,20 @@ dependencies {
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
 
-    annotationProcessor "com.google.auto.value:auto-value:1.6.2"
+    annotationProcessor "com.google.auto.value:auto-value:1.6.5"
     annotationProcessor 'com.google.dagger:dagger-compiler:2.24'
 
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'org.robolectric:robolectric:4.2'
+    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation 'org.robolectric:robolectric:4.1'
     testImplementation 'org.mockito:mockito-core:2.25.0'
 
     androidTestImplementation 'junit:junit:4.13-beta-3'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation 'org.mockito:mockito-android:2.25.0'

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -57,7 +57,7 @@ android {
 
 dependencies {
     implementation project(':transport:transport-api')
-    implementation 'com.google.dagger:dagger:2.24'
+    implementation 'com.google.dagger:dagger:2.27'
     implementation 'androidx.annotation:annotation:1.1.0'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"


### PR DESCRIPTION
Large payloads are stored in a separate table as 80KB chunks of data keyed
by (sequence_num,event_id).
The motivation for the change is to avoid the Android SQLite
implementation limitation, that uses `CursorWindow`s of a limited size
that is unknown at runtime and vendors can change arbitrarily, hence the
conservative choice of 80KB instead of 2048KB that is present in AOSP
source code.

The way it manifests is that it is possible to write rows in the the db
that is impossible to read back as an exception gets thrown.

An altertative approach that was considered was to store file paths in
the DB and store blobs in the file-system. But that would introduce more
complexity to the storage system:

* Loss of ACID semantics, i.e. if we fail to commit we may fail to
  delete the underlying file.
* Should we store it in cache dir or in file dir?
* What if cache is cleared but the event reference still exists in the db?
* etc.