### PR TITLE
Check for user ID file before trying to read it

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
@@ -305,10 +305,13 @@ public class CrashlyticsReportPersistence {
     }
 
     String userId = null;
-    try {
-      userId = readTextFile(new File(sessionDirectory, USER_FILE_NAME));
-    } catch (IOException e) {
-      Logger.getLogger().d("Could not read user ID file in " + sessionDirectory.getName(), e);
+    final File userIdFile = new File(sessionDirectory, USER_FILE_NAME);
+    if (userIdFile.isFile()) {
+      try {
+        userId = readTextFile(userIdFile);
+      } catch (IOException e) {
+        Logger.getLogger().d("Could not read user ID file in " + sessionDirectory.getName(), e);
+      }
     }
 
     final File reportFile = new File(sessionDirectory, REPORT_FILE_NAME);


### PR DESCRIPTION
The user ID file will be missing if no user ID was set, so check
if it exists before trying to read from it to avoid unnecessary
error logging.

Fixes one of the prevalent issues in
https://github.com/firebase/firebase-android-sdk/issues/1559