### PR TITLE
docs: add ktx/crashlytics.md to .opensource/project.json

### DIFF
--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -8,6 +8,7 @@
     "pages": {
         "README.md": "Development Guide",
         "docs/ktx/common.md": "Common KTX",
+        "docs/ktx/crashlytics.md": "Crashlytics KTX",
         "docs/ktx/dynamic-links.md": "Dynamic Links KTX",
         "docs/ktx/firestore.md": "Firestore KTX",
         "docs/ktx/functions.md": "Functions KTX",


### PR DESCRIPTION
When /docs/ktx/crashlytics.md was created in #1620 , it wasn't added to .opensource/project.json, which is causing it to not be shown in the sidebar menu on [firebaseopensource.com](https://firebaseopensource.com/projects/firebase/firebase-android-sdk/)

cc @rlazo 