### PR TITLE
Add dynamic loading support to component discovery.

### DIFF
--- a/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
@@ -48,6 +48,7 @@ import com.google.firebase.components.ComponentRuntime;
 import com.google.firebase.components.Lazy;
 import com.google.firebase.events.Publisher;
 import com.google.firebase.heartbeatinfo.DefaultHeartBeatInfo;
+import com.google.firebase.inject.Provider;
 import com.google.firebase.internal.DataCollectionConfigStorage;
 import com.google.firebase.platforminfo.DefaultUserAgentPublisher;
 import com.google.firebase.platforminfo.KotlinDetector;
@@ -416,13 +417,13 @@ public class FirebaseApp {
     this.name = Preconditions.checkNotEmpty(name);
     this.options = Preconditions.checkNotNull(options);
 
-    List<ComponentRegistrar> registrars =
+    List<Provider<ComponentRegistrar>> registrars =
         ComponentDiscovery.forContext(applicationContext, ComponentDiscoveryService.class)
-            .discover();
+            .discoverLazy();
 
     String kotlinVersion = KotlinDetector.detectVersion();
     componentRuntime =
-        new ComponentRuntime(
+        ComponentRuntime.create(
             UI_EXECUTOR,
             registrars,
             Component.of(applicationContext, Context.class),

--- a/firebase-components/src/main/java/com/google/firebase/components/ComponentDiscovery.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/ComponentDiscovery.java
@@ -21,7 +21,9 @@ import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
 import android.os.Bundle;
 import android.util.Log;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import com.google.firebase.inject.Provider;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,7 +51,7 @@ public final class ComponentDiscovery<T> {
     List<String> retrieve(T ctx);
   }
 
-  private static final String TAG = "ComponentDiscovery";
+  static final String TAG = "ComponentDiscovery";
   private static final String COMPONENT_SENTINEL_VALUE =
       "com.google.firebase.components.ComponentRegistrar";
   private static final String COMPONENT_KEY_PREFIX = "com.google.firebase.components:";
@@ -68,37 +70,62 @@ public final class ComponentDiscovery<T> {
     this.retriever = retriever;
   }
 
-  /** Returns the discovered {@link ComponentRegistrar}s. */
+  /**
+   * Returns the discovered {@link ComponentRegistrar}s.
+   *
+   * @deprecated Use {@link #discoverLazy()} instead.
+   */
+  @Deprecated
   public List<ComponentRegistrar> discover() {
-    return instantiate(retriever.retrieve(context));
-  }
-
-  private static List<ComponentRegistrar> instantiate(List<String> registrarNames) {
-    List<ComponentRegistrar> registrars = new ArrayList<>();
-    for (String name : registrarNames) {
+    List<ComponentRegistrar> result = new ArrayList<>();
+    for (String registrarName : retriever.retrieve(context)) {
       try {
-        Class<?> loadedClass = Class.forName(name);
-        if (!ComponentRegistrar.class.isAssignableFrom(loadedClass)) {
-          Log.w(
-              TAG,
-              String.format("Class %s is not an instance of %s", name, COMPONENT_SENTINEL_VALUE));
-          continue;
+        ComponentRegistrar registrar = instantiate(registrarName);
+        if (registrar != null) {
+          result.add(registrar);
         }
-        registrars.add((ComponentRegistrar) loadedClass.getDeclaredConstructor().newInstance());
-      } catch (ClassNotFoundException e) {
-        Log.w(TAG, String.format("Class %s is not an found.", name), e);
-      } catch (IllegalAccessException e) {
-        Log.w(TAG, String.format("Could not instantiate %s.", name), e);
-      } catch (InstantiationException e) {
-        Log.w(TAG, String.format("Could not instantiate %s.", name), e);
-      } catch (NoSuchMethodException e) {
-        Log.w(TAG, String.format("Could not instantiate %s", name), e);
-      } catch (InvocationTargetException e) {
-        Log.w(TAG, String.format("Could not instantiate %s", name), e);
+      } catch (InvalidRegistrarException ex) {
+        Log.w(TAG, "Invalid component registrar.", ex);
       }
     }
+    return result;
+  }
 
-    return registrars;
+  public List<Provider<ComponentRegistrar>> discoverLazy() {
+    List<Provider<ComponentRegistrar>> result = new ArrayList<>();
+    for (String registrarName : retriever.retrieve(context)) {
+      result.add(() -> instantiate(registrarName));
+    }
+    return result;
+  }
+
+  @Nullable
+  private static ComponentRegistrar instantiate(String registrarName) {
+    try {
+      Class<?> loadedClass = Class.forName(registrarName);
+      if (!ComponentRegistrar.class.isAssignableFrom(loadedClass)) {
+        throw new InvalidRegistrarException(
+            String.format(
+                "Class %s is not an instance of %s", registrarName, COMPONENT_SENTINEL_VALUE));
+      }
+      return (ComponentRegistrar) loadedClass.getDeclaredConstructor().newInstance();
+    } catch (ClassNotFoundException e) {
+      Log.w(TAG, String.format("Class %s is not an found.", registrarName), e);
+      return null;
+    } catch (IllegalAccessException e) {
+      throw new InvalidRegistrarException(
+          String.format("Could not instantiate %s.", registrarName), e);
+
+    } catch (InstantiationException e) {
+      throw new InvalidRegistrarException(
+          String.format("Could not instantiate %s.", registrarName), e);
+    } catch (NoSuchMethodException e) {
+      throw new InvalidRegistrarException(
+          String.format("Could not instantiate %s", registrarName), e);
+    } catch (InvocationTargetException e) {
+      throw new InvalidRegistrarException(
+          String.format("Could not instantiate %s", registrarName), e);
+    }
   }
 
   private static class MetadataRegistrarNameRetriever implements RegistrarNameRetriever<Context> {

--- a/firebase-components/src/main/java/com/google/firebase/components/ComponentDiscovery.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/ComponentDiscovery.java
@@ -91,6 +91,21 @@ public final class ComponentDiscovery<T> {
     return result;
   }
 
+  /**
+   * Returns a list of candidate {@link ComponentRegistrar} {@link Provider}s.
+   *
+   * <p>The returned list contains lazy providers that are based on <strong>all</strong> discovered
+   * registrar names. However, when called the providers behave in the following way:
+   *
+   * <ul>
+   *   <li>If the registrar class is not found, it will return {@code null}. It's possible that this
+   *       provider will return valid registrar at a later time.
+   *   <li>If the registrar does not implement {@link ComponentRegistrar}, will throw {@link
+   *       InvalidRegistrarException}.
+   *   <li>If the registrar is a private class, will throw {@link InvalidRegistrarException}.
+   *   <li>If the registrar has a private constructor, will throw {@link InvalidRegistrarException}.
+   *   <li>If the registrar's constructor fails, will throw {@link InvalidRegistrarException}.
+   */
   public List<Provider<ComponentRegistrar>> discoverLazy() {
     List<Provider<ComponentRegistrar>> result = new ArrayList<>();
     for (String registrarName : retriever.retrieve(context)) {

--- a/firebase-components/src/main/java/com/google/firebase/components/ComponentRuntime.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/ComponentRuntime.java
@@ -150,9 +150,6 @@ public class ComponentRuntime extends AbstractComponentContainer implements Comp
   }
 
   private static <T> List<T> iterableToList(Iterable<T> iterable) {
-    if (iterable instanceof List) {
-      return (List<T>) iterable;
-    }
     ArrayList<T> result = new ArrayList<>();
     for (T item : iterable) {
       result.add(item);

--- a/firebase-components/src/main/java/com/google/firebase/components/ComponentRuntime.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/ComponentRuntime.java
@@ -14,9 +14,11 @@
 
 package com.google.firebase.components;
 
+import android.util.Log;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
 import androidx.annotation.VisibleForTesting;
+import com.google.firebase.dynamicloading.ComponentLoader;
 import com.google.firebase.events.Publisher;
 import com.google.firebase.events.Subscriber;
 import com.google.firebase.inject.Provider;
@@ -24,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,35 +38,86 @@ import java.util.concurrent.Executor;
  * <p>Does {@link Component} dependency resolution and provides access to resolved {@link
  * Component}s via {@link #get(Class)} method.
  */
-public class ComponentRuntime extends AbstractComponentContainer {
+public class ComponentRuntime extends AbstractComponentContainer implements ComponentLoader {
   private static final Provider<Set<Object>> EMPTY_PROVIDER = Collections::emptySet;
   private final Map<Component<?>, Provider<?>> components = new HashMap<>();
   private final Map<Class<?>, Provider<?>> lazyInstanceMap = new HashMap<>();
-  private final Map<Class<?>, Provider<Set<?>>> lazySetMap = new HashMap<>();
+  private final Map<Class<?>, LazySet<?>> lazySetMap = new HashMap<>();
+  private final List<Provider<ComponentRegistrar>> unprocessedRegistrarProviders;
   private final EventBus eventBus;
+  private Boolean eagerComponentsInitializedWith = null;
+
+  /**
+   * Creates an instance of {@link ComponentRuntime} for the provided {@link ComponentRegistrar}s
+   * and any additional components.
+   *
+   * @deprecated Use {@link #create(Executor, Iterable, Component[])} instead.
+   */
+  @Deprecated
+  public ComponentRuntime(
+      Executor defaultEventExecutor,
+      Iterable<ComponentRegistrar> registrars,
+      Component<?>... additionalComponents) {
+    this(defaultEventExecutor, toProviders(registrars), true, additionalComponents);
+  }
 
   /**
    * Creates an instance of {@link ComponentRuntime} for the provided {@link ComponentRegistrar}s
    * and any additional components.
    */
-  public ComponentRuntime(
+  public static ComponentRuntime create(
       Executor defaultEventExecutor,
-      Iterable<ComponentRegistrar> registrars,
+      Iterable<Provider<ComponentRegistrar>> registrars,
+      Component<?>... additionalComponents) {
+    return new ComponentRuntime(defaultEventExecutor, registrars, true, additionalComponents);
+  }
+
+  private ComponentRuntime(
+      Executor defaultEventExecutor,
+      Iterable<Provider<ComponentRegistrar>> registrars,
+      boolean disambiguateConstructorOverload,
       Component<?>... additionalComponents) {
     eventBus = new EventBus(defaultEventExecutor);
-    List<Component<?>> componentsToAdd = new ArrayList<>();
-    componentsToAdd.add(Component.of(eventBus, EventBus.class, Subscriber.class, Publisher.class));
 
-    for (ComponentRegistrar registrar : registrars) {
-      componentsToAdd.addAll(registrar.getComponents());
-    }
+    List<Component<?>> componentsToAdd = new ArrayList<>();
+
+    componentsToAdd.add(Component.of(eventBus, EventBus.class, Subscriber.class, Publisher.class));
+    componentsToAdd.add(Component.of(this, ComponentLoader.class));
     for (Component<?> additionalComponent : additionalComponents) {
       if (additionalComponent != null) {
         componentsToAdd.add(additionalComponent);
       }
     }
 
-    CycleDetector.detect(componentsToAdd);
+    unprocessedRegistrarProviders = iterableToList(registrars);
+
+    discoverComponents(componentsToAdd);
+  }
+
+  private synchronized void discoverComponents(List<Component<?>> componentsToAdd) {
+
+    Iterator<Provider<ComponentRegistrar>> iterator = unprocessedRegistrarProviders.iterator();
+    while (iterator.hasNext()) {
+      Provider<ComponentRegistrar> provider = iterator.next();
+      try {
+        ComponentRegistrar registrar = provider.get();
+        if (registrar != null) {
+          componentsToAdd.addAll(registrar.getComponents());
+          iterator.remove();
+        }
+      } catch (InvalidRegistrarException ex) {
+        iterator.remove();
+        Log.w(ComponentDiscovery.TAG, "Invalid component registrar.", ex);
+      }
+    }
+
+    if (components.isEmpty()) {
+      CycleDetector.detect(componentsToAdd);
+    } else {
+      ArrayList<Component<?>> allComponents = new ArrayList<>(this.components.keySet());
+      allComponents.addAll(componentsToAdd);
+      CycleDetector.detect(allComponents);
+    }
 
     for (Component<?> component : componentsToAdd) {
       Lazy<?> lazy =
@@ -73,21 +127,57 @@ public class ComponentRuntime extends AbstractComponentContainer {
 
       components.put(component, lazy);
     }
-    processInstanceComponents();
+
+    processInstanceComponents(componentsToAdd);
     processSetComponents();
     processDependencies();
+    maybeInitializeEagerComponents();
   }
 
-  private void processInstanceComponents() {
-    for (Map.Entry<Component<?>, Provider<?>> entry : components.entrySet()) {
-      Component<?> component = entry.getKey();
+  private void maybeInitializeEagerComponents() {
+    if (eagerComponentsInitializedWith != null) {
+      doInitializeEagerComponents(eagerComponentsInitializedWith);
+    }
+  }
+
+  private static Iterable<Provider<ComponentRegistrar>> toProviders(
+      Iterable<ComponentRegistrar> registrars) {
+    List<Provider<ComponentRegistrar>> result = new ArrayList<>();
+    for (ComponentRegistrar registrar : registrars) {
+      result.add(() -> registrar);
+    }
+    return result;
+  }
+
+  private static <T> List<T> iterableToList(Iterable<T> iterable) {
+    if (iterable instanceof List) {
+      return (List<T>) iterable;
+    }
+    ArrayList<T> result = new ArrayList<>();
+    for (T item : iterable) {
+      result.add(item);
+    }
+    return result;
+  }
+
+  private void processInstanceComponents(List<Component<?>> componentsToProcess) {
+    for (Component<?> component : componentsToProcess) {
       if (!component.isValue()) {
         continue;
       }
 
-      Provider<?> provider = entry.getValue();
+      Provider<?> provider = components.get(component);
       for (Class<?> anInterface : component.getProvidedInterfaces()) {
-        lazyInstanceMap.put(anInterface, provider);
+        if (!lazyInstanceMap.containsKey(anInterface)) {
+          lazyInstanceMap.put(anInterface, provider);
+        } else {
+          Provider<?> existingProvider = lazyInstanceMap.get(anInterface);
+          @SuppressWarnings("unchecked")
+          OptionalProvider<Object> deferred = (OptionalProvider<Object>) existingProvider;
+          @SuppressWarnings("unchecked")
+          Provider<Object> castedProvider = (Provider<Object>) provider;
+          deferred.set(castedProvider);
+        }
       }
     }
   }
@@ -114,21 +204,28 @@ public class ComponentRuntime extends AbstractComponentContainer {
     }
 
     for (Map.Entry<Class<?>, Set<Provider<?>>> entry : setIndex.entrySet()) {
-      lazySetMap.put(entry.getKey(), LazySet.fromCollection(entry.getValue()));
+      if (!lazySetMap.containsKey(entry.getKey())) {
+        lazySetMap.put(entry.getKey(), LazySet.fromCollection(entry.getValue()));
+      } else {
+        LazySet<Object> existingSet = (LazySet<Object>) lazySetMap.get(entry.getKey());
+        for (Provider<?> provider : entry.getValue()) {
+          existingSet.add((Provider<Object>) provider);
+        }
+      }
     }
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T> Provider<T> getProvider(Class<T> anInterface) {
+  public synchronized <T> Provider<T> getProvider(Class<T> anInterface) {
     Preconditions.checkNotNull(anInterface, "Null interface requested.");
     return (Provider<T>) lazyInstanceMap.get(anInterface);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T> Provider<Set<T>> setOfProvider(Class<T> anInterface) {
-    Provider<Set<?>> provider = lazySetMap.get(anInterface);
+  public synchronized <T> Provider<Set<T>> setOfProvider(Class<T> anInterface) {
+    LazySet<?> provider = lazySetMap.get(anInterface);
     if (provider != null) {
       return (Provider<Set<T>>) (Provider<?>) provider;
     }
@@ -142,7 +239,15 @@ public class ComponentRuntime extends AbstractComponentContainer {
    *
    * <p>Note: the method is idempotent.
    */
-  public void initializeEagerComponents(boolean isDefaultApp) {
+  public synchronized void initializeEagerComponents(boolean isDefaultApp) {
+    if (eagerComponentsInitializedWith != null) {
+      return;
+    }
+    eagerComponentsInitializedWith = isDefaultApp;
+    doInitializeEagerComponents(isDefaultApp);
+  }
+
+  private void doInitializeEagerComponents(boolean isDefaultApp) {
     for (Map.Entry<Component<?>, Provider<?>> entry : components.entrySet()) {
       Component<?> component = entry.getKey();
       Provider<?> provider = entry.getValue();
@@ -153,6 +258,14 @@ public class ComponentRuntime extends AbstractComponentContainer {
     }
 
     eventBus.enablePublishingAndFlushPending();
+  }
+
+  @Override
+  public synchronized void discoverComponents() {
+    if (unprocessedRegistrarProviders.isEmpty()) {
+      return;
+    }
+    discoverComponents(new ArrayList<>());
   }
 
   @VisibleForTesting
@@ -175,7 +288,7 @@ public class ComponentRuntime extends AbstractComponentContainer {
                     "Unsatisfied dependency for component %s: %s",
                     component, dependency.getInterface()));
           } else if (!dependency.isSet()) {
-            lazyInstanceMap.put(dependency.getInterface(), new Deferred<>());
+            lazyInstanceMap.put(dependency.getInterface(), new OptionalProvider<>());
           }
         }
       }

--- a/firebase-components/src/main/java/com/google/firebase/components/InvalidRegistrarException.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/InvalidRegistrarException.java
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.components;
+
+/**
+ * Exception thrown when a {@link ComponentRegistrar} is invalid.
+ *
+ * <p>This can happen for the following reasons:
+ *
+ * <ul>
+ *   <li>Class does not implement {@link ComponentRegistrar}
+ *   <li>Class is private or has a private constructor
+ *   <li>Class's constructor throws an exception
+ */
+public class InvalidRegistrarException extends RuntimeException {
+  public InvalidRegistrarException(String message) {
+    super(message);
+  }
+
+  public InvalidRegistrarException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/firebase-components/src/main/java/com/google/firebase/components/LazySet.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/LazySet.java
@@ -38,12 +38,10 @@ class LazySet<T> implements Provider<Set<T>> {
     this.providers.addAll(providers);
   }
 
-  static Provider<Set<?>> fromCollection(Collection<Provider<?>> providers) {
+  static LazySet<?> fromCollection(Collection<Provider<?>> providers) {
     @SuppressWarnings("unchecked")
-    Provider<Set<?>> result =
-        (Provider<Set<?>>)
-            (Provider<?>) new LazySet<>((Collection<Provider<Object>>) (Set<?>) providers);
-    return result;
+    Collection<Provider<Object>> casted = (Collection<Provider<Object>>) (Set<?>) providers;
+    return new LazySet<>(casted);
   }
 
   @Override

--- a/firebase-components/src/main/java/com/google/firebase/components/OptionalProvider.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/OptionalProvider.java
@@ -24,7 +24,7 @@ import com.google.firebase.inject.Provider;
  * <p>The intent of this class is to be used in place of missing {@link Component} dependencies so
  * that they can be updated if dependencies are loaded later.
  */
-class Deferred<T> implements Provider<T> {
+class OptionalProvider<T> implements Provider<T> {
   private static final Provider<Object> EMPTY_PROVIDER = () -> null;
 
   @SuppressWarnings("unchecked")

--- a/firebase-components/src/main/java/com/google/firebase/components/RestrictedComponentContainer.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/RestrictedComponentContainer.java
@@ -67,12 +67,12 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
   /**
    * Returns an instance of the requested class if it is allowed.
    *
-   * @throws IllegalArgumentException otherwise.
+   * @throws DependencyException otherwise.
    */
   @Override
   public <T> T get(Class<T> anInterface) {
     if (!allowedDirectInterfaces.contains(anInterface)) {
-      throw new IllegalArgumentException(
+      throw new DependencyException(
           String.format("Attempting to request an undeclared dependency %s.", anInterface));
     }
 
@@ -93,12 +93,12 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
   /**
    * Returns an instance of the provider for the requested class if it is allowed.
    *
-   * @throws IllegalArgumentException otherwise.
+   * @throws DependencyException otherwise.
    */
   @Override
   public <T> Provider<T> getProvider(Class<T> anInterface) {
     if (!allowedProviderInterfaces.contains(anInterface)) {
-      throw new IllegalArgumentException(
+      throw new DependencyException(
           String.format(
               "Attempting to request an undeclared dependency Provider<%s>.", anInterface));
     }
@@ -108,12 +108,12 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
   /**
    * Returns an instance of the provider for the set of requested classes if it is allowed.
    *
-   * @throws IllegalArgumentException otherwise.
+   * @throws DependencyException otherwise.
    */
   @Override
   public <T> Provider<Set<T>> setOfProvider(Class<T> anInterface) {
     if (!allowedSetProviderInterfaces.contains(anInterface)) {
-      throw new IllegalArgumentException(
+      throw new DependencyException(
           String.format(
               "Attempting to request an undeclared dependency Provider<Set<%s>>.", anInterface));
     }
@@ -123,12 +123,12 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
   /**
    * Returns a set of requested classes if it is allowed.
    *
-   * @throws IllegalArgumentException otherwise.
+   * @throws DependencyException otherwise.
    */
   @Override
   public <T> Set<T> setOf(Class<T> anInterface) {
     if (!allowedSetDirectInterfaces.contains(anInterface)) {
-      throw new IllegalArgumentException(
+      throw new DependencyException(
           String.format("Attempting to request an undeclared dependency Set<%s>.", anInterface));
     }
     return delegateContainer.setOf(anInterface);
@@ -150,7 +150,7 @@ final class RestrictedComponentContainer extends AbstractComponentContainer {
     @Override
     public void publish(Event<?> event) {
       if (!allowedPublishedEvents.contains(event.getType())) {
-        throw new IllegalArgumentException(
+        throw new DependencyException(
             String.format("Attempting to publish an undeclared event %s.", event));
       }
       delegate.publish(event);

--- a/firebase-components/src/main/java/com/google/firebase/dynamicloading/ComponentLoader.java
+++ b/firebase-components/src/main/java/com/google/firebase/dynamicloading/ComponentLoader.java
@@ -1,0 +1,19 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.firebase.dynamicloading;
+
+/** Provides ability to discover newly loaded components. */
+public interface ComponentLoader {
+  void discoverComponents();
+}

--- a/firebase-components/src/main/java/com/google/firebase/dynamicloading/package-info.java
+++ b/firebase-components/src/main/java/com/google/firebase/dynamicloading/package-info.java
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/** @hide */
+package com.google.firebase.dynamicloading;

--- a/firebase-components/src/test/java/com/google/firebase/components/OptionalProviderTest.java
+++ b/firebase-components/src/test/java/com/google/firebase/components/OptionalProviderTest.java
@@ -21,16 +21,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class DeferredTest {
+public class OptionalProviderTest {
   private static final String DEFERRED_VALUE = "hello";
 
   @Test
   public void test() {
-    Deferred<String> deferred = new Deferred<>();
-    assertThat(deferred.get()).isNull();
+    OptionalProvider<String> optional = new OptionalProvider<>();
+    assertThat(optional.get()).isNull();
 
-    deferred.set(() -> DEFERRED_VALUE);
+    optional.set(() -> DEFERRED_VALUE);
 
-    assertThat(deferred.get()).isEqualTo(DEFERRED_VALUE);
+    assertThat(optional.get()).isEqualTo(DEFERRED_VALUE);
   }
 }

--- a/firebase-components/src/test/java/com/google/firebase/components/RestrictedComponentContainerTest.java
+++ b/firebase-components/src/test/java/com/google/firebase/components/RestrictedComponentContainerTest.java
@@ -66,7 +66,7 @@ public final class RestrictedComponentContainerTest {
     try {
       container.get(List.class);
       fail("Expected exception not thrown.");
-    } catch (IllegalArgumentException ex) {
+    } catch (DependencyException ex) {
       assertThat(ex.getMessage()).contains("java.util.List");
     }
   }
@@ -76,7 +76,7 @@ public final class RestrictedComponentContainerTest {
     try {
       container.get(Double.class);
       fail("Expected exception not thrown.");
-    } catch (IllegalArgumentException ex) {
+    } catch (DependencyException ex) {
       assertThat(ex.getMessage()).contains("java.lang.Double");
     }
   }
@@ -86,7 +86,7 @@ public final class RestrictedComponentContainerTest {
     try {
       container.get(Publisher.class);
       fail("Expected exception not thrown.");
-    } catch (IllegalArgumentException ex) {
+    } catch (DependencyException ex) {
       assertThat(ex.getMessage()).contains("events.Publisher");
     }
   }
@@ -105,7 +105,7 @@ public final class RestrictedComponentContainerTest {
     try {
       container.getProvider(List.class);
       fail("Expected exception not thrown.");
-    } catch (IllegalArgumentException ex) {
+    } catch (DependencyException ex) {
       assertThat(ex.getMessage()).contains("java.util.List");
     }
   }
@@ -115,7 +115,7 @@ public final class RestrictedComponentContainerTest {
     try {
       container.getProvider(Float.class);
       fail("Expected exception not thrown.");
-    } catch (IllegalArgumentException ex) {
+    } catch (DependencyException ex) {
       assertThat(ex.getMessage()).contains("java.lang.Float");
     }
   }
@@ -134,7 +134,7 @@ public final class RestrictedComponentContainerTest {
     try {
       container.setOf(List.class);
       fail("Expected exception not thrown.");
-    } catch (IllegalArgumentException ex) {
+    } catch (DependencyException ex) {
       assertThat(ex.getMessage()).contains("java.util.List");
     }
   }
@@ -153,7 +153,7 @@ public final class RestrictedComponentContainerTest {
     try {
       container.setOf(List.class);
       fail("Expected exception not thrown.");
-    } catch (IllegalArgumentException ex) {
+    } catch (DependencyException ex) {
       assertThat(ex.getMessage()).contains("java.util.List");
     }
   }
@@ -179,7 +179,7 @@ public final class RestrictedComponentContainerTest {
     try {
       publisher.publish(event);
       fail("Expected exception not thrown.");
-    } catch (IllegalArgumentException ex) {
+    } catch (DependencyException ex) {
       assertThat(ex.getMessage()).contains("java.lang.Double");
     }
 


### PR DESCRIPTION
* `ComponentRuntime` will now store any registrar names that failed to
  load due to `ClassNotFoundException` for future use.
* `ComponentRuntime` will provide a new `ComponentLoader` component that
  can be used by interested parties to trigger component discovery. This
  will be used by the new "dynamic-module-support" sdk to trigger
  discovery upon new module installation.