### PR TITLE
Log FIS auth token instead of displaying it in the RC test app.

### DIFF
--- a/firebase-config/bandwagoner/src/main/java/com/googletest/firebase/remoteconfig/bandwagoner/ApiFragment.java
+++ b/firebase-config/bandwagoner/src/main/java/com/googletest/firebase/remoteconfig/bandwagoner/ApiFragment.java
@@ -110,7 +110,11 @@ public class ApiFragment extends Fragment {
               }
 
               if (installationAuthTokenTask.isSuccessful()) {
-                apiCallResultsText.setText(installationAuthTokenTask.getResult().getToken());
+                Log.i(
+                    TAG,
+                    String.format(
+                        "Installation authentication token: %s",
+                        installationAuthTokenTask.getResult().getToken()));
               } else {
                 Log.e(
                     TAG,


### PR DESCRIPTION
Displaying the token after a network call creates a race condition that sometimes replaces the contents of this field Espresso integration tests. Besides, it's more useful to have the token in a copy-able log than displayed in the app.