### PR TITLE
inital implementation of typeToken for decoder

### DIFF
--- a/encoders/firebase-decoders-json/api.txt
+++ b/encoders/firebase-decoders-json/api.txt
@@ -1,0 +1,27 @@
+// Signature format: 2.0
+package com.google.firebase.decoders {
+
+  public abstract class Safe<T> {
+    ctor public Safe();
+  }
+
+  public abstract class TypeToken<T> {
+    method @NonNull public static <T> com.google.firebase.decoders.TypeToken<T> of(@NonNull com.google.firebase.decoders.Safe<T>);
+    method @NonNull public static <T> com.google.firebase.decoders.TypeToken<T> of(@NonNull Class<T>);
+  }
+
+  public static class TypeToken.ArrayToken<T> extends com.google.firebase.decoders.TypeToken<T> {
+    method @NonNull public com.google.firebase.decoders.TypeToken<?> getComponentType();
+  }
+
+  public static class TypeToken.ClassToken<T> extends com.google.firebase.decoders.TypeToken<T> {
+    method @NonNull public Class<T> getRawType();
+    method @NonNull public com.google.firebase.decoders.TypeTokenContainer getTypeArguments();
+  }
+
+  public interface TypeTokenContainer {
+    method @NonNull public <T> com.google.firebase.decoders.TypeToken<T> at(int);
+  }
+
+}
+

