### PR TITLE
Retry GoogleDataTransport Connection Errors

### DIFF
--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
@@ -48,9 +48,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -268,6 +270,9 @@ final class CctTransportBackend implements TransportBackend {
       // JsonWriter often writes one character at a time.
       dataEncoder.encode(
           request.requestBody, new BufferedWriter(new OutputStreamWriter(outputStream)));
+    } catch (ConnectException | UnknownHostException e) {
+      Logging.e(LOG_TAG, "Couldn't open connection, returning with 500", e);
+      return new HttpResponse(500, null, 0);
     } catch (EncodingException | IOException e) {
       Logging.e(LOG_TAG, "Couldn't encode request, returning with 400", e);
       return new HttpResponse(400, null, 0);


### PR DESCRIPTION
 - In cases where there is bad connection, the current behavior deletes the cached reports because they are caught as an `IOException`. They appear to be encoding errors, when in reality it's an error opening the `OutputStream` that is the connection.

 - This changes it so that when the `IOException` is due to connection problems, we retry the upload instead of deleting it. 

This is where we transform status numbers into success, fatal, and transient errors: [CctTransportBackend.java](https://github.com/firebase/firebase-android-sdk/blob/master/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java#L329-L356)

 - 400-level errors (except 404) are treated as fatal errors, which are deleted
 - 500-level errors are treated as transient errors, which are retried

This is where we decide to delete fatal errors, and retry transient errors: [Uploader.java](https://github.com/firebase/firebase-android-sdk/blob/master/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java#L128-L144)