### PR TITLE
feat: Implement firebase-crashlytics-ktx

### DIFF
--- a/firebase-crashlytics/ktx/api.txt
+++ b/firebase-crashlytics/ktx/api.txt
@@ -4,7 +4,17 @@ package com.google.firebase.crashlytics.ktx {
   public final class FirebaseCrashlyticsKt {
     ctor public FirebaseCrashlyticsKt();
     method @NonNull public static com.google.firebase.crashlytics.FirebaseCrashlytics getCrashlytics(@NonNull com.google.firebase.ktx.Firebase);
-    method public static void setCustomKeys(@NonNull com.google.firebase.crashlytics.FirebaseCrashlytics, @NonNull kotlin.Pair<java.lang.String,?>... pairs);
+    method public static void setCustomKeys(@NonNull com.google.firebase.crashlytics.FirebaseCrashlytics, @NonNull kotlin.jvm.functions.Function1<? super com.google.firebase.crashlytics.ktx.KeyValueBuilder,kotlin.Unit> init);
+  }
+
+  public final class KeyValueBuilder {
+    ctor public KeyValueBuilder(@NonNull com.google.firebase.crashlytics.FirebaseCrashlytics crashlytics);
+    method public void key(@NonNull String key, boolean value);
+    method public void key(@NonNull String key, double value);
+    method public void key(@NonNull String key, float value);
+    method public void key(@NonNull String key, int value);
+    method public void key(@NonNull String key, long value);
+    method public void key(@NonNull String key, @NonNull String value);
   }
 
 }

--- a/firebase-crashlytics/ktx/api.txt
+++ b/firebase-crashlytics/ktx/api.txt
@@ -1,0 +1,11 @@
+// Signature format: 2.0
+package com.google.firebase.crashlytics.ktx {
+
+  public final class FirebaseCrashlyticsKt {
+    ctor public FirebaseCrashlyticsKt();
+    method @NonNull public static com.google.firebase.crashlytics.FirebaseCrashlytics getCrashlytics(@NonNull com.google.firebase.ktx.Firebase);
+    method public static void setCustomKeys(@NonNull com.google.firebase.crashlytics.FirebaseCrashlytics, @NonNull kotlin.Pair<java.lang.String,?>... pairs);
+  }
+
+}
+

--- a/firebase-crashlytics/ktx/build.gradle
+++ b/firebase-crashlytics/ktx/build.gradle
@@ -1,0 +1,57 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id 'firebase-library'
+    id 'kotlin-android'
+}
+
+firebaseLibrary {
+    releaseWith project(':firebase-crashlytics')
+    publishJavadoc = true
+    publishSources = true
+}
+
+android {
+    compileSdkVersion project.targetSdkVersion
+    defaultConfig {
+        minSdkVersion 16
+        multiDexEnabled true
+        targetSdkVersion project.targetSdkVersion
+        versionName version
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+        test.java {
+            srcDir 'src/test/kotlin'
+        }
+    }
+    testOptions.unitTests.includeAndroidResources = true
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+
+    implementation project(':firebase-common')
+    implementation project(':firebase-components')
+    implementation project(':firebase-common:ktx')
+    implementation project(':firebase-crashlytics')
+    implementation 'androidx.annotation:annotation:1.1.0'
+
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+}

--- a/firebase-crashlytics/ktx/gradle.properties
+++ b/firebase-crashlytics/ktx/gradle.properties
@@ -1,0 +1,1 @@
+android.enableUnitTestBinaryResources=true

--- a/firebase-crashlytics/ktx/src/main/AndroidManifest.xml
+++ b/firebase-crashlytics/ktx/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 
     <application>
         <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
-            <meta-data android:name="com.google.firebase.components:com.google.firebase.crashlytics.ktx.FirebaseCrashlyticsRegistrar"
+            <meta-data android:name="com.google.firebase.components:com.google.firebase.crashlytics.ktx.FirebaseCrashlyticsKtxRegistrar"
                 android:value="com.google.firebase.components.ComponentRegistrar" />
         </service>
     </application>

