### PR TITLE
feat(database-ktx): add KTX functions for event listeners

### DIFF
--- a/firebase-database/ktx/src/main/kotlin/com/google/firebase/database/ktx/Database.kt
+++ b/firebase-database/ktx/src/main/kotlin/com/google/firebase/database/ktx/Database.kt
@@ -63,52 +63,33 @@ inline fun <reified T> MutableData.getValue(): T? {
     return getValue(object : GenericTypeIndicator<T>() {})
 }
 
+/**
+ * Add a listener for changes in the data at this location. Each time time the data changes, your
+ * listener will be called with an non-null snapshot of the data.
+ */
 inline fun DatabaseReference.addValueEventListener(
-        crossinline onDataChange: (snapshot: DataSnapshot) -> Unit,
-        crossinline onCancelled: (error: DatabaseError) -> Unit
+        crossinline onValue: (snapshot: DataSnapshot?, error: DatabaseError?) -> Unit
 ): ValueEventListener {
     val listener = object : ValueEventListener {
-        override fun onDataChange(snapshot: DataSnapshot) = onDataChange(snapshot)
-        override fun onCancelled(error: DatabaseError) = onCancelled(error)
+        override fun onDataChange(snapshot: DataSnapshot) = onValue(snapshot, null)
+        override fun onCancelled(error: DatabaseError) = onValue(null, error)
     }
     addValueEventListener(listener)
     return listener
 }
 
+/**
+ * Add a listener for a single change in the data at this location. This listener will be
+ * triggered once with the value of the data at the location.
+ */
 inline fun DatabaseReference.addListenerForSingleValueEvent(
-        crossinline onDataChange: (snapshot: DataSnapshot) -> Unit,
-        crossinline onCancelled: (error: DatabaseError) -> Unit
+        crossinline onceValue: (snapshot: DataSnapshot?, error: DatabaseError?) -> Unit
 ): ValueEventListener {
     val listener = object : ValueEventListener {
-        override fun onDataChange(snapshot: DataSnapshot) = onDataChange(snapshot)
-        override fun onCancelled(error: DatabaseError) = onCancelled(error)
+        override fun onDataChange(snapshot: DataSnapshot) = onceValue(snapshot, null)
+        override fun onCancelled(error: DatabaseError) = onceValue(null, error)
     }
     addListenerForSingleValueEvent(listener)
-    return listener
-}
-
-inline fun DatabaseReference.addChildEventListener(
-        crossinline onChildAdded: (snapshot: DataSnapshot, previousChildName: String?) -> Unit,
-        crossinline onChildChanged: (snapshot: DataSnapshot, previousChildName: String?) -> Unit,
-        crossinline onChildRemoved: (snapshot: DataSnapshot) -> Unit,
-        crossinline onChildMoved: (snapshot: DataSnapshot, previousChildName: String?) -> Unit,
-        crossinline onCancelled: (error: DatabaseError) -> Unit
-): ChildEventListener {
-    val listener = object : ChildEventListener {
-        override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) =
-                onChildAdded(snapshot, previousChildName)
-
-        override fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?) =
-                onChildChanged(snapshot, previousChildName)
-
-        override fun onChildRemoved(snapshot: DataSnapshot) = onChildRemoved(snapshot)
-
-        override fun onChildMoved(snapshot: DataSnapshot, previousChildName: String?) =
-                onChildMoved(snapshot, previousChildName)
-
-        override fun onCancelled(error: DatabaseError) = onCancelled(error)
-    }
-    addChildEventListener(listener)
     return listener
 }
 

--- a/firebase-database/ktx/src/main/kotlin/com/google/firebase/database/ktx/Database.kt
+++ b/firebase-database/ktx/src/main/kotlin/com/google/firebase/database/ktx/Database.kt
@@ -18,10 +18,14 @@ import androidx.annotation.Keep
 import com.google.firebase.FirebaseApp
 import com.google.firebase.components.Component
 import com.google.firebase.components.ComponentRegistrar
+import com.google.firebase.database.ChildEventListener
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.GenericTypeIndicator
 import com.google.firebase.database.MutableData
+import com.google.firebase.database.ValueEventListener
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.platforminfo.LibraryVersionComponent
 
