### PR TITLE
Fix reflection error in com.google.android.datatransport.Priority when using aggressive Proguard rules.

### DIFF
--- a/transport/transport-api/proguard.txt
+++ b/transport/transport-api/proguard.txt
@@ -1,2 +1,5 @@
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.AutoValue$Builder
+-keepclassmembers enum com.google.android.datatransport.Priority {
+     *;
+ }

--- a/transport/transport-api/proguard.txt
+++ b/transport/transport-api/proguard.txt
@@ -1,5 +1,3 @@
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.AutoValue$Builder
--keepclassmembers enum com.google.android.datatransport.Priority {
-     *;
- }
+

--- a/transport/transport-api/proguard.txt
+++ b/transport/transport-api/proguard.txt
@@ -1,3 +1,2 @@
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.AutoValue$Builder
-

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/util/PriorityMapping.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/util/PriorityMapping.java
@@ -17,11 +17,11 @@ package com.google.android.datatransport.runtime.util;
 import android.util.SparseArray;
 import androidx.annotation.NonNull;
 import com.google.android.datatransport.Priority;
-import java.util.EnumMap;
+import java.util.HashMap;
 
 public final class PriorityMapping {
   private static SparseArray<Priority> PRIORITY_MAP = new SparseArray<>();
-  private static EnumMap<Priority, Integer> PRIORITY_INT_MAP = new EnumMap<>(Priority.class);
+  private static HashMap<Priority, Integer> PRIORITY_INT_MAP = new HashMap<>();
 
   static {
     PRIORITY_INT_MAP.put(Priority.DEFAULT, 0);


### PR DESCRIPTION
The enum's values are accessed via reflection, so aggressive Proguard
rules can cause it to be stripped out.
e.g., https://github.com/firebase/firebase-android-sdk/issues/1996