--- a/firebase-crashlytics/ktx/src/main/AndroidManifest.xml
+++ b/firebase-crashlytics/ktx/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<!-- Copyright 2020 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.crashlytics.ktx">
+    <!--<uses-sdk android:minSdkVersion="16"/>-->
+
+    <application>
+        <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
+            <meta-data android:name="com.google.firebase.components:com.google.firebase.crashlytics.ktx.FirebaseCrashlyticsRegistrar"
+                android:value="com.google.firebase.components.ComponentRegistrar" />
+        </service>
+    </application>
+</manifest>

--- a/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
+++ b/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
@@ -26,21 +26,12 @@ import com.google.firebase.platforminfo.LibraryVersionComponent
 val Firebase.crashlytics: FirebaseCrashlytics
     get() = FirebaseCrashlytics.getInstance()
 
-fun FirebaseCrashlytics.setCustomKeys(vararg pairs: Pair<String, Any>) {
-    for ((key, value) in pairs) {
-        when (value) {
-            is Boolean -> setCustomKey(key, value)
-            is Double -> setCustomKey(key, value)
-            is Float -> setCustomKey(key, value)
-            is Int -> setCustomKey(key, value)
-            is Long -> setCustomKey(key, value)
-            is String -> setCustomKey(key, value)
-            else -> {
-                val valueType = value::class.java.componentType!!.canonicalName
-                throw IllegalArgumentException("Illegal value type $valueType for key \"$key\"")
-            }
-        }
-    }
+/**
+ * Associates all key-value parameters with the reports
+ */
+fun FirebaseCrashlytics.setCustomKeys(init: KeyValueBuilder.() -> Unit) {
+    val builder = KeyValueBuilder(this)
+    builder.init()
 }
 
 internal const val LIBRARY_NAME: String = "fire-cls-ktx"

--- a/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
+++ b/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
@@ -38,7 +38,7 @@ internal const val LIBRARY_NAME: String = "fire-cls-ktx"
 
 /** @suppress */
 @Keep
-class FirebaseCrashlyticsRegistrar : ComponentRegistrar {
+class FirebaseCrashlyticsKtxRegistrar : ComponentRegistrar {
     override fun getComponents(): List<Component<*>> =
             listOf(LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME))
 }

--- a/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
+++ b/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.ktx
+
+import androidx.annotation.Keep
+import com.google.firebase.FirebaseApp
+import com.google.firebase.components.Component
+import com.google.firebase.components.ComponentRegistrar
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.platforminfo.LibraryVersionComponent
+
+/** Returns the [FirebaseCrashlytics] instance of the default [FirebaseApp]. */
+val Firebase.crashlytics: FirebaseCrashlytics
+    get() = FirebaseCrashlytics.getInstance()
+
+fun FirebaseCrashlytics.setCustomKeys(vararg pairs: Pair<String, Any>) {
+    for ((key, value) in pairs) {
+        when (value) {
+            is Boolean -> setCustomKey(key, value)
+            is Double -> setCustomKey(key, value)
+            is Float -> setCustomKey(key, value)
+            is Int -> setCustomKey(key, value)
+            is Long -> setCustomKey(key, value)
+            is String -> setCustomKey(key, value)
+            else -> {
+                val valueType = value::class.java.componentType!!.canonicalName
+                throw IllegalArgumentException("Illegal value type $valueType for key \"$key\"")
+            }
+        }
+    }
+}
+
+internal const val LIBRARY_NAME: String = "fire-cls-ktx"
+
+/** @suppress */
+@Keep
+class FirebaseCrashlyticsRegistrar : ComponentRegistrar {
+    override fun getComponents(): List<Component<*>> =
+            listOf(LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME))
+}

