### PR TITLE
Remove `@hide` javadoc from generated classes

### DIFF
--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
@@ -97,7 +97,6 @@ public class EncodableProcessor extends AbstractProcessor {
     // before and after 9. See https://github.com/google/dagger/pull/882
     TypeSpec.Builder encoderBuilder =
         TypeSpec.classBuilder(className)
-            .addJavadoc("@hide")
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addSuperinterface(configurator)
             .addField(


### PR DESCRIPTION
It's not needed for the documentation purposes as javadoc and dokka only run on source, not generated code.