### PR TITLE
Fix NotInFilter matching

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -659,7 +659,7 @@ public class QueryTest {
     // With Null.
     List<Object> nullArray = new ArrayList<>();
     nullArray.add(null);
-    snapshot = waitFor(collection.whereNotIn("key", nullArray).get());
+    snapshot = waitFor(collection.whereNotIn("zip", nullArray).get());
     assertEquals(new ArrayList<>(), querySnapshotToValues(snapshot));
 
     // With NaN.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/NotInFilter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/NotInFilter.java
@@ -30,6 +30,9 @@ public class NotInFilter extends FieldFilter {
 
   @Override
   public boolean matches(Document doc) {
+    if (Values.contains(getValue().getArrayValue(), Values.NULL_VALUE)) {
+      return false;
+    }
     Value other = doc.getField(getField());
     return other != null && !Values.contains(getValue().getArrayValue(), other);
   }


### PR DESCRIPTION
`whereNotIn(path, Array(null))` always returns an empty list, which means that `NotInFilter.matches()` needs to also not match any documents if the filter's value contains `null`. 

Also added a null serialization test for notIn.