### PR TITLE
Changed TypeTokenContainer from interface to class

### DIFF
--- a/encoders/firebase-decoders-json/api.txt
+++ b/encoders/firebase-decoders-json/api.txt
@@ -19,8 +19,10 @@ package com.google.firebase.decoders {
     method @NonNull public com.google.firebase.decoders.TypeTokenContainer getTypeArguments();
   }
 
-  public class TypeTokenContainer {
+  public final class TypeTokenContainer {
+    ctor public TypeTokenContainer(@NonNull com.google.firebase.decoders.TypeToken[]);
     method @NonNull public <T> com.google.firebase.decoders.TypeToken<T> at(int);
+    field @NonNull public static final com.google.firebase.decoders.TypeTokenContainer EMPTY;
   }
 
 }

--- a/encoders/firebase-decoders-json/api.txt
+++ b/encoders/firebase-decoders-json/api.txt
@@ -19,7 +19,7 @@ package com.google.firebase.decoders {
     method @NonNull public com.google.firebase.decoders.TypeTokenContainer getTypeArguments();
   }
 
-  public interface TypeTokenContainer {
+  public class TypeTokenContainer {
     method @NonNull public <T> com.google.firebase.decoders.TypeToken<T> at(int);
   }
 

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
@@ -53,7 +53,8 @@ public abstract class TypeToken<T> {
     if (superclass instanceof Class) {
       throw new IllegalArgumentException("Missing type parameters");
     }
-    @SuppressWarnings("ConstantConditions") // Safe because superclass is not instanceof Class
+    // Safe because superclass is not instanceof Class
+    @SuppressWarnings("ConstantConditions")
     Type type = ((ParameterizedType) superclass).getActualTypeArguments()[0];
     return of(type);
   }
@@ -84,8 +85,8 @@ public abstract class TypeToken<T> {
       return new ArrayToken<T>(TypeToken.of(componentType));
     } else if (type instanceof ParameterizedType) {
       ParameterizedType parameterizedType = (ParameterizedType) type;
-      @SuppressWarnings(
-          "unchecked") // Safe because rawType of parameterizedType is always instance of Class<T>
+      // Safe because rawType of parameterizedType is always instance of Class<T>
+      @SuppressWarnings("unchecked")
       Class<T> rawType = (Class<T>) parameterizedType.getRawType();
       Type[] types = parameterizedType.getActualTypeArguments();
       TypeToken[] typeTokens = new TypeToken[types.length];
@@ -94,13 +95,13 @@ public abstract class TypeToken<T> {
       }
       return new ClassToken<T>(rawType, new TypeTokenContainer(typeTokens));
     } else if (type instanceof Class<?>) {
-      @SuppressWarnings("unchecked") // Safe because type is instance of Class<?>
+      // Safe because type is instance of Class<?>
+      @SuppressWarnings("unchecked")
       Class<T> typeToken = (Class<T>) type;
       if (typeToken.isArray()) {
         Class<?> componentTypeToken = typeToken.getComponentType();
-        @SuppressWarnings(
-            "ConstantConditions") // Safe because typeToken is an Array and componentTypeToken will
-                                  // never be null
+        // Safe because typeToken is an Array and componentTypeToken will never be null
+        @SuppressWarnings("ConstantConditions")
         ArrayToken<T> arrayToken = new ArrayToken<T>(TypeToken.of(componentTypeToken));
         return arrayToken;
       }

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeTokenContainer.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeTokenContainer.java
@@ -15,13 +15,33 @@
 package com.google.firebase.decoders;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import java.lang.reflect.Type;
 
 /**
  * {@link TypeTokenContainer} is used to get actual type parameter in a generic class at given
  * index.
  */
-// TODO: change from interface to class
-public interface TypeTokenContainer {
+public class TypeTokenContainer {
+  private final TypeToken<?>[] typeTokens;
+
+  TypeTokenContainer(@Nullable Type[] types) {
+    TypeToken[] typeTokens;
+    if (types == null) {
+      typeTokens = new TypeToken[0];
+    } else {
+      typeTokens = new TypeToken[types.length];
+      for (int i = 0; i < types.length; i++) {
+        typeTokens[i] = TypeToken.of(types[i]);
+      }
+    }
+    this.typeTokens = typeTokens;
+  }
+
   @NonNull
-  <T> TypeToken<T> at(int index);
+  public <T> TypeToken<T> at(int index) {
+    if (index >= typeTokens.length)
+      throw new NullPointerException("No type token at index: " + index);
+    return (TypeToken<T>) typeTokens[index];
+  }
 }

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeTokenContainer.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeTokenContainer.java
@@ -15,33 +15,30 @@
 package com.google.firebase.decoders;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import java.lang.reflect.Type;
 
 /**
  * {@link TypeTokenContainer} is used to get actual type parameter in a generic class at given
  * index.
  */
-public class TypeTokenContainer {
+public final class TypeTokenContainer {
   private final TypeToken<?>[] typeTokens;
 
-  TypeTokenContainer(@Nullable Type[] types) {
-    TypeToken[] typeTokens;
-    if (types == null) {
-      typeTokens = new TypeToken[0];
-    } else {
-      typeTokens = new TypeToken[types.length];
-      for (int i = 0; i < types.length; i++) {
-        typeTokens[i] = TypeToken.of(types[i]);
-      }
-    }
+  @NonNull public static final TypeTokenContainer EMPTY = new TypeTokenContainer();
+
+  private TypeTokenContainer() {
+    typeTokens = new TypeToken[0];
+  }
+
+  public TypeTokenContainer(@NonNull TypeToken[] typeTokens) {
     this.typeTokens = typeTokens;
   }
 
   @NonNull
   public <T> TypeToken<T> at(int index) {
-    if (index >= typeTokens.length)
-      throw new NullPointerException("No type token at index: " + index);
-    return (TypeToken<T>) typeTokens[index];
+    if (index >= typeTokens.length || index < 0)
+      throw new IllegalArgumentException("No type token at index: " + index);
+    @SuppressWarnings("unchecked")
+    TypeToken<T> typeToken = (TypeToken<T>) typeTokens[index];
+    return typeToken;
   }
 }

--- a/encoders/firebase-decoders-json/src/test/java/com/google/firebase/decoders/TypeTokenTest.java
+++ b/encoders/firebase-decoders-json/src/test/java/com/google/firebase/decoders/TypeTokenTest.java
@@ -153,15 +153,11 @@ public class TypeTokenTest {
 
   @Test
   public void boundedWildcardTypeWithSuper_notSupported() {
-    TypeToken<List<? super Foo>> typeToken = TypeToken.of(new Safe<List<? super Foo>>() {});
-    assertThat(typeToken).isInstanceOf(TypeToken.ClassToken.class);
-    TypeToken.ClassToken<List<? super Foo>> typeClassToken =
-        (TypeToken.ClassToken<List<? super Foo>>) typeToken;
     assertThrows(
         "<? super T> is not supported",
-        RuntimeException.class,
+        IllegalArgumentException.class,
         () -> {
-          typeClassToken.getTypeArguments().at(0);
+          TypeToken.of(new Safe<List<? super Foo>>() {});
         });
   }
 }


### PR DESCRIPTION
- Changed `TypeTokenContainer` from an interface to a class.
- Changed field `typeArguments` of type `TypeTokenContainer` in non-generic `ClassToken` from null to an empty instance. 
- Changed `TypeToken` to throw an exception when a non-supported type `<? super Foo>` is passed to create a `TypeToken`, instead of throwing an exception only when trying to get the type arguments from it.