### PR TITLE
Disable debug build for apk size measurements.

### DIFF
--- a/apk-size/app/default.gradle
+++ b/apk-size/app/default.gradle
@@ -51,6 +51,18 @@ android {
             signingConfig signingConfigs.debug
             matchingFallbacks = ['release']
         }
+        release {
+            debuggable false
+            minifyEnabled false
+            shrinkResources false
+        }
+    }
+
+    variantFilter { variant ->
+        def buildTypeName = variant.buildType*.name
+        if (buildTypeName.contains('debug')) {
+            setIgnore(true)
+        }
     }
 }
 


### PR DESCRIPTION
Android Gradle Plugin does not guarantee that debug build produces reproducible artifacts.

I cannot verify whether `debuggable = true/false` affects indeterminism as I was not able to reproduce indeterministic debug builds locally. Therefore, I'm disabling the debug build all together.