### PR TITLE
feat(database-ktx): add reified function getValue() to MutableData

### DIFF
--- a/docs/ktx/database.md
+++ b/docs/ktx/database.md
@@ -80,3 +80,21 @@ val messages: List<Message> = snapshot.getValue(typeIndicator)
 val snapshot: DocumentSnapshot = ...
 val messages: List<Message> = snapshot.getValue<List<@JvmSuppressWildcards Message>>()
 ```
+
+### Convert a MutableData to a POJO in a Transaction
+
+**Kotlin**
+```kotlin
+override fun doTransaction(mutableData: MutableData): Transaction.Result {
+    val post = mutableData.getValue(Post::class.java)
+    // ...
+}
+```
+
+**Kotlin + KTX**
+```kotlin
+override fun doTransaction(mutableData: MutableData): Transaction.Result {
+    val post = mutableData.getValue<Post>()
+    // ...
+}
+```

--- a/firebase-database/ktx/api.txt
+++ b/firebase-database/ktx/api.txt
@@ -8,6 +8,7 @@ package com.google.firebase.database.ktx {
     method @NonNull public static com.google.firebase.database.FirebaseDatabase database(@NonNull com.google.firebase.ktx.Firebase, @NonNull com.google.firebase.FirebaseApp app, @NonNull String url);
     method @NonNull public static com.google.firebase.database.FirebaseDatabase getDatabase(@NonNull com.google.firebase.ktx.Firebase);
     method @Nullable public static inline <reified T> T getValue(@NonNull com.google.firebase.database.DataSnapshot);
+    method @Nullable public static inline <reified T> T getValue(@NonNull com.google.firebase.database.MutableData);
   }
 
 }

--- a/firebase-database/ktx/src/main/kotlin/com/google/firebase/database/ktx/Database.kt
+++ b/firebase-database/ktx/src/main/kotlin/com/google/firebase/database/ktx/Database.kt
@@ -21,6 +21,7 @@ import com.google.firebase.database.GenericTypeIndicator
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.components.Component
 import com.google.firebase.components.ComponentRegistrar
+import com.google.firebase.database.MutableData
 
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.platforminfo.LibraryVersionComponent
@@ -46,6 +47,16 @@ FirebaseDatabase.getInstance(app, url)
  * use the type `T`, and not `? extends T`.
  */
 inline fun <reified T> DataSnapshot.getValue(): T? {
+    return getValue(object : GenericTypeIndicator<T>() {})
+}
+
+/**
+ * Returns the content of the MutableData converted to a POJO.
+ *
+ * Supports generics like List<> or Map<>. Use @JvmSuppressWildcards to force the compiler to
+ * use the type `T`, and not `? extends T`.
+ */
+inline fun <reified T> MutableData.getValue(): T? {
     return getValue(object : GenericTypeIndicator<T>() {})
 }
 

--- a/firebase-database/ktx/src/test/kotlin/com/google/firebase/database/DataSnapshotUtil.kt
+++ b/firebase-database/ktx/src/test/kotlin/com/google/firebase/database/DataSnapshotUtil.kt
@@ -28,3 +28,14 @@ fun createDataSnapshot(data: Any?, db: FirebaseDatabase): DataSnapshot {
     val node = NodeUtilities.NodeFromJSON(data)
     return DataSnapshot(ref, IndexedNode.from(node))
 }
+
+/**
+ * Creates a custom MutableData.
+ *
+ * This method is a workaround that enables the creation of a custom
+ * MutableData using package-private methods.
+ */
+fun createMutableData(data: Any?): MutableData {
+    val node = NodeUtilities.NodeFromJSON(data)
+    return MutableData(node)
+}

--- a/firebase-database/ktx/src/test/kotlin/com/google/firebase/database/ktx/DatabaseTests.kt
+++ b/firebase-database/ktx/src/test/kotlin/com/google/firebase/database/ktx/DatabaseTests.kt
@@ -218,7 +218,7 @@ class MutableDataTests : BaseTestCase() {
                 goalkeeper = false,
                 avg_goals_per_game = 0.35
         )
-        val mutableData = createMutableData(data)
+        val mutableData = createMutableData(data.toMap())
         assertThat(mutableData.getValue<Player>()).isEqualTo(data)
     }
 }

--- a/firebase-database/ktx/src/test/kotlin/com/google/firebase/database/ktx/DatabaseTests.kt
+++ b/firebase-database/ktx/src/test/kotlin/com/google/firebase/database/ktx/DatabaseTests.kt
@@ -19,6 +19,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.createDataSnapshot
+import com.google.firebase.database.createMutableData
 import com.google.firebase.database.IgnoreExtraProperties
 import com.google.firebase.database.Exclude
 import com.google.firebase.ktx.Firebase
@@ -164,6 +165,61 @@ class DataSnapshotTests : BaseTestCase() {
         )
         val dataSnapshot = createDataSnapshot(data.toMap(), Firebase.database)
         assertThat(dataSnapshot.getValue<Player>()).isEqualTo(data)
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class MutableDataTests : BaseTestCase() {
+    @Test
+    fun `reified getValue works with basic types`() {
+        val data = mapOf(
+                "name" to "John Doe",
+                "jersey" to 35L,
+                "goalkeeper" to false,
+                "avg_goals_per_game" to 0.35
+        )
+        val mutableData = createMutableData(data)
+
+        assertThat(mutableData.child("name").getValue<String>()).isEqualTo("John Doe")
+        assertThat(mutableData.child("jersey").getValue<Long>()).isEqualTo(35L)
+        assertThat(mutableData.child("goalkeeper").getValue<Boolean>()).isEqualTo(false)
+        assertThat(mutableData.child("avg_goals_per_game").getValue<Double>()).isEqualTo(0.35)
+    }
+
+    @Test
+    fun `reified getValue works with maps`() {
+        val data = mapOf(
+                "name" to "John Doe",
+                "jersey" to 35L,
+                "goalkeeper" to false,
+                "avg_goals_per_game" to 0.35
+        )
+        val mutableData = createMutableData(data)
+        assertThat(mutableData.getValue<Map<String, Any>>()).isEqualTo(data)
+    }
+
+    @Test
+    fun `reified getValue works with lists types`() {
+        val data = listOf(
+                "George",
+                "John",
+                "Paul",
+                "Ringo"
+        )
+        val mutableData = createMutableData(data)
+        assertThat(mutableData.getValue<List<String>>()).isEqualTo(data)
+    }
+
+    @Test
+    fun `reified getValue works with custom types`() {
+        val data = Player(
+                name = "John Doe",
+                jersey = 35,
+                goalkeeper = false,
+                avg_goals_per_game = 0.35
+        )
+        val mutableData = createMutableData(data)
+        assertThat(mutableData.getValue<Player>()).isEqualTo(data)
     }
 }
 


### PR DESCRIPTION
This allows developers to use `mutableData.getValue<Post>()` instead of `mutableData.getValue(Post::class.java)` in Transactions.