### PR TITLE
Add `FieldDescriptor` support to DataEncoder.

### DIFF
--- a/encoders/firebase-encoders-json/api.txt
+++ b/encoders/firebase-encoders-json/api.txt
@@ -15,6 +15,7 @@ package com.google.firebase.encoders {
     method @NonNull public static com.google.firebase.encoders.FieldDescriptor.Builder builder(@NonNull String);
     method @NonNull public String getName();
     method @Nullable public <T extends java.lang.annotation.Annotation> T getProperty(@NonNull Class<T>);
+    method @NonNull public static com.google.firebase.encoders.FieldDescriptor of(@NonNull String);
   }
 
   public static final class FieldDescriptor.Builder {
@@ -26,13 +27,19 @@ package com.google.firebase.encoders {
   }
 
   public interface ObjectEncoderContext {
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, @Nullable Object) throws java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, double) throws java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, int) throws java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, long) throws java.io.IOException;
-    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, boolean) throws java.io.IOException;
+    method @Deprecated @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, @Nullable Object) throws java.io.IOException;
+    method @Deprecated @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, double) throws java.io.IOException;
+    method @Deprecated @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, int) throws java.io.IOException;
+    method @Deprecated @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, long) throws java.io.IOException;
+    method @Deprecated @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull String, boolean) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull com.google.firebase.encoders.FieldDescriptor, @Nullable Object) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull com.google.firebase.encoders.FieldDescriptor, double) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull com.google.firebase.encoders.FieldDescriptor, int) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull com.google.firebase.encoders.FieldDescriptor, long) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext add(@NonNull com.google.firebase.encoders.FieldDescriptor, boolean) throws java.io.IOException;
     method @NonNull public com.google.firebase.encoders.ObjectEncoderContext inline(@Nullable Object) throws java.io.IOException;
     method @NonNull public com.google.firebase.encoders.ObjectEncoderContext nested(@NonNull String) throws java.io.IOException;
+    method @NonNull public com.google.firebase.encoders.ObjectEncoderContext nested(@NonNull com.google.firebase.encoders.FieldDescriptor) throws java.io.IOException;
   }
 
   public interface ValueEncoder<T> {

--- a/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContext.java
+++ b/encoders/firebase-encoders-json/src/json/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContext.java
@@ -19,6 +19,7 @@ import android.util.JsonWriter;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.encoders.EncodingException;
+import com.google.firebase.encoders.FieldDescriptor;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.ValueEncoder;
@@ -104,6 +105,38 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
   @NonNull
   @Override
+  public ObjectEncoderContext add(@NonNull FieldDescriptor field, @Nullable Object obj)
+      throws IOException {
+    return add(field.getName(), obj);
+  }
+
+  @NonNull
+  @Override
+  public ObjectEncoderContext add(@NonNull FieldDescriptor field, double value) throws IOException {
+    return add(field.getName(), value);
+  }
+
+  @NonNull
+  @Override
+  public ObjectEncoderContext add(@NonNull FieldDescriptor field, int value) throws IOException {
+    return add(field.getName(), value);
+  }
+
+  @NonNull
+  @Override
+  public ObjectEncoderContext add(@NonNull FieldDescriptor field, long value) throws IOException {
+    return add(field.getName(), value);
+  }
+
+  @NonNull
+  @Override
+  public ObjectEncoderContext add(@NonNull FieldDescriptor field, boolean value)
+      throws IOException {
+    return add(field.getName(), value);
+  }
+
+  @NonNull
+  @Override
   public ObjectEncoderContext inline(@Nullable Object value) throws IOException {
     return add(value, true);
   }
@@ -116,6 +149,12 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
     jsonWriter.name(name);
     jsonWriter.beginObject();
     return childContext;
+  }
+
+  @NonNull
+  @Override
+  public ObjectEncoderContext nested(@NonNull FieldDescriptor field) throws IOException {
+    return nested(field.getName());
   }
 
   @NonNull

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/FieldDescriptor.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/FieldDescriptor.java
@@ -68,6 +68,11 @@ public final class FieldDescriptor {
   }
 
   @NonNull
