### PR TITLE
Fix NotEquals tests to use deterministic document ordering

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertTrue;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.gms.tasks.Task;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.firebase.firestore.Query.Direction;
 import com.google.firebase.firestore.testutil.EventAccumulator;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -37,6 +37,7 @@ import com.google.firebase.firestore.Query.Direction;
 import com.google.firebase.firestore.testutil.EventAccumulator;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
@@ -507,7 +508,7 @@ public class QueryTest {
     CollectionReference collection = testCollectionWithDocs(allDocs);
 
     // Search for zips not matching 98101.
-    Map<String, Map<String, Object>> expectedDocsMap = Maps.newHashMap(allDocs);
+    Map<String, Map<String, Object>> expectedDocsMap = new LinkedHashMap<>(allDocs);
     expectedDocsMap.remove("c");
     expectedDocsMap.remove("i");
     expectedDocsMap.remove("j");
@@ -516,7 +517,7 @@ public class QueryTest {
     assertEquals(Lists.newArrayList(expectedDocsMap.values()), querySnapshotToValues(snapshot));
 
     // With objects.
-    expectedDocsMap = Maps.newHashMap(allDocs);
+    expectedDocsMap = new LinkedHashMap<>(allDocs);
     expectedDocsMap.remove("h");
     expectedDocsMap.remove("i");
     expectedDocsMap.remove("j");
@@ -524,14 +525,14 @@ public class QueryTest {
     assertEquals(Lists.newArrayList(expectedDocsMap.values()), querySnapshotToValues(snapshot));
 
     // With Null.
-    expectedDocsMap = Maps.newHashMap(allDocs);
+    expectedDocsMap = new LinkedHashMap<>(allDocs);
     expectedDocsMap.remove("i");
     expectedDocsMap.remove("j");
     snapshot = waitFor(collection.whereNotEqualTo("zip", null).get());
     assertEquals(Lists.newArrayList(expectedDocsMap.values()), querySnapshotToValues(snapshot));
 
     // With NaN.
-    expectedDocsMap = Maps.newHashMap(allDocs);
+    expectedDocsMap = new LinkedHashMap<>(allDocs);
     expectedDocsMap.remove("a");
     expectedDocsMap.remove("i");
     expectedDocsMap.remove("j");
@@ -636,7 +637,7 @@ public class QueryTest {
     CollectionReference collection = testCollectionWithDocs(allDocs);
 
     // Search for zips not matching 98101, 98103, or [98101, 98102].
-    Map<String, Map<String, Object>> expectedDocsMap = Maps.newHashMap(allDocs);
+    Map<String, Map<String, Object>> expectedDocsMap = new LinkedHashMap<>(allDocs);
     expectedDocsMap.remove("c");
     expectedDocsMap.remove("d");
     expectedDocsMap.remove("f");
@@ -648,7 +649,7 @@ public class QueryTest {
     assertEquals(Lists.newArrayList(expectedDocsMap.values()), querySnapshotToValues(snapshot));
 
     // With objects.
-    expectedDocsMap = Maps.newHashMap(allDocs);
+    expectedDocsMap = new LinkedHashMap<>(allDocs);
     expectedDocsMap.remove("h");
     expectedDocsMap.remove("i");
     expectedDocsMap.remove("j");
@@ -662,7 +663,7 @@ public class QueryTest {
     assertEquals(new ArrayList<>(), querySnapshotToValues(snapshot));
 
     // With NaN.
-    expectedDocsMap = Maps.newHashMap(allDocs);
+    expectedDocsMap = new LinkedHashMap<>(allDocs);
     expectedDocsMap.remove("a");
     expectedDocsMap.remove("i");
     expectedDocsMap.remove("j");
@@ -670,7 +671,7 @@ public class QueryTest {
     assertEquals(Lists.newArrayList(expectedDocsMap.values()), querySnapshotToValues(snapshot));
 
     // With NaN and a number.
-    expectedDocsMap = Maps.newHashMap(allDocs);
+    expectedDocsMap = new LinkedHashMap<>(allDocs);
     expectedDocsMap.remove("a");
     expectedDocsMap.remove("c");
     expectedDocsMap.remove("i");

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -78,6 +78,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -96,7 +97,7 @@ public class TestUtil {
 
   @SuppressWarnings("unchecked")
   public static <T> Map<String, T> map(Object... entries) {
-    Map<String, T> res = new HashMap<>();
+    Map<String, T> res = new LinkedHashMap<>();
     for (int i = 0; i < entries.length; i += 2) {
       res.put((String) entries[i], (T) entries[i + 1]);
     }


### PR DESCRIPTION
This should fix the test failures in Google3: https://g3c.corp.google.com/results/invocations/1dc2a7dd-1aed-422a-9ddd-282f208b6cd1/targets/%2F%2Fthird_party%2Ffirebase%2Fandroid%2Ffirebase_firestore%2Ftests%2Fintegration_tests:firestore/tests