### PR TITLE
Wait for DataTransport callback task at crash time

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -435,9 +435,10 @@ class CrashlyticsController {
                             // Data collection is enabled, so it's safe to send the report.
                             boolean dataCollectionToken = true;
                             sendSessionReports(appSettingsData, dataCollectionToken);
-                            reportingCoordinator.sendReports(
-                                executor, DataTransportState.getState(appSettingsData));
-                            return recordFatalFirebaseEventTask;
+                            return Tasks.whenAll(
+                                reportingCoordinator.sendReports(
+                                    executor, DataTransportState.getState(appSettingsData)),
+                                recordFatalFirebaseEventTask);
                           }
                         });
               }


### PR DESCRIPTION
Improves reliability of sending crash reports at crash time in the
case that the process would exit before Crashlytics has received
the asynchronous callback from DataTransport.