### PR TITLE
test(installations-ktx): Functions --> Installations

### DIFF
--- a/firebase-installations/ktx/src/test/kotlin/com/google/firebase/installations/ktx/InstallationsTests.kt
+++ b/firebase-installations/ktx/src/test/kotlin/com/google/firebase/installations/ktx/InstallationsTests.kt
@@ -64,14 +64,14 @@ abstract class BaseTestCase {
 }
 
 @RunWith(RobolectricTestRunner::class)
-class FunctionsTests : BaseTestCase() {
+class InstallationsTests : BaseTestCase() {
     @Test
-    fun `installations should delegate to FirebaseFunctions#getInstance()`() {
+    fun `installations should delegate to FirebaseInstallations#getInstance()`() {
         Truth.assertThat(Firebase.installations).isSameInstanceAs(FirebaseInstallations.getInstance())
     }
 
     @Test
-    fun `functions(app) should delegate to FirebaseFunctions#getInstance(FirebaseApp)`() {
+    fun `installations(app) should delegate to FirebaseInstallations#getInstance(FirebaseApp)`() {
         val app = Firebase.app(EXISTING_APP)
         Truth.assertThat(Firebase.installations(app)).isSameInstanceAs(FirebaseInstallations.getInstance(app))
     }


### PR DESCRIPTION
This is a minor issue: it looks like there was a copy-paste error when writing the tests for firebase-installations-ktx.

cc: @vkryachko 