### PR TITLE
Add missing parenthesis to link.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -69,7 +69,7 @@ public class FirebaseRemoteConfig {
    * <p>Note: Also initializes the Firebase installations SDK that creates installation IDs to
    * identify Firebase installations and periodically sends data to Firebase servers. Remote Config
    * requires installation IDs for Fetch requests. To stop the periodic sync, call {@link
-   * com.google.firebase.installations.FirebaseInstallations#delete}. Sending a Fetch request after
+   * com.google.firebase.installations.FirebaseInstallations#delete()}. Sending a Fetch request after
    * deletion will create a new installation ID for this Firebase installation and resume the
    * periodic sync.
    *
@@ -333,7 +333,7 @@ public class FirebaseRemoteConfig {
    * <p>Note: Also initializes the Firebase installations SDK that creates installation IDs to
    * identify Firebase installations and periodically sends data to Firebase servers. Remote Config
    * requires installation IDs for Fetch requests. To stop the periodic sync, call {@link
-   * com.google.firebase.installations.FirebaseInstallations#delete}. Sending a Fetch request after
+   * com.google.firebase.installations.FirebaseInstallations#delete()}. Sending a Fetch request after
    * deletion will create a new installation ID for this Firebase installation and resume the
    * periodic sync.
    *

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -308,7 +308,7 @@ public class FirebaseRemoteConfig {
    * <p>Note: Also initializes the Firebase installations SDK that creates installation IDs to
    * identify Firebase installations and periodically sends data to Firebase servers. Remote Config
    * requires installation IDs for Fetch requests. To stop the periodic sync, call {@link
-   * com.google.firebase.installations.FirebaseInstallations#delete}. Sending a Fetch request after
+   * com.google.firebase.installations.FirebaseInstallations#delete()}. Sending a Fetch request after
    * deletion will create a new installation ID for this Firebase installation and resume the
    * periodic sync.
    *


### PR DESCRIPTION
Without the parenthesis, the link is broken.