### PR TITLE
Increase number of retries before deleting events

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -54,7 +54,7 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
 
   private static final String LOG_TAG = "SQLiteEventStore";
 
-  static final int MAX_RETRIES = 10;
+  static final int MAX_RETRIES = 16;
 
   private static final int LOCK_RETRY_BACK_OFF_MILLIS = 50;
   private static final Encoding PROTOBUF_ENCODING = Encoding.of("proto");


### PR DESCRIPTION
The current retry logic will delete an event after 10 retries,
which will only take ~17 minutes for high priority events.
If a device is on a bad network for that period of time, we could
relatively easily lose these events.

Increasing this to 16 will extend this timeframe to ~18 hours,
giving more opportunity for a retry to occur when the device has
a better network connection.