--- a/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/KeyValueBuilder.kt
+++ b/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/KeyValueBuilder.kt
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.ktx
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+/** Helper class to enable fluent syntax in [setCustomKeys] */
+class KeyValueBuilder(
+        private val crashlytics: FirebaseCrashlytics
+) {
+
+    /** Sets a custom key and value that are associated with reports.  */
+    fun key(key: String, value: Boolean) = crashlytics.setCustomKey(key, value)
+
+    /** Sets a custom key and value that are associated with reports.  */
+    fun key(key: String, value: Double) = crashlytics.setCustomKey(key, value)
+
+    /** Sets a custom key and value that are associated with reports.  */
+    fun key(key: String, value: Float) = crashlytics.setCustomKey(key, value)
+
+    /** Sets a custom key and value that are associated with reports.  */
+    fun key(key: String, value: Int) = crashlytics.setCustomKey(key, value)
+
+    /** Sets a custom key and value that are associated with reports.  */
+    fun key(key: String, value: Long) = crashlytics.setCustomKey(key, value)
+
+    /** Sets a custom key and value that are associated with reports.  */
+    fun key(key: String, value: String) = crashlytics.setCustomKey(key, value)
+}

--- a/firebase-crashlytics/ktx/src/test/java/com/google/firebase/crashlytics/ktx/CrashlyticsTests.kt
+++ b/firebase-crashlytics/ktx/src/test/java/com/google/firebase/crashlytics/ktx/CrashlyticsTests.kt
@@ -29,8 +29,8 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
-const val APP_ID = "APP_ID"
-const val API_KEY = "API_KEY"
+const val APP_ID = "1:1234567890:android:321abc456def7890"
+const val API_KEY = "AIzaSyDOCAbC123dEf456GhI789jKl012-MnO"
 
 const val EXISTING_APP = "existing"
 

--- a/firebase-crashlytics/ktx/src/test/java/com/google/firebase/crashlytics/ktx/CrashlyticsTests.kt
+++ b/firebase-crashlytics/ktx/src/test/java/com/google/firebase/crashlytics/ktx/CrashlyticsTests.kt
@@ -1,0 +1,83 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.ktx
+
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.ktx.app
+import com.google.firebase.ktx.initialize
+import com.google.firebase.platforminfo.UserAgentPublisher
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+const val APP_ID = "APP_ID"
+const val API_KEY = "API_KEY"
+
+const val EXISTING_APP = "existing"
+
+abstract class BaseTestCase {
+    @Before
+    fun setUp() {
+        Firebase.initialize(
+                RuntimeEnvironment.application,
+                FirebaseOptions.Builder()
+                        .setApplicationId(APP_ID)
+                        .setApiKey(API_KEY)
+                        .setProjectId("123")
+                        .build()
+        )
+
+        Firebase.initialize(
+                RuntimeEnvironment.application,
+                FirebaseOptions.Builder()
+                        .setApplicationId(APP_ID)
+                        .setApiKey(API_KEY)
+                        .setProjectId("123")
+                        .build(),
+                EXISTING_APP
+        )
+    }
+
+    @After
+    fun cleanUp() {
+        FirebaseApp.clearInstancesForTest()
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class CrashlyticsTests : BaseTestCase() {
+
+    @Test
+    fun `Firebase#crashlytics should delegate to FirebaseCrashlytics#getInstance()`() {
+        assertThat(Firebase.crashlytics).isSameInstanceAs(FirebaseCrashlytics.getInstance())
+    }
+
+}
+
+@RunWith(RobolectricTestRunner::class)
+class LibraryVersionTest : BaseTestCase() {
+    @Test
+    fun `library version should be registered with runtime`() {
+        val publisher = Firebase.app.get(UserAgentPublisher::class.java)
+        assertThat(publisher.userAgent).contains(LIBRARY_NAME)
+    }
+}

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -8,6 +8,7 @@ firebase-config
 firebase-config:ktx
 firebase-config:bandwagoner
 firebase-crashlytics
+firebase-crashlytics:ktx
 firebase-crashlytics-ndk
 firebase-database
 firebase-database:ktx


### PR DESCRIPTION
Adding Kotlin Extensions for the new Crashlytics SDK :)


Not only this allows to use `Firebase.crashlytics`, but also setting custom keys:

```kotlin
Firebase.crashlytics.setCustomKeys(
    "str_key" to "hello",
    "bool_key" to true,
    "int_key" to 1,
    "long_key" to 1L,
    "float_key" to 1.0f,
    "double_key" to 1.0
)
```