@@ -57,6 +61,55 @@ inline fun <reified T> DataSnapshot.getValue(): T? {
  */
 inline fun <reified T> MutableData.getValue(): T? {
     return getValue(object : GenericTypeIndicator<T>() {})
+}
+
+inline fun DatabaseReference.addValueEventListener(
+        crossinline onDataChange: (snapshot: DataSnapshot) -> Unit,
+        crossinline onCancelled: (error: DatabaseError) -> Unit
+): ValueEventListener {
+    val listener = object : ValueEventListener {
+        override fun onDataChange(snapshot: DataSnapshot) = onDataChange(snapshot)
+        override fun onCancelled(error: DatabaseError) = onCancelled(error)
+    }
+    addValueEventListener(listener)
+    return listener
+}
+
+inline fun DatabaseReference.addListenerForSingleValueEvent(
+        crossinline onDataChange: (snapshot: DataSnapshot) -> Unit,
+        crossinline onCancelled: (error: DatabaseError) -> Unit
+): ValueEventListener {
+    val listener = object : ValueEventListener {
+        override fun onDataChange(snapshot: DataSnapshot) = onDataChange(snapshot)
+        override fun onCancelled(error: DatabaseError) = onCancelled(error)
+    }
+    addListenerForSingleValueEvent(listener)
+    return listener
+}
+
+inline fun DatabaseReference.addChildEventListener(
+        crossinline onChildAdded: (snapshot: DataSnapshot, previousChildName: String?) -> Unit,
+        crossinline onChildChanged: (snapshot: DataSnapshot, previousChildName: String?) -> Unit,
+        crossinline onChildRemoved: (snapshot: DataSnapshot) -> Unit,
+        crossinline onChildMoved: (snapshot: DataSnapshot, previousChildName: String?) -> Unit,
+        crossinline onCancelled: (error: DatabaseError) -> Unit
+): ChildEventListener {
+    val listener = object : ChildEventListener {
+        override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) =
+                onChildAdded(snapshot, previousChildName)
+
+        override fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?) =
+                onChildChanged(snapshot, previousChildName)
+
+        override fun onChildRemoved(snapshot: DataSnapshot) = onChildRemoved(snapshot)
+
+        override fun onChildMoved(snapshot: DataSnapshot, previousChildName: String?) =
+                onChildMoved(snapshot, previousChildName)
+
+        override fun onCancelled(error: DatabaseError) = onCancelled(error)
+    }
+    addChildEventListener(listener)
+    return listener
 }
 
 internal const val LIBRARY_NAME: String = "fire-db-ktx"


### PR DESCRIPTION
### Feature Suggestion: Lambda functions for database event listeners

Particularly, I'm not a fan of the whole `object` kotlin syntax used to add listeners to Database References:
```kotlin
ref.addValueEventListener(object : ValueEventListener {
        override fun onDataChange(snapshot: DataSnapshot) {
            // Use the values
        }
        override fun onCancelled(error: DatabaseError) {
            // Handle the error
        }
    })
```

I would like to suggest using lambda functions to remove some of the boilerplate code.

**Updated suggestion (04/10/2020):** After taking a second look at this, I thought it would be better to use a single lambda function with `DataSnapshot` and `DatabaseError`, making this similar to Firestore's `addSnapshotListener()`:
```kotlin
ref.addValueEventListener { snapshot, error ->
    snapshot?.let {
        // use the values
    }
    error?.let {
        // handle errors
    }
}
```

And I removed the `addChildEventListener()` ktx function from the original suggestion.

#### Original suggestion for reference:

```kotlin
ref.addValueEventListener(
    onDataChange = { snapshot  ->
        // Use the values
    },
    onCancelled = { error ->
        // Handle the error
    }
)
```

The same would happen for **`ChildEventListener`**:
```kotlin
ref.addChildEventListener(
    onChildAdded = { snapshot, previousChildName ->

    },
    onChildChanged = { snapshot, previousChildName ->

    },
    onChildMoved = { snapshot, previousChildName ->

    },
    onChildRemoved = { previousChildName ->

    },
    onCancelled = { error ->

    }
)
```

---

Inspired by the [Animator Listeners](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-master-dev/core/core-ktx/src/main/java/androidx/core/animation/Animator.kt) from Android KTX.