### PR TITLE
Port ComponentProvider

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ComponentProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ComponentProvider.java
@@ -1,0 +1,157 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.core;
+
+import android.content.Context;
+import androidx.annotation.Nullable;
+import com.google.firebase.firestore.FirebaseFirestoreSettings;
+import com.google.firebase.firestore.auth.User;
+import com.google.firebase.firestore.local.GarbageCollectionScheduler;
+import com.google.firebase.firestore.local.LocalStore;
+import com.google.firebase.firestore.local.Persistence;
+import com.google.firebase.firestore.remote.ConnectivityMonitor;
+import com.google.firebase.firestore.remote.Datastore;
+import com.google.firebase.firestore.remote.RemoteStore;
+import com.google.firebase.firestore.util.AsyncQueue;
+
+/**
+ * Initializes and wires up all core components for Firestore.
+ *
+ * <p>Implementations provide custom components by overriding the `createX()` methods.
+ */
+public abstract class ComponentProvider {
+
+  private Persistence persistence;
+  private LocalStore localStore;
+  private SyncEngine syncEngine;
+  private RemoteStore remoteStore;
+  private EventManager eventManager;
+  private ConnectivityMonitor connectityMonitor;
+  @Nullable private GarbageCollectionScheduler gargabeCollectionScheduler;
+
+  /** Configuration options for the component provider. */
+  public static class Configuration {
+
+    private final Context context;
+    private final AsyncQueue asyncQueue;
+    private final DatabaseInfo databaseInfo;
+    private final Datastore datastore;
+    private final User initialUser;
+    private final int maxConcurrentLimboResolutions;
+    private final FirebaseFirestoreSettings settings;
+
+    public Configuration(
+        Context context,
+        AsyncQueue asyncQueue,
+        DatabaseInfo databaseInfo,
+        Datastore datastore,
+        User initialUser,
+        int maxConcurrentLimboResolutions,
+        FirebaseFirestoreSettings settings) {
+      this.context = context;
+      this.asyncQueue = asyncQueue;
+      this.databaseInfo = databaseInfo;
+      this.datastore = datastore;
+      this.initialUser = initialUser;
+      this.maxConcurrentLimboResolutions = maxConcurrentLimboResolutions;
+      this.settings = settings;
+    }
+
+    FirebaseFirestoreSettings getSettings() {
+      return settings;
+    }
+
+    AsyncQueue getAsyncQueue() {
+      return asyncQueue;
+    }
+
+    DatabaseInfo getDatabaseInfo() {
+      return databaseInfo;
+    }
+
+    Datastore getDatastore() {
+      return datastore;
+    }
+
+    User getInitialUser() {
+      return initialUser;
+    }
+
+    int getMaxConcurrentLimboResolutions() {
+      return maxConcurrentLimboResolutions;
+    }
+
+    Context getContext() {
+      return context;
+    }
+  }
+
+  public Persistence getPersistence() {
+    return persistence;
+  }
+
+  @Nullable
+  public GarbageCollectionScheduler getGargabeCollectionScheduler() {
+    return gargabeCollectionScheduler;
+  }
+
+  public LocalStore getLocalStore() {
+    return localStore;
+  }
+
+  public SyncEngine getSyncEngine() {
+    return syncEngine;
+  }
+
+  public RemoteStore getRemoteStore() {
+    return remoteStore;
+  }
+
+  public EventManager getEventManager() {
+    return eventManager;
+  }
+
+  protected ConnectivityMonitor getConnectivityMonitor() {
+    return connectityMonitor;
+  }
+
+  public void initialize(Configuration configuration) {
+    persistence = createPersistence(configuration);
+    persistence.start();
+    localStore = createLocalStore(configuration);
+    connectityMonitor = createConnectivityMonitor(configuration);
+    remoteStore = createRemoteStore(configuration);
+    syncEngine = createSyncEngine(configuration);
+    eventManager = createEventManager(configuration);
+    localStore.start();
+    remoteStore.start();
+    gargabeCollectionScheduler = createGarbageCollectionScheduler(configuration);
+  }
+
+  protected abstract GarbageCollectionScheduler createGarbageCollectionScheduler(
+      Configuration configuration);
+
+  protected abstract EventManager createEventManager(Configuration configuration);
+
+  protected abstract LocalStore createLocalStore(Configuration configuration);
+
+  protected abstract ConnectivityMonitor createConnectivityMonitor(Configuration configuration);
+
+  protected abstract Persistence createPersistence(Configuration configuration);
+
+  protected abstract RemoteStore createRemoteStore(Configuration configuration);
+
+  protected abstract SyncEngine createSyncEngine(Configuration configuration);
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -21,7 +21,6 @@ import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
-import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.FirebaseFirestoreException.Code;
@@ -29,33 +28,21 @@ import com.google.firebase.firestore.FirebaseFirestoreSettings;
 import com.google.firebase.firestore.auth.CredentialsProvider;
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.core.EventManager.ListenOptions;
-import com.google.firebase.firestore.local.IndexFreeQueryEngine;
-import com.google.firebase.firestore.local.LocalSerializer;
+import com.google.firebase.firestore.local.GarbageCollectionScheduler;
 import com.google.firebase.firestore.local.LocalStore;
-import com.google.firebase.firestore.local.LruDelegate;
-import com.google.firebase.firestore.local.LruGarbageCollector;
-import com.google.firebase.firestore.local.MemoryPersistence;
 import com.google.firebase.firestore.local.Persistence;
-import com.google.firebase.firestore.local.QueryEngine;
 import com.google.firebase.firestore.local.QueryResult;
-import com.google.firebase.firestore.local.SQLitePersistence;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MaybeDocument;
 import com.google.firebase.firestore.model.NoDocument;
 import com.google.firebase.firestore.model.mutation.Mutation;
-import com.google.firebase.firestore.model.mutation.MutationBatchResult;
-import com.google.firebase.firestore.remote.AndroidConnectivityMonitor;
-import com.google.firebase.firestore.remote.ConnectivityMonitor;
 import com.google.firebase.firestore.remote.Datastore;
 import com.google.firebase.firestore.remote.GrpcMetadataProvider;
-import com.google.firebase.firestore.remote.RemoteEvent;
-import com.google.firebase.firestore.remote.RemoteSerializer;
 import com.google.firebase.firestore.remote.RemoteStore;
 import com.google.firebase.firestore.util.AsyncQueue;
 import com.google.firebase.firestore.util.Function;
 import com.google.firebase.firestore.util.Logger;
-import io.grpc.Status;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -64,7 +51,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * FirestoreClient is a top-level class that constructs and owns all of the pieces of the client SDK
  * architecture.
  */
-public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
+public final class FirestoreClient {
 
   private static final String LOG_TAG = "FirestoreClient";
   private static final int MAX_CONCURRENT_LIMBO_RESOLUTIONS = 100;
@@ -81,7 +68,7 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
   private final GrpcMetadataProvider metadataProvider;
 
   // LRU-related
-  @Nullable private LruGarbageCollector.Scheduler lruScheduler;
+  @Nullable private GarbageCollectionScheduler gcScheduler;
 
   public FirestoreClient(
       final Context context,
@@ -106,11 +93,7 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
           try {
             // Block on initial user being available
             User initialUser = Tasks.await(firstUser.getTask());
-            initialize(
-                context,
-                initialUser,
-                settings.isPersistenceEnabled(),
-                settings.getCacheSizeBytes());
+            initialize(context, initialUser, settings);
           } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
           }
@@ -149,8 +132,8 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
         () -> {
           remoteStore.shutdown();
           persistence.shutdown();
-          if (lruScheduler != null) {
-            lruScheduler.stop();
+          if (gcScheduler != null) {
+            gcScheduler.stop();
           }
         });
   }
@@ -241,52 +224,39 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
     return source.getTask();
   }
 
