### PR TITLE
Adds firebase-dynamic-module-support SDK.

### DIFF
--- a/firebase-common/src/main/AndroidManifest.xml
+++ b/firebase-common/src/main/AndroidManifest.xml
@@ -30,6 +30,11 @@
             android:name="com.google.firebase.components.ComponentDiscoveryService"
             android:directBootAware="true"
             android:exported="false"
-            tools:targetApi="n" />
+            tools:targetApi="n">
+            <!--This registrar is not defined in the dynamic-module-support sdk itself to allow non-firebase
+                clients to use it as well, by defining this registrar in their own core/common library.-->
+            <meta-data android:name="com.google.firebase.components:com.google.firebase.dynamicloading.DynamicLoadingRegistrar"
+              android:value="com.google.firebase.components.ComponentRegistrar" />
+        </service>
     </application>
 </manifest>

--- a/firebase-components/firebase-dynamic-module-support/api.txt
+++ b/firebase-components/firebase-dynamic-module-support/api.txt
@@ -1,0 +1,1 @@
+// Signature format: 2.0

--- a/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle
+++ b/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle
@@ -1,0 +1,47 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id 'firebase-library'
+}
+
+firebaseLibrary {
+    testLab.enabled = false
+    publishSources = true
+}
+
+android {
+    compileSdkVersion project.targetSdkVersion
+    defaultConfig {
+      minSdkVersion project.minSdkVersion
+      targetSdkVersion project.targetSdkVersion
+      versionName version
+      testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    implementation project(':firebase-common')
+    implementation project(':firebase-components')
+    implementation 'com.google.android.play:core:1.8.2'
+}

--- a/firebase-components/firebase-dynamic-module-support/src/main/AndroidManifest.xml
+++ b/firebase-components/firebase-dynamic-module-support/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.firebase.dynamicloading">
+    <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
+    <!--<uses-sdk android:minSdkVersion="14"/>-->
+</manifest>

--- a/firebase-components/firebase-dynamic-module-support/src/main/java/com/google/firebase/dynamicloading/DynamicLoadingRegistrar.java
+++ b/firebase-components/firebase-dynamic-module-support/src/main/java/com/google/firebase/dynamicloading/DynamicLoadingRegistrar.java
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.dynamicloading;
+
+import android.content.Context;
+import com.google.firebase.components.Component;
+import com.google.firebase.components.ComponentRegistrar;
+import com.google.firebase.components.Dependency;
+import java.util.Collections;
+import java.util.List;
+
+public class DynamicLoadingRegistrar implements ComponentRegistrar {
+
+  @Override
+  public List<Component<?>> getComponents() {
+    return Collections.singletonList(
+        Component.builder(DynamicLoadingSupport.class)
+            .add(Dependency.required(Context.class))
+            .add(Dependency.required(ComponentLoader.class))
+            .alwaysEager()
+            .factory(
+                container ->
+                    new DynamicLoadingSupport(
+                        container.get(Context.class), container.get(ComponentLoader.class)))
+            .build());
+  }
+}

--- a/firebase-components/firebase-dynamic-module-support/src/main/java/com/google/firebase/dynamicloading/DynamicLoadingSupport.java
+++ b/firebase-components/firebase-dynamic-module-support/src/main/java/com/google/firebase/dynamicloading/DynamicLoadingSupport.java
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.dynamicloading;
+
+import android.content.Context;
+import com.google.android.play.core.splitinstall.SplitInstallManagerFactory;
+import com.google.android.play.core.splitinstall.SplitInstallSessionState;
+import com.google.android.play.core.splitinstall.SplitInstallStateUpdatedListener;
+import com.google.android.play.core.splitinstall.model.SplitInstallSessionStatus;
+
+/** Registers a {@link SplitInstallStateUpdatedListener} to trigger component discovery. */
+class DynamicLoadingSupport implements SplitInstallStateUpdatedListener {
+  private final ComponentLoader loader;
+
+  DynamicLoadingSupport(Context applicationContext, ComponentLoader loader) {
+    this.loader = loader;
+    // TODO(vkryachko): make sure this listener runs before any developers' listeners.
+    // TODO(vkryachko): we should probably postpone this via Handler#post(Runnable).
+    SplitInstallManagerFactory.create(applicationContext).registerListener(this);
+  }
+
+  @Override
+  public void onStateUpdate(SplitInstallSessionState state) {
+    if (state.status() == SplitInstallSessionStatus.INSTALLED) {
+      loader.discoverComponents();
+    }
+  }
+}

--- a/firebase-components/firebase-dynamic-module-support/src/main/java/com/google/firebase/dynamicloading/package-info.java
+++ b/firebase-components/firebase-dynamic-module-support/src/main/java/com/google/firebase/dynamicloading/package-info.java
@@ -1,0 +1,16 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @hide */
+package com.google.firebase.dynamicloading;

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -3,6 +3,7 @@ firebase-common
 firebase-common:data-collection-tests
 firebase-common:ktx
 firebase-components
+firebase-components:firebase-dynamic-module-support
 firebase-config
 firebase-config:ktx
 firebase-config:bandwagoner


### PR DESCRIPTION
This SDK will be declared as a dependency in the developers' base bundle.
This ensures that:
* `firebase-common` ends up in the base bundle, which is required since it
  exposes an exported android component, namely `FirebaseInitProvider`.
  Failing to do so would result in the app crashing at start up while
  trying to load the missing content provider.
* Upon install of new modules, an attempt is made to load
  `ComponentRegistrars` that were previouly missing(if any). This makes
  it possible for developers to start using newly loaded Firebase SDKs
  immediately upon install.