--- a/encoders/firebase-decoders-json/firebase-decoders-json.gradle
+++ b/encoders/firebase-decoders-json/firebase-decoders-json.gradle
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id 'firebase-library'
+}
+
+firebaseLibrary {
+    publishSources = true
+    publishJavadoc = false
+}
+
+android {
+    compileSdkVersion project.targetSdkVersion
+    defaultConfig {
+        minSdkVersion project.minSdkVersion
+        targetSdkVersion project.targetSdkVersion
+        versionName version
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.annotation:annotation:1.1.0'
+
+    testImplementation 'androidx.test:runner:1.2.0'
+    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation 'junit:junit:4.13-rc-1'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Werror"
+}

--- a/encoders/firebase-decoders-json/gradle.properties
+++ b/encoders/firebase-decoders-json/gradle.properties
@@ -1,0 +1,16 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version=16.1.1
+latestReleasedVersion=16.1.0

--- a/encoders/firebase-decoders-json/src/main/AndroidManifest.xml
+++ b/encoders/firebase-decoders-json/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<!-- Copyright 2020 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.decoders.json" />

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/Safe.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/Safe.java
@@ -1,0 +1,27 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.decoders;
+
+/**
+ * Represents a generic type {@code T}.
+ *
+ * <p>It forces clients to create a subclass to be able to retrieve the type information even at
+ * runtime.
+ *
+ * <p>For example, creating an empty anonymous inner class:
+ *
+ * <p>{@code Safe<List<String>> list = new Safe<List<String>>() {};}
+ */
+public abstract class Safe<T> {}

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
@@ -1,0 +1,156 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.decoders;
+
+import androidx.annotation.NonNull;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+
+// TODO: implement hashCode(), equals(), and toString().
+
+/**
+ * {@link TypeToken} is used to represent types supported by the library in a type-safe manner.
+ *
+ * <p>{@link TypeToken} supports the following types:
+ *
+ * <ol>
+ *   <li>Primitive types
+ *   <li>Array Types: primitive arrays(i.e. {@code int[]}) and object arrays(i.e. {@code Foo[]})
+ *   <li>Plain class types. i.e. {@code Foo}
+ *   <li>Generic types. i.e. {@code Foo<String, Double>}
+ *   <li>Wildcard types: only support {@code Foo<? extend Bar>} by downgrading it to {@code
+ *       Foo<Bar>}, and throw exception when stumbled upon {@code Foo<? super Bar>}.
+ * </ol>
+ */
+public abstract class TypeToken<T> {
+
+  /**
+   * Return an {@link TypeToken} to represent generic type {@code T}.
+   *
+   * <p>For example:
+   *
+   * <p>Create an {@code TypeToken<List<String>} of generic type {@code List<String>}:
+   *
+   * <p>{@code TypeToken<Link<String>> token = TypeToken.of(new Safe<Link<String>>() {});}
+   */
+  @NonNull
+  public static <T> TypeToken<T> of(@NonNull Safe<T> token) {
+    Type superclass = token.getClass().getGenericSuperclass();
+    if (superclass instanceof Class) {
+      throw new IllegalArgumentException("Missing type parameters");
+    }
+    Type type = ((ParameterizedType) superclass).getActualTypeArguments()[0];
+    return of(type);
+  }
+
+  /**
+   * Return an {@link TypeToken} to represent plain class type {@code T}.
+   *
+   * <p>For example:
+   *
+   * <p>Create an {@code TypeToken<Foo>} of type {@code Foo}:
+   *
+   * <p>{@code TypeToken<Foo> token = TypeToken.of(Foo.class);}
+   */
+  @NonNull
+  public static <T> TypeToken<T> of(@NonNull Class<T> typeToken) {
+    return of((Type) typeToken);
+  }
+
+  @NonNull
+  private static <T> TypeToken<T> of(@NonNull Type type) {
+    if (type instanceof WildcardType) {
+      if (((WildcardType) type).getLowerBounds().length == 0) {
+        return of(((WildcardType) type).getUpperBounds()[0]);
+      }
+      throw new IllegalArgumentException("<? super T> is not supported");
+    } else if (type instanceof GenericArrayType) {
+      Type componentType = ((GenericArrayType) type).getGenericComponentType();
+      return new ArrayToken<T>(TypeToken.of(componentType));
+    } else if (type instanceof ParameterizedType) {
+      ParameterizedType parameterizedType = (ParameterizedType) type;
+      Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+      Class<T> rawType = (Class<T>) parameterizedType.getRawType();
+      TypeTokenContainer container =
+          new TypeTokenContainer() {
+            @NonNull
+            @Override
+            public <V> TypeToken<V> at(int index) {
+              return TypeToken.of(actualTypeArguments[index]);
+            }
+          };
+      return new ClassToken<T>(rawType, container);
+    } else if (type instanceof Class<?>) {
+      Class<T> typeToken = (Class<T>) type;
+      if (typeToken.isArray()) {
+        Class<?> componentTypeToken = typeToken.getComponentType();
+        return new ArrayToken<T>(TypeToken.of(componentTypeToken));
+      }
+      return new ClassToken<T>((Class<T>) typeToken);
+    } else {
+      throw new IllegalArgumentException("Type: " + type.toString() + " not supported.");
+    }
+  }
+
+  private TypeToken() {}
+
+  /**
+   * {@link ClassToken} is used to represent types in a type-safe manner, including Primitive types,
+   * Plain class types, Generic types, and Wildcard types.
+   */
+  public static class ClassToken<T> extends TypeToken<T> {
+    private final Class<T> rawType;
+    private final TypeTokenContainer typeArguments;
+
+    private ClassToken(Class<T> token) {
+      this.rawType = token;
+      this.typeArguments = null;
+    }
+
+    private ClassToken(Class<T> rawType, TypeTokenContainer typeArguments) {
+      this.rawType = rawType;
+      this.typeArguments = typeArguments;
+    }
+
+    @NonNull
+    public Class<T> getRawType() {
+      return rawType;
+    }
+
+    @NonNull
+    public TypeTokenContainer getTypeArguments() {
+      return typeArguments;
+    }
+  }
+
+  /**
+   * {@link ArrayToken} is used to represent Array types in a type-safe manner. such as: primitive
+   * arrays(i.e. {@code int[]}) and object arrays(i.e. {@code Foo[]})
+   */
+  public static class ArrayToken<T> extends TypeToken<T> {
+    private final TypeToken<?> componentType;
+
+    private ArrayToken(TypeToken<?> componentType) {
+      this.componentType = componentType;
+    }
+
+    @NonNull
+    public TypeToken<?> getComponentType() {
+      return componentType;
+    }
+  }
+}

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeTokenContainer.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeTokenContainer.java
@@ -1,0 +1,27 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.decoders;
+
+import androidx.annotation.NonNull;
+
+/**
+ * {@link TypeTokenContainer} is used to get actual type parameter in a generic class at given
+ * index.
+ */
+// TODO: change from interface to class
+public interface TypeTokenContainer {
+  @NonNull
+  <T> TypeToken<T> at(int index);
+}

--- a/encoders/firebase-decoders-json/src/test/java/com/google/firebase/decoders/TypeTokenTest.java
+++ b/encoders/firebase-decoders-json/src/test/java/com/google/firebase/decoders/TypeTokenTest.java
@@ -1,0 +1,167 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.decoders;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TypeTokenTest {
+  static class Foo {}
+
+  // Primitive type
+  @Test
+  public void primitiveType_typeIsCorrectlyCaptured() {
+    TypeToken<Integer> integerTypeToken = TypeToken.of(int.class);
+    assertThat(integerTypeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<Integer> intToken = (TypeToken.ClassToken<Integer>) integerTypeToken;
+    assertThat(intToken.getRawType()).isEqualTo(int.class);
+
+    TypeToken<Boolean> booleanTypeToken = TypeToken.of(boolean.class);
+    assertThat(booleanTypeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<Boolean> booleanToken = (TypeToken.ClassToken<Boolean>) booleanTypeToken;
+    assertThat(booleanToken.getRawType()).isEqualTo(boolean.class);
+  }
+
+  // Array type
+  @Test
+  public void generalArrayTypeWithSafe_componentTypeIsCorrectlyCaptured() {
+    TypeToken<Foo[]> typeToken = TypeToken.of(new Safe<Foo[]>() {});
+    assertThat(typeToken).isInstanceOf(TypeToken.ArrayToken.class);
+    TypeToken.ArrayToken<Foo[]> arrayToken = (TypeToken.ArrayToken<Foo[]>) typeToken;
+    TypeToken<?> componentTypeToken = arrayToken.getComponentType();
+    assertThat(componentTypeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<Foo> componentToken = (TypeToken.ClassToken<Foo>) componentTypeToken;
+    assertThat(componentToken.getRawType()).isEqualTo(Foo.class);
+  }
+
+  @Test
+  public void generalArrayTypeWithoutSafe_componentTypeIsCorrectlyCaptured() {
+    TypeToken<Foo[]> typeToken = TypeToken.of(Foo[].class);
+    assertThat(typeToken).isInstanceOf(TypeToken.ArrayToken.class);
+    TypeToken.ArrayToken<Foo[]> arrayToken = (TypeToken.ArrayToken<Foo[]>) typeToken;
+    TypeToken<?> componentTypeToken = arrayToken.getComponentType();
+    assertThat(componentTypeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<Foo> componentToken = (TypeToken.ClassToken<Foo>) componentTypeToken;
+    assertThat(componentToken.getRawType()).isEqualTo(Foo.class);
+  }
+
+  @Test
+  public void genericArrayType_rawTypeIsCorrectlyCaptured() {
+    TypeToken<List<String>[]> typeToken = TypeToken.of(new Safe<List<String>[]>() {});
+    assertThat(typeToken).isInstanceOf(TypeToken.ArrayToken.class);
+    TypeToken.ArrayToken<List<String>[]> arrayToken =
+        (TypeToken.ArrayToken<List<String>[]>) typeToken;
+    TypeToken<List<String>> componentType = (TypeToken<List<String>>) arrayToken.getComponentType();
+    assertThat(componentType).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<List<String>> componentClassType =
+        (TypeToken.ClassToken<List<String>>) componentType;
+    assertThat(componentClassType.getRawType()).isEqualTo(List.class);
+    TypeToken<String> argumentType =
+        ((TypeToken.ClassToken<List<String>>) componentType).getTypeArguments().at(0);
+    assertThat(argumentType).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<String> argumentClassType = (TypeToken.ClassToken<String>) argumentType;
+    assertThat(argumentClassType.getRawType()).isEqualTo(String.class);
+  }
+
+  // Plain Class Type
+  @Test
+  public void plainClassTypeWithSafe_rawTypeIsCorrectlyCaptured() {
+    TypeToken<Foo> typeToken = TypeToken.of(new Safe<Foo>() {});
+    assertThat(typeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<Foo> typeClassToken = (TypeToken.ClassToken<Foo>) typeToken;
+    assertThat(typeClassToken.getRawType()).isEqualTo(Foo.class);
+  }
+
+  @Test
+  public void plainClassTypeWithoutSafe_rawTypeIsCorrectlyCaptured() {
+    TypeToken<Foo> typeToken = TypeToken.of(Foo.class);
+    assertThat(typeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<Foo> typeClassToken = (TypeToken.ClassToken<Foo>) typeToken;
+    assertThat(typeClassToken.getRawType()).isEqualTo(Foo.class);
+  }
+
+  // Generic Type
+  @Test
+  public void genericType_actualTypeParametersAreCorrectlyCaptured() {
+    TypeToken<Map<String, Foo>> mapTypeToken = TypeToken.of(new Safe<Map<String, Foo>>() {});
+    assertThat(mapTypeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<Map<String, Foo>> mapClassToken =
+        (TypeToken.ClassToken<Map<String, Foo>>) mapTypeToken;
+    TypeTokenContainer typeTokenContainer = mapClassToken.getTypeArguments();
+    TypeToken<String> firstArgumentToken = typeTokenContainer.at(0);
+    TypeToken<Foo> secondArgumentTypeToken = typeTokenContainer.at(1);
+    assertThat(firstArgumentToken).isInstanceOf(TypeToken.ClassToken.class);
+    assertThat(secondArgumentTypeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<String> firstArgumentClassToken =
+        (TypeToken.ClassToken<String>) firstArgumentToken;
+    TypeToken.ClassToken<Foo> secondArgumentClassToken =
+        (TypeToken.ClassToken<Foo>) secondArgumentTypeToken;
+    assertThat(firstArgumentClassToken.getRawType()).isEqualTo(String.class);
+    assertThat(secondArgumentClassToken.getRawType()).isEqualTo(Foo.class);
+  }
+
+  @Test
+  public void nestedGenericType_actualTypeParametersAreCorrectlyCaptured() {
+    TypeToken<List<List<String>>> typeToken = TypeToken.of(new Safe<List<List<String>>>() {});
+    assertThat(typeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<List<List<String>>> typeClassToken =
+        (TypeToken.ClassToken<List<List<String>>>) typeToken;
+    TypeToken<List<String>> componentToken = typeClassToken.getTypeArguments().at(0);
+    assertThat(componentToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<List<String>> componentClassToken =
+        (TypeToken.ClassToken<List<String>>) componentToken;
+    assertThat(componentClassToken.getRawType()).isEqualTo(List.class);
+    TypeToken<String> innerComponentToken = componentClassToken.getTypeArguments().at(0);
+    assertThat(innerComponentToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<String> innerComponentClassToken =
+        (TypeToken.ClassToken<String>) innerComponentToken;
+    assertThat(innerComponentClassToken.getRawType()).isEqualTo(String.class);
+  }
+
+  // Bounded Wildcard Type
+  @Test
+  public void boundedWildcardTypeWithExtend_actualTypeParameterIsCastedToUpperBound() {
+    TypeToken<List<? extends Number>> typeToken =
+        TypeToken.of(new Safe<List<? extends Number>>() {});
+    assertThat(typeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<List<? extends Number>> typeClassToken =
+        (TypeToken.ClassToken<List<? extends Number>>) typeToken;
+    TypeToken<Number> componentType = typeClassToken.getTypeArguments().at(0);
+    assertThat(componentType).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<Number> componentClassType = (TypeToken.ClassToken<Number>) componentType;
+    assertThat(componentClassType.getRawType()).isEqualTo(Number.class);
+  }
+
+  @Test
+  public void boundedWildcardTypeWithSuper_notSupported() {
+    TypeToken<List<? super Foo>> typeToken = TypeToken.of(new Safe<List<? super Foo>>() {});
+    assertThat(typeToken).isInstanceOf(TypeToken.ClassToken.class);
+    TypeToken.ClassToken<List<? super Foo>> typeClassToken =
+        (TypeToken.ClassToken<List<? super Foo>>) typeToken;
+    assertThrows(
+        "<? super T> is not supported",
+        RuntimeException.class,
+        () -> {
+          typeClassToken.getTypeArguments().at(0);
+        });
+  }
+}

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -36,6 +36,7 @@ encoders:firebase-encoders-json
 encoders:firebase-encoders-processor
 encoders:firebase-encoders-processor:test-support
 encoders:firebase-encoders-reflective
+encoders:firebase-decoders-json
 
 tools:errorprone
 tools:lint


### PR DESCRIPTION
Initial Implementation of TypeToken for Decoder:
TypeToken will be used to represent types supported by the library in a type-safe manner.