### PR TITLE
Fix "changed" tasks.

### DIFF
--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
@@ -69,7 +69,7 @@ public class AffectedProjectFinder {
   private static Set<String> changedPaths(File workDir) {
     try {
       Process process =
-          Runtime.getRuntime().exec("git diff --name-only --submodule=diff", null, workDir);
+          Runtime.getRuntime().exec("git diff --name-only --submodule=diff HEAD@{0} HEAD@{1}", null, workDir);
       process.waitFor();
       return ImmutableSet.copyOf(
           CharStreams.readLines(new InputStreamReader(process.getInputStream())));

--- a/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/ContinuousIntegrationPlugin.java
+++ b/buildSrc/src/main/groovy/com/google/firebase/gradle/plugins/ci/ContinuousIntegrationPlugin.java
@@ -101,9 +101,9 @@ public class ContinuousIntegrationPlugin implements Plugin<Project> {
     Set<Project> affectedProjects =
         new AffectedProjectFinder(project, extension.getIgnorePaths()).find();
 
-    setupChangedTask(project, affectedProjects, "checkChanged");
-    setupChangedTask(project, affectedProjects, "checkCoverageChanged");
-    setupChangedTask(project, affectedProjects, "deviceCheckChanged");
+    setupChangedTask(project, affectedProjects, "check");
+    setupChangedTask(project, affectedProjects, "checkCoverage");
+    setupChangedTask(project, affectedProjects, "deviceCheck");
   }
 
   private static void setupChangedTask(
@@ -114,7 +114,7 @@ public class ContinuousIntegrationPlugin implements Plugin<Project> {
             check + "Changed",
             task -> {
               task.setGroup("verification");
-              task.setDescription("Runs the " + check + " task in all changed projects.");
+              task.setDescription("Runs the " + check + "Changed task in all changed projects.");
               task.setDependsOn(
                   affectedProjects.stream()
                       .map(p -> p.getPath() + ":" + check + "Dependents")


### PR DESCRIPTION
Regression introduced during java migration of build logic (#1516).
Essentially diff detection is missing required arguments `HEAD@{0} HEAD@{1}`