### PR TITLE
Fix a multiple-definition linker error in the native API.

### DIFF
--- a/firebase-crashlytics-ndk/src/main/jni/Application.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI := armeabi armeabi-v7a arm64-v8a x86 x86_64
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_STL := c++_static
 NDK_TOOLCHAIN_VERSION=4.9

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/external/crashlytics.h
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/external/crashlytics.h
@@ -39,6 +39,9 @@ namespace firebase { namespace crashlytics {
 /// this header file is NOT required for Android NDK crash reporting.
 inline bool Initialize();
 
+/// Deprecated
+inline void Terminate();
+
 /// @brief Logs a message to be included in the next fatal or non-fatal report.
 inline void Log(const char* msg);
 
@@ -107,6 +110,10 @@ inline void invoke(const std::function<void (const __crashlytics_context_t *)>& 
 
 inline bool Initialize() {
     return detail::__crashlytics_context() != nullptr;
+}
+
+inline void Terminate() {
+    // no-op
 }
 
 inline void Log(const char* msg) {

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/external/crashlytics.h
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/external/crashlytics.h
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <string>
+#include <memory>
 #include <dlfcn.h>
 
 /// @brief Firebase Crashlytics NDK API, for Android apps which use native code.
@@ -25,141 +26,116 @@
 /// for information on using Firebase Crashlytics in your NDK-enabled Android apps.
 namespace firebase { namespace crashlytics {
 
-    /** PUBLIC API **/
+/** PUBLIC API **/
 
-    /// @brief Initialize the Crashlytics NDK API, for Android apps using native code.
-    ///
-    /// This must be called prior to calling any other methods in the firebase:crashlytics
-    /// namespace. This call is only required for adding custom metadata to crash reports. Use of
-    /// this header file is NOT required for Android NDK crash reporting.
-    inline void Initialize();
+/// @brief Initialize the Crashlytics NDK API, for Android apps using native code.
+///
+/// This must be called prior to calling any other methods in the firebase:crashlytics
+/// namespace. This call is only required for adding custom metadata to crash reports. Use of
+/// this header file is NOT required for Android NDK crash reporting.
+inline bool Initialize();
 
-    /// @brief Terminate the Crashlytics NDK API.
-    ///
-    /// Cleans up resources associated with the API. Subsequent calls to the Crashlytics native API
-    /// will have no effect.
-    inline void Terminate();
+/// @brief Logs a message to be included in the next fatal or non-fatal report.
+inline void Log(const char* msg);
 
-    /// @brief Logs a message to be included in the next fatal or non-fatal report.
-    inline void Log(const char* msg);
+/// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
+/// reports.
+inline void SetCustomKey(const char* key, bool value);
 
-    /// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
-    /// reports.
-    inline void SetCustomKey(const char* key, bool value);
+/// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
+/// reports.
+inline void SetCustomKey(const char* key, const char *value);
 
-    /// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
-    /// reports.
-    inline void SetCustomKey(const char* key, const char *value);
+/// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
+/// reports.
+inline void SetCustomKey(const char* key, double value);
 
-    /// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
-    /// reports.
-    inline void SetCustomKey(const char* key, double value);
+/// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
+/// reports.
+inline void SetCustomKey(const char* key, float value);
 
-    /// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
-    /// reports.
-    inline void SetCustomKey(const char* key, float value);
+/// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
+/// reports.
+inline void SetCustomKey(const char* key, int value);
 
-    /// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
-    /// reports.
-    inline void SetCustomKey(const char* key, int value);
+/// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
+/// reports.
+inline void SetCustomKey(const char* key, long value);
 
-    /// @brief Records a custom key and value to be associated with subsequent fatal and non-fatal
-    /// reports.
-    inline void SetCustomKey(const char* key, long value);
+/// @brief Records a user ID (identifier) that's associated with subsequent fatal and non-fatal
+/// reports.
+inline void SetUserId(const char* id);
 
-    /// @brief Records a user ID (identifier) that's associated with subsequent fatal and non-fatal
-    /// reports.
-    inline void SetUserId(const char* id);
+/** END PUBLIC API **/
 
-    /** END PUBLIC API **/
+namespace detail {
 
-    struct         __crashlytics_context;
-    struct         __crashlytics_unspecified;
-    typedef struct __crashlytics_context                    __crashlytics_context_t;
-    typedef struct __crashlytics_unspecified                __crashlytics_unspecified_t;
+struct         __crashlytics_context;
+struct         __crashlytics_unspecified;
+typedef struct __crashlytics_context                    __crashlytics_context_t;
+typedef struct __crashlytics_unspecified                __crashlytics_unspecified_t;
 
-    typedef __crashlytics_unspecified_t*    (*__crashlytics_initialize_t)      ();
-    typedef void                            (*__crashlytics_set_internal_t)    (__crashlytics_unspecified_t *, const char *, const char *);
-    typedef void                            (*__crashlytics_log_internal_t)    (__crashlytics_unspecified_t *, const char *);
-    typedef void                            (*__crashlytics_set_user_id_internal_t)(__crashlytics_unspecified_t *, const char *);
-    typedef void                            (*__crashlytics_dispose_t)         (__crashlytics_unspecified_t *);
+typedef __crashlytics_unspecified_t*    (*__crashlytics_initialize_t)           ();
+typedef void                            (*__crashlytics_set_internal_t)         (__crashlytics_unspecified_t *, const char *, const char *);
+typedef void                            (*__crashlytics_log_internal_t)         (__crashlytics_unspecified_t *, const char *);
+typedef void                            (*__crashlytics_set_user_id_internal_t) (__crashlytics_unspecified_t *, const char *);
+typedef void                            (*__crashlytics_dispose_t)              (__crashlytics_unspecified_t *);
 
-    struct __crashlytics_context {
+struct __crashlytics_context {
+    __crashlytics_set_internal_t __set;
+    __crashlytics_log_internal_t __log;
+    __crashlytics_set_user_id_internal_t __set_user_id;
 
-        __crashlytics_set_internal_t __set;
-        __crashlytics_log_internal_t __log;
-        __crashlytics_set_user_id_internal_t __set_user_id;
-
-        __crashlytics_unspecified_t* __ctx;
-        __crashlytics_dispose_t __dispose;
-    };
+    __crashlytics_unspecified_t* __ctx;
+    __crashlytics_dispose_t __dispose;
+};
 
 #define __CRASHLYTICS_NULL_CONTEXT                             (struct __crashlytics_context *) 0
 #define __CRASHLYTICS_INITIALIZE_FAILURE                       (struct __crashlytics_unspecified *) 0
 #define __CRASHLYTICS_DECORATED                                __attribute__ ((always_inline))
 
+inline __crashlytics_context_t* __crashlytics_context()                                 __CRASHLYTICS_DECORATED;
+inline __crashlytics_context_t* __crashlytics_init()                                    __CRASHLYTICS_DECORATED;
 
-    static inline __crashlytics_context_t* __crashlytics_init() __CRASHLYTICS_DECORATED;
-    static inline void                     __crashlytics_free(__crashlytics_context_t** context) __CRASHLYTICS_DECORATED;
+} // end namespace detail
 
-    __crashlytics_context_t* __context;
+inline bool Initialize() {
+    return detail::__crashlytics_context() != nullptr;
+}
 
-    inline bool VerifyCrashlytics() {
-        if (__context) {
-            return true;
-        }
-        return false;
-    }
+inline void Log(const char* msg) {
+    detail::__crashlytics_context()->__log(detail::__crashlytics_context()->__ctx, msg);
+}
 
-    inline void Initialize() {
-        __context = __crashlytics_init();
-        VerifyCrashlytics();
-    }
+inline void SetCustomKey(const char* key, const char* value) {
+    detail::__crashlytics_context()->__set(detail::__crashlytics_context()->__ctx, key, value);
+}
 
-    inline void Terminate() {
-        if (VerifyCrashlytics()) {
-            __crashlytics_free(&__context);
-        }
-    }
+inline void SetCustomKey(const char* key, bool value) {
+    SetCustomKey(key, value ? "true" : "false");
+}
 
-    inline void Log(const char* msg) {
-        if (VerifyCrashlytics()) {
-            __context->__log(__context->__ctx, msg);
-        }
-    }
+inline void SetCustomKey(const char* key, double value) {
+    SetCustomKey(key, std::to_string(value).c_str());
+}
 
-    inline void SetCustomKey(const char* key, const char* value) {
-        if (VerifyCrashlytics()) {
-            __context->__set(__context->__ctx, key, value);
-        }
-    }
+inline void SetCustomKey(const char* key, float value) {
+    SetCustomKey(key, std::to_string(value).c_str());
+}
 
-    inline void SetCustomKey(const char* key, bool value) {
-        SetCustomKey(key, value ? "true" : "false");
-    }
+inline void SetCustomKey(const char* key, int value) {
+    SetCustomKey(key, std::to_string(value).c_str());
+}
 
-    inline void SetCustomKey(const char* key, double value) {
-        SetCustomKey(key, std::to_string(value).c_str());
-    }
+inline void SetCustomKey(const char* key, long value) {
+    SetCustomKey(key, std::to_string(value).c_str());
+}
 
-    inline void SetCustomKey(const char* key, float value) {
-        SetCustomKey(key, std::to_string(value).c_str());
-    }
+inline void SetUserId(const char* id) {
+    detail::__crashlytics_context()->__set_user_id(detail::__crashlytics_context()->__ctx, id);
+}
 
-    inline void SetCustomKey(const char* key, int value) {
-        SetCustomKey(key, std::to_string(value).c_str());
-    }
-
-    inline void SetCustomKey(const char* key, long value) {
-        SetCustomKey(key, std::to_string(value).c_str());
-    }
-
-    inline void SetUserId(const char* id) {
-        if (VerifyCrashlytics()) {
-            __context->__set_user_id(__context->__ctx, id);
-        }
-    }
-
+namespace detail {
 
 #define __CRASHLYTICS_NULL_ON_NULL(expression)                          \
     do {                                                                \
@@ -168,69 +144,58 @@ namespace firebase { namespace crashlytics {
         }                                                               \
     } while (0)
 
-    static inline __crashlytics_context_t* __crashlytics_allocate() __CRASHLYTICS_DECORATED;
-    static inline __crashlytics_context_t* __crashlytics_allocate() {
-        return new __crashlytics_context_t;
-    }
+inline __crashlytics_context_t* __crashlytics_construct(
+        __crashlytics_unspecified_t* ctx, void* sym_set, void* sym_log, void* sym_dispose, void* sym_set_user_id)  __CRASHLYTICS_DECORATED;
+inline __crashlytics_context_t* __crashlytics_construct(
+        __crashlytics_unspecified_t* ctx, void* sym_set, void* sym_log, void* sym_dispose, void* sym_set_user_id) {
+    __crashlytics_context_t* context;
 
-    static inline __crashlytics_context_t* __crashlytics_construct(
-            __crashlytics_unspecified_t* ctx, void* sym_set, void* sym_log, void* sym_dispose, void* sym_set_user_id)  __CRASHLYTICS_DECORATED;
-    static inline __crashlytics_context_t* __crashlytics_construct(
-            __crashlytics_unspecified_t* ctx, void* sym_set, void* sym_log, void* sym_dispose, void* sym_set_user_id) {
-        __crashlytics_context_t* context;
+    __CRASHLYTICS_NULL_ON_NULL(context = new __crashlytics_context_t);
 
-        __CRASHLYTICS_NULL_ON_NULL(context = __crashlytics_allocate());
+    context->__set = (__crashlytics_set_internal_t) sym_set;
+    context->__log = (__crashlytics_log_internal_t) sym_log;
+    context->__set_user_id = (__crashlytics_set_user_id_internal_t) sym_set_user_id;
+    context->__ctx = ctx;
+    context->__dispose = (__crashlytics_dispose_t) sym_dispose;
 
-        context->__set = (__crashlytics_set_internal_t) sym_set;
-        context->__log = (__crashlytics_log_internal_t) sym_log;
-        context->__set_user_id = (__crashlytics_set_user_id_internal_t) sym_set_user_id;
-        context->__ctx = ctx;
-        context->__dispose = (__crashlytics_dispose_t) sym_dispose;
+    return context;
+}
 
-        return context;
-    }
+inline __crashlytics_context_t* __crashlytics_context() {
+    static std::unique_ptr<__crashlytics_context_t> context(__crashlytics_init());
+    return context.get();
+}
 
-    static inline __crashlytics_context_t* __crashlytics_init() {
-        void* lib;
-        void* sym_ini;
-        void* sym_log;
-        void* sym_set;
-        void* sym_dispose;
-        void* sym_set_user_id;
+inline __crashlytics_context_t* __crashlytics_init() {
+    void* lib;
+    void* sym_ini;
+    void* sym_log;
+    void* sym_set;
+    void* sym_dispose;
+    void* sym_set_user_id;
 
-        __CRASHLYTICS_NULL_ON_NULL(lib = dlopen("libcrashlytics.so", RTLD_LAZY | RTLD_LOCAL));
-        __CRASHLYTICS_NULL_ON_NULL(sym_ini = dlsym(lib, "external_api_initialize"));
-        __CRASHLYTICS_NULL_ON_NULL(sym_set = dlsym(lib, "external_api_set"));
-        __CRASHLYTICS_NULL_ON_NULL(sym_log = dlsym(lib, "external_api_log"));
-        __CRASHLYTICS_NULL_ON_NULL(sym_dispose = dlsym(lib, "external_api_dispose"));
-        __CRASHLYTICS_NULL_ON_NULL(sym_set_user_id = dlsym(lib, "external_api_set_user_id"));
+    __CRASHLYTICS_NULL_ON_NULL(lib = dlopen("libcrashlytics.so", RTLD_LAZY | RTLD_LOCAL));
+    __CRASHLYTICS_NULL_ON_NULL(sym_ini = dlsym(lib, "external_api_initialize"));
+    __CRASHLYTICS_NULL_ON_NULL(sym_set = dlsym(lib, "external_api_set"));
+    __CRASHLYTICS_NULL_ON_NULL(sym_log = dlsym(lib, "external_api_log"));
+    __CRASHLYTICS_NULL_ON_NULL(sym_dispose = dlsym(lib, "external_api_dispose"));
+    __CRASHLYTICS_NULL_ON_NULL(sym_set_user_id = dlsym(lib, "external_api_set_user_id"));
 
-        __crashlytics_unspecified_t* ctx = ((__crashlytics_initialize_t) sym_ini)();
+    __crashlytics_unspecified_t* ctx = ((__crashlytics_initialize_t) sym_ini)();
 
-        return ctx == __CRASHLYTICS_INITIALIZE_FAILURE ? __CRASHLYTICS_NULL_CONTEXT
-                                                       : __crashlytics_construct(
-                        ctx,
-                        sym_set,
-                        sym_log,
-                        sym_dispose,
-                        sym_set_user_id
-                );
-    }
+    return ctx == __CRASHLYTICS_INITIALIZE_FAILURE
+        ? __CRASHLYTICS_NULL_CONTEXT
+        : __crashlytics_construct(
+            ctx,
+            sym_set,
+            sym_log,
+            sym_dispose,
+            sym_set_user_id
+        );
+}
 
-    static inline void __crashlytics_deallocate(__crashlytics_context_t* context)  __CRASHLYTICS_DECORATED;
-    static inline void __crashlytics_deallocate(__crashlytics_context_t* context) {
-        delete context;
-    }
+} // end namespace detail
 
-    static inline void __crashlytics_free(__crashlytics_context_t** context) {
-        if ((*context) != __CRASHLYTICS_NULL_CONTEXT) {
-            (*context)->__dispose((*context)->__ctx);
-
-            __crashlytics_deallocate(*context);
-
-            (*context) = __CRASHLYTICS_NULL_CONTEXT;
-        }
-    }
 }}  // end namespace firebase::crashlytics
 
 #endif /* __CRASHLYTICS_H__ */

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/external/crashlytics.h
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/external/crashlytics.h
@@ -31,8 +31,11 @@ namespace firebase { namespace crashlytics {
 
 /// @brief Initialize the Crashlytics NDK API, for Android apps using native code.
 ///
-/// This must be called prior to calling any other methods in the firebase:crashlytics
-/// namespace. This call is only required for adding custom metadata to crash reports. Use of
+/// This allows finer grained control of when the native API is initialized. Calling this
+/// function is not not strictly necessary as the API will be initialized on the first call
+/// to any of the functions within the firebase::crashlytics namespace.
+///
+/// This call is only required for adding custom metadata to crash reports. Use of
 /// this header file is NOT required for Android NDK crash reporting.
 inline bool Initialize();
 

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/external/crashlytics.h
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/external/crashlytics.h
@@ -39,7 +39,7 @@ namespace firebase { namespace crashlytics {
 /// this header file is NOT required for Android NDK crash reporting.
 inline bool Initialize();
 
-/// Deprecated
+/// Deprecated; now a no-op and does not need to be called.
 inline void Terminate();
 
 /// @brief Logs a message to be included in the next fatal or non-fatal report.

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/handler/maps.h
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/include/crashlytics/handler/maps.h
@@ -56,8 +56,8 @@ public:
     typedef typename Storage::value_type entry_type;
     typedef typename Storage::size_type size_type;
 
-    constexpr size_type upper_bound() { return std::tuple_size<Storage>::value; }
-    constexpr size_type entry_bound() { return maps_entry_length<entry_type>::value; }
+    constexpr size_type upper_bound() const { return std::tuple_size<Storage>::value; }
+    constexpr size_type entry_bound() const { return maps_entry_length<entry_type>::value; }
 
     maps() : count(0) {}
    ~maps() {}

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/src/external/api.cpp
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/src/external/api.cpp
@@ -331,15 +331,13 @@ namespace {
 void force_crashlytics_h_to_compile_as_cplusplus() __attribute__((unused));
 void force_crashlytics_h_to_compile_as_cplusplus()
 {
-    crashlytics_context_t* context = crashlytics_init();
+    using namespace firebase::crashlytics;
 
-    context->set(context, "key", "value");
-    context->log(context, "message");
+    Initialize();
 
-    context->set_user_id(context, "identifier");
-
-    crashlytics_free(&context);
-
+    Log("message");
+    SetCustomKey("key", "value");
+    SetUserId("user");
 
     //! Make sure everything is defined.
     external_api_initialize();

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/src/external/api.cpp
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/src/external/api.cpp
@@ -339,6 +339,8 @@ void force_crashlytics_h_to_compile_as_cplusplus()
     SetCustomKey("key", "value");
     SetUserId("user");
 
+    Terminate();
+
     //! Make sure everything is defined.
     external_api_initialize();
     external_api_dispose(nullptr);


### PR DESCRIPTION
Remove unnecessary API implementation functions.
Fix warnings.