### PR TITLE
Move `rawType` to `TypeToken`

### DIFF
--- a/encoders/firebase-decoders-json/api.txt
+++ b/encoders/firebase-decoders-json/api.txt
@@ -66,6 +66,7 @@ package com.google.firebase.decoders {
     method @NonNull public Class<T> getRawType();
     method @NonNull public static <T> com.google.firebase.decoders.TypeToken<T> of(@NonNull com.google.firebase.decoders.Safe<T>);
     method @NonNull public static <T> com.google.firebase.decoders.TypeToken<T> of(@NonNull Class<T>);
+    field @NonNull protected Class<T> rawType;
   }
 
   public static class TypeToken.ArrayToken<T> extends com.google.firebase.decoders.TypeToken<T> {

--- a/encoders/firebase-decoders-json/api.txt
+++ b/encoders/firebase-decoders-json/api.txt
@@ -63,6 +63,7 @@ package com.google.firebase.decoders {
   }
 
   public abstract class TypeToken<T> {
+    method @NonNull public Class<T> getRawType();
     method @NonNull public static <T> com.google.firebase.decoders.TypeToken<T> of(@NonNull com.google.firebase.decoders.Safe<T>);
     method @NonNull public static <T> com.google.firebase.decoders.TypeToken<T> of(@NonNull Class<T>);
   }
@@ -72,7 +73,6 @@ package com.google.firebase.decoders {
   }
 
   public static class TypeToken.ClassToken<T> extends com.google.firebase.decoders.TypeToken<T> {
-    method @NonNull public Class<T> getRawType();
     method @NonNull public com.google.firebase.decoders.TypeTokenContainer getTypeArguments();
   }
 

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
@@ -36,8 +36,7 @@ import java.lang.reflect.WildcardType;
  * </ol>
  */
 public abstract class TypeToken<T> {
-  @NonNull
-  protected Class<T> rawType;
+  @NonNull protected Class<T> rawType;
 
   @NonNull
   public Class<T> getRawType() {
@@ -92,7 +91,7 @@ public abstract class TypeToken<T> {
       throw new IllegalArgumentException("<? super T> is not supported");
     } else if (type instanceof GenericArrayType) {
       throw new IllegalArgumentException(
-          "Generic Arrays are not supported, " + "please use Lists instead.");
+          "Generic Arrays are not supported, please use Lists instead.");
     } else if (type instanceof ParameterizedType) {
       ParameterizedType parameterizedType = (ParameterizedType) type;
       // Safe because rawType of parameterizedType is always instance of Class<T>
@@ -162,8 +161,7 @@ public abstract class TypeToken<T> {
         return false;
       }
       ClassToken<?> that = (ClassToken<?>) o;
-      return rawType.equals(that.getRawType())
-          && this.typeArguments.equals(that.typeArguments);
+      return rawType.equals(that.getRawType()) && this.typeArguments.equals(that.typeArguments);
     }
 
     @NonNull

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
@@ -86,6 +86,7 @@ public abstract class TypeToken<T> {
       }
       throw new IllegalArgumentException("<? super T> is not supported");
     } else if (type instanceof GenericArrayType) {
+      // TODO: Support GenericArrayType
       throw new IllegalArgumentException("GenericArrayType is not supported.");
     } else if (type instanceof ParameterizedType) {
       ParameterizedType parameterizedType = (ParameterizedType) type;

--- a/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
+++ b/encoders/firebase-decoders-json/src/main/java/com/google/firebase/decoders/TypeToken.java
@@ -36,7 +36,8 @@ import java.lang.reflect.WildcardType;
  * </ol>
  */
 public abstract class TypeToken<T> {
-  private Class<T> rawType;
+  @NonNull
+  protected Class<T> rawType;
 
   @NonNull
   public Class<T> getRawType() {
@@ -149,7 +150,7 @@ public abstract class TypeToken<T> {
 
     @Override
     public int hashCode() {
-      return 11 * getRawType().hashCode() + typeArguments.hashCode();
+      return 11 * rawType.hashCode() + typeArguments.hashCode();
     }
 
     @Override
@@ -161,14 +162,14 @@ public abstract class TypeToken<T> {
         return false;
       }
       ClassToken<?> that = (ClassToken<?>) o;
-      return getRawType().equals(that.getRawType())
+      return rawType.equals(that.getRawType())
           && this.typeArguments.equals(that.typeArguments);
     }
 
     @NonNull
     @Override
     String getTypeTokenLiteral() {
-      return getRawType().getSimpleName() + typeArguments;
+      return rawType.getSimpleName() + typeArguments;
     }
   }
 

--- a/encoders/firebase-decoders-json/src/test/java/com/google/firebase/decoders/TypeTokenTest.java
+++ b/encoders/firebase-decoders-json/src/test/java/com/google/firebase/decoders/TypeTokenTest.java
@@ -65,21 +65,18 @@ public class TypeTokenTest {
   }
 
   @Test
-  public void genericArrayType_rawTypeIsCorrectlyCaptured() {
-    TypeToken<List<String>[]> typeToken = TypeToken.of(new Safe<List<String>[]>() {});
-    assertThat(typeToken).isInstanceOf(TypeToken.ArrayToken.class);
-    TypeToken.ArrayToken<List<String>[]> arrayToken =
-        (TypeToken.ArrayToken<List<String>[]>) typeToken;
-    TypeToken<List<String>> componentType = (TypeToken<List<String>>) arrayToken.getComponentType();
-    assertThat(componentType).isInstanceOf(TypeToken.ClassToken.class);
-    TypeToken.ClassToken<List<String>> componentClassType =
-        (TypeToken.ClassToken<List<String>>) componentType;
-    assertThat(componentClassType.getRawType()).isEqualTo(List.class);
-    TypeToken<String> argumentType =
-        ((TypeToken.ClassToken<List<String>>) componentType).getTypeArguments().at(0);
-    assertThat(argumentType).isInstanceOf(TypeToken.ClassToken.class);
-    TypeToken.ClassToken<String> argumentClassType = (TypeToken.ClassToken<String>) argumentType;
-    assertThat(argumentClassType.getRawType()).isEqualTo(String.class);
+  public void arrayToken_shouldObtainCorrectRawType() {
+    assertThat(TypeToken.of(new Safe<Foo[]>() {}).getRawType()).isEqualTo(Foo[].class);
+  }
+
+  @Test
+  public void genericArrayType_shouldThrowException() {
+    assertThrows(
+        "GenericArray is not supported",
+        IllegalArgumentException.class,
+        () -> {
+          TypeToken.of(new Safe<List<String>[]>() {});
+        });
   }
 
   // Plain Class Type


### PR DESCRIPTION
Move the `rawType` to `TypeToken` level instead of only inside `ClassToken` so that `ArrayToken` will also be able to get its raw type, which enables us to decode arrays of object.

Geting `Class<?>` type from `GenericArrayType` is not straightforward and hard, we will not support `GenericArrayType` for now.