### PR TITLE
Enable errorprone only by request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Firebase Android libraries exercise all three types of tests recommended by the
 Depending on the requirements of the specific project, some or all of these
 tests may be used to support changes.
 
+> :warning: **Running tests with errorprone**
+>
+> To run with errorprone add `withErrorProne` to the command line, e.g.
+>
+> `./gradlew :<firebase-project>:check withErrorProne`.
+
 ### Unit Testing
 
 These are tests that run on your machine's local Java Virtual Machine (JVM). At

--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,11 @@ buildscript {
 }
 
 apply from: 'sdkProperties.gradle'
+apply from: "gradle/errorProne.gradle"
 
 ext {
     playServicesVersion = '16.0.1'
     supportAnnotationsVersion = '28.0.0'
-    errorproneVersion = '2.3.2'
-    errorproneJavacVersion = '9+181-r4173-1'
     googleTruthVersion = '0.45'
     robolectricVersion = '4.1'
 }
@@ -72,12 +71,7 @@ configure(subprojects) {
         jcenter()
         mavenLocal()
     }
-    apply plugin: 'net.ltgt.errorprone'
-    dependencies {
-        errorprone "com.google.errorprone:error_prone_core:$errorproneVersion"
-        errorproneJavac "com.google.errorprone:javac:$errorproneJavacVersion"
 
-    }
     apply plugin: 'com.github.sherter.google-java-format'
     googleJavaFormat {
         toolVersion = '1.7'
@@ -97,10 +91,6 @@ configure(subprojects) {
         exclude 'src/testUtil/java/com/google/firebase/firestore/testutil/Assert.java'
         exclude 'src/testUtil/java/com/google/firebase/firestore/testutil/ThrowingRunnable.java'
         exclude '**/package-info.java'
-    }
-
-    tasks.withType(JavaCompile) {
-        options.errorprone.excludedPaths = '.*/build/generated/.*'
     }
 
     apply plugin: "org.jlleitschuh.gradle.ktlint"

--- a/firebase-abt/src/main/java/com/google/firebase/abt/FirebaseABTesting.java
+++ b/firebase-abt/src/main/java/com/google/firebase/abt/FirebaseABTesting.java
@@ -15,8 +15,6 @@
 package com.google.firebase.abt;
 
 import static com.google.firebase.abt.AbtExperimentInfo.validateAbtExperimentInfo;
-import static com.google.firebase.abt.FirebaseABTesting.OriginService.INAPP_MESSAGING;
-import static com.google.firebase.abt.FirebaseABTesting.OriginService.REMOTE_CONFIG;
 
 import android.content.Context;
 import androidx.annotation.Nullable;
@@ -67,7 +65,7 @@ public class FirebaseABTesting {
    * Select keys of fields in the experiment descriptions returned from the Firebase Remote Config
    * server.
    */
-  @StringDef({REMOTE_CONFIG, INAPP_MESSAGING})
+  @StringDef({OriginService.REMOTE_CONFIG, OriginService.INAPP_MESSAGING})
   @Retention(RetentionPolicy.SOURCE)
   public @interface OriginService {
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
@@ -14,23 +14,6 @@
 
 package com.google.firebase.remoteconfig;
 
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_ID;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.VARIANT_ID;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.ANALYTICS_USER_PROPERTIES;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_ID;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_VERSION;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.COUNTRY_CODE;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.INSTANCE_ID;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.INSTANCE_ID_TOKEN;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.LANGUAGE_CODE;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.PACKAGE_NAME;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.PLATFORM_VERSION;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.SDK_VERSION;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.TIME_ZONE;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.ENTRIES;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.EXPERIMENT_DESCRIPTIONS;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.STATE;
-
 import androidx.annotation.StringDef;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -41,7 +24,7 @@ import java.lang.annotation.RetentionPolicy;
  * @author Lucas Png
  * @hide
  */
-public class RemoteConfigConstants {
+public final class RemoteConfigConstants {
   public static final String FETCH_REGEX_URL =
       "https://firebaseremoteconfig.googleapis.com/v1/projects/%s/namespaces/%s:fetch";
 
@@ -50,17 +33,17 @@ public class RemoteConfigConstants {
    * server.
    */
   @StringDef({
-    INSTANCE_ID,
-    INSTANCE_ID_TOKEN,
-    APP_ID,
-    COUNTRY_CODE,
-    LANGUAGE_CODE,
-    PLATFORM_VERSION,
-    TIME_ZONE,
-    APP_VERSION,
-    PACKAGE_NAME,
-    SDK_VERSION,
-    ANALYTICS_USER_PROPERTIES
+    RequestFieldKey.INSTANCE_ID,
+    RequestFieldKey.INSTANCE_ID_TOKEN,
+    RequestFieldKey.APP_ID,
+    RequestFieldKey.COUNTRY_CODE,
+    RequestFieldKey.LANGUAGE_CODE,
+    RequestFieldKey.PLATFORM_VERSION,
+    RequestFieldKey.TIME_ZONE,
+    RequestFieldKey.APP_VERSION,
+    RequestFieldKey.PACKAGE_NAME,
+    RequestFieldKey.SDK_VERSION,
+    RequestFieldKey.ANALYTICS_USER_PROPERTIES
   })
   @Retention(RetentionPolicy.SOURCE)
   public @interface RequestFieldKey {
@@ -78,7 +61,11 @@ public class RemoteConfigConstants {
   }
 
   /** Keys of fields in the Fetch response body from the Firebase Remote Config server. */
-  @StringDef({ENTRIES, EXPERIMENT_DESCRIPTIONS, STATE})
+  @StringDef({
+    ResponseFieldKey.ENTRIES,
+    ResponseFieldKey.EXPERIMENT_DESCRIPTIONS,
+    ResponseFieldKey.STATE
+  })
   @Retention(RetentionPolicy.SOURCE)
   public @interface ResponseFieldKey {
     String ENTRIES = "entries";
@@ -90,7 +77,10 @@ public class RemoteConfigConstants {
    * Select keys of fields in the experiment descriptions returned from the Firebase Remote Config
    * server.
    */
-  @StringDef({EXPERIMENT_ID, VARIANT_ID})
+  @StringDef({
+    ExperimentDescriptionFieldKey.EXPERIMENT_ID,
+    ExperimentDescriptionFieldKey.VARIANT_ID
+  })
   @Retention(RetentionPolicy.SOURCE)
   public @interface ExperimentDescriptionFieldKey {
     String EXPERIMENT_ID = "experimentId";

--- a/gradle/errorProne.gradle
+++ b/gradle/errorProne.gradle
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+def isErrorProneRequested = getGradle().getStartParameter().getTaskNames().contains("withErrorProne")
+
+def errorproneVersion = '2.3.2'
+def errorproneJavacVersion = '9+181-r4173-1'
+
+if (isErrorProneRequested) {
+    configure(subprojects) {
+        apply plugin: 'net.ltgt.errorprone'
+        dependencies {
+            errorprone "com.google.errorprone:error_prone_core:$errorproneVersion"
+            errorproneJavac "com.google.errorprone:javac:$errorproneJavacVersion"
+
+        }
+        tasks.withType(JavaCompile) {
+            options.errorprone.excludedPaths = '.*/build/generated/.*'
+        }
+    }
+}
+
+// marker task to enable errorprone diagnostics.
+task withErrorProne {}


### PR DESCRIPTION
The motivation is that errorprone produces different bytecode than javac
this confuses retrolambda's desugaring where it fails to correctly
desugar try-with-resources.

To enable errorprone one needs to run:

```
./gradlew :mylib:mytask withErrorProne
```