### PR TITLE
Remove hard limit on Crashlytics payload size

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/send/DataTransportCrashlyticsReportSenderTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/send/DataTransportCrashlyticsReportSenderTest.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import androidx.test.runner.AndroidJUnit4;

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/send/DataTransportCrashlyticsReportSenderTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/send/DataTransportCrashlyticsReportSenderTest.java
@@ -129,26 +129,6 @@ public class DataTransportCrashlyticsReportSenderTest {
     assertEquals(ex, send2.getException());
   }
 
-  @Test
-  public void testSendLargeReport_successfulWithoutSchedulingToDataTransport() throws Exception {
-    doAnswer(callbackAnswer(null)).when(mockTransport).schedule(any(), any());
-
-    final CrashlyticsReportWithSessionId report = mockReportWithSessionId();
-
-    when(mockTransform.apply(report.getReport())).thenReturn(new byte[1024 * 1024]);
-
-    final Task<CrashlyticsReportWithSessionId> send = reportSender.sendReport(report);
-
-    try {
-      Tasks.await(send);
-    } catch (ExecutionException e) {
-      // Allow this to fall through
-    }
-
-    assertTrue(send.isSuccessful());
-    verify(mockTransport, never()).schedule(any(), any());
-  }
-
   private static Answer<Void> callbackAnswer(Exception failure) {
     return (i) -> {
       final TransportScheduleCallback callback = i.getArgument(1);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/send/DataTransportCrashlyticsReportSender.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/send/DataTransportCrashlyticsReportSender.java
@@ -24,8 +24,6 @@ import com.google.android.datatransport.cct.CCTDestination;
 import com.google.android.datatransport.runtime.TransportRuntime;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
-import com.google.android.gms.tasks.Tasks;
-import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.common.CrashlyticsReportWithSessionId;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.model.serialization.CrashlyticsReportJsonTransform;


### PR DESCRIPTION
DataTransport SDK will support larger payloads going forward, and
we will continue to iterate on more precise changes to reduce
payload sizes in the future.

DO NOT MERGE until DataTransport SDK upgrades are shipped: https://github.com/firebase/firebase-android-sdk/pull/1431