### PR TITLE
Make `ComponentRuntime` mutable.

### DIFF
--- a/firebase-components/firebase-components.gradle
+++ b/firebase-components/firebase-components.gradle
@@ -46,7 +46,7 @@ dependencies {
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:2.25.0'
 

--- a/firebase-components/src/main/java/com/google/firebase/components/Deferred.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/Deferred.java
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+import com.google.firebase.inject.Provider;
+
+/**
+ * Mutable thread-safe {@link Provider}.
+ *
+ * <p>Can be updated to a new value with the {@link #set(Provider)} method.
+ *
+ * <p>The intent of this class is to be used in place of missing {@link Component} dependencies so
+ * that they can be updated if dependencies are loaded later.
+ */
+class Deferred<T> implements Provider<T> {
+  private static final Provider<Object> EMPTY_PROVIDER = () -> null;
+
+  @SuppressWarnings("unchecked")
+  private volatile Provider<T> delegate = (Provider<T>) EMPTY_PROVIDER;
+
+  @Override
+  public T get() {
+    return delegate.get();
+  }
+
+  void set(Provider<T> newProvider) {
+    delegate = newProvider;
+  }
+}

--- a/firebase-components/src/main/java/com/google/firebase/components/LazySet.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/LazySet.java
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+import com.google.firebase.inject.Provider;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Lazy mutable thread-safe {@link Provider} for {@link Set}s.
+ *
+ * <p>The actual set is materialized only when first requested via {@link #get()}.
+ *
+ * <p>As new values are added to the set via {@link #add(Provider)}, the underlying set is updated
+ * with the new value.
+ */
+class LazySet<T> implements Provider<Set<T>> {
+
+  private volatile Set<Provider<T>> providers;
+  private volatile Set<T> actualSet = null;
+
+  LazySet(Collection<Provider<T>> providers) {
+    this.providers = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    this.providers.addAll(providers);
+  }
+
+  static Provider<Set<?>> fromCollection(Collection<Provider<?>> providers) {
+    @SuppressWarnings("unchecked")
+    Provider<Set<?>> result =
+        (Provider<Set<?>>)
+            (Provider<?>) new LazySet<>((Collection<Provider<Object>>) (Set<?>) providers);
+    return result;
+  }
+
+  @Override
+  public Set<T> get() {
+    if (actualSet == null) {
+      synchronized (this) {
+        if (actualSet == null) {
+          actualSet = Collections.newSetFromMap(new ConcurrentHashMap<>());
+          updateSet();
+        }
+      }
+    }
+    return Collections.unmodifiableSet(actualSet);
+  }
+
+  void add(Provider<T> newProvider) {
+    if (actualSet == null) {
+      synchronized (this) {
+        if (actualSet == null) {
+          providers.add(newProvider);
+        }
+      }
+    } else {
+      actualSet.add(newProvider.get());
+    }
+  }
+
+  private synchronized void updateSet() {
+    for (Provider<T> provider : providers) {
+      actualSet.add(provider.get());
+    }
+    providers = null;
+  }
+}

--- a/firebase-components/src/test/java/com/google/firebase/components/ComponentRuntimeTest.java
+++ b/firebase-components/src/test/java/com/google/firebase/components/ComponentRuntimeTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -301,7 +302,8 @@ public final class ComponentRuntimeTest {
             Component.intoSet(1, Integer.class),
             Component.intoSet(2, Integer.class));
 
-    assertThat(runtime.setOf(Integer.class)).containsExactly(1, 2);
+    Set<Integer> integers = runtime.setOf(Integer.class);
+    assertThat(integers).containsExactly(1, 2);
   }
 
   @Test

--- a/firebase-components/src/test/java/com/google/firebase/components/DeferredTest.java
+++ b/firebase-components/src/test/java/com/google/firebase/components/DeferredTest.java
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DeferredTest {
+  private static final String DEFERRED_VALUE = "hello";
+
+  @Test
+  public void test() {
+    Deferred<String> deferred = new Deferred<>();
+    assertThat(deferred.get()).isNull();
+
+    deferred.set(() -> DEFERRED_VALUE);
+
+    assertThat(deferred.get()).isEqualTo(DEFERRED_VALUE);
+  }
+}

--- a/firebase-components/src/test/java/com/google/firebase/components/LazySetTest.java
+++ b/firebase-components/src/test/java/com/google/firebase/components/LazySetTest.java
@@ -1,0 +1,107 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.firebase.inject.Provider;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class LazySetTest {
+
+  @Test
+  public void lazySet_shouldBeExternallyImmutable() {
+    Set<Integer> integers = setOf(() -> 1, () -> 2).get();
+    assertThrows(UnsupportedOperationException.class, () -> integers.add(3));
+  }
+
+  @Test
+  public void add_whenUnderlyingSetAlreadyInitialized_shouldUpdateUnderlyingSet() {
+
+    LazySet<Integer> lazySet = setOf(() -> 1, () -> 2);
+
+    Set<Integer> integers = lazySet.get();
+    assertThat(integers).containsExactly(1, 2);
+
+    lazySet.add(() -> 3);
+
+    assertThat(integers).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  public void add_whenUnderlyingSetNotInitializedYet_shouldUpdateProviderSet() {
+
+    LazySet<Integer> lazySet = setOf(() -> 1, () -> 2);
+
+    lazySet.add(() -> 3);
+
+    Set<Integer> integers = lazySet.get();
+    assertThat(integers).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  public void get_shouldInitializeEachSetMemberExactlyOnce() {
+    AtomicInteger initialized = new AtomicInteger(0);
+    LazySet<Integer> lazySet =
+        setOf(
+            () -> 1,
+            () -> {
+              initialized.incrementAndGet();
+              return 2;
+            });
+    assertThat(initialized.get()).isEqualTo(0);
+
+    lazySet.add(() -> 3);
+
+    assertThat(initialized.get()).isEqualTo(0);
+
+    Set<Integer> integers = lazySet.get();
+    assertThat(integers).containsExactly(1, 2, 3);
+    assertThat(initialized.get()).isEqualTo(1);
+
+    lazySet.get();
+    assertThat(initialized.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void add_whenSetNotInitializedYet_shouldNotInitializeSet() {
+    AtomicInteger initialized = new AtomicInteger(0);
+    LazySet<Integer> lazySet =
+        setOf(
+            () -> 1,
+            () -> {
+              initialized.incrementAndGet();
+              return 2;
+            });
+    assertThat(initialized.get()).isEqualTo(0);
+
+    lazySet.add(() -> 3);
+
+    assertThat(initialized.get()).isEqualTo(0);
+  }
+
+  @SafeVarargs
+  private final <T> LazySet<T> setOf(Provider<T>... ts) {
+    return new LazySet<>(new HashSet<>(Arrays.asList(ts)));
+  }
+}

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseContextProvider.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseContextProvider.java
@@ -37,7 +37,7 @@ class FirebaseContextProvider implements ContextProvider {
   @Override
   public Task<HttpsCallableContext> getContext() {
 
-    if (tokenProvider == null) {
+    if (tokenProvider == null || tokenProvider.get() == null) {
       TaskCompletionSource<HttpsCallableContext> tcs = new TaskCompletionSource<>();
       tcs.setResult(new HttpsCallableContext(null, instanceId.get().getToken()));
       return tcs.getTask();


### PR DESCRIPTION
This is done in preparation for dynamic module loading support.

The gist of the change is to make:

* Missing optional dependencies backed by "empty" providers. That can be
  mutated at runtime to start returning non-null values if dependencies
  become available
* Set components backed by thread-safe `Set`s that can be extended with
  newly loaded dependencies.