+  public static FieldDescriptor of(@NonNull String name) {
+    return new FieldDescriptor(name, Collections.emptyMap());
+  }
+
+  @NonNull
   public static Builder builder(@NonNull String name) {
     return new Builder(name);
   }

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/ObjectEncoderContext.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/ObjectEncoderContext.java
@@ -35,12 +35,74 @@ public interface ObjectEncoderContext {
    *
    * <p>{@code obj} can be an array. If the elements of the array are primitive types, they will be
    * directly encoded. Otherwise, the matching {@code Encoder} registered for the type will be used.
-   * In this case, the value of the entry will be an encoded array obtained by sequencially applying
+   * In this case, the value of the entry will be an encoded array obtained by sequentially applying
    * the encoder to each element of the array. Nested arrays are supported.
    *
    * <p>{@code obj} can be a {@link java.util.Collection}. The matching {@code Encoder} registered
    * for the type contained within the collection will be used. In this case, the value of the entry
-   * will be an encoded array obtained by sequencially applying the encoder to each element of the
+   * will be an encoded array obtained by sequentially applying the encoder to each element of the
+   * array. Nested collections are supported.
+   *
+   * <p>If {@code obj} does not match any of the criteria above, or if there's no matching {@code
+   * Encoder} for the type, an {@code EncodingException} will be thrown. Also, any exceptions thrown
+   * by the encoders will be propagated.
+   *
+   * @deprecated Use {@link #add(FieldDescriptor, Object)} instead.
+   */
+  @Deprecated
+  @NonNull
+  ObjectEncoderContext add(@NonNull String name, @Nullable Object obj) throws IOException;
+
+  /**
+   * Add an entry with {@code name} mapped to the encoded primitive type of {@code value}.
+   *
+   * @deprecated Use {@link #add(FieldDescriptor, double)} instead.
+   */
+  @Deprecated
+  @NonNull
+  ObjectEncoderContext add(@NonNull String name, double value) throws IOException;
+
+  /**
+   * Add an entry with {@code name} mapped to the encoded primitive type of {@code value}.
+   *
+   * @deprecated Use {@link #add(FieldDescriptor, double)} instead.
+   */
+  @Deprecated
+  @NonNull
+  ObjectEncoderContext add(@NonNull String name, int value) throws IOException;
+
+  /**
+   * Add an entry with {@code name} mapped to the encoded primitive type of {@code value}.
+   *
+   * @deprecated Use {@link #add(FieldDescriptor, double)} instead.
+   */
+  @Deprecated
+  @NonNull
+  ObjectEncoderContext add(@NonNull String name, long value) throws IOException;
+
+  /**
+   * Add an entry with {@code name} mapped to the encoded primitive type of {@code value}.
+   *
+   * @deprecated Use {@link #add(FieldDescriptor, double)} instead.
+   */
+  @Deprecated
+  @NonNull
+  ObjectEncoderContext add(@NonNull String name, boolean value) throws IOException;
+
+  /**
+   * Add an entry with {@code field} mapped to the encoded version of {@code obj}.
+   *
+   * <p>{@code obj} can be a regular type with a matching {@code Encoder} registered. In this case,
+   * the value of the entry will be the encoded version of {@code obj}.
+   *
+   * <p>{@code obj} can be an array. If the elements of the array are primitive types, they will be
+   * directly encoded. Otherwise, the matching {@code Encoder} registered for the type will be used.
+   * In this case, the value of the entry will be an encoded array obtained by sequentially applying
+   * the encoder to each element of the array. Nested arrays are supported.
+   *
+   * <p>{@code obj} can be a {@link java.util.Collection}. The matching {@code Encoder} registered
+   * for the type contained within the collection will be used. In this case, the value of the entry
+   * will be an encoded array obtained by sequentially applying the encoder to each element of the
    * array. Nested collections are supported.
    *
    * <p>If {@code obj} does not match any of the criteria above, or if there's no matching {@code
@@ -48,23 +110,23 @@ public interface ObjectEncoderContext {
    * by the encoders will be propagated.
    */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, @Nullable Object obj) throws IOException;
+  ObjectEncoderContext add(@NonNull FieldDescriptor field, @Nullable Object obj) throws IOException;
 
-  /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
+  /** Add an entry with {@code field} mapped to the encoded primitive type of {@code value}. */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, double value) throws IOException;
+  ObjectEncoderContext add(@NonNull FieldDescriptor field, double value) throws IOException;
 
-  /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
+  /** Add an entry with {@code field} mapped to the encoded primitive type of {@code value}. */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, int value) throws IOException;
+  ObjectEncoderContext add(@NonNull FieldDescriptor field, int value) throws IOException;
 
-  /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
+  /** Add an entry with {@code field} mapped to the encoded primitive type of {@code value}. */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, long value) throws IOException;
+  ObjectEncoderContext add(@NonNull FieldDescriptor field, long value) throws IOException;
 
