### PR TITLE
Added null check before accessing message type

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -256,6 +256,11 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
 
     final BindingWrapper bindingWrapper;
 
+    if (inAppMessage.getMessageType() == null) {
+      Logging.loge("The message type is null and not supported.");
+      return;
+    }
+
     switch (inAppMessage.getMessageType()) {
       case BANNER:
         bindingWrapper = bindingWrapperFactory.createBannerBindingWrapper(config, inAppMessage);


### PR DESCRIPTION
Added null check before accessing message type in FirebaseInAppMessagingDisplay.java:259
This pull request should solve this [issue](https://github.com/firebase/firebase-android-sdk/issues/1680) (ref no. 160002227).