### PR TITLE
Update Picasso to 2.8

### DIFF
--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/LicenseResolverPluginTests.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/LicenseResolverPluginTests.kt
@@ -135,7 +135,7 @@ class LicenseResolverPluginTests {
             google()
         }
         dependencies {
-            implementation 'com.squareup.picasso:picasso:2.71828'
+            implementation 'com.squareup.picasso:picasso:2.8'
             implementation 'com.squareup.okhttp:okhttp:2.7.5'
         }
 

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
     implementation "com.google.dagger:dagger:2.27"
 
-    implementation "com.squareup.picasso:picasso:2.71828"
+    implementation "com.squareup.picasso:picasso:2.8"
     implementation "com.squareup.okhttp:okhttp:2.7.5"
 
     annotationProcessor "com.google.dagger:dagger-compiler:2.24"


### PR DESCRIPTION
from 2.71828. Closes #1736.

Changelog:
https://github.com/square/picasso/blob/2.8/CHANGELOG.md#version-28-2019-08-10

The notable change is that it migrates Picasso to androidx, so
`firebase-inappmessaging-display` shouldn't need Jetifier anymore.

There was also discussion in the issue linked above around decoupling image loading, but I hope that it wouldn't block a change like this.