### PR TITLE
Bump crashlytics to use the latest version of IID

### DIFF
--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -58,8 +58,9 @@ dependencies {
     implementation project(':transport:transport-api')
     implementation project(':transport:transport-runtime')
     implementation project(':transport:transport-backend-cct')
-    implementation ('com.google.firebase:firebase-iid:19.0.0') {
+    implementation ('com.google.firebase:firebase-iid:20.1.5') {
         exclude group: "com.google.firebase", module: "firebase-common"
+        exclude group: "com.google.firebase", module: "firebase-components"
     }
     implementation 'com.google.firebase:firebase-iid-interop:17.0.0'
     implementation 'com.google.firebase:firebase-measurement-connector:18.0.0'


### PR DESCRIPTION
- Exclude firebase-components because it is depended-upon locally.