### PR TITLE
Make firebase-common StrictMode-compliant.

### DIFF
--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -84,17 +84,11 @@ dependencies {
 
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 
-    androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.25.0'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
-    androidTestImplementation ('com.google.firebase:firebase-auth:17.0.0') {
-        exclude group: "com.google.firebase", module: "firebase-common"
-    }
-
-    androidTestImplementation ('com.google.firebase:firebase-core:16.0.9') {
-        exclude group: "com.google.firebase", module: "firebase-common"
-    }
 }

--- a/firebase-common/src/androidTest/java/com/google/firebase/FirebaseAppTest.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/FirebaseAppTest.java
@@ -39,9 +39,7 @@ import androidx.test.InstrumentationRegistry;
 import androidx.test.runner.AndroidJUnit4;
 import com.google.android.gms.common.api.internal.BackgroundDetector;
 import com.google.common.base.Defaults;
-import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.components.EagerSdkVerifier;
-import com.google.firebase.components.InitTracker;
 import com.google.firebase.components.TestComponentOne;
 import com.google.firebase.components.TestComponentTwo;
 import com.google.firebase.components.TestUserAgentDependentComponent;
@@ -144,10 +142,8 @@ public class FirebaseAppTest {
 
     // After sorting the user agents are expected to be {"fire-android/", "fire-auth/x.y.z",
     // "fire-core/x.y.z", "test-component/1.2.3"}
-    assertThat(actualUserAgent[0]).contains("fire-analytics");
-    assertThat(actualUserAgent[1]).contains("fire-android");
-    assertThat(actualUserAgent[2]).contains("fire-auth");
-    assertThat(actualUserAgent[3]).contains("fire-core");
+    assertThat(actualUserAgent[0]).contains("fire-android");
+    assertThat(actualUserAgent[1]).contains("fire-core");
   }
 
   @Test
