### PR TITLE
Read stdout of the process before waiting for it to complete.

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/AffectedProjectFinder.java
@@ -69,10 +69,14 @@ public class AffectedProjectFinder {
   private static Set<String> changedPaths(File workDir) {
     try {
       Process process =
-          Runtime.getRuntime().exec("git diff --name-only --submodule=diff HEAD@{0} HEAD@{1}", null, workDir);
-      process.waitFor();
-      return ImmutableSet.copyOf(
-          CharStreams.readLines(new InputStreamReader(process.getInputStream())));
+          Runtime.getRuntime()
+              .exec("git diff --name-only --submodule=diff HEAD@{0} HEAD@{1}", null, workDir);
+      try {
+        return ImmutableSet.copyOf(
+            CharStreams.readLines(new InputStreamReader(process.getInputStream())));
+      } finally {
+        process.waitFor();
+      }
     } catch (IOException e) {
       throw new GradleException("Could not determine changed files", e);
     } catch (InterruptedException e) {


### PR DESCRIPTION
The issue is that the process can block on writing to stdout if the
amount of data written is bigger than default buffer size.

Hence not trying to read from the process until it finishes causes it to
block forever trying to write to its stdout.