-  /** Add an entry with {@code name} mapped to the encoded primitive type of {@code value}. */
+  /** Add an entry with {@code field} mapped to the encoded primitive type of {@code value}. */
   @NonNull
-  ObjectEncoderContext add(@NonNull String name, boolean value) throws IOException;
+  ObjectEncoderContext add(@NonNull FieldDescriptor field, boolean value) throws IOException;
 
   /**
    * Encodes a given object inline in current context.
@@ -109,4 +171,28 @@ public interface ObjectEncoderContext {
    */
   @NonNull
   ObjectEncoderContext nested(@NonNull String name) throws IOException;
+
+  /**
+   * Begin a nested JSON object.
+   *
+   * <p>Unlike {@code add()} methods, this method returns a new "child" context that's used to
+   * populate the nested JSON object. This context can only be used until the parent context is
+   * mutated by calls to {@code add()} or {@code nested()}, violating this will result in a {@link
+   * IllegalStateException}.
+   *
+   * <p>Nesting can be arbitrarily deep.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * ctx.add("key", "value");
+   * ObjectEncoderContext nested = ctx.nested("nested");
+   * nested.add("key", "value");
+   *
+   * // After this call the above nested context is invalid.
+   * ctx.add("anotherKey", 1);
+   * }</pre>
+   */
+  @NonNull
+  ObjectEncoderContext nested(@NonNull FieldDescriptor field) throws IOException;
 }

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
@@ -18,9 +18,13 @@ import androidx.annotation.VisibleForTesting;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import com.google.firebase.encoders.annotations.Encodable;
+import com.google.firebase.encoders.processor.getters.AnnotationDescriptor;
+import com.google.firebase.encoders.processor.getters.AnnotationProperty;
 import com.google.firebase.encoders.processor.getters.Getter;
 import com.google.firebase.encoders.processor.getters.GetterFactory;
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.CodeBlock.Builder;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -57,6 +61,7 @@ import javax.lang.model.util.Types;
 @SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class EncodableProcessor extends AbstractProcessor {
 
+  private static final String CODEGEN_VERSION = "2";
   static final String ENCODABLE_ANNOTATION = "com.google.firebase.encoders.annotations.Encodable";
   private Elements elements;
   private Types types;
@@ -84,6 +89,11 @@ public class EncodableProcessor extends AbstractProcessor {
   }
 
   private void processClass(Element element) {
+    if (types.isAssignable(
+        element.asType(), elements.getTypeElement("java.lang.annotation.Annotation").asType())) {
+      return;
+    }
+
     // generates class of the following shape:
     //
     // public class AutoFooEncoder implements Configurator {
@@ -107,7 +117,7 @@ public class EncodableProcessor extends AbstractProcessor {
                         Modifier.PUBLIC,
                         Modifier.STATIC,
                         Modifier.FINAL)
-                    .initializer("1")
+                    .initializer(CODEGEN_VERSION)
                     .build())
             .addField(
                 FieldSpec.builder(
@@ -259,12 +269,50 @@ public class EncodableProcessor extends AbstractProcessor {
               .addAnnotation(Override.class);
 
       Set<TypeMirror> result = new LinkedHashSet<>();
+      Set<FieldSpec> descriptorFields = new LinkedHashSet<>();
+      ClassName fieldDescriptor = ClassName.get("com.google.firebase.encoders", "FieldDescriptor");
       for (Getter getter : getterFactory.allGetters((DeclaredType) type)) {
         result.addAll(getTypesToVisit(getter.getUnderlyingType()));
         if (getter.inline()) {
           methodBuilder.addCode("ctx.inline(value.$L);\n", getter.expression());
         } else {
-          methodBuilder.addCode("ctx.add($S, value.$L);\n", getter.name(), getter.expression());
+          Builder codeBuilder;
+          if (getter.annotationDescriptors().isEmpty()) {
+            codeBuilder = CodeBlock.builder().add("$T.of($S)", fieldDescriptor, getter.name());
+          } else {
+            codeBuilder =
+                CodeBlock.builder()
+                    .add("$T.builder($S)\n", fieldDescriptor, getter.name())
+                    .indent()
+                    .indent();
+            for (AnnotationDescriptor desc : getter.annotationDescriptors()) {
+              ClassName annotationBuilder =
+                  builderName(
+                      ClassName.get((TypeElement) desc.type().getAnnotationType().asElement()));
+              desc.properties().stream()
+                  .map(p -> p.value().toString())
+                  .collect(Collectors.joining(","));
+              codeBuilder.add(".withProperty($T.builder()\n", annotationBuilder);
+              for (AnnotationProperty property : desc.properties()) {
+                codeBuilder.add("$>.$L($L)\n$<", property.name(), property.value());
+              }
+              codeBuilder.add("$>.build())\n$<");
+            }
+            codeBuilder.add(".build()").unindent().unindent();
+          }
+          descriptorFields.add(
+              FieldSpec.builder(
+                      fieldDescriptor,
+                      getter.name().toUpperCase() + "_DESCRIPTOR",
+                      Modifier.PRIVATE,
+                      Modifier.FINAL,
+                      Modifier.STATIC)
+                  .initializer(codeBuilder.build())
+                  .build());
+          methodBuilder.addCode(
+              "ctx.add($L_DESCRIPTOR, value.$L);\n",
+              getter.name().toUpperCase(),
+              getter.expression());
         }
       }
 
@@ -281,10 +329,23 @@ public class EncodableProcessor extends AbstractProcessor {
                   FieldSpec.builder(className, "INSTANCE", Modifier.FINAL, Modifier.STATIC)
                       .initializer("new $T()", className)
                       .build())
+              .addFields(descriptorFields)
               .addMethod(methodBuilder.build())
               .build();
       encoded.put(types.erasure(type), encoder);
       return VisitResult.of(result, Encoder.create(types.erasure(type), encoder));
+    }
+
+    private ClassName builderName(ClassName annotation) {
+      return ClassName.get(annotation.packageName(), compositeName(annotation));
+    }
+
+    private String compositeName(ClassName annotation) {
+      ClassName parentName = annotation.enclosingClassName();
+      if (parentName == null) {
+        return "At" + annotation.simpleName();
+      }
+      return compositeName(parentName) + annotation.simpleName();
     }
 
     private Set<TypeMirror> getTypesToVisit(TypeMirror type) {

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
@@ -24,7 +24,6 @@ import com.google.firebase.encoders.processor.getters.Getter;
 import com.google.firebase.encoders.processor.getters.GetterFactory;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.CodeBlock.Builder;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -276,7 +275,7 @@ public class EncodableProcessor extends AbstractProcessor {
         if (getter.inline()) {
           methodBuilder.addCode("ctx.inline(value.$L);\n", getter.expression());
         } else {
-          Builder codeBuilder;
+          CodeBlock.Builder codeBuilder;
           if (getter.annotationDescriptors().isEmpty()) {
             codeBuilder = CodeBlock.builder().add("$T.of($S)", fieldDescriptor, getter.name());
           } else {
@@ -289,9 +288,6 @@ public class EncodableProcessor extends AbstractProcessor {
               ClassName annotationBuilder =
                   builderName(
                       ClassName.get((TypeElement) desc.type().getAnnotationType().asElement()));
-              desc.properties().stream()
-                  .map(p -> p.value().toString())
-                  .collect(Collectors.joining(","));
               codeBuilder.add(".withProperty($T.builder()\n", annotationBuilder);
               for (AnnotationProperty property : desc.properties()) {
                 codeBuilder.add("$>.$L($L)\n$<", property.name(), property.value());

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/annotations/AnnotationBuilder.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/annotations/AnnotationBuilder.java
@@ -21,7 +21,6 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import com.squareup.javapoet.TypeSpec.Builder;
 import com.squareup.javapoet.WildcardTypeName;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -80,7 +79,7 @@ public final class AnnotationBuilder {
 
   private static TypeSpec createBuilder(
       ClassName builderName, ClassName annotationName, AnnotationImpl annotationImpl) {
-    Builder annotationBuilder =
+    TypeSpec.Builder annotationBuilder =
         TypeSpec.classBuilder(builderName)
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addType(annotationImpl.typeSpec);
@@ -172,7 +171,7 @@ public final class AnnotationBuilder {
 
   private static AnnotationImpl createAnnotationImpl(TypeElement annotation) {
     String implName = annotation.getSimpleName().toString() + "Impl";
-    Builder annotationImpl =
+    TypeSpec.Builder annotationImpl =
         TypeSpec.classBuilder(implName)
             .addModifiers(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
             .addSuperinterface(TypeName.get(annotation.asType()))

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/annotations/ToStringMethod.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/annotations/ToStringMethod.java
@@ -17,7 +17,6 @@ package com.google.firebase.encoders.processor.annotations;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.MethodSpec.Builder;
 import java.util.List;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -27,7 +26,7 @@ import javax.lang.model.util.ElementFilter;
 final class ToStringMethod {
   static MethodSpec generate(TypeElement element) {
     ClassName.get(element).reflectionName();
-    Builder result =
+    MethodSpec.Builder result =
         MethodSpec.methodBuilder("toString")
             .addModifiers(Modifier.PUBLIC)
             .returns(String.class)

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/AnnotationDescriptor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/AnnotationDescriptor.java
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor.getters;
+
+import com.google.auto.value.AutoValue;
+import java.util.List;
+import javax.lang.model.element.AnnotationMirror;
+
+/** Represents an annotation with its explicitly set properties. */
+@AutoValue
+public abstract class AnnotationDescriptor {
+
+  /** Annotation type. */
+  public abstract AnnotationMirror type();
+
+  /** List of annotation properties. */
+  public abstract List<AnnotationProperty> properties();
+
+  public static AnnotationDescriptor create(
+      AnnotationMirror type, List<AnnotationProperty> properties) {
+    return new AutoValue_AnnotationDescriptor(type, properties);
+  }
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/AnnotationProperty.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/AnnotationProperty.java
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.processor.getters;
+
+import com.google.auto.value.AutoValue;
+import javax.lang.model.element.AnnotationValue;
+
+/** Represents an annotation property/method with its value as explicitly set in source. */
+@AutoValue
+public abstract class AnnotationProperty {
+  /** Name of the property, e.g. \"value\". */
+  public abstract String name();
+
+  /** Value of the property. */
+  public abstract AnnotationValue value();
+
+  public static AnnotationProperty create(String name, AnnotationValue value) {
+    return new AutoValue_AnnotationProperty(name, value);
+  }
+}

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/Getter.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/Getter.java
@@ -15,6 +15,7 @@
 package com.google.firebase.encoders.processor.getters;
 
 import com.google.auto.value.AutoValue;
+import java.util.Set;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -23,6 +24,12 @@ import javax.lang.model.type.TypeMirror;
 public abstract class Getter {
   /** Encoded name of the getter. */
   public abstract String name();
+
+  /**
+   * {@link com.google.firebase.encoders.annotations.ExtraProperty} annotations present on the
+   * getter.
+   */
+  public abstract Set<AnnotationDescriptor> annotationDescriptors();
 
   /**
    * Java expression to get the getter's value
@@ -49,7 +56,11 @@ public abstract class Getter {
   }
 
   public static Getter create(
-      String name, String expression, TypeMirror returnType, boolean inline) {
-    return new AutoValue_Getter(name, expression, returnType, inline);
+      String name,
+      Set<AnnotationDescriptor> descriptors,
+      String expression,
+      TypeMirror returnType,
+      boolean inline) {
+    return new AutoValue_Getter(name, descriptors, expression, returnType, inline);
   }
 }

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/GetterFactory.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/getters/GetterFactory.java
@@ -15,13 +15,17 @@
 package com.google.firebase.encoders.processor.getters;
 
 import com.google.firebase.encoders.annotations.Encodable;
+import com.google.firebase.encoders.annotations.ExtraProperty;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.processing.Messager;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -81,7 +85,7 @@ public final class GetterFactory {
       return Optional.empty();
     }
     Optional<String> fieldName = inferName(element);
-    if (!fieldName.isPresent()) {
+    if (fieldName.isEmpty()) {
       return Optional.empty();
     }
     TypeMirror returnType = resolveTypeArguments(ownerType, element.getReturnType());
@@ -109,7 +113,31 @@ public final class GetterFactory {
 
     return Optional.of(
         Getter.create(
-            fieldName.get(), getterExpression, returnType, field != null && field.inline()));
+            fieldName.get(),
+            inferDescriptors(element),
+            getterExpression,
+            returnType,
+            field != null && field.inline()));
+  }
+
+  private Set<AnnotationDescriptor> inferDescriptors(ExecutableElement element) {
+    Set<AnnotationDescriptor> annotationDescriptors = new HashSet<>();
+    for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
+      ExtraProperty extraProperty =
+          annotationMirror.getAnnotationType().asElement().getAnnotation(ExtraProperty.class);
+      if (extraProperty == null) {
+        continue;
+      }
+      List<AnnotationProperty> annotationValues =
+          annotationMirror.getElementValues().entrySet().stream()
+              .map(
+                  e ->
+                      AnnotationProperty.create(
+                          e.getKey().getSimpleName().toString(), e.getValue()))
+              .collect(Collectors.toList());
+      annotationDescriptors.add(AnnotationDescriptor.create(annotationMirror, annotationValues));
+    }
+    return annotationDescriptors;
   }
 
   private TypeMirror resolveTypeArguments(DeclaredType ownerType, TypeMirror genericType) {

--- a/encoders/firebase-encoders-processor/src/test/java/com/google/firebase/encoders/processor/EncodableProcessorTest.java
+++ b/encoders/firebase-encoders-processor/src/test/java/com/google/firebase/encoders/processor/EncodableProcessorTest.java
@@ -219,7 +219,7 @@ public class EncodableProcessorTest {
     assertThat(result)
         .generatedSourceFile("AutoWithOptionalEncoder")
         .contentsAsUtf8String()
-        .contains("\"hello\", value.getOptional().orElse(null)");
+        .contains("HELLO_DESCRIPTOR, value.getOptional().orElse(null)");
   }
 
   @Test
@@ -445,6 +445,38 @@ public class EncodableProcessorTest {
         .generatedSourceFile("AutoOuterTypeEncoder")
         .contentsAsUtf8String()
         .contains("ctx.inline(value.getMember());");
+  }
+
+  @Test
+  public void compile_withExtraProperty_annotation_shouldIncludeThePropertyInFieldDescriptor() {
+    Compilation result =
+        javac()
+            .withProcessors(new EncodableProcessor(), new ExtraPropertyProcessor())
+            .compile(
+                JavaFileObjects.forSourceLines(
+                    "com.example.MyAnnotation",
+                    "package com.example;",
+                    "import com.google.firebase.encoders.annotations.ExtraProperty;",
+                    "@ExtraProperty",
+                    "@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)",
+                    "public @interface MyAnnotation {",
+                    "  int value();",
+                    "  boolean myBool() default true;",
+                    "}"),
+                JavaFileObjects.forSourceLines(
+                    "MyClass",
+                    "import com.google.firebase.encoders.annotations.Encodable;",
+                    "@Encodable",
+                    "class MyClass {",
+                    "@com.example.MyAnnotation(42)",
+                    "public String getHello() { return null; }",
+                    "}"));
+
+    assertThat(result).succeededWithoutWarnings();
+    assertThat(result)
+        .generatedSourceFile("AutoMyClassEncoder")
+        .hasSourceEquivalentTo(
+            JavaFileObjects.forResource("ExpectedMyClassEncoderWithExtraProperty.java"));
   }
 
   @Test

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoder.java
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import com.google.firebase.encoders.FieldDescriptor;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -19,8 +20,10 @@ import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
 import java.lang.Override;
 
+/**
+ * @hide */
 public final class AutoGenericsEncoder implements Configurator {
-    public static final int CODEGEN_VERSION = 1;
+    public static final int CODEGEN_VERSION = 2;
 
     public static final Configurator CONFIG = new AutoGenericsEncoder();
 
@@ -43,38 +46,50 @@ public final class AutoGenericsEncoder implements Configurator {
     private static final class GenericsEncoder implements ObjectEncoder<Generics> {
         static final GenericsEncoder INSTANCE = new GenericsEncoder();
 
+        private static final FieldDescriptor BAR3_DESCRIPTOR = FieldDescriptor.of("bar3");
+
+        private static final FieldDescriptor BAR4_DESCRIPTOR = FieldDescriptor.of("bar4");
+
+        private static final FieldDescriptor MULTI_DESCRIPTOR = FieldDescriptor.of("multi");
+
         @Override
         public void encode(Generics value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add("bar3", value.getBar3());
-            ctx.add("bar4", value.getBar4());
-            ctx.add("multi", value.getMulti());
+            ctx.add(BAR3_DESCRIPTOR, value.getBar3());
+            ctx.add(BAR4_DESCRIPTOR, value.getBar4());
+            ctx.add(MULTI_DESCRIPTOR, value.getMulti());
         }
     }
 
     private static final class BarEncoder implements ObjectEncoder<Bar> {
         static final BarEncoder INSTANCE = new BarEncoder();
 
+        private static final FieldDescriptor FOO_DESCRIPTOR = FieldDescriptor.of("foo");
+
         @Override
         public void encode(Bar value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add("foo", value.getFoo());
+            ctx.add(FOO_DESCRIPTOR, value.getFoo());
         }
     }
 
     private static final class BazEncoder implements ObjectEncoder<Baz> {
         static final BazEncoder INSTANCE = new BazEncoder();
 
+        private static final FieldDescriptor T_DESCRIPTOR = FieldDescriptor.of("t");
+
         @Override
         public void encode(Baz value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add("t", value.getT());
+            ctx.add(T_DESCRIPTOR, value.getT());
         }
     }
 
     private static final class FooEncoder implements ObjectEncoder<Foo> {
         static final FooEncoder INSTANCE = new FooEncoder();
 
+        private static final FieldDescriptor T_DESCRIPTOR = FieldDescriptor.of("t");
+
         @Override
         public void encode(Foo value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add("t", value.getT());
+            ctx.add(T_DESCRIPTOR, value.getT());
         }
     }
 
@@ -97,10 +112,14 @@ public final class AutoGenericsEncoder implements Configurator {
     private static final class MultiEncoder implements ObjectEncoder<Multi> {
         static final MultiEncoder INSTANCE = new MultiEncoder();
 
+        private static final FieldDescriptor FOOT_DESCRIPTOR = FieldDescriptor.of("fooT");
+
+        private static final FieldDescriptor FOOU_DESCRIPTOR = FieldDescriptor.of("fooU");
+
         @Override
         public void encode(Multi value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add("fooT", value.getFooT());
-            ctx.add("fooU", value.getFooU());
+            ctx.add(FOOT_DESCRIPTOR, value.getFooT());
+            ctx.add(FOOU_DESCRIPTOR, value.getFooU());
         }
     }
 

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedMyClassEncoderWithExtraProperty.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedMyClassEncoderWithExtraProperty.java
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import com.example.AtMyAnnotation;
 import com.google.firebase.encoders.FieldDescriptor;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
@@ -22,30 +23,31 @@ import java.lang.Override;
 
 /**
  * @hide */
-public final class AutoGenericClassEncoder implements Configurator {
-    public static final int CODEGEN_VERSION = 2;
+public final class AutoMyClassEncoder implements Configurator {
+  public static final int CODEGEN_VERSION = 2;
 
-    public static final Configurator CONFIG = new AutoGenericClassEncoder();
+  public static final Configurator CONFIG = new AutoMyClassEncoder();
 
-    private AutoGenericClassEncoder() {
-    }
+  private AutoMyClassEncoder() {
+  }
+
+  @Override
+  public void configure(EncoderConfig<?> cfg) {
+    cfg.registerEncoder(MyClass.class, MyClassEncoder.INSTANCE);
+  }
+
+  private static final class MyClassEncoder implements ObjectEncoder<MyClass> {
+    static final MyClassEncoder INSTANCE = new MyClassEncoder();
+
+    private static final FieldDescriptor HELLO_DESCRIPTOR = FieldDescriptor.builder("hello")
+        .withProperty(AtMyAnnotation.builder()
+            .value(42)
+            .build())
+        .build();
 
     @Override
-    public void configure(EncoderConfig<?> cfg) {
-        cfg.registerEncoder(GenericClass.class, GenericClassEncoder.INSTANCE);
+    public void encode(MyClass value, ObjectEncoderContext ctx) throws IOException {
+      ctx.add(HELLO_DESCRIPTOR, value.getHello());
     }
-
-    private static final class GenericClassEncoder implements ObjectEncoder<GenericClass> {
-        static final GenericClassEncoder INSTANCE = new GenericClassEncoder();
-
-        private static final FieldDescriptor T_DESCRIPTOR = FieldDescriptor.of("t");
-
-        private static final FieldDescriptor U_DESCRIPTOR = FieldDescriptor.of("u");
-
-        @Override
-        public void encode(GenericClass value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add(T_DESCRIPTOR, value.getT());
-            ctx.add(U_DESCRIPTOR, value.getU());
-        }
-    }
+  }
 }

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedRecursiveGenericEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedRecursiveGenericEncoder.java
@@ -14,6 +14,7 @@
 
 package com.example;
 
+import com.google.firebase.encoders.FieldDescriptor;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -21,8 +22,10 @@ import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
 import java.lang.Override;
 
+/**
+ * @hide */
 public final class AutoMainClassEncoder implements Configurator {
-    public static final int CODEGEN_VERSION = 1;
+    public static final int CODEGEN_VERSION = 2;
 
     public static final Configurator CONFIG = new AutoMainClassEncoder();
 
@@ -38,20 +41,28 @@ public final class AutoMainClassEncoder implements Configurator {
     private static final class MainClassEncoder implements ObjectEncoder<MainClass> {
         static final MainClassEncoder INSTANCE = new MainClassEncoder();
 
+        private static final FieldDescriptor CHILD_DESCRIPTOR = FieldDescriptor.of("child");
+
         @Override
         public void encode(MainClass value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add("child", value.getChild());
+            ctx.add(CHILD_DESCRIPTOR, value.getChild());
         }
     }
 
     private static final class ChildEncoder implements ObjectEncoder<Child> {
         static final ChildEncoder INSTANCE = new ChildEncoder();
 
+        private static final FieldDescriptor STRINGCHILD_DESCRIPTOR = FieldDescriptor.of("stringChild");
+
+        private static final FieldDescriptor INTCHILD_DESCRIPTOR = FieldDescriptor.of("intChild");
+
+        private static final FieldDescriptor MAIN_DESCRIPTOR = FieldDescriptor.of("main");
+
         @Override
         public void encode(Child value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add("stringChild", value.getStringChild());
-            ctx.add("intChild", value.getIntChild());
-            ctx.add("main", value.getMain());
+            ctx.add(STRINGCHILD_DESCRIPTOR, value.getStringChild());
+            ctx.add(INTCHILD_DESCRIPTOR, value.getIntChild());
+            ctx.add(MAIN_DESCRIPTOR, value.getMain());
         }
     }
 }

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedSimpleClassEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedSimpleClassEncoder.java
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import com.google.firebase.encoders.FieldDescriptor;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -19,12 +20,15 @@ import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
 import java.lang.Override;
 
+/**
+ * @hide */
 public final class AutoSimpleClassEncoder implements Configurator {
-  public static final int CODEGEN_VERSION = 1;
+  public static final int CODEGEN_VERSION = 2;
 
   public static final Configurator CONFIG = new AutoSimpleClassEncoder();
 
-  private AutoSimpleClassEncoder() {}
+  private AutoSimpleClassEncoder() {
+  }
 
   @Override
   public void configure(EncoderConfig<?> cfg) {
@@ -34,13 +38,20 @@ public final class AutoSimpleClassEncoder implements Configurator {
   private static final class SimpleClassEncoder implements ObjectEncoder<SimpleClass> {
     static final SimpleClassEncoder INSTANCE = new SimpleClassEncoder();
 
+    private static final FieldDescriptor INT_DESCRIPTOR = FieldDescriptor.of("int");
+
+    private static final FieldDescriptor BOOL_DESCRIPTOR = FieldDescriptor.of("bool");
+
+    private static final FieldDescriptor MAP_DESCRIPTOR = FieldDescriptor.of("map");
+
+    private static final FieldDescriptor FOO_DESCRIPTOR = FieldDescriptor.of("foo");
+
     @Override
-    public void encode(SimpleClass value, ObjectEncoderContext ctx)
-        throws IOException {
-      ctx.add("int", value.getInt());
-      ctx.add("bool", value.isBool());
-      ctx.add("map", value.getMap());
-      ctx.add("foo", value.getField());
+    public void encode(SimpleClass value, ObjectEncoderContext ctx) throws IOException {
+      ctx.add(INT_DESCRIPTOR, value.getInt());
+      ctx.add(BOOL_DESCRIPTOR, value.isBool());
+      ctx.add(MAP_DESCRIPTOR, value.getMap());
+      ctx.add(FOO_DESCRIPTOR, value.getField());
     }
   }
 }

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedTypeWithListEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedTypeWithListEncoder.java
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import com.google.firebase.encoders.FieldDescriptor;
 import com.google.firebase.encoders.ObjectEncoder;
 import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
@@ -22,7 +23,7 @@ import java.lang.Override;
 /**
  * @hide */
 public final class AutoTypeWithListEncoder implements Configurator {
-    public static final int CODEGEN_VERSION = 1;
+    public static final int CODEGEN_VERSION = 2;
 
     public static final Configurator CONFIG = new AutoTypeWithListEncoder();
 
@@ -38,9 +39,11 @@ public final class AutoTypeWithListEncoder implements Configurator {
     private static final class TypeWithListEncoder implements ObjectEncoder<TypeWithList> {
         static final TypeWithListEncoder INSTANCE = new TypeWithListEncoder();
 
+        private static final FieldDescriptor MEMBER_DESCRIPTOR = FieldDescriptor.of("member");
+
         @Override
         public void encode(TypeWithList value, ObjectEncoderContext ctx) throws IOException {
-            ctx.add("member", value.getMember());
+            ctx.add(MEMBER_DESCRIPTOR, value.getMember());
         }
     }
 


### PR DESCRIPTION
The change updates `ObjectEncoderContext` with new overloads that use
`FieldDescriptors` and deprecates that ones that take `String` field names.

Additionally updates codegen logic in `firebase-encoder-processor` to
infer and use `FieldDescriptors`.