### PR TITLE
Use the javaversion constant instead of string.

### DIFF
--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -42,8 +42,8 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
-        sourceCompatibility = '1.8'
-        targetCompatibility = '1.8'
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     sourceSets {
         androidTest {


### PR DESCRIPTION
This is compatible with the way it's done in all other projects.

https://github.com/firebase/firebase-android-sdk/search?p=1&q=targetCompatibility&unscoped_q=targetCompatibility