@@ -304,7 +300,7 @@ public class FirebaseAppTest {
   // Order of test cases matters.
   @Test(expected = IllegalStateException.class)
   public void testMissingInit() {
-    FirebaseAuth.getInstance();
+    FirebaseApp.getInstance();
   }
 
   @Test
@@ -313,10 +309,9 @@ public class FirebaseAppTest {
     assertThat(firebaseApp.isDefaultApp()).isFalse();
 
     EagerSdkVerifier sdkVerifier = firebaseApp.get(EagerSdkVerifier.class);
-    assertThat(sdkVerifier.isAuthInitialized()).isTrue();
-
-    // Analytics is only initialized for the default app.
-    assertThat(sdkVerifier.isAnalyticsInitialized()).isFalse();
+    assertThat(sdkVerifier.isEagerInitialized()).isTrue();
+    assertThat(sdkVerifier.isEagerInDefaultAppInitialized()).isFalse();
+    assertThat(sdkVerifier.isLazyInitialized()).isFalse();
   }
 
   @Test
@@ -326,8 +321,9 @@ public class FirebaseAppTest {
     assertThat(firebaseApp.isDefaultApp()).isTrue();
 
     EagerSdkVerifier sdkVerifier = firebaseApp.get(EagerSdkVerifier.class);
-    assertThat(sdkVerifier.isAuthInitialized()).isTrue();
-    assertThat(sdkVerifier.isAnalyticsInitialized()).isTrue();
+    assertThat(sdkVerifier.isEagerInitialized()).isTrue();
+    assertThat(sdkVerifier.isEagerInDefaultAppInitialized()).isTrue();
+    assertThat(sdkVerifier.isLazyInitialized()).isFalse();
   }
 
   @Test
@@ -372,25 +368,20 @@ public class FirebaseAppTest {
     isUserUnlocked.set(false);
     FirebaseApp firebaseApp = FirebaseApp.initializeApp(mockContext);
 
-    InitTracker tracker = firebaseApp.get(InitTracker.class);
     EagerSdkVerifier sdkVerifier = firebaseApp.get(EagerSdkVerifier.class);
 
-    // APIs are not initialized.
-    assertThat(tracker.isInitialized()).isFalse();
-
-    assertThat(sdkVerifier.isAuthInitialized()).isFalse();
-    assertThat(sdkVerifier.isAnalyticsInitialized()).isFalse();
+    assertThat(sdkVerifier.isEagerInitialized()).isFalse();
+    assertThat(sdkVerifier.isEagerInDefaultAppInitialized()).isFalse();
+    assertThat(sdkVerifier.isLazyInitialized()).isFalse();
 
     // User unlocks the device.
     isUserUnlocked.set(true);
     Intent userUnlockBroadcast = new Intent(Intent.ACTION_USER_UNLOCKED);
     localBroadcastManager.sendBroadcastSync(userUnlockBroadcast);
 
-    // APIs are initialized.
-    assertThat(tracker.isInitialized()).isTrue();
-
-    assertThat(sdkVerifier.isAuthInitialized()).isTrue();
-    assertThat(sdkVerifier.isAnalyticsInitialized()).isTrue();
+    assertThat(sdkVerifier.isEagerInitialized()).isTrue();
+    assertThat(sdkVerifier.isEagerInDefaultAppInitialized()).isTrue();
+    assertThat(sdkVerifier.isLazyInitialized()).isFalse();
   }
 
   @Test

--- a/firebase-common/src/androidTest/java/com/google/firebase/StrictModeTest.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/StrictModeTest.java
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase;
+
+import android.os.StrictMode;
+import android.os.StrictMode.ThreadPolicy;
+import android.os.StrictMode.VmPolicy;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.firebase.FirebaseOptions.Builder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
+public class StrictModeTest {
+
+  interface Fn<E extends Throwable> {
+    void call() throws E;
+  }
+
+  static <E extends Throwable> void withStrictMode(Fn<E> fn) throws E {
+    ThreadPolicy threadPolicy = StrictMode.getThreadPolicy();
+    VmPolicy vmPolicy = StrictMode.getVmPolicy();
+
+    StrictMode.setThreadPolicy(new ThreadPolicy.Builder().detectAll().penaltyDeath().build());
+    StrictMode.setVmPolicy(new VmPolicy.Builder().detectAll().penaltyDeath().build());
+    try {
+      fn.call();
+    } finally {
+      StrictMode.setThreadPolicy(threadPolicy);
+      StrictMode.setVmPolicy(vmPolicy);
+    }
+  }
+
+  @Test
+  public void initializingFirebaseApp_shouldNotViolateStrictMode() {
+    withStrictMode(
+        () -> {
+          FirebaseApp app =
+              FirebaseApp.initializeApp(
+                  ApplicationProvider.getApplicationContext(),
+                  new Builder()
+                      .setApiKey("api")
+                      .setProjectId("123")
+                      .setApplicationId("appId")
+                      .build(),
+                  "hello");
+
+          app.initializeAllComponents();
+        });
+  }
+}

--- a/firebase-common/src/androidTest/java/com/google/firebase/components/EagerComponent.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/components/EagerComponent.java
@@ -1,0 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+class EagerComponent extends InitializingComponent {
+
+  EagerComponent(InitializationTracker tracker) {
+    super(tracker);
+  }
+}

--- a/firebase-common/src/androidTest/java/com/google/firebase/components/EagerInDefaultAppComponent.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/components/EagerInDefaultAppComponent.java
@@ -1,0 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+class EagerInDefaultAppComponent extends InitializingComponent {
+
+  EagerInDefaultAppComponent(InitializationTracker tracker) {
+    super(tracker);
+  }
+}

--- a/firebase-common/src/androidTest/java/com/google/firebase/components/InitializationTracker.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/components/InitializationTracker.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,22 +14,17 @@
 
 package com.google.firebase.components;
 
-public class EagerSdkVerifier {
-  private final InitializationTracker initializationTracker;
+import java.util.HashSet;
+import java.util.Set;
 
-  public EagerSdkVerifier(InitializationTracker initializationTracker) {
-    this.initializationTracker = initializationTracker;
+public class InitializationTracker {
+  private final Set<Class<? extends InitializingComponent>> initialized = new HashSet<>();
+
+  synchronized void initialize(Class<? extends InitializingComponent> component) {
+    initialized.add(component);
   }
 
-  public boolean isLazyInitialized() {
-    return initializationTracker.isInitialized(LazyComponent.class);
-  }
-
-  public boolean isEagerInitialized() {
-    return initializationTracker.isInitialized(EagerComponent.class);
-  }
-
-  public boolean isEagerInDefaultAppInitialized() {
-    return initializationTracker.isInitialized(EagerInDefaultAppComponent.class);
+  synchronized boolean isInitialized(Class<? extends InitializingComponent> component) {
+    return initialized.contains(component);
   }
 }

--- a/firebase-common/src/androidTest/java/com/google/firebase/components/InitializingComponent.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/components/InitializingComponent.java
@@ -1,0 +1,21 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+abstract class InitializingComponent {
+  InitializingComponent(InitializationTracker tracker) {
+    tracker.initialize(this.getClass());
+  }
+}

--- a/firebase-common/src/androidTest/java/com/google/firebase/components/LazyComponent.java
+++ b/firebase-common/src/androidTest/java/com/google/firebase/components/LazyComponent.java
@@ -1,0 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+class LazyComponent extends InitializingComponent {
+
+  LazyComponent(InitializationTracker tracker) {
+    super(tracker);
+  }
+}

--- a/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
@@ -29,6 +29,8 @@ import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.RestrictTo.Scope;
 import androidx.annotation.VisibleForTesting;
 import androidx.collection.ArrayMap;
 import androidx.core.os.UserManagerCompat;
@@ -450,6 +452,13 @@ public class FirebaseApp {
   @VisibleForTesting
   public boolean isDefaultApp() {
     return DEFAULT_APP_NAME.equals(getName());
+  }
+
+  /** @hide */
+  @VisibleForTesting
+  @RestrictTo(Scope.TESTS)
+  void initializeAllComponents() {
+    componentRuntime.initializeAllComponentsForTests();
   }
 
   private void notifyBackgroundStateChangeListeners(boolean background) {

--- a/firebase-common/src/main/java/com/google/firebase/heartbeatinfo/DefaultHeartBeatInfo.java
+++ b/firebase-common/src/main/java/com/google/firebase/heartbeatinfo/DefaultHeartBeatInfo.java
@@ -16,31 +16,31 @@ package com.google.firebase.heartbeatinfo;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
-import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.Dependency;
+import com.google.firebase.components.Lazy;
+import com.google.firebase.inject.Provider;
 
 /** Provides information as whether to send heart beat or not. */
 public class DefaultHeartBeatInfo implements HeartBeatInfo {
 
-  private HeartBeatInfoStorage storage;
+  private Provider<HeartBeatInfoStorage> storage;
 
   private DefaultHeartBeatInfo(Context context) {
-    storage = HeartBeatInfoStorage.getInstance(context);
+    this(new Lazy<>(() -> HeartBeatInfoStorage.getInstance(context)));
   }
 
   @VisibleForTesting
-  @RestrictTo(RestrictTo.Scope.TESTS)
-  DefaultHeartBeatInfo(HeartBeatInfoStorage testStorage) {
+  DefaultHeartBeatInfo(Provider<HeartBeatInfoStorage> testStorage) {
     storage = testStorage;
   }
 
   @Override
   public @NonNull HeartBeat getHeartBeatCode(@NonNull String heartBeatTag) {
     long presentTime = System.currentTimeMillis();
-    boolean shouldSendSdkHB = storage.shouldSendSdkHeartBeat(heartBeatTag, presentTime);
-    boolean shouldSendGlobalHB = storage.shouldSendGlobalHeartBeat(presentTime);
+    boolean shouldSendSdkHB = storage.get().shouldSendSdkHeartBeat(heartBeatTag, presentTime);
+    boolean shouldSendGlobalHB = storage.get().shouldSendGlobalHeartBeat(presentTime);
     if (shouldSendSdkHB && shouldSendGlobalHB) {
       return HeartBeat.COMBINED;
     } else if (shouldSendGlobalHB) {

--- a/firebase-common/src/test/java/com/google/firebase/heartbeatinfo/DefaultHeartBeatInfoTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/heartbeatinfo/DefaultHeartBeatInfoTest.java
@@ -28,7 +28,7 @@ import org.junit.runners.JUnit4;
 public class DefaultHeartBeatInfoTest {
   private String testSdk = "fire-test";
   private HeartBeatInfoStorage storage = mock(HeartBeatInfoStorage.class);
-  private DefaultHeartBeatInfo heartBeatInfo = new DefaultHeartBeatInfo(storage);
+  private DefaultHeartBeatInfo heartBeatInfo = new DefaultHeartBeatInfo(() -> storage);
 
   @Test
   public void getHeartBeatCode_noHeartBeat() {

--- a/firebase-components/src/main/java/com/google/firebase/components/ComponentRuntime.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/ComponentRuntime.java
@@ -14,6 +14,9 @@
 
 package com.google.firebase.components;
 
+import androidx.annotation.RestrictTo;
+import androidx.annotation.RestrictTo.Scope;
+import androidx.annotation.VisibleForTesting;
 import com.google.firebase.events.Publisher;
 import com.google.firebase.events.Subscriber;
 import com.google.firebase.inject.Provider;
@@ -160,6 +163,14 @@ public class ComponentRuntime extends AbstractComponentContainer {
     }
 
     eventBus.enablePublishingAndFlushPending();
+  }
+
+  @VisibleForTesting
+  @RestrictTo(Scope.TESTS)
+  public void initializeAllComponentsForTests() {
+    for (Lazy<?> component : components.values()) {
+      component.get();
+    }
   }
 
   private void validateDependencies() {

--- a/firebase-installations/src/main/AndroidManifest.xml
+++ b/firebase-installations/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-    <uses-sdk android:minSdkVersion="14"/>
+<!--    <uses-sdk android:minSdkVersion="14"/>-->
     <application>
         <service
             android:name="com.google.firebase.components.ComponentDiscoveryService"


### PR DESCRIPTION
see: b/128433971

* Makes HeartBeat storage lazy.
* Adds strict mode test for `FirebaseApp#initializeApp()`
* Removes auth and analytics tests, these should be part of product test suites