### PR TITLE
Add dependency vendoring support.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -75,6 +75,11 @@ gradlePlugin {
             id = "firebase-java-library"
             implementationClass = 'com.google.firebase.gradle.plugins.FirebaseJavaLibraryPlugin'
         }
+
+        firebaseVendorPlugin {
+            id = "firebase-vendor"
+            implementationClass = 'com.google.firebase.gradle.plugins.VendorPlugin'
+        }
     }
 }
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VendorPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VendorPlugin.kt
@@ -1,0 +1,260 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins
+
+import com.android.build.api.transform.Format
+import com.android.build.api.transform.QualifiedContent
+import com.android.build.api.transform.Transform
+import com.android.build.api.transform.TransformInvocation
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.LibraryPlugin
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.logging.Logger
+
+class VendorPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.plugins.all {
+            when (this) {
+                is LibraryPlugin -> configureAndroid(project)
+            }
+        }
+    }
+
+    fun configureAndroid(project: Project) {
+
+        val vendor = project.configurations.create("vendor")
+        project.configurations.all {
+            when (name) {
+                "compileOnly", "testImplementation", "androidTestImplementation" -> extendsFrom(vendor)
+            }
+        }
+
+        val jarJar = project.configurations.create("firebaseJarJarArtifact")
+        project.dependencies.add("firebaseJarJarArtifact", "org.pantsbuild:jarjar:1.7.2")
+
+        val android = project.extensions.getByType(LibraryExtension::class.java)
+
+        android.registerTransform(VendorTransform(
+                android,
+                vendor,
+                JarJarTransformer(
+                        parentPackageProvider = {
+                            android.libraryVariants.find { it.name == "release" }!!.applicationId
+                        },
+                        jarJarProvider = { jarJar.resolve() },
+                        project = project,
+                        logger = project.logger),
+                logger = project.logger))
+    }
+}
+
+interface JarTransformer {
+    fun transform(inputJar: File, outputJar: File, packagesToVendor: Set<String>)
+}
+
+class JarJarTransformer(
+    private val parentPackageProvider: () -> String,
+    private val jarJarProvider: () -> Collection<File>,
+    private val project: Project,
+    private val logger: Logger
+) : JarTransformer {
+    override fun transform(inputJar: File, outputJar: File, packagesToVendor: Set<String>) {
+        val parentPackage = parentPackageProvider()
+        val rulesFile = File.createTempFile(parentPackage, ".jarjar")
+        rulesFile.printWriter().use {
+            for (externalPackageName in packagesToVendor) {
+                it.println("rule $externalPackageName.** $parentPackage.@0")
+            }
+        }
+        logger.info("The following JarJar configuration will be used:\n ${rulesFile.readText()}")
+
+        project.javaexec {
+            main = "org.pantsbuild.jarjar.Main"
+            classpath = project.files(jarJarProvider())
+            // jvmArgs = listOf("-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005")
+            args = listOf("process", rulesFile.absolutePath, inputJar.absolutePath, outputJar.absolutePath)
+            systemProperties = mapOf("verbose" to "true", "misplacedClassStrategy" to "FATAL")
+        }.assertNormalExitValue()
+    }
+}
+
+class VendorTransform(
+    private val android: LibraryExtension,
+    private val configuration: Configuration,
+    private val jarTransformer: JarTransformer,
+    private val logger: Logger
+) :
+        Transform() {
+    override fun getName() = "firebaseVendorTransform"
+
+    override fun getInputTypes(): MutableSet<QualifiedContent.ContentType> {
+        return mutableSetOf(QualifiedContent.DefaultContentType.CLASSES)
+    }
+
+    override fun isIncremental() = false
+
+    override fun getScopes(): MutableSet<in QualifiedContent.Scope> {
+        return mutableSetOf(QualifiedContent.Scope.PROJECT)
+    }
+
+    override fun getReferencedScopes(): MutableSet<in QualifiedContent.Scope> {
+        return mutableSetOf(QualifiedContent.Scope.PROJECT)
+    }
+
+    override fun transform(transformInvocation: TransformInvocation) {
+        if (configuration.resolve().isEmpty()) {
+            logger.info("Nothing to vendor. " +
+                    "If you don't need vendor functionality please disable 'firebase-vendor' plugin. " +
+                    "Otherwise use the 'vendor' configuration to add dependencies you want vendored in.")
+            for (input in transformInvocation.inputs) {
+                for (directoryInput in input.directoryInputs) {
+                    val directoryOutput = transformInvocation.outputProvider.getContentLocation(
+                            directoryInput.name,
+                            setOf(QualifiedContent.DefaultContentType.CLASSES),
+                            mutableSetOf(QualifiedContent.Scope.PROJECT),
+                            Format.DIRECTORY)
+                    directoryInput.file.copyRecursively(directoryOutput, overwrite = true)
+                }
+            }
+            return
+        }
+
+        val contentLocation = transformInvocation.outputProvider.getContentLocation(
+                "sourceAndVendoredLibraries",
+                setOf(QualifiedContent.DefaultContentType.CLASSES),
+                mutableSetOf(QualifiedContent.Scope.PROJECT),
+                Format.DIRECTORY)
+        contentLocation.deleteRecursively()
+        contentLocation.mkdirs()
+        val tmpDir = File(contentLocation, "tmp")
+        tmpDir.mkdirs()
+        try {
+            val fatJar = process(tmpDir, transformInvocation)
+            unzipJar(fatJar, contentLocation)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    private fun isTest(transformInvocation: TransformInvocation): Boolean {
+        return android.testVariants.find { it.name == transformInvocation.context.variantName } != null
+    }
+
+    private fun process(workDir: File, transformInvocation: TransformInvocation): File {
+        transformInvocation.context.variantName
+        val unzippedDir = File(workDir, "unzipped")
+        val unzippedExcludedDir = File(workDir, "unzipped-excluded")
+        unzippedDir.mkdirs()
+        unzippedExcludedDir.mkdirs()
+
+        val externalCodeDir = if (isTest(transformInvocation)) unzippedExcludedDir else unzippedDir
+
+        for (input in transformInvocation.inputs) {
+            for (directoryInput in input.directoryInputs) {
+                directoryInput.file.copyRecursively(unzippedDir)
+            }
+        }
+
+        val ownPackageNames = inferPackages(unzippedDir)
+
+        for (jar in configuration.resolve()) {
+            unzipJar(jar, externalCodeDir)
+        }
+        val externalPackageNames = inferPackages(externalCodeDir) subtract ownPackageNames
+        val java = File(externalCodeDir, "java")
+        val javax = File(externalCodeDir, "javax")
+        if (java.exists() || javax.exists()) {
+            // JarJar unconditionally skips any classes whose package name starts with "java" or "javax".
+            throw GradleException("Vendoring java or javax packages is not supported. " +
+                    "Please exclude one of the direct or transitive dependencies: \n" +
+                    configuration.resolvedConfiguration.resolvedArtifacts.joinToString(separator = "\n"))
+        }
+        val jar = File(workDir, "intermediate.jar")
+        zipAll(unzippedDir, jar)
+        val outputJar = File(workDir, "output.jar")
+
+        jarTransformer.transform(jar, outputJar, externalPackageNames)
+        return outputJar
+    }
+
+    private fun inferPackages(dir: File): Set<String> {
+        return dir.walk().filter { it.name.endsWith(".class") }.map { it.parentFile.toRelativeString(dir).replace('/', '.') }.toSet()
+    }
+}
+
+fun unzipJar(jar: File, directory: File) {
+    ZipFile(jar).use { zip ->
+        zip.entries().asSequence().filter { !it.isDirectory && !it.name.startsWith("META-INF") }.forEach { entry ->
+            zip.getInputStream(entry).use { input ->
+                val entryFile = File(directory, entry.name)
+                entryFile.parentFile.mkdirs()
+                entryFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+    }
+}
+
+fun zipAll(directory: File, zipFile: File) {
+
+    ZipOutputStream(BufferedOutputStream(FileOutputStream(zipFile))).use {
+        zipFiles(it, directory, "")
+    }
+}
+
+private fun zipFiles(zipOut: ZipOutputStream, sourceFile: File, parentDirPath: String) {
+    val data = ByteArray(2048)
+    sourceFile.listFiles()?.forEach { f ->
+        if (f.isDirectory) {
+            val path = if (parentDirPath == "") {
+                f.name
+            } else {
+                parentDirPath + File.separator + f.name
+            }
+            // Call recursively to add files within this directory
+            zipFiles(zipOut, f, path)
+        } else {
+            FileInputStream(f).use { fi ->
+                BufferedInputStream(fi).use { origin ->
+                    val path = parentDirPath + File.separator + f.name
+                    val entry = ZipEntry(path)
+                    entry.time = f.lastModified()
+                    entry.isDirectory
+                    entry.size = f.length()
+                    zipOut.putNextEntry(entry)
+                    while (true) {
+                        val readBytes = origin.read(data)
+                        if (readBytes == -1) {
+                            break
+                        }
+                        zipOut.write(data, 0, readBytes)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VendorPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VendorPlugin.kt
@@ -94,7 +94,6 @@ class JarJarTransformer(
         project.javaexec {
             main = "org.pantsbuild.jarjar.Main"
             classpath = project.files(jarJarProvider())
-            // jvmArgs = listOf("-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005")
             args = listOf("process", rulesFile.absolutePath, inputJar.absolutePath, outputJar.absolutePath)
             systemProperties = mapOf("verbose" to "true", "misplacedClassStrategy" to "FATAL")
         }.assertNormalExitValue()
@@ -126,7 +125,7 @@ class VendorTransform(
 
     override fun transform(transformInvocation: TransformInvocation) {
         if (configuration.resolve().isEmpty()) {
-            logger.info("Nothing to vendor. " +
+            logger.warn("Nothing to vendor. " +
                     "If you don't need vendor functionality please disable 'firebase-vendor' plugin. " +
                     "Otherwise use the 'vendor' configuration to add dependencies you want vendored in.")
             for (input in transformInvocation.inputs) {

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/VendorTests.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/VendorTests.kt
@@ -1,0 +1,190 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.nio.file.Paths
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+private const val MANIFEST = """<?xml version="1.0" encoding="utf-8"?>
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                  package="com.example">
+            <uses-sdk android:minSdkVersion="14"/>
+        </manifest>
+        """
+
+@RunWith(JUnit4::class)
+class VendorPluginTests {
+    @Rule
+    @JvmField
+    val testProjectDir = TemporaryFolder()
+
+    @Test
+    fun `vendor guava not excluding javax transitive deps should fail`() {
+        val buildFailure = assertThrows(UnexpectedBuildFailure::class.java) {
+            buildWith("vendor 'com.google.guava:guava:29.0-android'")
+        }
+
+        assertThat(buildFailure.message).contains("Vendoring java or javax packages is not supported.")
+    }
+
+    @Test
+    fun `vendor guava excluding javax transitive deps should include subset of guava`() {
+        val classes = buildWith("""
+            vendor('com.google.guava:guava:29.0-android') {
+              exclude group: 'com.google.code.findbugs', module: 'jsr305'
+            }
+        """.trimIndent(),
+                SourceFile(name = "com/example/Hello.java", content = """
+                    package com.example;
+
+                    import com.google.common.base.Preconditions;
+
+                    public class Hello {
+                      public static void main(String[] args) {
+                        Preconditions.checkNotNull(args);
+                      }
+                    }
+                    """.trimIndent()))
+        // expected to vendor preconditions and errorprone annotations from transitive dep.
+        assertThat(classes).containsAtLeast(
+                "com/example/Hello.class",
+                "com/example/com/google/common/base/Preconditions.class",
+                "com/example/com/google/errorprone/annotations/CanIgnoreReturnValue.class")
+
+        // ImmutableList is not used, so it should be stripped out.
+        assertThat(classes).doesNotContain("com/google/common/collect/ImmutableList.class")
+    }
+
+    @Test
+    fun `vendor dagger excluding javax transitive deps and not using it should include dagger`() {
+        val classes = buildWith("""
+            vendor ('com.google.dagger:dagger:2.27') {
+              exclude group: "javax.inject", module: "javax.inject"
+            }
+        """.trimIndent(),
+                SourceFile(name = "com/example/Hello.java", content = """
+                    package com.example;
+
+                    public class Hello {
+                      public static void main(String[] args) {}
+                    }
+                    """.trimIndent()))
+        // expected classes
+        assertThat(classes).containsAtLeast(
+                "com/example/Hello.class",
+                "com/example/BuildConfig.class",
+                "com/example/dagger/Lazy.class")
+    }
+
+    @Test
+    fun `vendor dagger excluding javax transitive deps should include dagger`() {
+        val classes = buildWith("""
+            vendor ('com.google.dagger:dagger:2.27') {
+              exclude group: "javax.inject", module: "javax.inject"
+            }
+        """.trimIndent(),
+                SourceFile(name = "com/example/Hello.java", content = """
+                    package com.example;
+
+                    import dagger.Module;
+
+                    @Module
+                    public class Hello {
+                      public static void main(String[] args) {}
+                    }
+                    """.trimIndent()))
+        // expected classes
+        assertThat(classes).containsAtLeast(
+                "com/example/Hello.class",
+                "com/example/BuildConfig.class",
+                "com/example/dagger/Module.class")
+    }
+
+    private fun buildWith(deps: String, vararg files: SourceFile): List<String> {
+        testProjectDir.newFile("build.gradle").writeText("""
+            buildscript {
+                repositories {
+                    google()
+                    jcenter()
+                }
+            }
+            plugins {
+                id 'com.android.library'
+                id 'firebase-vendor'
+            }
+            repositories {
+                google()
+                jcenter()
+            }
+
+            android.compileSdkVersion = 26
+
+            dependencies {
+                $deps
+            }
+        """.trimIndent())
+        testProjectDir.newFile("settings.gradle")
+                .writeText("rootProject.name = 'testlib'")
+
+        testProjectDir.newFolder("src/main/java")
+        testProjectDir
+                .newFile("src/main/AndroidManifest.xml")
+                .writeText(MANIFEST)
+
+        for (file in files) {
+            // if (1+1 == 2) {throw RuntimeException("src/main/java/${Paths.get(file.name).parent}")}
+            testProjectDir.newFolder("src/main/java/${Paths.get(file.name).parent}")
+            testProjectDir.newFile("src/main/java/${file.name}").writeText(file.content)
+        }
+
+        GradleRunner.create()
+                .withArguments("assemble")
+                .withProjectDir(testProjectDir.root)
+                .withPluginClasspath()
+                .build()
+
+        val aarFile = File(testProjectDir.root, "build/outputs/aar/testlib-release.aar")
+        assertThat(aarFile.exists()).isTrue()
+
+        val zipFile = ZipFile(aarFile)
+        val classesJar = zipFile.entries().asSequence()
+                .filter { it.name == "classes.jar" }
+                .first()
+        return ZipInputStream(zipFile.getInputStream(classesJar)).use {
+            val entries = mutableListOf<String>()
+            var currentEntry = it.nextEntry
+            while (currentEntry != null) {
+                if (!currentEntry.isDirectory) {
+                    entries.add(currentEntry.name)
+                }
+                currentEntry = it.nextEntry
+            }
+            entries
+        }
+    }
+}
+
+data class SourceFile(val name: String, val content: String)

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -14,6 +14,7 @@
 
 plugins {
     id 'firebase-library'
+    id 'firebase-vendor'
 }
 
 firebaseLibrary {
@@ -75,12 +76,16 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
-    implementation "com.google.dagger:dagger:2.27"
 
     implementation "com.squareup.picasso:picasso:2.71828"
     implementation "com.squareup.okhttp:okhttp:2.7.5"
 
-    annotationProcessor "com.google.dagger:dagger-compiler:2.24"
+    vendor ('com.google.dagger:dagger:2.27') {
+        exclude group: "javax.inject", module: "javax.inject"
+    }
+    implementation 'javax.inject:javax.inject:1'
+
+    annotationProcessor "com.google.dagger:dagger-compiler:2.27"
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
     annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
 
@@ -88,7 +93,6 @@ dependencies {
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.25.0"
     testImplementation "com.google.truth:truth:1.0"
-    testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'com.google.guava:guava:27.1-android'
 
     androidTestImplementation "org.mockito:mockito-core:2.25.0"

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -93,6 +93,7 @@ dependencies {
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.25.0"
     testImplementation "com.google.truth:truth:1.0"
+    testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'com.google.guava:guava:27.1-android'
 
     androidTestImplementation "org.mockito:mockito-core:2.25.0"

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -15,6 +15,7 @@
 plugins {
     id 'firebase-library'
     id 'com.google.protobuf'
+    id 'firebase-vendor'
 }
 
 firebaseLibrary {
@@ -111,6 +112,7 @@ dependencies {
     implementation project(':firebase-datatransport')
     implementation project(':firebase-installations-interop')
     runtimeOnly project(':firebase-installations')
+    implementation 'javax.inject:javax.inject:1'
 
     //To provide @Generated annotations
     compileOnly 'javax.annotation:jsr250-api:1.0'
@@ -119,7 +121,6 @@ dependencies {
     implementation "io.grpc:grpc-stub:$grpcVersion"
     implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"
     implementation "io.grpc:grpc-okhttp:$grpcVersion"
-    implementation 'com.google.dagger:dagger:2.24'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.14'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
@@ -128,7 +129,11 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
     }
 
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.24'
+    vendor ('com.google.dagger:dagger:2.27') {
+        exclude group: "javax.inject", module: "javax.inject"
+    }
+
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.27'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
     annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
 
@@ -151,5 +156,5 @@ dependencies {
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.25.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
 
-    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.24'
+    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.27'
 }

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -14,6 +14,7 @@
 
 plugins {
     id 'firebase-library'
+    id 'firebase-vendor'
 }
 
 firebaseLibrary {
@@ -59,13 +60,18 @@ android {
 
 dependencies {
     implementation project(':transport:transport-api')
-    implementation 'com.google.dagger:dagger:2.27'
     implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'javax.inject:javax.inject:1'
+
+
+    vendor ('com.google.dagger:dagger:2.27') {
+        exclude group: "javax.inject", module: "javax.inject"
+    }
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"
 
     annotationProcessor "com.google.auto.value:auto-value:1.6.5"
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.24'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.27'
 
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
@@ -82,5 +88,5 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation 'org.mockito:mockito-android:2.25.0'
 
-    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.24'
+    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.27'
 }


### PR DESCRIPTION
The `VendorPlugin`(applied with `id 'firebase-vendor'`) adds a dedicated
`vendor` gradle configuration to the project, which can be used to
include the dependencies in the output library. Such dependencies are
are shaded under the library's package name to avoid symbol collisions.

Example use:
```kotlin
plugins {
  id("com.android.library")
  id("firebase-vendor")
}

android {
  // ...
}

dependencies {
  implementation("com.example:somelib:1.0")

  // this will make this library available at compile time as well as
  // will vendor it inside the produced aar under `com.mylib.com.example`.
  vendor("com.example:libtovendor:1.0") {
    // IMPORTANT: if the library (transitively) depends on any library
    // that contains `javax` or `java` packages, it must be excluded here
    // and added as a pom dependency below.
    exclude("javax.inject", "javax.inject")
  }
  implementation("javax.inject:javax.inject:1")
}
```