### PR TITLE
Make schemas back and forth compatible

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -15,6 +15,7 @@ package com.google.android.datatransport.runtime.scheduling.persistence;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Build;
 import java.util.Arrays;
@@ -30,12 +31,20 @@ final class SchemaManager extends SQLiteOpenHelper {
   private boolean configured = false;
 
   // Schema migration guidelines
-  // 1. Model migration at Vn as an operation performed on the database at Vn-1.
-  // 2. Append the migration to the ordered list of Migrations in the static initializer
-  // 3. Write tests that cover the following scenarios migrating to Vn from V0..Vn-1
+  // 1. Only migrations that are backward compatible are allowed. Developers may move back and forth
+  // between versions
+    // ✔ Adding a nullable column
+    // ✔ Adding a non null column with default
+    // Adding a table may or may not be acceptable
+  // ❌ Deleting a column,table,index
+  // ❌ Renaming a column,table,index
+
+  // 2. Model migration at Vn as an operation performed on the database at Vn-1.
+  // 3. Append the migration to the ordered list of Migrations in the static initializer
+  // 4. Write tests that cover the following scenarios migrating to Vn from V0..Vn-1
   // Note: Migrations handle only upgrades. Downgrades will drop and recreate all tables/indices.
   private static final String CREATE_EVENTS_SQL_V1 =
-      "CREATE TABLE events "
+      "CREATE TABLE IF NOT EXISTS events "
           + "(_id INTEGER PRIMARY KEY,"
           + " context_id INTEGER NOT NULL,"
           + " transport_name TEXT NOT NULL,"
@@ -47,7 +56,7 @@ final class SchemaManager extends SQLiteOpenHelper {
           + "FOREIGN KEY (context_id) REFERENCES transport_contexts(_id) ON DELETE CASCADE)";
 
   private static final String CREATE_EVENT_METADATA_SQL_V1 =
-      "CREATE TABLE event_metadata "
+      "CREATE TABLE IF NOT EXISTS event_metadata "
           + "(_id INTEGER PRIMARY KEY,"
           + " event_id INTEGER NOT NULL,"
           + " name TEXT NOT NULL,"
@@ -55,26 +64,20 @@ final class SchemaManager extends SQLiteOpenHelper {
           + "FOREIGN KEY (event_id) REFERENCES events(_id) ON DELETE CASCADE)";
 
   private static final String CREATE_CONTEXTS_SQL_V1 =
-      "CREATE TABLE transport_contexts "
+      "CREATE TABLE IF NOT EXISTS transport_contexts "
           + "(_id INTEGER PRIMARY KEY,"
           + " backend_name TEXT NOT NULL,"
           + " priority INTEGER NOT NULL,"
           + " next_request_ms INTEGER NOT NULL)";
 
   private static final String CREATE_EVENT_BACKEND_INDEX_V1 =
-      "CREATE INDEX events_backend_id on events(context_id)";
+      "CREATE INDEX IF NOT EXISTS events_backend_id on events(context_id)";
 
   private static final String CREATE_CONTEXT_BACKEND_PRIORITY_INDEX_V1 =
-      "CREATE UNIQUE INDEX contexts_backend_priority on transport_contexts(backend_name, priority)";
-
-  private static final String DROP_EVENTS_SQL = "DROP TABLE events";
-
-  private static final String DROP_EVENT_METADATA_SQL = "DROP TABLE event_metadata";
-
-  private static final String DROP_CONTEXTS_SQL = "DROP TABLE transport_contexts";
+      "CREATE UNIQUE INDEX IF NOT EXISTS contexts_backend_priority on transport_contexts(backend_name, priority)";
 
   private static final String CREATE_PAYLOADS_TABLE_V4 =
-      "CREATE TABLE event_payloads "
+      "CREATE TABLE IF NOT EXISTS event_payloads "
           + "(sequence_num INTEGER NOT NULL,"
           + " event_id INTEGER NOT NULL,"
           + " bytes BLOB NOT NULL,"
@@ -94,18 +97,35 @@ final class SchemaManager extends SQLiteOpenHelper {
 
   private static final SchemaManager.Migration MIGRATE_TO_V2 =
       (db) -> {
-        db.execSQL("ALTER TABLE transport_contexts ADD COLUMN extras BLOB");
+        try {
+          db.execSQL("ALTER TABLE transport_contexts ADD COLUMN extras BLOB");
+        } catch (SQLiteException ignored) {
+        }
+
         db.execSQL(
-            "CREATE UNIQUE INDEX contexts_backend_priority_extras on transport_contexts(backend_name, priority, extras)");
-        db.execSQL("DROP INDEX contexts_backend_priority");
+            "CREATE UNIQUE INDEX IF NOT EXISTS contexts_backend_priority_extras on transport_contexts(backend_name, priority, extras)");
+
+        // This migration is safe since all older versions delete tables and recreate onDowngrade.
+        // We no longer allow these mutations
+        db.execSQL("DROP INDEX IF EXISTS contexts_backend_priority");
       };
 
   private static final SchemaManager.Migration MIGRATE_TO_V3 =
-      db -> db.execSQL("ALTER TABLE events ADD COLUMN payload_encoding TEXT");
+      (db) -> {
+        try {
+          db.execSQL("ALTER TABLE events ADD COLUMN payload_encoding TEXT");
+        } catch (SQLiteException ignored) {
+        }
+      };
 
   private static final SchemaManager.Migration MIGRATE_TO_V4 =
       db -> {
-        db.execSQL("ALTER TABLE events ADD COLUMN inline BOOLEAN NOT NULL DEFAULT 1");
+        try {
+          db.execSQL("ALTER TABLE events ADD COLUMN inline BOOLEAN NOT NULL DEFAULT 1");
+        } catch (SQLiteException ignored) {
+
+        }
+
         db.execSQL(CREATE_PAYLOADS_TABLE_V4);
       };
 
@@ -119,6 +139,7 @@ final class SchemaManager extends SQLiteOpenHelper {
       @Named("SCHEMA_VERSION") int schemaVersion) {
     super(context, dbName, null, schemaVersion);
     this.schemaVersion = schemaVersion;
+
   }
 
   @Override
@@ -157,14 +178,7 @@ final class SchemaManager extends SQLiteOpenHelper {
   }
 
   @Override
-  public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-    db.execSQL(DROP_EVENTS_SQL);
-    db.execSQL(DROP_EVENT_METADATA_SQL);
-    db.execSQL(DROP_CONTEXTS_SQL);
-    // Indices are dropped automatically when the tables are dropped
-
-    onCreate(db, newVersion);
-  }
+  public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {}
 
   @Override
   public void onOpen(SQLiteDatabase db) {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -142,8 +142,12 @@ final class SchemaManager extends SQLiteOpenHelper {
 
   @Override
   public void onCreate(SQLiteDatabase db) {
+    onCreate(db, schemaVersion);
+  }
+
+  private void onCreate(SQLiteDatabase db, int version) {
     ensureConfigured(db);
-    upgrade(db, 0, schemaVersion);
+    upgrade(db, 0, version);
   }
 
   @Override
@@ -159,7 +163,7 @@ final class SchemaManager extends SQLiteOpenHelper {
     db.execSQL(DROP_CONTEXTS_SQL);
     // Indices are dropped automatically when the tables are dropped
 
-    onCreate(db);
+    onCreate(db, newVersion);
   }
 
   @Override

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -99,13 +99,11 @@ final class SchemaManager extends SQLiteOpenHelper {
         db.execSQL("ALTER TABLE transport_contexts ADD COLUMN extras BLOB");
         db.execSQL(
             "CREATE UNIQUE INDEX contexts_backend_priority_extras on transport_contexts(backend_name, priority, extras)");
-        db.execSQL("DROP INDEX IF EXISTS contexts_backend_priority");
+        db.execSQL("DROP INDEX contexts_backend_priority");
       };
 
   private static final SchemaManager.Migration MIGRATE_TO_V3 =
-      db -> {
-        db.execSQL("ALTER TABLE events ADD COLUMN payload_encoding TEXT");
-      };
+      db -> db.execSQL("ALTER TABLE events ADD COLUMN payload_encoding TEXT");
   private static final SchemaManager.Migration MIGRATE_TO_V4 =
       db -> {
         db.execSQL("ALTER TABLE events ADD COLUMN inline BOOLEAN NOT NULL DEFAULT 1");

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -33,12 +33,6 @@ final class SchemaManager extends SQLiteOpenHelper {
   // Schema migration guidelines
   // 1. Only migrations that are backward compatible are allowed. Developers may move back and forth
   // between versions
-    // ✔ Adding a nullable column
-    // ✔ Adding a non null column with default
-    // Adding a table may or may not be acceptable
-  // ❌ Deleting a column,table,index
-  // ❌ Renaming a column,table,index
-
   // 2. Model migration at Vn as an operation performed on the database at Vn-1.
   // 3. Append the migration to the ordered list of Migrations in the static initializer
   // 4. Write tests that cover the following scenarios migrating to Vn from V0..Vn-1
@@ -123,7 +117,6 @@ final class SchemaManager extends SQLiteOpenHelper {
         try {
           db.execSQL("ALTER TABLE events ADD COLUMN inline BOOLEAN NOT NULL DEFAULT 1");
         } catch (SQLiteException ignored) {
-
         }
 
         db.execSQL(CREATE_PAYLOADS_TABLE_V4);
@@ -139,7 +132,6 @@ final class SchemaManager extends SQLiteOpenHelper {
       @Named("SCHEMA_VERSION") int schemaVersion) {
     super(context, dbName, null, schemaVersion);
     this.schemaVersion = schemaVersion;
-
   }
 
   @Override

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -15,7 +15,6 @@ package com.google.android.datatransport.runtime.scheduling.persistence;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Build;
 import java.util.Arrays;
@@ -97,12 +96,7 @@ final class SchemaManager extends SQLiteOpenHelper {
 
   private static final SchemaManager.Migration MIGRATE_TO_V2 =
       (db) -> {
-        try {
-          db.execSQL("ALTER TABLE transport_contexts ADD COLUMN extras BLOB");
-        } catch (SQLiteException ignored) {
-
-        }
-        db.execSQL("DROP INDEX IF EXISTS contexts_backend_priority_extras");
+        db.execSQL("ALTER TABLE transport_contexts ADD COLUMN extras BLOB");
         db.execSQL(
             "CREATE UNIQUE INDEX contexts_backend_priority_extras on transport_contexts(backend_name, priority, extras)");
         db.execSQL("DROP INDEX IF EXISTS contexts_backend_priority");
@@ -110,18 +104,11 @@ final class SchemaManager extends SQLiteOpenHelper {
 
   private static final SchemaManager.Migration MIGRATE_TO_V3 =
       db -> {
-        try {
-          db.execSQL("ALTER TABLE events ADD COLUMN payload_encoding TEXT");
-        } catch (SQLiteException ignored) {
-        }
+        db.execSQL("ALTER TABLE events ADD COLUMN payload_encoding TEXT");
       };
   private static final SchemaManager.Migration MIGRATE_TO_V4 =
       db -> {
-        try {
-          db.execSQL("ALTER TABLE events ADD COLUMN inline BOOLEAN NOT NULL DEFAULT 1");
-        } catch (SQLiteException ignored) {
-
-        }
+        db.execSQL("ALTER TABLE events ADD COLUMN inline BOOLEAN NOT NULL DEFAULT 1");
         db.execSQL(DROP_PAYLOADS_SQL);
         db.execSQL(CREATE_PAYLOADS_TABLE_V4);
       };
@@ -159,8 +146,12 @@ final class SchemaManager extends SQLiteOpenHelper {
 
   @Override
   public void onCreate(SQLiteDatabase db) {
+    onCreate(db, schemaVersion);
+  }
+
+  private void onCreate(SQLiteDatabase db, int version) {
     ensureConfigured(db);
-    upgrade(db, 0, schemaVersion);
+    upgrade(db, 0, version);
   }
 
   @Override
@@ -177,7 +168,7 @@ final class SchemaManager extends SQLiteOpenHelper {
     db.execSQL(DROP_PAYLOADS_SQL);
     // Indices are dropped automatically when the tables are dropped
 
-    onCreate(db);
+    onCreate(db, newVersion);
   }
 
   @Override

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerMigrationTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerMigrationTest.java
@@ -1,0 +1,85 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.android.datatransport.runtime.scheduling.persistence;
+
+import static com.google.android.datatransport.runtime.scheduling.persistence.SchemaManager.DB_NAME;
+import static com.google.android.datatransport.runtime.scheduling.persistence.SchemaManager.SCHEMA_VERSION;
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.ContentValues;
+import android.database.sqlite.SQLiteDatabase;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.android.datatransport.Encoding;
+import com.google.android.datatransport.Priority;
+import com.google.android.datatransport.runtime.EncodedPayload;
+import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
+import com.google.android.datatransport.runtime.time.TestClock;
+import com.google.android.datatransport.runtime.time.UptimeClock;
+import com.google.android.datatransport.runtime.util.PriorityMapping;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class SchemaManagerMigrationTest {
+    private final int toVersion;
+    private final int fromVersion;
+
+    @ParameterizedRobolectricTestRunner.Parameters(name = "lowVersion = {0}, highVersion = {1}")
+    public static Collection<Object[]> data() {
+        Collection<Object[]> params = new ArrayList<>();
+        for(int fromVersion  = 1 ; fromVersion < SCHEMA_VERSION; fromVersion ++) {
+            for (int toVersion = fromVersion + 1; toVersion <= SCHEMA_VERSION; toVersion++) {
+                params.add(new Object[]{fromVersion, toVersion});
+            }
+        }
+        return params;
+    }
+
+    public SchemaManagerMigrationTest(int fromVersion, int toVersion) {
+        this.fromVersion = fromVersion;
+        this.toVersion = toVersion;
+    }
+
+    @Test
+    public void upgrade_migratesSuccessfully() {
+        SchemaManager schemaManager =
+                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, fromVersion);
+        schemaManager.onUpgrade(schemaManager.getWritableDatabase(), fromVersion, toVersion);
+    }
+
+    @Test
+    public void downgrade_migratesSuccessfully() {
+        SchemaManager schemaManager =
+                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, toVersion);
+        schemaManager.onDowngrade(schemaManager.getWritableDatabase(), toVersion, fromVersion);
+    }
+
+    @Test
+    public void downgrade_upgrade_migratesSuccessfully() {
+        SchemaManager schemaManager =
+                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, toVersion);
+
+        schemaManager.onDowngrade(schemaManager.getWritableDatabase(), toVersion, fromVersion);
+        schemaManager.onUpgrade(schemaManager.getWritableDatabase(), fromVersion, toVersion);
+    }
+}

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerMigrationTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerMigrationTest.java
@@ -13,73 +13,128 @@
 // limitations under the License.
 package com.google.android.datatransport.runtime.scheduling.persistence;
 
+import android.content.ContentValues;
+import android.database.sqlite.SQLiteDatabase;
+
 import static com.google.android.datatransport.runtime.scheduling.persistence.SchemaManager.DB_NAME;
 import static com.google.android.datatransport.runtime.scheduling.persistence.SchemaManager.SCHEMA_VERSION;
 import static com.google.common.truth.Truth.assertThat;
 
-import android.content.ContentValues;
-import android.database.sqlite.SQLiteDatabase;
 import androidx.test.core.app.ApplicationProvider;
-import com.google.android.datatransport.Encoding;
-import com.google.android.datatransport.Priority;
-import com.google.android.datatransport.runtime.EncodedPayload;
+
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
-import com.google.android.datatransport.runtime.time.TestClock;
-import com.google.android.datatransport.runtime.time.UptimeClock;
 import com.google.android.datatransport.runtime.util.PriorityMapping;
-import java.nio.charset.Charset;
+
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
-import org.robolectric.RobolectricTestRunner;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
 public class SchemaManagerMigrationTest {
-    private final int toVersion;
-    private final int fromVersion;
+    private final int highVersion;
+    private final int lowVersion;
 
+    private static Map<Integer, StateSimulations.StateSimulator> simulatorMap = new HashMap<>();
+    static {
+        simulatorMap.put(1, new StateSimulations.V1());
+        simulatorMap.put(2, new StateSimulations.V2());
+        simulatorMap.put(3, new StateSimulations.V3());
+        simulatorMap.put(4, new StateSimulations.V4());
+    }
     @ParameterizedRobolectricTestRunner.Parameters(name = "lowVersion = {0}, highVersion = {1}")
     public static Collection<Object[]> data() {
         Collection<Object[]> params = new ArrayList<>();
-        for(int fromVersion  = 1 ; fromVersion < SCHEMA_VERSION; fromVersion ++) {
-            for (int toVersion = fromVersion + 1; toVersion <= SCHEMA_VERSION; toVersion++) {
-                params.add(new Object[]{fromVersion, toVersion});
+        for(int lowVersion  = 1 ; lowVersion < SCHEMA_VERSION; lowVersion ++) {
+            for (int highVersion = lowVersion + 1; highVersion <= SCHEMA_VERSION; highVersion++) {
+                params.add(new Object[]{lowVersion, highVersion});
             }
         }
         return params;
     }
 
-    public SchemaManagerMigrationTest(int fromVersion, int toVersion) {
-        this.fromVersion = fromVersion;
-        this.toVersion = toVersion;
+    public SchemaManagerMigrationTest(int lowVersion, int highVersion) {
+        this.lowVersion = lowVersion;
+        this.highVersion = highVersion;
     }
 
     @Test
     public void upgrade_migratesSuccessfully() {
         SchemaManager schemaManager =
-                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, fromVersion);
-        schemaManager.onUpgrade(schemaManager.getWritableDatabase(), fromVersion, toVersion);
+                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, lowVersion);
+        schemaManager.onUpgrade(schemaManager.getWritableDatabase(), lowVersion, highVersion);
+        simulatorMap.get(highVersion).simulate(schemaManager);
     }
 
     @Test
     public void downgrade_migratesSuccessfully() {
         SchemaManager schemaManager =
-                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, toVersion);
-        schemaManager.onDowngrade(schemaManager.getWritableDatabase(), toVersion, fromVersion);
+                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, highVersion);
+        schemaManager.onDowngrade(schemaManager.getWritableDatabase(), highVersion, lowVersion);
+        simulatorMap.get(lowVersion).simulate(schemaManager);
     }
 
     @Test
     public void downgrade_upgrade_migratesSuccessfully() {
         SchemaManager schemaManager =
-                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, toVersion);
+                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, highVersion);
 
-        schemaManager.onDowngrade(schemaManager.getWritableDatabase(), toVersion, fromVersion);
-        schemaManager.onUpgrade(schemaManager.getWritableDatabase(), fromVersion, toVersion);
+        schemaManager.onDowngrade(schemaManager.getWritableDatabase(), highVersion, lowVersion);
+        simulatorMap.get(lowVersion).simulate(schemaManager);
+
+        schemaManager.onUpgrade(schemaManager.getWritableDatabase(), lowVersion, highVersion);
+        simulatorMap.get(highVersion).simulate(schemaManager);
+    }
+
+    @Test
+    public void upgrade_downgrade_upgrade_migratesSuccessfully() {
+        SchemaManager schemaManager =
+                new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, lowVersion);
+
+        schemaManager.onUpgrade(schemaManager.getWritableDatabase(), lowVersion, highVersion);
+        simulatorMap.get(highVersion).simulate(schemaManager);
+
+        schemaManager.onDowngrade(schemaManager.getWritableDatabase(), highVersion, lowVersion);
+        simulatorMap.get(lowVersion).simulate(schemaManager);
+
+        schemaManager.onUpgrade(schemaManager.getWritableDatabase(), lowVersion, highVersion);
+        simulatorMap.get(highVersion).simulate(schemaManager);
+    }
+
+    private PersistedEvent simulatedPersistOnV1Database(
+            SchemaManager schemaManager, TransportContext transportContext, EventInternal eventInternal) {
+        SQLiteDatabase db = schemaManager.getWritableDatabase();
+
+        ContentValues record = new ContentValues();
+        record.put("backend_name", transportContext.getBackendName());
+        record.put("priority", PriorityMapping.toInt(transportContext.getPriority()));
+        record.put("next_request_ms", 0);
+        long contextId = db.insert("transport_contexts", null, record);
+
+        ContentValues values = new ContentValues();
+        values.put("context_id", contextId);
+        values.put("transport_name", eventInternal.getTransportName());
+        values.put("timestamp_ms", eventInternal.getEventMillis());
+        values.put("uptime_ms", eventInternal.getUptimeMillis());
+        values.put("payload", eventInternal.getPayload());
+        values.put("code", eventInternal.getCode());
+        values.put("num_attempts", 0);
+        long newEventId = db.insert("events", null, values);
+
+        for (Map.Entry<String, String> entry : eventInternal.getMetadata().entrySet()) {
+            ContentValues metadata = new ContentValues();
+            metadata.put("event_id", newEventId);
+            metadata.put("name", entry.getKey());
+            metadata.put("value", entry.getValue());
+            db.insert("event_metadata", null, metadata);
+        }
+
+        return PersistedEvent.create(newEventId, transportContext, eventInternal);
     }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
@@ -141,33 +141,6 @@ public class SchemaManagerTest {
   }
 
   @Test
-  public void downgradeV2ToV1_withNonEmptyDB_isLossy() {
-    int fromVersion = 2;
-    int toVersion = fromVersion - 1;
-    SchemaManager schemaManager =
-        new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, fromVersion);
-    SQLiteEventStore store = new SQLiteEventStore(clock, new UptimeClock(), CONFIG, schemaManager);
-    PersistedEvent event1 = store.persist(CONTEXT1, EVENT1);
-
-    schemaManager.onDowngrade(schemaManager.getWritableDatabase(), toVersion, fromVersion);
-
-    long contextCount =
-        schemaManager
-            .getReadableDatabase()
-            .compileStatement("select count(*) from transport_contexts")
-            .simpleQueryForLong();
-
-    long eventCount =
-        schemaManager
-            .getReadableDatabase()
-            .compileStatement("select count(*) from events")
-            .simpleQueryForLong();
-
-    assertThat(contextCount).isEqualTo(0);
-    assertThat(eventCount).isEqualTo(0);
-  }
-
-  @Test
   public void upgrade_toANonExistentVersion_fails() {
     int oldVersion = 1;
     int nonExistentVersion = 1000;

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/StateSimulations.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/StateSimulations.java
@@ -14,169 +14,182 @@
 
 package com.google.android.datatransport.runtime.scheduling.persistence;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
-
 import com.google.android.datatransport.Encoding;
 import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.util.PriorityMapping;
-
 import java.nio.charset.Charset;
 import java.util.Random;
 
-import static com.google.common.truth.Truth.assertThat;
-
 class StateSimulations {
-    private static final Encoding PROTOBUF_ENCODING = Encoding.of("proto");
-    
-    interface StateSimulator {
-        void simulate(SchemaManager schemaManager);
+  private static final Encoding PROTOBUF_ENCODING = Encoding.of("proto");
+
+  interface StateSimulator {
+    void simulate(SchemaManager schemaManager);
+  }
+
+  static class V1 implements StateSimulator {
+    @Override
+    public void simulate(SchemaManager schemaManager) {
+      SQLiteDatabase db = schemaManager.getWritableDatabase();
+
+      ContentValues record = new ContentValues();
+      record.put("backend_name", "b1");
+      record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+      record.put("next_request_ms", 0);
+      long contextId = db.insert("transport_contexts", null, record);
+      assertThat(contextId).isNotEqualTo(-1);
+
+      ContentValues values = new ContentValues();
+      values.put("context_id", contextId);
+      values.put("transport_name", "42");
+      values.put("timestamp_ms", 1);
+      values.put("uptime_ms", 2);
+      values.put(
+          "payload",
+          new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset()))
+              .getBytes());
+      values.put("code", 1);
+      values.put("num_attempts", 0);
+      long newEventId = db.insert("events", null, values);
+      assertThat(newEventId).isNotEqualTo(-1);
+
+      ContentValues metadata = new ContentValues();
+      metadata.put("event_id", newEventId);
+      metadata.put("name", "key1");
+      metadata.put("value", "value1");
+      long metadataId = db.insert("event_metadata", null, metadata);
+      assertThat(metadataId).isNotEqualTo(-1);
     }
-    static class V1 implements StateSimulator {
-        @Override
-        public void simulate(SchemaManager schemaManager) {
-            SQLiteDatabase db = schemaManager.getWritableDatabase();
+  }
 
-            ContentValues record = new ContentValues();
-            record.put("backend_name", "b1");
-            record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
-            record.put("next_request_ms", 0);
-            long contextId = db.insert("transport_contexts", null, record);
-            assertThat(contextId).isNotEqualTo(-1);
+  static class V2 implements StateSimulator {
+    @Override
+    public void simulate(SchemaManager schemaManager) {
+      SQLiteDatabase db = schemaManager.getWritableDatabase();
+      Random rd = new Random();
+      byte[] arr = new byte[7];
+      rd.nextBytes(arr);
 
-            ContentValues values = new ContentValues();
-            values.put("context_id", contextId);
-            values.put("transport_name", "42");
-            values.put("timestamp_ms", 1);
-            values.put("uptime_ms", 2);
-            values.put("payload", new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset())).getBytes());
-            values.put("code", 1);
-            values.put("num_attempts", 0);
-            long newEventId = db.insert("events", null, values);
-            assertThat(newEventId).isNotEqualTo(-1);
+      ContentValues record = new ContentValues();
+      record.put("backend_name", "b1");
+      record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+      record.put("next_request_ms", 0);
+      record.put("extras", arr);
+      long contextId = db.insert("transport_contexts", null, record);
+      assertThat(contextId).isNotEqualTo(-1);
 
-            ContentValues metadata = new ContentValues();
-            metadata.put("event_id", newEventId);
-            metadata.put("name", "key1");
-            metadata.put("value", "value1");
-            long metadataId = db.insert("event_metadata", null, metadata);
-            assertThat(metadataId).isNotEqualTo(-1);
-        }
+      ContentValues values = new ContentValues();
+      values.put("context_id", contextId);
+      values.put("transport_name", "42");
+      values.put("timestamp_ms", 1);
+      values.put("uptime_ms", 2);
+      values.put(
+          "payload",
+          new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset()))
+              .getBytes());
+      values.put("code", 1);
+      values.put("num_attempts", 0);
+      long newEventId = db.insert("events", null, values);
+      assertThat(newEventId).isNotEqualTo(-1);
+
+      ContentValues metadata = new ContentValues();
+      metadata.put("event_id", newEventId);
+      metadata.put("name", "key1");
+      metadata.put("value", "value1");
+      long metadataId = db.insert("event_metadata", null, metadata);
+      assertThat(metadataId).isNotEqualTo(-1);
     }
+  }
 
-    static class V2 implements StateSimulator {
-        @Override
-        public void simulate(SchemaManager schemaManager) {
-            SQLiteDatabase db = schemaManager.getWritableDatabase();
-            Random rd = new Random();
-            byte[] arr = new byte[7];
-            rd.nextBytes(arr);
+  static class V3 implements StateSimulator {
+    @Override
+    public void simulate(SchemaManager schemaManager) {
+      SQLiteDatabase db = schemaManager.getWritableDatabase();
+      Random rd = new Random();
+      byte[] arr = new byte[7];
+      rd.nextBytes(arr);
 
-            ContentValues record = new ContentValues();
-            record.put("backend_name", "b1");
-            record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
-            record.put("next_request_ms", 0);
-            record.put("extras", arr);
-            long contextId = db.insert("transport_contexts", null, record);
-            assertThat(contextId).isNotEqualTo(-1);
+      ContentValues record = new ContentValues();
+      record.put("backend_name", "b1");
+      record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+      record.put("next_request_ms", 0);
+      record.put("extras", arr);
+      long contextId = db.insert("transport_contexts", null, record);
+      assertThat(contextId).isNotEqualTo(-1);
 
-            ContentValues values = new ContentValues();
-            values.put("context_id", contextId);
-            values.put("transport_name", "42");
-            values.put("timestamp_ms", 1);
-            values.put("uptime_ms", 2);
-            values.put("payload", new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset())).getBytes());
-            values.put("code", 1);
-            values.put("num_attempts", 0);
-            long newEventId = db.insert("events", null, values);
-            assertThat(newEventId).isNotEqualTo(-1);
+      ContentValues values = new ContentValues();
+      values.put("context_id", contextId);
+      values.put("transport_name", "42");
+      values.put("timestamp_ms", 1);
+      values.put("uptime_ms", 2);
+      values.put(
+          "payload",
+          new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset()))
+              .getBytes());
+      values.put("code", 1);
+      values.put("num_attempts", 0);
+      values.put("payload_encoding", "encoding");
+      long newEventId = db.insert("events", null, values);
+      assertThat(newEventId).isNotEqualTo(-1);
 
-            ContentValues metadata = new ContentValues();
-            metadata.put("event_id", newEventId);
-            metadata.put("name", "key1");
-            metadata.put("value", "value1");
-            long metadataId = db.insert("event_metadata", null, metadata);
-            assertThat(metadataId).isNotEqualTo(-1);
-        }
+      ContentValues metadata = new ContentValues();
+      metadata.put("event_id", newEventId);
+      metadata.put("name", "key1");
+      metadata.put("value", "value1");
+      long metadataId = db.insert("event_metadata", null, metadata);
+      assertThat(metadataId).isNotEqualTo(-1);
     }
