### PR TITLE
Also infer Database URL for default App

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -57,7 +57,7 @@ public class FirebaseDatabase {
     if (instance == null) {
       throw new DatabaseException("You must call FirebaseApp.initialize() first.");
     }
-    return getInstance(instance, instance.getOptions().getDatabaseUrl());
+    return getInstance(instance);
   }
 
   /**


### PR DESCRIPTION
This fixes a bug in https://github.com/firebase/firebase-android-sdk/pull/1898. In the original PR, the code path to infer the project ID was not invoked when using the default app.