### PR TITLE
Call `setDoOutput(true)` on auth POSTs

### DIFF
--- a/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
@@ -372,6 +372,7 @@ public class FirebaseInstallationServiceClient {
       try {
         httpURLConnection.setRequestMethod("POST");
         httpURLConnection.addRequestProperty("Authorization", "FIS_v2 " + refreshToken);
+        httpURLConnection.setDoOutput(true);
 
         writeGenerateAuthTokenRequestBodyToOutputStream(httpURLConnection);
 


### PR DESCRIPTION
The FirebaseInstallationsServiceClient wasn't calling `setDoOutput(true)` on the `generateAuthToken` method, which was confusing some SSL providers and causing requests to unceremoniously fail. There's a separate issue causing the task failure not to get correctly propagated back to the caller (in this case FCM), but for now this is an easy and correct-seeming fix.