-  private void initialize(Context context, User user, boolean usePersistence, long cacheSizeBytes) {
+  private void initialize(Context context, User user, FirebaseFirestoreSettings settings) {
     // Note: The initialization work must all be synchronous (we can't dispatch more work) since
     // external write/listen operations could get queued to run before that subsequent work
     // completes.
     Logger.debug(LOG_TAG, "Initializing. user=%s", user.getUid());
 
-    LruGarbageCollector gc = null;
-    if (usePersistence) {
-      LocalSerializer serializer =
-          new LocalSerializer(new RemoteSerializer(databaseInfo.getDatabaseId()));
-      LruGarbageCollector.Params params =
-          LruGarbageCollector.Params.WithCacheSizeBytes(cacheSizeBytes);
-      SQLitePersistence sqlitePersistence =
-          new SQLitePersistence(
-              context,
-              databaseInfo.getPersistenceKey(),
-              databaseInfo.getDatabaseId(),
-              serializer,
-              params);
-      LruDelegate lruDelegate = sqlitePersistence.getReferenceDelegate();
-      gc = lruDelegate.getGarbageCollector();
-      persistence = sqlitePersistence;
-    } else {
-      persistence = MemoryPersistence.createEagerGcMemoryPersistence();
-    }
-
-    persistence.start();
-    QueryEngine queryEngine = new IndexFreeQueryEngine();
-    localStore = new LocalStore(persistence, queryEngine, user);
-    if (gc != null) {
-      lruScheduler = gc.newScheduler(asyncQueue, localStore);
-      lruScheduler.start();
-    }
-
     Datastore datastore =
         new Datastore(databaseInfo, asyncQueue, credentialsProvider, context, metadataProvider);
-    ConnectivityMonitor connectivityMonitor = new AndroidConnectivityMonitor(context);
-    remoteStore = new RemoteStore(this, localStore, datastore, asyncQueue, connectivityMonitor);
+    ComponentProvider.Configuration configuration =
+        new ComponentProvider.Configuration(
+            context,
+            asyncQueue,
+            databaseInfo,
+            datastore,
+            user,
+            MAX_CONCURRENT_LIMBO_RESOLUTIONS,
+            settings);
 
-    syncEngine = new SyncEngine(localStore, remoteStore, user, MAX_CONCURRENT_LIMBO_RESOLUTIONS);
-    eventManager = new EventManager(syncEngine);
+    ComponentProvider provider =
+        settings.isPersistenceEnabled()
+            ? new SQLiteComponentProvider()
+            : new MemoryComponentProvider();
+    provider.initialize(configuration);
+    persistence = provider.getPersistence();
+    gcScheduler = provider.getGargabeCollectionScheduler();
+    localStore = provider.getLocalStore();
+    remoteStore = provider.getRemoteStore();
+    syncEngine = provider.getSyncEngine();
+    eventManager = provider.getEventManager();
 
-    // NOTE: RemoteStore depends on LocalStore (for persisting stream tokens, refilling mutation
-    // queue, etc.) so must be started after LocalStore.
-    localStore.start();
-    remoteStore.start();
+    if (gcScheduler != null) {
+      gcScheduler.start();
+    }
   }
 
   public void addSnapshotsInSyncListener(EventListener<Void> listener) {
@@ -305,35 +275,5 @@ public final class FirestoreClient implements RemoteStore.RemoteStoreCallback {
     if (this.isTerminated()) {
       throw new IllegalStateException("The client has already been terminated");
     }
-  }
-
-  @Override
-  public void handleRemoteEvent(RemoteEvent remoteEvent) {
-    syncEngine.handleRemoteEvent(remoteEvent);
-  }
-
-  @Override
-  public void handleRejectedListen(int targetId, Status error) {
-    syncEngine.handleRejectedListen(targetId, error);
-  }
-
-  @Override
-  public void handleSuccessfulWrite(MutationBatchResult mutationBatchResult) {
-    syncEngine.handleSuccessfulWrite(mutationBatchResult);
-  }
-
-  @Override
-  public void handleRejectedWrite(int batchId, Status error) {
-    syncEngine.handleRejectedWrite(batchId, error);
-  }
-
-  @Override
-  public void handleOnlineStateChange(OnlineState onlineState) {
-    syncEngine.handleOnlineStateChange(onlineState);
-  }
-
-  @Override
-  public ImmutableSortedSet<DocumentKey> getRemoteKeysForTarget(int targetId) {
-    return syncEngine.getRemoteKeysForTarget(targetId);
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/MemoryComponentProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/MemoryComponentProvider.java
@@ -1,0 +1,122 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.core;
+
+import androidx.annotation.Nullable;
+import com.google.firebase.database.collection.ImmutableSortedSet;
+import com.google.firebase.firestore.local.GarbageCollectionScheduler;
+import com.google.firebase.firestore.local.IndexFreeQueryEngine;
+import com.google.firebase.firestore.local.LocalStore;
+import com.google.firebase.firestore.local.MemoryPersistence;
+import com.google.firebase.firestore.local.Persistence;
+import com.google.firebase.firestore.model.DocumentKey;
+import com.google.firebase.firestore.model.mutation.MutationBatchResult;
+import com.google.firebase.firestore.remote.AndroidConnectivityMonitor;
+import com.google.firebase.firestore.remote.RemoteEvent;
+import com.google.firebase.firestore.remote.RemoteStore;
+import io.grpc.Status;
+
+/**
+ * Provides all components needed for Firestore with in-memory persistence. Uses EagerGC garbage
+ * collection.
+ */
+public class MemoryComponentProvider extends ComponentProvider {
+
+  @Override
+  @Nullable
+  protected GarbageCollectionScheduler createGarbageCollectionScheduler(
+      Configuration configuration) {
+    return null;
+  }
+
+  @Override
+  protected EventManager createEventManager(Configuration configuration) {
+    return new EventManager(getSyncEngine());
+  }
+
+  @Override
+  protected LocalStore createLocalStore(Configuration configuration) {
+    return new LocalStore(
+        getPersistence(), new IndexFreeQueryEngine(), configuration.getInitialUser());
+  }
+
+  @Override
+  protected AndroidConnectivityMonitor createConnectivityMonitor(Configuration configuration) {
+    return new AndroidConnectivityMonitor(configuration.getContext());
+  }
+
+  @Override
+  protected Persistence createPersistence(Configuration configuration) {
+    return MemoryPersistence.createEagerGcMemoryPersistence();
+  }
+
+  @Override
+  protected RemoteStore createRemoteStore(Configuration configuration) {
+    return new RemoteStore(
+        new RemoteStoreCallback(),
+        getLocalStore(),
+        configuration.getDatastore(),
+        configuration.getAsyncQueue(),
+        getConnectivityMonitor());
+  }
+
+  @Override
+  protected SyncEngine createSyncEngine(Configuration configuration) {
+    return new SyncEngine(
+        getLocalStore(),
+        getRemoteStore(),
+        configuration.getInitialUser(),
+        configuration.getMaxConcurrentLimboResolutions());
+  }
+
+  /**
+   * A callback interface used by RemoteStore. All calls are forwarded to SyncEngine.
+   *
+   * <p>This interface exists to allow RemoteStore to access functionality provided by SyncEngine
+   * even though SyncEngine is created after RemoteStore.
+   */
+  private class RemoteStoreCallback implements RemoteStore.RemoteStoreCallback {
+
+    @Override
+    public void handleRemoteEvent(RemoteEvent remoteEvent) {
+      getSyncEngine().handleRemoteEvent(remoteEvent);
+    }
+
+    @Override
+    public void handleRejectedListen(int targetId, Status error) {
+      getSyncEngine().handleRejectedListen(targetId, error);
+    }
+
+    @Override
+    public void handleSuccessfulWrite(MutationBatchResult mutationBatchResult) {
+      getSyncEngine().handleSuccessfulWrite(mutationBatchResult);
+    }
+
+    @Override
+    public void handleRejectedWrite(int batchId, Status error) {
+      getSyncEngine().handleRejectedWrite(batchId, error);
+    }
+
+    @Override
+    public void handleOnlineStateChange(OnlineState onlineState) {
+      getSyncEngine().handleOnlineStateChange(onlineState);
+    }
+
+    @Override
+    public ImmutableSortedSet<DocumentKey> getRemoteKeysForTarget(int targetId) {
+      return getSyncEngine().getRemoteKeysForTarget(targetId);
+    }
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SQLiteComponentProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SQLiteComponentProvider.java
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.core;
+
+import com.google.firebase.firestore.local.GarbageCollectionScheduler;
+import com.google.firebase.firestore.local.LocalSerializer;
+import com.google.firebase.firestore.local.LruDelegate;
+import com.google.firebase.firestore.local.LruGarbageCollector;
+import com.google.firebase.firestore.local.Persistence;
+import com.google.firebase.firestore.local.SQLitePersistence;
+import com.google.firebase.firestore.remote.RemoteSerializer;
+
+/** Provides all components needed for Firestore with SQLite persistence. */
+public class SQLiteComponentProvider extends MemoryComponentProvider {
+
+  @Override
+  protected GarbageCollectionScheduler createGarbageCollectionScheduler(
+      Configuration configuration) {
+    LruDelegate lruDelegate = ((SQLitePersistence) getPersistence()).getReferenceDelegate();
+    LruGarbageCollector gc = lruDelegate.getGarbageCollector();
+    return gc.newScheduler(configuration.getAsyncQueue(), getLocalStore());
+  }
+
+  @Override
+  protected Persistence createPersistence(Configuration configuration) {
+    LocalSerializer serializer =
+        new LocalSerializer(new RemoteSerializer(configuration.getDatabaseInfo().getDatabaseId()));
+    LruGarbageCollector.Params params =
+        LruGarbageCollector.Params.WithCacheSizeBytes(
+            configuration.getSettings().getCacheSizeBytes());
+    return new SQLitePersistence(
+        configuration.getContext(),
+        configuration.getDatabaseInfo().getPersistenceKey(),
+        configuration.getDatabaseInfo().getDatabaseId(),
+        serializer,
+        params);
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/GarbageCollectionScheduler.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/GarbageCollectionScheduler.java
@@ -1,0 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.local;
+
+/** Helper interface to control the Garbage Collector. */
+public interface GarbageCollectionScheduler {
+  void start();
+
+  void stop();
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruGarbageCollector.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LruGarbageCollector.java
@@ -111,7 +111,7 @@ public class LruGarbageCollector {
    * This class is responsible for the scheduling of LRU garbage collection. It handles checking
    * whether or not GC is enabled, as well as which delay to use before the next run.
    */
-  public class Scheduler {
+  public class Scheduler implements GarbageCollectionScheduler {
     private final AsyncQueue asyncQueue;
     private final LocalStore localStore;
     private boolean hasRun = false;
@@ -122,12 +122,14 @@ public class LruGarbageCollector {
       this.localStore = localStore;
     }
 
+    @Override
     public void start() {
       if (params.minBytesThreshold != Params.COLLECTION_DISABLED) {
         scheduleGC();
       }
     }
 
+    @Override
     public void stop() {
       if (gcTask != null) {
         gcTask.cancel();

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/PersistenceTestHelpers.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/PersistenceTestHelpers.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore.local;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
+import com.google.firebase.firestore.core.DatabaseInfo;
 import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.remote.RemoteSerializer;
 
@@ -28,6 +29,14 @@ public final class PersistenceTestHelpers {
     return "test-" + databaseNameCounter++;
   }
 
+  public static DatabaseInfo nextDatabaseInfo() {
+    return new DatabaseInfo(
+        DatabaseId.forDatabase("project", "database"),
+        nextSQLiteDatabaseName(),
+        "localhost",
+        /* sslEnabled= */ false);
+  }
+
   public static SQLitePersistence createSQLitePersistence(String name) {
     return openSQLitePersistence(name, LruGarbageCollector.Params.Default());
   }
@@ -37,7 +46,7 @@ public final class PersistenceTestHelpers {
    * @return a new SQLitePersistence with an empty database and an up-to-date schema.
    */
   public static SQLitePersistence createSQLitePersistence() {
-    return createSQLitePersistence(LruGarbageCollector.Params.Default());
+    return openSQLitePersistence(nextSQLiteDatabaseName(), LruGarbageCollector.Params.Default());
   }
 
   public static SQLitePersistence createSQLitePersistence(LruGarbageCollector.Params params) {
@@ -52,10 +61,6 @@ public final class PersistenceTestHelpers {
     MemoryPersistence persistence = MemoryPersistence.createEagerGcMemoryPersistence();
     persistence.start();
     return persistence;
-  }
-
-  public static MemoryPersistence createLRUMemoryPersistence() {
-    return createLRUMemoryPersistence(LruGarbageCollector.Params.Default());
   }
 
   public static MemoryPersistence createLRUMemoryPersistence(LruGarbageCollector.Params params) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/MockDatastore.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/MockDatastore.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import com.google.firebase.firestore.auth.EmptyCredentialsProvider;
 import com.google.firebase.firestore.core.DatabaseInfo;
 import com.google.firebase.firestore.local.TargetData;
-import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.model.mutation.MutationResult;
@@ -214,14 +213,8 @@ public class MockDatastore extends Datastore {
   private int writeStreamRequestCount;
   private int watchStreamRequestCount;
 
-  public MockDatastore(AsyncQueue workerQueue, Context context) {
-    super(
-        new DatabaseInfo(
-            DatabaseId.forDatabase("project", "database"), "persistenceKey", "host", false),
-        workerQueue,
-        new EmptyCredentialsProvider(),
-        context,
-        null);
+  public MockDatastore(DatabaseInfo databaseInfo, AsyncQueue workerQueue, Context context) {
+    super(databaseInfo, workerQueue, new EmptyCredentialsProvider(), context, null);
     this.serializer = new RemoteSerializer(getDatabaseInfo().getDatabaseId());
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/MemorySpecTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/MemorySpecTest.java
@@ -14,8 +14,14 @@
 
 package com.google.firebase.firestore.spec;
 
+import com.google.firebase.firestore.core.ComponentProvider;
+import com.google.firebase.firestore.core.MemoryComponentProvider;
+import com.google.firebase.firestore.local.LocalSerializer;
+import com.google.firebase.firestore.local.LruGarbageCollector;
+import com.google.firebase.firestore.local.MemoryPersistence;
 import com.google.firebase.firestore.local.Persistence;
-import com.google.firebase.firestore.local.PersistenceTestHelpers;
+import com.google.firebase.firestore.model.DatabaseId;
+import com.google.firebase.firestore.remote.RemoteSerializer;
 import java.util.Set;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -33,11 +39,23 @@ public class MemorySpecTest extends SpecTestCase {
   }
 
   @Override
-  Persistence getPersistence(boolean garbageCollectionEnabled) {
-    if (garbageCollectionEnabled) {
-      return PersistenceTestHelpers.createEagerGCMemoryPersistence();
-    } else {
-      return PersistenceTestHelpers.createLRUMemoryPersistence();
-    }
+  protected MemoryComponentProvider initializeComponentProvider(
+      ComponentProvider.Configuration configuration, final boolean garbageCollectionEnabled) {
+    MemoryComponentProvider provider =
+        new MemoryComponentProvider() {
+          @Override
+          protected Persistence createPersistence(Configuration configuration) {
+            if (garbageCollectionEnabled) {
+              return MemoryPersistence.createEagerGcMemoryPersistence();
+            } else {
+              DatabaseId databaseId = DatabaseId.forProject("projectId");
+              LocalSerializer serializer = new LocalSerializer(new RemoteSerializer(databaseId));
+              return MemoryPersistence.createLruGcMemoryPersistence(
+                  LruGarbageCollector.Params.Default(), serializer);
+            }
+          }
+        };
+    provider.initialize(configuration);
+    return provider;
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/MemorySpecTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/MemorySpecTest.java
@@ -40,7 +40,7 @@ public class MemorySpecTest extends SpecTestCase {
 
   @Override
   protected MemoryComponentProvider initializeComponentProvider(
-      ComponentProvider.Configuration configuration, final boolean garbageCollectionEnabled) {
+      ComponentProvider.Configuration configuration, boolean garbageCollectionEnabled) {
     MemoryComponentProvider provider =
         new MemoryComponentProvider() {
           @Override

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SQLiteSpecTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SQLiteSpecTest.java
@@ -40,7 +40,7 @@ public class SQLiteSpecTest extends SpecTestCase {
 
   @Override
   protected SQLiteComponentProvider initializeComponentProvider(
-      ComponentProvider.Configuration configuration, final boolean garbageCollectionEnabled) {
+      ComponentProvider.Configuration configuration, boolean garbageCollectionEnabled) {
     SQLiteComponentProvider provider = new SQLiteComponentProvider();
     provider.initialize(configuration);
     return provider;

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SQLiteSpecTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SQLiteSpecTest.java
@@ -14,8 +14,8 @@
 
 package com.google.firebase.firestore.spec;
 
-import com.google.firebase.firestore.local.Persistence;
-import com.google.firebase.firestore.local.PersistenceTestHelpers;
+import com.google.firebase.firestore.core.ComponentProvider;
+import com.google.firebase.firestore.core.SQLiteComponentProvider;
 import java.util.Set;
 import org.json.JSONObject;
 import org.junit.runner.RunWith;
@@ -27,23 +27,23 @@ import org.robolectric.annotation.Config;
 public class SQLiteSpecTest extends SpecTestCase {
 
   private static final String EAGER_GC = "eager-gc";
-  private String databaseName;
 
   @Override
   protected void specSetUp(JSONObject config) {
-    databaseName = PersistenceTestHelpers.nextSQLiteDatabaseName();
     super.specSetUp(config);
   }
 
   @Override
   protected void specTearDown() throws Exception {
-    databaseName = null;
     super.specTearDown();
   }
 
   @Override
-  Persistence getPersistence(boolean garbageCollectionEnabled) {
-    return PersistenceTestHelpers.createSQLitePersistence(databaseName);
+  protected SQLiteComponentProvider initializeComponentProvider(
+      ComponentProvider.Configuration configuration, final boolean garbageCollectionEnabled) {
+    SQLiteComponentProvider provider = new SQLiteComponentProvider();
+    provider.initialize(configuration);
+    return provider;
   }
 
   @Override

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -242,7 +242,7 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
   //
 
   protected abstract ComponentProvider initializeComponentProvider(
-      ComponentProvider.Configuration configuration, final boolean garbageCollectionEnabled);
+      ComponentProvider.Configuration configuration, boolean garbageCollectionEnabled);
 
   private boolean shouldRun(Set<String> tags) {
     for (String tag : tags) {


### PR DESCRIPTION
Ports the component provider from Web: https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/core/component_provider.ts

It also updates `FirestoreClient` and `SpecTestRunner` to use the new component provider. Note that the initialization in `FirestoreClient` is slightly different as there is no memory-only build, so we can decide much later which component provider to use.