### PR TITLE
Add logging of data collection state

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -17,6 +17,7 @@ package com.google.firebase.crashlytics.internal.common;
 import android.content.Context;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
@@ -247,7 +248,7 @@ public class CrashlyticsCore {
 
   // endregion
 
-  public void setCrashlyticsCollectionEnabled(Boolean enabled) {
+  public void setCrashlyticsCollectionEnabled(@Nullable Boolean enabled) {
     dataCollectionArbiter.setCrashlyticsDataCollectionEnabled(enabled);
   }
 


### PR DESCRIPTION
Keeps track of what the current state of data collection is, and
logs the current state and where it was read from every time the
state is checked.

Also adds @Nullable annotations to clarify internal method calls.