### PR TITLE
Increase number of retries to 18

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -54,7 +54,7 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
 
   private static final String LOG_TAG = "SQLiteEventStore";
 
-  static final int MAX_RETRIES = 16;
+  static final int MAX_RETRIES = 18;
 
   private static final int LOCK_RETRY_BACK_OFF_MILLIS = 50;
   private static final Encoding PROTOBUF_ENCODING = Encoding.of("proto");


### PR DESCRIPTION
This will extend the timeout period for high-priority events to 6 days, up from 1.5 days.