### PR TITLE
chore(fiam + fiamd): re-generate api.txt files

### DIFF
--- a/firebase-inappmessaging-display/api.txt
+++ b/firebase-inappmessaging-display/api.txt
@@ -1,15 +1,15 @@
 // Signature format: 2.0
 package com.google.firebase.inappmessaging.display {
 
-  @Keep public class FirebaseInAppMessagingDisplay implements android.app.Application.ActivityLifecycleCallbacks com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplay {
+  public class FirebaseInAppMessagingDisplay implements android.app.Application.ActivityLifecycleCallbacks com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplay {
     method public void displayMessage(com.google.firebase.inappmessaging.model.InAppMessage, com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplayCallbacks);
-    method @NonNull @Keep public static com.google.firebase.inappmessaging.display.FirebaseInAppMessagingDisplay getInstance();
+    method @NonNull public static com.google.firebase.inappmessaging.display.FirebaseInAppMessagingDisplay getInstance();
     method public void onActivityCreated(android.app.Activity, android.os.Bundle);
-    method @Keep public void onActivityDestroyed(android.app.Activity);
-    method @Keep public void onActivityPaused(android.app.Activity);
-    method @Keep public void onActivityResumed(android.app.Activity);
+    method public void onActivityDestroyed(android.app.Activity);
+    method public void onActivityPaused(android.app.Activity);
+    method public void onActivityResumed(android.app.Activity);
     method public void onActivitySaveInstanceState(android.app.Activity, android.os.Bundle);
-    method @Keep public void onActivityStarted(android.app.Activity);
+    method public void onActivityStarted(android.app.Activity);
     method public void onActivityStopped(android.app.Activity);
   }
 

--- a/firebase-inappmessaging/api.txt
+++ b/firebase-inappmessaging/api.txt
@@ -18,7 +18,7 @@ package com.google.firebase.inappmessaging {
     method public void setAutomaticDataCollectionEnabled(boolean);
     method public void setMessageDisplayComponent(@NonNull com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplay);
     method public void setMessagesSuppressed(@NonNull Boolean);
-    method public void triggerEvent(String);
+    method public void triggerEvent(@NonNull String);
   }
 
   public interface FirebaseInAppMessagingClickListener {


### PR DESCRIPTION
After the CI fix implemented in #1692 , the build in new PRs is failing because the current `api.txt` files from `in-app-messaging` and `in-app-messaging-display` are outdated:

```
> Task :firebase-inappmessaging:apiInformation FAILED
Aborting: Your changes have resulted in differences in the signature file
for the public API.
The changes may be compatible, but the signature file needs to be updated.
Diffs:
--- /home/prow/go/src/github.com/firebase/firebase-android-sdk/firebase-inappmessaging/api.txt	2020-06-22 16:47:15.984360721 +0000
+++ /home/prow/go/src/github.com/firebase/firebase-android-sdk/build/apiinfo/firebase-inappmessaging_api.txt	2020-06-22 16:52:35.872100325 +0000
@@ -18,7 +18,7 @@
     method public void setAutomaticDataCollectionEnabled(boolean);
     method public void setMessageDisplayComponent(@NonNull com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplay);
     method public void setMessagesSuppressed(@NonNull Boolean);
-    method public void triggerEvent(String);
+    method public void triggerEvent(@NonNull String);
   }
```

This PR should fix these files so that they can be parsed properly.

cc: @rlazo @JasonAHeron 