### PR TITLE
Unified emulator settings for Firestore

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -30,6 +30,7 @@ import com.google.firebase.database.core.utilities.ParsedUrl;
 import com.google.firebase.database.core.utilities.Utilities;
 import com.google.firebase.database.core.utilities.Validation;
 import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.emulators.EmulatorSettings;
 import com.google.firebase.emulators.FirebaseEmulator;
 
 /**
@@ -39,6 +40,13 @@ import com.google.firebase.emulators.FirebaseEmulator;
  */
 public class FirebaseDatabase {
 
+  /**
+   * Emulator identifier. See {@link FirebaseApp#enableEmulators(EmulatorSettings)}
+   *
+   * <p>TODO(samstern): Un-hide this once Firestore, Database, and Functions are implemented
+   *
+   * @hide
+   */
   public static final FirebaseEmulator EMULATOR = FirebaseEmulator.forName("database");
 
   private static final String SDK_VERSION = BuildConfig.VERSION_NAME;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AccessHelper.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AccessHelper.java
@@ -41,6 +41,7 @@ public final class AccessHelper {
         asyncQueue,
         firebaseApp,
         instanceRegistry,
+        null,
         null);
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -27,6 +27,9 @@ import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.internal.InternalAuthProvider;
+import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.emulators.EmulatorSettings;
+import com.google.firebase.emulators.FirebaseEmulator;
 import com.google.firebase.firestore.FirebaseFirestoreException.Code;
 import com.google.firebase.firestore.auth.CredentialsProvider;
 import com.google.firebase.firestore.auth.EmptyCredentialsProvider;
@@ -55,6 +58,9 @@ import java.util.concurrent.Executor;
  */
 public class FirebaseFirestore {
 
+  /** Emulator identifier. See {@link FirebaseApp#enableEmulators(EmulatorSettings)} */
+  public static FirebaseEmulator EMULATOR = FirebaseEmulator.forName("firestore");
+
   /**
    * Provides a registry management interface for {@code FirebaseFirestore} instances.
    *
@@ -81,6 +87,7 @@ public class FirebaseFirestore {
   private FirebaseFirestoreSettings settings;
   private volatile FirestoreClient client;
   private final GrpcMetadataProvider metadataProvider;
+  private final EmulatedServiceSettings emulatorSettings;
 
   @NonNull
   public static FirebaseFirestore getInstance() {
@@ -144,7 +151,8 @@ public class FirebaseFirestore {
             queue,
             app,
             instanceRegistry,
-            metadataProvider);
+            metadataProvider,
+            app.getEmulatorSettings().getServiceSettings(EMULATOR));
     return firestore;
   }
 
@@ -157,7 +165,8 @@ public class FirebaseFirestore {
       AsyncQueue asyncQueue,
       @Nullable FirebaseApp firebaseApp,
       InstanceRegistry instanceRegistry,
-      @Nullable GrpcMetadataProvider metadataProvider) {
+      @Nullable GrpcMetadataProvider metadataProvider,
+      @Nullable EmulatedServiceSettings emulatorSettings) {
     this.context = checkNotNull(context);
     this.databaseId = checkNotNull(checkNotNull(databaseId));
     this.userDataReader = new UserDataReader(databaseId);
@@ -168,8 +177,12 @@ public class FirebaseFirestore {
     this.firebaseApp = firebaseApp;
     this.instanceRegistry = instanceRegistry;
     this.metadataProvider = metadataProvider;
+    this.emulatorSettings = emulatorSettings;
 
-    settings = new FirebaseFirestoreSettings.Builder().build();
+    this.settings = new FirebaseFirestoreSettings.Builder().build();
+    if (this.emulatorSettings != null) {
+      this.settings = mergeEmulatorSettings(settings, emulatorSettings);
+    }
   }
 
   /** Returns the settings used by this {@code FirebaseFirestore} object. */
@@ -193,6 +206,11 @@ public class FirebaseFirestore {
                 + "You can only call setFirestoreSettings() before calling any other methods on a "
                 + "FirebaseFirestore object.");
       }
+
+      if (this.emulatorSettings != null) {
+        settings = mergeEmulatorSettings(settings, this.emulatorSettings);
+      }
+
       this.settings = settings;
     }
   }
@@ -213,6 +231,23 @@ public class FirebaseFirestore {
           new FirestoreClient(
               context, databaseInfo, settings, credentialsProvider, asyncQueue, metadataProvider);
     }
