### PR TITLE
Datatransport failures should not crash the app.

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/SafeLoggingExecutor.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/SafeLoggingExecutor.java
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.android.datatransport.runtime;
+
+import com.google.android.datatransport.runtime.logging.Logging;
+import java.util.concurrent.Executor;
+
+/**
+ * Protects underlying threads from crashing.
+ *
+ * <p>Exceptions thrown by executed {@link Runnable}s are logged and swallowed.
+ */
+class SafeLoggingExecutor implements Executor {
+  private final Executor delegate;
+
+  SafeLoggingExecutor(Executor delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    delegate.execute(new SafeLoggingRunnable(command));
+  }
+
+  static class SafeLoggingRunnable implements Runnable {
+    private final Runnable delegate;
+
+    SafeLoggingRunnable(Runnable delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void run() {
+      try {
+        delegate.run();
+      } catch (Exception e) {
+        Logging.e("Executor", "Background execution failure.", e);
+      }
+    }
+  }
+}

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/SafeLoggingExecutorTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/SafeLoggingExecutorTest.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,17 +14,26 @@
 
 package com.google.android.datatransport.runtime;
 
-import dagger.Module;
-import dagger.Provides;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import javax.inject.Singleton;
+import static org.junit.Assert.fail;
 
-@Module
-abstract class ExecutionModule {
-  @Singleton
-  @Provides
-  static Executor executor() {
-    return new SafeLoggingExecutor(Executors.newSingleThreadExecutor());
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class SafeLoggingExecutorTest {
+
+  private static final SafeLoggingExecutor EXECUTOR = new SafeLoggingExecutor(Runnable::run);
+
+  @Test
+  public void execute() {
+    try {
+      EXECUTOR.execute(
+          () -> {
+            throw new RuntimeException("Test exception");
+          });
+    } catch (Exception e) {
+      fail("Expected exception to be caught but was not: " + e);
+    }
   }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/SafeLoggingExecutorTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/SafeLoggingExecutorTest.java
@@ -26,7 +26,7 @@ public class SafeLoggingExecutorTest {
   private static final SafeLoggingExecutor EXECUTOR = new SafeLoggingExecutor(Runnable::run);
 
   @Test
-  public void execute() {
+  public void execute_shouldNotCrashThread() {
     try {
       EXECUTOR.execute(
           () -> {


### PR DESCRIPTION
This is achieved by protecting the executor thread by a catch all. This
makes sure that failures are logged to logcat but do not cause the
underlying thread to crash itself.

Mitigates #1436 until a more detailed repro is provided.