### PR TITLE
Improve kotlindoc rendering.

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
@@ -102,7 +102,8 @@ public class FirebaseLibraryPlugin implements Plugin<Project> {
                     .setFreeCompilerArgs(
                         ImmutableList.of("-module-name", kotlinModuleName(project))));
 
-    project.afterEvaluate(p -> Dokka.configure(project, android, firebaseLibrary));
+
+    Dokka.configure(project, android, firebaseLibrary);
   }
 
   private static void setupApiInformationAnalysis(Project project, LibraryExtension android) {

--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -66,6 +66,9 @@ dependencies {
     implementation 'com.google.android.gms:play-services-basement:17.0.0'
     implementation "com.google.android.gms:play-services-tasks:17.0.0"
 
+    // FirebaseApp references storage, so storage needs to be on classpath when dokka runs.
+    javadocClasspath project(path: ':firebase-storage')
+
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 

--- a/kotlindoc/package-lists/firebase/package-list
+++ b/kotlindoc/package-lists/firebase/package-list
@@ -41,6 +41,7 @@ com.google.firebase.inappmessaging.display
 com.google.firebase.inappmessaging.display.ktx
 com.google.firebase.inappmessaging.ktx
 com.google.firebase.inappmessaging.model
+com.google.firebase.installations
 com.google.firebase.ktx
 com.google.firebase.messaging
 com.google.firebase.ml.common


### PR DESCRIPTION
Specifically allows SDKs to declare dependencies via `javadocClasspath`
configuration for the dokka run to make `{@link}` tags render properly.

Depends on https://android-review.googlesource.com/c/platform/external/dokka/+/1365296
for rendering to work correctly.