+  }
+
+  private FirebaseFirestoreSettings mergeEmulatorSettings(
+      @NonNull FirebaseFirestoreSettings settings,
+      @NonNull EmulatedServiceSettings emulatorSettings) {
+
+    if (!FirebaseFirestoreSettings.DEFAULT_HOST.equals(settings.getHost())) {
+      throw new IllegalStateException(
+          "Cannot change the Firestore host through FirebaseFirestoreSettings when "
+              + "EmulatedServiceSettings are also in effect. "
+              + "Make sure to only set the host in one location.");
+    }
+
+    return new FirebaseFirestoreSettings.Builder(settings)
+        .setHost(emulatorSettings.getHost() + ":" + emulatorSettings.getPort())
+        .setSslEnabled(false)
+        .build();
   }
 
   /** Returns the FirebaseApp instance to which this {@code FirebaseFirestore} belongs. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -58,7 +58,13 @@ import java.util.concurrent.Executor;
  */
 public class FirebaseFirestore {
 
-  /** Emulator identifier. See {@link FirebaseApp#enableEmulators(EmulatorSettings)} */
+  /**
+   * Emulator identifier. See {@link FirebaseApp#enableEmulators(EmulatorSettings)}
+   *
+   * <p>TODO(samstern): Un-hide this once Firestore, Database, and Functions are implemented
+   *
+   * @hide
+   */
   public static FirebaseEmulator EMULATOR = FirebaseEmulator.forName("firestore");
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
@@ -27,9 +27,11 @@ public final class FirebaseFirestoreSettings {
    */
   public static final long CACHE_SIZE_UNLIMITED = -1;
 
+  /** @hide */
+  public static final String DEFAULT_HOST = "firestore.googleapis.com";
+
   private static final long MINIMUM_CACHE_BYTES = 1 * 1024 * 1024; // 1 MB
   private static final long DEFAULT_CACHE_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB
-  private static final String DEFAULT_HOST = "firestore.googleapis.com";
   private static final boolean DEFAULT_TIMESTAMPS_IN_SNAPSHOTS_ENABLED = true;
 
   /** A Builder for creating {@code FirebaseFirestoreSettings}. */

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/FirebaseFirestoreTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/FirebaseFirestoreTest.java
@@ -1,0 +1,97 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import androidx.annotation.NonNull;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.emulators.EmulatorSettings;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class FirebaseFirestoreTest {
+
+  @Test
+  public void getInstance_withEmulator() {
+    FirebaseApp app = getApp("getInstance_withEmulator");
+
+    app.enableEmulators(
+        new EmulatorSettings.Builder()
+            .addEmulatedService(
+                FirebaseFirestore.EMULATOR, new EmulatedServiceSettings("10.0.2.2", 8080))
+            .build());
+
+    FirebaseFirestore firestore = FirebaseFirestore.getInstance(app);
+    FirebaseFirestoreSettings settings = firestore.getFirestoreSettings();
+
+    assertEquals(settings.getHost(), "10.0.2.2:8080");
+    assertFalse(settings.isSslEnabled());
+  }
+
+  @Test
+  public void getInstance_withEmulator_mergeSettingsSuccess() {
+    FirebaseApp app = getApp("getInstance_withEmulator_mergeSettingsSuccess");
+    app.enableEmulators(
+        new EmulatorSettings.Builder()
+            .addEmulatedService(
+                FirebaseFirestore.EMULATOR, new EmulatedServiceSettings("10.0.2.2", 8080))
+            .build());
+
+    FirebaseFirestore firestore = FirebaseFirestore.getInstance(app);
+    firestore.setFirestoreSettings(
+        new FirebaseFirestoreSettings.Builder().setPersistenceEnabled(false).build());
+
+    FirebaseFirestoreSettings settings = firestore.getFirestoreSettings();
+
+    assertEquals(settings.getHost(), "10.0.2.2:8080");
+    assertFalse(settings.isSslEnabled());
+    assertFalse(settings.isPersistenceEnabled());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void getInstance_withEmulator_mergeSettingsFailure() {
+    FirebaseApp app = getApp("getInstance_withEmulator_mergeSettingsFailure");
+    app.enableEmulators(
+        new EmulatorSettings.Builder()
+            .addEmulatedService(
+                FirebaseFirestore.EMULATOR, new EmulatedServiceSettings("10.0.2.2", 8080))
+            .build());
+
+    FirebaseFirestore firestore = FirebaseFirestore.getInstance(app);
+    firestore.setFirestoreSettings(
+        new FirebaseFirestoreSettings.Builder().setHost("myhost.com").build());
+  }
+
+  @NonNull
+  private FirebaseApp getApp(@NonNull String name) {
+    return FirebaseApp.initializeApp(
+        InstrumentationRegistry.getInstrumentation().getContext(),
+        new FirebaseOptions.Builder()
+            .setApplicationId("appid")
+            .setApiKey("apikey")
+            .setProjectId("projectid")
+            .build(),
+        name);
+  }
+}

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/FirebaseFirestoreTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/FirebaseFirestoreTest.java
@@ -110,6 +110,28 @@ public class FirebaseFirestoreTest {
   }
 
   @Test
+  public void setSettings_repeatedSuccess_withEmulator() {
+    FirebaseApp app = getApp("setSettings_repeatedSuccess_withEmulator");
+    app.enableEmulators(
+        new EmulatorSettings.Builder()
+            .addEmulatedService(
+                FirebaseFirestore.EMULATOR, new EmulatedServiceSettings("10.0.2.2", 8080))
+            .build());
+
+    FirebaseFirestore firestore = FirebaseFirestore.getInstance(app);
+
+    FirebaseFirestoreSettings settings =
+        new FirebaseFirestoreSettings.Builder().setPersistenceEnabled(false).build();
+    firestore.setFirestoreSettings(settings);
+
+    // This should 'start' Firestore
+    DocumentReference reference = firestore.document("foo/bar");
+
+    // Second settings set should pass because the settings are equal
+    firestore.setFirestoreSettings(settings);
+  }
+
+  @Test
   public void setSettings_repeatedFailure() {
     FirebaseApp app = getApp("setSettings_repeatedFailure");
     FirebaseFirestore firestore = FirebaseFirestore.getInstance(app);


### PR DESCRIPTION
Follow up to #1672 but for `FirebaseFirestore`

Note:

- This now throws an `IlegalStateException` if the developer tries to set the host through the `EmulatedServiceSettings` as well as `FirebaseFirestoreSettings`.  The settings method already throws unchecked exceptions so I thought this was the correct behavior, but I could convert it to a warning.