### PR TITLE
Fix python subprocess call.

### DIFF
--- a/ci/fireci/fireci/uploader.py
+++ b/ci/fireci/fireci/uploader.py
@@ -57,5 +57,5 @@ def _construct_request_endpoint():
 
 
 def _get_commit_hash(revision):
-  result = subprocess.run(['git', 'rev-parse', revision], capture_output=True, check=True)
+  result = subprocess.run(['git', 'rev-parse', revision], stdout=subprocess.PIPE, check=True)
   return result.stdout.decode('utf-8').strip()


### PR DESCRIPTION
`capture_output` seems available only after python 3.7, but our CI is running 3.6.

https://docs.python.org/3.6/library/subprocess.html