### PR TITLE
Fix auto-value codegen.

### DIFF
--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
@@ -17,6 +17,8 @@ package com.google.firebase.encoders.processor;
 import androidx.annotation.VisibleForTesting;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.firebase.encoders.annotations.Encodable;
 import com.google.firebase.encoders.processor.getters.Getter;
 import com.google.firebase.encoders.processor.getters.GetterFactory;
@@ -30,7 +32,6 @@ import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -127,7 +128,7 @@ public class EncodableProcessor extends AbstractProcessor {
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(Override.class);
 
-    Map<String, TypeSpec> autoValueSupportClasses = new HashMap<>();
+    Multimap<String, TypeSpec> autoValueSupportClasses = ArrayListMultimap.create();
 
     for (Encoder encoder : encoders) {
       encoderBuilder.addType(encoder.code());
@@ -153,7 +154,7 @@ public class EncodableProcessor extends AbstractProcessor {
 
     try {
       file.writeTo(processingEnv.getFiler());
-      for (Map.Entry<String, TypeSpec> autoValue : autoValueSupportClasses.entrySet()) {
+      for (Map.Entry<String, TypeSpec> autoValue : autoValueSupportClasses.entries()) {
         JavaFile.builder(autoValue.getKey(), autoValue.getValue())
             .build()
             .writeTo(processingEnv.getFiler());

--- a/encoders/firebase-encoders-processor/src/test/java/com/google/firebase/encoders/processor/EncodableProcessorTest.java
+++ b/encoders/firebase-encoders-processor/src/test/java/com/google/firebase/encoders/processor/EncodableProcessorTest.java
@@ -254,13 +254,21 @@ public class EncodableProcessorTest {
                     "package com.example;",
                     "import com.google.firebase.encoders.annotations.Encodable;",
                     "@Encodable public class Foo {",
-                    "public com.example.sub.Member getField() { return null; }",
+                    "public com.example.sub.Member getMember() { return null; }",
+                    "public com.example.sub.AnotherMember getAnotherMember() { return null; }",
                     "}"),
                 JavaFileObjects.forSourceLines(
                     "com.example.sub.Member",
                     "package com.example.sub;",
                     "import com.google.auto.value.AutoValue;",
                     "@AutoValue public abstract class Member {",
+                    "public abstract String getField();",
+                    "}"),
+                JavaFileObjects.forSourceLines(
+                    "com.example.sub.AnotherMember",
+                    "package com.example.sub;",
+                    "import com.google.auto.value.AutoValue;",
+                    "@AutoValue public abstract class AnotherMember {",
                     "public abstract String getField();",
                     "}"));
 
@@ -272,10 +280,22 @@ public class EncodableProcessorTest {
             "cfg.registerEncoder("
                 + "com.example.sub.EncodableComExampleFooMemberAutoValueSupport.TYPE,"
                 + " MemberEncoder.INSTANCE)");
+    assertThat(result).succeededWithoutWarnings();
+    assertThat(result)
+        .generatedSourceFile("com/example/AutoFooEncoder")
+        .contentsAsUtf8String()
+        .contains(
+            "cfg.registerEncoder("
+                + "com.example.sub.EncodableComExampleFooAnotherMemberAutoValueSupport.TYPE,"
+                + " AnotherMemberEncoder.INSTANCE)");
     assertThat(result)
         .generatedSourceFile("com/example/sub/EncodableComExampleFooMemberAutoValueSupport")
         .contentsAsUtf8String()
         .contains("Class<? extends Member> TYPE = AutoValue_Member.class");
+    assertThat(result)
+        .generatedSourceFile("com/example/sub/EncodableComExampleFooAnotherMemberAutoValueSupport")
+        .contentsAsUtf8String()
+        .contains("Class<? extends AnotherMember> TYPE = AutoValue_AnotherMember.class");
   }
 
   @Test


### PR DESCRIPTION
The issue arises when there is more than one auto-value class in a
given package, in which case only one "support" class is generated.