-    static class V3 implements StateSimulator {
-        @Override
-        public void simulate(SchemaManager schemaManager) {
-            SQLiteDatabase db = schemaManager.getWritableDatabase();
-            Random rd = new Random();
-            byte[] arr = new byte[7];
-            rd.nextBytes(arr);
+  }
 
-            ContentValues record = new ContentValues();
-            record.put("backend_name", "b1");
-            record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
-            record.put("next_request_ms", 0);
-            record.put("extras", arr);
-            long contextId = db.insert("transport_contexts", null, record);
-            assertThat(contextId).isNotEqualTo(-1);
+  static class V4 implements StateSimulator {
+    @Override
+    public void simulate(SchemaManager schemaManager) {
+      SQLiteDatabase db = schemaManager.getWritableDatabase();
+      Random rd = new Random();
+      byte[] arr = new byte[7];
+      rd.nextBytes(arr);
 
-            ContentValues values = new ContentValues();
-            values.put("context_id", contextId);
-            values.put("transport_name", "42");
-            values.put("timestamp_ms", 1);
-            values.put("uptime_ms", 2);
-            values.put("payload", new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset())).getBytes());
-            values.put("code", 1);
-            values.put("num_attempts", 0);
-            values.put("payload_encoding" ,"encoding");
-            long newEventId = db.insert("events", null, values);
-            assertThat(newEventId).isNotEqualTo(-1);
+      ContentValues record = new ContentValues();
+      record.put("backend_name", "b1");
+      record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+      record.put("next_request_ms", 0);
+      record.put("extras", arr);
+      long contextId = db.insert("transport_contexts", null, record);
+      assertThat(contextId).isNotEqualTo(-1);
 
-            ContentValues metadata = new ContentValues();
-            metadata.put("event_id", newEventId);
-            metadata.put("name", "key1");
-            metadata.put("value", "value1");
-            long metadataId = db.insert("event_metadata", null, metadata);
-            assertThat(metadataId).isNotEqualTo(-1);
-        }
+      ContentValues values = new ContentValues();
+      values.put("context_id", contextId);
+      values.put("transport_name", "42");
+      values.put("timestamp_ms", 1);
+      values.put("uptime_ms", 2);
+      values.put(
+          "payload",
+          new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset()))
+              .getBytes());
+      values.put("code", 1);
+      values.put("num_attempts", 0);
+      values.put("payload_encoding", "encoding");
+      values.put("inline", true);
+      long newEventId = db.insert("events", null, values);
+      assertThat(newEventId).isNotEqualTo(-1);
+
+      ContentValues payloads = new ContentValues();
+      values.put("sequence_num", newEventId);
+      values.put("event_id", "42");
+      values.put("bytes", "event".getBytes());
+      long payloadId = db.insert("event_payloads", null, payloads);
+
+      ContentValues metadata = new ContentValues();
+      metadata.put("event_id", newEventId);
+      metadata.put("name", "key1");
+      metadata.put("value", "value1");
+      long metadataId = db.insert("event_metadata", null, metadata);
+      assertThat(metadataId).isNotEqualTo(-1);
     }
