### PR TITLE
Double check for events after parsing report data

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
@@ -306,6 +306,12 @@ public class CrashlyticsReportPersistence {
       }
     }
 
+    // b/168902195
+    if (events.isEmpty()) {
+      Logger.getLogger().d("Could not parse event files for session " + sessionDirectory.getName());
+      return;
+    }
+
     String userId = null;
     final File userIdFile = new File(sessionDirectory, USER_FILE_NAME);
     if (userIdFile.isFile()) {


### PR DESCRIPTION
In the case that event files are found but cannot be read or
parsed, we might write a session with no events. To mitigate this,
we will double-check to make sure we've parsed the events properly
before synthesizing a report file.