### PR TITLE
Enforce asserts only in debug builds

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,6 +1,12 @@
-# Unreleased
+# 19.5.1 (Unreleased)
+- [fixed] Fixes a regression in v19.4 that may cause assertion failures,
+  especially when persistence is enabled.
+
+# 19.5.0
 - [changed] The SDK can now infer a default database URL if none is provided in
   the config.
+
+# 19.4.0
 - [changed] Added internal HTTP header to the WebChannel connection.
 - [feature] Realtime Database now supports connecting to a local emulator via
  `FirebaseDatabase#useEmulator()`

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/Utilities.java
@@ -16,10 +16,12 @@ package com.google.firebase.database.core.utilities;
 
 import android.net.Uri;
 import android.util.Base64;
+import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.firebase.database.BuildConfig;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseException;
 import com.google.firebase.database.DatabaseReference;
@@ -231,7 +233,11 @@ public class Utilities {
 
   public static void hardAssert(boolean condition, String message) {
     if (!condition) {
-      throw new AssertionError("hardAssert failed: " + message);
+      if (BuildConfig.DEBUG) {
+        throw new AssertionError("hardAssert failed: " + message);
+      } else {
+        Log.w("FirebaseDatabase", "Assertion failed: " + message);
+      }
     }
   }
 


### PR DESCRIPTION
In 19.4, we replaced Java `assert` statements with custom asserts to address lint warnings, as `assert` is disabled on Android. This however caused the clients to crash, which indicates that at least some of our asserts are problematic. We can safely revert to the previous state by only enabling these asserts in debug builds.

Fixes https://github.com/firebase/firebase-android-sdk/issues/2069