-    static class V4 implements StateSimulator {
-        @Override
-        public void simulate(SchemaManager schemaManager) {
-            SQLiteDatabase db = schemaManager.getWritableDatabase();
-            Random rd = new Random();
-            byte[] arr = new byte[7];
-            rd.nextBytes(arr);
-
-            ContentValues record = new ContentValues();
-            record.put("backend_name", "b1");
-            record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
-            record.put("next_request_ms", 0);
-            record.put("extras", arr);
-            long contextId = db.insert("transport_contexts", null, record);
-            assertThat(contextId).isNotEqualTo(-1);
-
-            ContentValues values = new ContentValues();
-            values.put("context_id", contextId);
-            values.put("transport_name", "42");
-            values.put("timestamp_ms", 1);
-            values.put("uptime_ms", 2);
-            values.put("payload", new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset())).getBytes());
-            values.put("code", 1);
-            values.put("num_attempts", 0);
-            values.put("payload_encoding" ,"encoding");
-            values.put("inline" ,true);
-            long newEventId = db.insert("events", null, values);
-            assertThat(newEventId).isNotEqualTo(-1);
-
-            ContentValues payloads = new ContentValues();
-            values.put("sequence_num", newEventId);
-            values.put("event_id", "42");
-            values.put("bytes", "event".getBytes());
-            long payloadId = db.insert("event_payloads", null, payloads);
-
-            ContentValues metadata = new ContentValues();
-            metadata.put("event_id", newEventId);
-            metadata.put("name", "key1");
-            metadata.put("value", "value1");
-            long metadataId = db.insert("event_metadata", null, metadata);
-            assertThat(metadataId).isNotEqualTo(-1);
-        }
-    }
+  }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/StateSimulations.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/StateSimulations.java
@@ -1,0 +1,182 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.android.datatransport.runtime.scheduling.persistence;
+
+import android.content.ContentValues;
+import android.database.sqlite.SQLiteDatabase;
+
+import com.google.android.datatransport.Encoding;
+import com.google.android.datatransport.Priority;
+import com.google.android.datatransport.runtime.EncodedPayload;
+import com.google.android.datatransport.runtime.util.PriorityMapping;
+
+import java.nio.charset.Charset;
+import java.util.Random;
+
+import static com.google.common.truth.Truth.assertThat;
+
+class StateSimulations {
+    private static final Encoding PROTOBUF_ENCODING = Encoding.of("proto");
+    
+    interface StateSimulator {
+        void simulate(SchemaManager schemaManager);
+    }
+    static class V1 implements StateSimulator {
+        @Override
+        public void simulate(SchemaManager schemaManager) {
+            SQLiteDatabase db = schemaManager.getWritableDatabase();
+
+            ContentValues record = new ContentValues();
+            record.put("backend_name", "b1");
+            record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+            record.put("next_request_ms", 0);
+            long contextId = db.insert("transport_contexts", null, record);
+            assertThat(contextId).isNotEqualTo(-1);
+
+            ContentValues values = new ContentValues();
+            values.put("context_id", contextId);
+            values.put("transport_name", "42");
+            values.put("timestamp_ms", 1);
+            values.put("uptime_ms", 2);
+            values.put("payload", new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset())).getBytes());
+            values.put("code", 1);
+            values.put("num_attempts", 0);
+            long newEventId = db.insert("events", null, values);
+            assertThat(newEventId).isNotEqualTo(-1);
+
+            ContentValues metadata = new ContentValues();
+            metadata.put("event_id", newEventId);
+            metadata.put("name", "key1");
+            metadata.put("value", "value1");
+            long metadataId = db.insert("event_metadata", null, metadata);
+            assertThat(metadataId).isNotEqualTo(-1);
+        }
+    }
+
+    static class V2 implements StateSimulator {
+        @Override
+        public void simulate(SchemaManager schemaManager) {
+            SQLiteDatabase db = schemaManager.getWritableDatabase();
+            Random rd = new Random();
+            byte[] arr = new byte[7];
+            rd.nextBytes(arr);
+
+            ContentValues record = new ContentValues();
+            record.put("backend_name", "b1");
+            record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+            record.put("next_request_ms", 0);
+            record.put("extras", arr);
+            long contextId = db.insert("transport_contexts", null, record);
+            assertThat(contextId).isNotEqualTo(-1);
+
+            ContentValues values = new ContentValues();
+            values.put("context_id", contextId);
+            values.put("transport_name", "42");
+            values.put("timestamp_ms", 1);
+            values.put("uptime_ms", 2);
+            values.put("payload", new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset())).getBytes());
+            values.put("code", 1);
+            values.put("num_attempts", 0);
+            long newEventId = db.insert("events", null, values);
+            assertThat(newEventId).isNotEqualTo(-1);
+
+            ContentValues metadata = new ContentValues();
+            metadata.put("event_id", newEventId);
+            metadata.put("name", "key1");
+            metadata.put("value", "value1");
+            long metadataId = db.insert("event_metadata", null, metadata);
+            assertThat(metadataId).isNotEqualTo(-1);
+        }
+    }
+    static class V3 implements StateSimulator {
+        @Override
+        public void simulate(SchemaManager schemaManager) {
+            SQLiteDatabase db = schemaManager.getWritableDatabase();
+            Random rd = new Random();
+            byte[] arr = new byte[7];
+            rd.nextBytes(arr);
+
+            ContentValues record = new ContentValues();
+            record.put("backend_name", "b1");
+            record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+            record.put("next_request_ms", 0);
+            record.put("extras", arr);
+            long contextId = db.insert("transport_contexts", null, record);
+            assertThat(contextId).isNotEqualTo(-1);
+
+            ContentValues values = new ContentValues();
+            values.put("context_id", contextId);
+            values.put("transport_name", "42");
+            values.put("timestamp_ms", 1);
+            values.put("uptime_ms", 2);
+            values.put("payload", new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset())).getBytes());
+            values.put("code", 1);
+            values.put("num_attempts", 0);
+            values.put("payload_encoding" ,"encoding");
+            long newEventId = db.insert("events", null, values);
+            assertThat(newEventId).isNotEqualTo(-1);
+
+            ContentValues metadata = new ContentValues();
+            metadata.put("event_id", newEventId);
+            metadata.put("name", "key1");
+            metadata.put("value", "value1");
+            long metadataId = db.insert("event_metadata", null, metadata);
+            assertThat(metadataId).isNotEqualTo(-1);
+        }
+    }
+    static class V4 implements StateSimulator {
+        @Override
+        public void simulate(SchemaManager schemaManager) {
+            SQLiteDatabase db = schemaManager.getWritableDatabase();
+            Random rd = new Random();
+            byte[] arr = new byte[7];
+            rd.nextBytes(arr);
+
+            ContentValues record = new ContentValues();
+            record.put("backend_name", "b1");
+            record.put("priority", PriorityMapping.toInt(Priority.DEFAULT));
+            record.put("next_request_ms", 0);
+            record.put("extras", arr);
+            long contextId = db.insert("transport_contexts", null, record);
+            assertThat(contextId).isNotEqualTo(-1);
+
+            ContentValues values = new ContentValues();
+            values.put("context_id", contextId);
+            values.put("transport_name", "42");
+            values.put("timestamp_ms", 1);
+            values.put("uptime_ms", 2);
+            values.put("payload", new EncodedPayload(PROTOBUF_ENCODING, "Hello".getBytes(Charset.defaultCharset())).getBytes());
+            values.put("code", 1);
+            values.put("num_attempts", 0);
+            values.put("payload_encoding" ,"encoding");
+            values.put("inline" ,true);
+            long newEventId = db.insert("events", null, values);
+            assertThat(newEventId).isNotEqualTo(-1);
+
+            ContentValues payloads = new ContentValues();
+            values.put("sequence_num", newEventId);
+            values.put("event_id", "42");
+            values.put("bytes", "event".getBytes());
+            long payloadId = db.insert("event_payloads", null, payloads);
+
+            ContentValues metadata = new ContentValues();
+            metadata.put("event_id", newEventId);
+            metadata.put("name", "key1");
+            metadata.put("value", "value1");
+            long metadataId = db.insert("event_metadata", null, metadata);
+            assertThat(metadataId).isNotEqualTo(-1);
+        }
+    }
+}


### PR DESCRIPTION
#1548 evidences issues that we have with our Schema Manager when customers go back and forth between versions (here on referred to as Version Fluidity) Thanks @rafikhan .

These are our options:
1) We can either take Firestore's stand of being lossless when customers migrate back and forth between versions.
2) We can take a systematic cleanup approach that deletes *all* state when clients are migrated to older versions. 

We are leaning towards option 2
1. Given Firestore' s approach to preserve state, the advice from the API council was to take a similar approach.
2. Deleting old data might make in intractable to use Firelog for some use cases going foward. 

Design considerations
We have modified migrations (history), which is typically a red flag. However since we have modeled db creation as running all migrations(replaying history), there's not a cleaner way forward.

Modifications to existing migrations involves one of two things
1) Creating tables only if they don't exist. 
2) Altering columns if they exist. Since there's no sql construct, we catch exceptions around the operation.

# Version compatibility
The migrations and tests are no longer representative of this compatibility since we essentially changing history.

Version Fluidity matrix
 
||1|2|3|4|
|---|---|---|---|---|
|1|😐|✅|✅|❌|
|2|✅|😐|✅|❌|
|3|✅|✅|😐|❌|
|4|❌|❌|❌|😐|


