### PR TITLE
Remove timestampInSnapshots Setting

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Unreleased
+# Unreleased (22.0.0)
+- [changed] Removed the deprecated `timestampsInSnapshotsEnabled` setting.
+  Any timestamps in Firestore documents are now returned as `Timestamps`. To
+  convert `Timestamp` classed to `java.util.Date`, use `Timestamp.toDate()`.
 
 # 21.6.1
 - [changed] Added new internal HTTP headers to the gRPC connection.

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -184,7 +184,6 @@ package com.google.firebase.firestore {
   }
 
   public final class FirebaseFirestoreSettings {
-    method public boolean areTimestampsInSnapshotsEnabled();
     method public long getCacheSizeBytes();
     method @NonNull public String getHost();
     method public boolean isPersistenceEnabled();
@@ -204,7 +203,6 @@ package com.google.firebase.firestore {
     method @NonNull public com.google.firebase.firestore.FirebaseFirestoreSettings.Builder setHost(@NonNull String);
     method @NonNull public com.google.firebase.firestore.FirebaseFirestoreSettings.Builder setPersistenceEnabled(boolean);
     method @NonNull public com.google.firebase.firestore.FirebaseFirestoreSettings.Builder setSslEnabled(boolean);
-    method @Deprecated @NonNull public com.google.firebase.firestore.FirebaseFirestoreSettings.Builder setTimestampsInSnapshotsEnabled(boolean);
   }
 
   public class GeoPoint implements java.lang.Comparable<com.google.firebase.firestore.GeoPoint> {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -139,12 +139,6 @@ public class IntegrationTestUtil {
   }
 
   public static FirebaseFirestoreSettings newTestSettings() {
-    return newTestSettingsWithSnapshotTimestampsEnabled(true);
-  }
-
-  @SuppressWarnings("deprecation") // for setTimestampsInSnapshotsEnabled()
-  public static FirebaseFirestoreSettings newTestSettingsWithSnapshotTimestampsEnabled(
-      boolean enabled) {
     FirebaseFirestoreSettings.Builder settings = new FirebaseFirestoreSettings.Builder();
 
     if (CONNECT_TO_EMULATOR) {
@@ -155,7 +149,6 @@ public class IntegrationTestUtil {
     }
 
     settings.setPersistenceEnabled(true);
-    settings.setTimestampsInSnapshotsEnabled(enabled);
 
     return settings.build();
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestoreSettings.java
@@ -32,14 +32,12 @@ public final class FirebaseFirestoreSettings {
 
   private static final long MINIMUM_CACHE_BYTES = 1 * 1024 * 1024; // 1 MB
   private static final long DEFAULT_CACHE_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB
-  private static final boolean DEFAULT_TIMESTAMPS_IN_SNAPSHOTS_ENABLED = true;
 
   /** A Builder for creating {@code FirebaseFirestoreSettings}. */
   public static final class Builder {
     private String host;
     private boolean sslEnabled;
     private boolean persistenceEnabled;
-    private boolean timestampsInSnapshotsEnabled;
     private long cacheSizeBytes;
 
     /** Constructs a new {@code FirebaseFirestoreSettings} Builder object. */
@@ -47,7 +45,6 @@ public final class FirebaseFirestoreSettings {
       host = DEFAULT_HOST;
       sslEnabled = true;
       persistenceEnabled = true;
-      timestampsInSnapshotsEnabled = DEFAULT_TIMESTAMPS_IN_SNAPSHOTS_ENABLED;
       cacheSizeBytes = DEFAULT_CACHE_SIZE_BYTES;
     }
 
@@ -60,7 +57,6 @@ public final class FirebaseFirestoreSettings {
       host = settings.host;
       sslEnabled = settings.sslEnabled;
       persistenceEnabled = settings.persistenceEnabled;
-      timestampsInSnapshotsEnabled = settings.timestampsInSnapshotsEnabled;
     }
 
     /**
@@ -95,33 +91,6 @@ public final class FirebaseFirestoreSettings {
     @NonNull
     public Builder setPersistenceEnabled(boolean value) {
       this.persistenceEnabled = value;
-      return this;
-    }
-
-    /**
-     * Specifies whether to use {@link com.google.firebase.Timestamp Timestamps} for timestamp
-     * fields in {@link DocumentSnapshot DocumentSnapshots}. This is now enabled by default and
-     * should not be disabled.
-     *
-     * <p>Previously, Cloud Firestore returned timestamp fields as {@link java.util.Date} but {@link
-     * java.util.Date} only supports millisecond precision, which leads to truncation and causes
-     * unexpected behavior when using a timestamp from a snapshot as a part of a subsequent query.
-     *
-     * <p>So now Cloud Firestore returns {@link com.google.firebase.Timestamp Timestamp} values
-     * instead of {@link java.util.Date}, avoiding this kind of problem.
-     *
-     * <p>To opt into the old behavior of returning {@link java.util.Date Dates}, you can
-     * temporarily set {@link FirebaseFirestoreSettings#areTimestampsInSnapshotsEnabled} to false.
-     *
-     * @deprecated This setting now defaults to true and will be removed in a future release. If you
-     *     are already setting it to true, just remove the setting. If you are setting it to false,
-     *     you should update your code to expect {@link com.google.firebase.Timestamp Timestamps}
-     *     instead of {@link java.util.Date Dates} and then remove the setting.
-     */
-    @NonNull
-    @Deprecated
-    public Builder setTimestampsInSnapshotsEnabled(boolean value) {
-      this.timestampsInSnapshotsEnabled = value;
       return this;
     }
 
@@ -180,7 +149,6 @@ public final class FirebaseFirestoreSettings {
   private final String host;
   private final boolean sslEnabled;
   private final boolean persistenceEnabled;
-  private final boolean timestampsInSnapshotsEnabled;
   private final long cacheSizeBytes;
 
   /** Constructs a {@code FirebaseFirestoreSettings} object based on the values in the Builder. */
@@ -188,7 +156,6 @@ public final class FirebaseFirestoreSettings {
     host = builder.host;
     sslEnabled = builder.sslEnabled;
     persistenceEnabled = builder.persistenceEnabled;
-    timestampsInSnapshotsEnabled = builder.timestampsInSnapshotsEnabled;
     cacheSizeBytes = builder.cacheSizeBytes;
   }
 
@@ -205,7 +172,6 @@ public final class FirebaseFirestoreSettings {
     return host.equals(that.host)
         && sslEnabled == that.sslEnabled
         && persistenceEnabled == that.persistenceEnabled
-        && timestampsInSnapshotsEnabled == that.timestampsInSnapshotsEnabled
         && cacheSizeBytes == that.cacheSizeBytes;
   }
 
@@ -214,7 +180,6 @@ public final class FirebaseFirestoreSettings {
     int result = host.hashCode();
     result = 31 * result + (sslEnabled ? 1 : 0);
     result = 31 * result + (persistenceEnabled ? 1 : 0);
-    result = 31 * result + (timestampsInSnapshotsEnabled ? 1 : 0);
     result = 31 * result + (int) cacheSizeBytes;
     return result;
   }
@@ -229,8 +194,6 @@ public final class FirebaseFirestoreSettings {
         + sslEnabled
         + ", persistenceEnabled="
         + persistenceEnabled
-        + ", timestampsInSnapshotsEnabled="
-        + timestampsInSnapshotsEnabled
         + ", cacheSizeBytes="
         + cacheSizeBytes
         + "}";
@@ -250,14 +213,6 @@ public final class FirebaseFirestoreSettings {
   /** Returns whether or not to use local persistent storage. */
   public boolean isPersistenceEnabled() {
     return persistenceEnabled;
-  }
-
-  /**
-   * Returns whether or not {@link DocumentSnapshot DocumentSnapshots} return timestamp fields as
-   * {@link com.google.firebase.Timestamp Timestamps}.
-   */
-  public boolean areTimestampsInSnapshotsEnabled() {
-    return timestampsInSnapshotsEnabled;
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataWriter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/UserDataWriter.java
@@ -50,15 +50,12 @@ import java.util.Map;
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class UserDataWriter {
   private final FirebaseFirestore firestore;
-  private final boolean timestampsInSnapshots;
   private final DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior;
 
   UserDataWriter(
       FirebaseFirestore firestore,
-      boolean timestampsInSnapshots,
       DocumentSnapshot.ServerTimestampBehavior serverTimestampBehavior) {
     this.firestore = firestore;
-    this.timestampsInSnapshots = timestampsInSnapshots;
     this.serverTimestampBehavior = serverTimestampBehavior;
   }
 
@@ -118,12 +115,7 @@ public class UserDataWriter {
   }
 
   private Object convertTimestamp(com.google.protobuf.Timestamp value) {
-    Timestamp timestamp = new Timestamp(value.getSeconds(), value.getNanos());
-    if (timestampsInSnapshots) {
-      return timestamp;
-    } else {
-      return timestamp.toDate();
-    }
+    return new Timestamp(value.getSeconds(), value.getNanos());
   }
 
   private List<Object> convertArray(ArrayValue arrayValue) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/UserDataWriterTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/UserDataWriterTest.java
@@ -162,7 +162,7 @@ public class UserDataWriterTest {
       assertValueType(Value.ValueTypeCase.TIMESTAMP_VALUE, value);
       Object convertedValue = dateWriter.convertValue(value);
       assertTrue(convertedValue instanceof Timestamp);
-      assertEquals(d, ((Timestamp)convertedValue).toDate());
+      assertEquals(d, ((Timestamp) convertedValue).toDate());
     }
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/UserDataWriterTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/UserDataWriterTest.java
@@ -161,7 +161,8 @@ public class UserDataWriterTest {
       Value value = wrap(d);
       assertValueType(Value.ValueTypeCase.TIMESTAMP_VALUE, value);
       Object convertedValue = dateWriter.convertValue(value);
-      assertEquals(d, convertedValue);
+      assertTrue(convertedValue instanceof Timestamp);
+      assertEquals(d, ((Timestamp)convertedValue).toDate());
     }
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/UserDataWriterTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/UserDataWriterTest.java
@@ -48,8 +48,7 @@ import org.robolectric.annotation.Config;
 public class UserDataWriterTest {
 
   private final UserDataWriter writer =
-      new UserDataWriter(
-          TestUtil.firestore(), true, DocumentSnapshot.ServerTimestampBehavior.DEFAULT);
+      new UserDataWriter(TestUtil.firestore(), DocumentSnapshot.ServerTimestampBehavior.DEFAULT);
 
   @Test
   public void testConvertsNullValue() {
@@ -156,10 +155,7 @@ public class UserDataWriterTest {
   @Test
   public void testConvertsDateValue() {
     UserDataWriter dateWriter =
-        new UserDataWriter(
-            TestUtil.firestore(),
-            /* timestampsInSnapshots= */ false,
-            DocumentSnapshot.ServerTimestampBehavior.DEFAULT);
+        new UserDataWriter(TestUtil.firestore(), DocumentSnapshot.ServerTimestampBehavior.DEFAULT);
     List<Date> testCases = asList(new Date(0), new Date(1356048000000L));
     for (Date d : testCases) {
       Value value = wrap(d);


### PR DESCRIPTION
Snapshot data will now always use Timestamp values. Use `Timestamp.toDate()` to convert to `java.util.Date` if required.

`timestampsInSnapshots` was deprecated in January 2019 and has defaulted to true since then.

Port of https://github.com/firebase/firebase-ios-sdk/pull/6622