### PR TITLE
Add development_platform for Unity crash reports

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -218,7 +218,8 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
               "installerPackageName",
               "packageName",
               "versionCode",
-              "versionName");
+              "versionName",
+              unityVersionProvider);
 
       final CrashlyticsController controller =
           new CrashlyticsController(
@@ -233,7 +234,6 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
               reportManager,
               reportUploaderProvider,
               nativeComponent,
-              unityVersionProvider,
               analyticsEventLogger,
               testSettingsDataProvider);
       return controller;

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
@@ -25,6 +25,8 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution;
 import com.google.firebase.crashlytics.internal.stacktrace.StackTraceTrimmingStrategy;
+import com.google.firebase.crashlytics.internal.unity.ResourceUnityVersionProvider;
+import com.google.firebase.crashlytics.internal.unity.UnityVersionProvider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import java.util.List;
 import org.junit.Before;
@@ -55,7 +57,9 @@ public class CrashlyticsReportDataCaptureTest {
     final Context context = ApplicationProvider.getApplicationContext();
     final IdManager idManager =
         new IdManager(context, context.getPackageName(), installationsApiMock);
-    final AppData appData = AppData.create(context, idManager, "googleAppId", "buildId");
+    final UnityVersionProvider unityVersionProvider = new ResourceUnityVersionProvider(context);
+    final AppData appData =
+        AppData.create(context, idManager, "googleAppId", "buildId", unityVersionProvider);
     dataCapture =
         new CrashlyticsReportDataCapture(context, idManager, appData, stackTraceTrimmingStrategy);
     timestamp = System.currentTimeMillis();

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransformTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransformTest.java
@@ -42,7 +42,16 @@ public class CrashlyticsReportJsonTransformTest {
 
   @Test
   public void testReportToJsonAndBack_equals() throws IOException {
-    final CrashlyticsReport testReport = makeTestReport();
+    final CrashlyticsReport testReport = makeTestReport(false);
+    final String testReportJson = transform.reportToJson(testReport);
+    final CrashlyticsReport reifiedReport = transform.reportFromJson(testReportJson);
+    assertNotSame(reifiedReport, testReport);
+    assertEquals(reifiedReport, testReport);
+  }
+
+  @Test
+  public void testReportToJsonAndBack_with_developmentPlatform_equals() throws IOException {
+    final CrashlyticsReport testReport = makeTestReport(true);
     final String testReportJson = transform.reportToJson(testReport);
     final CrashlyticsReport reifiedReport = transform.reportFromJson(testReportJson);
     assertNotSame(reifiedReport, testReport);
@@ -58,7 +67,7 @@ public class CrashlyticsReportJsonTransformTest {
     assertEquals(reifiedEvent, testEvent);
   }
 
-  private static CrashlyticsReport makeTestReport() {
+  private static CrashlyticsReport makeTestReport(boolean useDevelopmentPlatform) {
     return CrashlyticsReport.builder()
         .setSdkVersion("sdkVersion")
         .setGmpAppId("gmpAppId")
@@ -66,29 +75,35 @@ public class CrashlyticsReportJsonTransformTest {
         .setInstallationUuid("installationId")
         .setBuildVersion("1")
         .setDisplayVersion("1.0.0")
-        .setSession(makeTestSession())
+        .setSession(makeTestSession(useDevelopmentPlatform))
         .build();
   }
 
-  private static CrashlyticsReport.Session makeTestSession() {
+  private static CrashlyticsReport.Session makeTestSession(boolean useDevelopmentPlatform) {
     return Session.builder()
         .setGenerator("generator")
         .setIdentifier("identifier")
         .setStartedAt(1L)
         .setEndedAt(1L)
         .setCrashed(true)
-        .setApp(makeTestApplication())
+        .setApp(makeTestApplication(useDevelopmentPlatform))
         .setUser(User.builder().setIdentifier("user").build())
         .setGeneratorType(3)
         .build();
   }
 
-  private static Application makeTestApplication() {
-    return Application.builder()
-        .setIdentifier("applicationId")
-        .setVersion("version")
-        .setDisplayVersion("displayVersion")
-        .build();
+  private static Application makeTestApplication(boolean useDevelopmentPlatform) {
+    final Application.Builder builder =
+        Application.builder()
+            .setIdentifier("applicationId")
+            .setVersion("version")
+            .setDisplayVersion("displayVersion");
+    if (useDevelopmentPlatform) {
+      builder
+          .setDevelopmentPlatform("developmentPlatform")
+          .setDevelopmentPlatformVersion("developmentPlatformVersion");
+    }
+    return builder.build();
   }
 
   private static ImmutableList<Event> makeTestEvents(int numEvents) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/AppData.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/AppData.java
@@ -17,6 +17,7 @@ package com.google.firebase.crashlytics.internal.common;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import com.google.firebase.crashlytics.internal.unity.UnityVersionProvider;
 
 /** Carries static information about the app. */
 class AppData {
@@ -29,8 +30,14 @@ class AppData {
   public final String versionCode;
   public final String versionName;
 
+  public final UnityVersionProvider unityVersionProvider;
+
   public static AppData create(
-      Context context, IdManager idManager, String googleAppId, String buildId)
+      Context context,
+      IdManager idManager,
+      String googleAppId,
+      String buildId,
+      UnityVersionProvider unityVersionProvider)
       throws PackageManager.NameNotFoundException {
     final String packageName = context.getPackageName();
     final String installerPackageName = idManager.getInstallerPackageName();
@@ -41,7 +48,13 @@ class AppData {
         packageInfo.versionName == null ? IdManager.DEFAULT_VERSION_NAME : packageInfo.versionName;
 
     return new AppData(
-        googleAppId, buildId, installerPackageName, packageName, versionCode, versionName);
+        googleAppId,
+        buildId,
+        installerPackageName,
+        packageName,
+        versionCode,
+        versionName,
+        unityVersionProvider);
   }
 
   public AppData(
@@ -50,12 +63,14 @@ class AppData {
       String installerPackageName,
       String packageName,
       String versionCode,
-      String versionName) {
+      String versionName,
+      UnityVersionProvider unityVersionProvider) {
     this.googleAppId = googleAppId;
     this.buildId = buildId;
     this.installerPackageName = installerPackageName;
     this.packageName = packageName;
     this.versionCode = versionCode;
     this.versionName = versionName;
+    this.unityVersionProvider = unityVersionProvider;
   }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -55,7 +55,6 @@ import com.google.firebase.crashlytics.internal.stacktrace.MiddleOutFallbackStra
 import com.google.firebase.crashlytics.internal.stacktrace.RemoveRepeatsStrategy;
 import com.google.firebase.crashlytics.internal.stacktrace.StackTraceTrimmingStrategy;
 import com.google.firebase.crashlytics.internal.stacktrace.TrimmedThrowableData;
-import com.google.firebase.crashlytics.internal.unity.UnityVersionProvider;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -294,7 +293,6 @@ class CrashlyticsController {
       ReportManager reportManager,
       ReportUploader.Provider reportUploaderProvider,
       CrashlyticsNativeComponent nativeComponent,
-      UnityVersionProvider unityVersionProvider,
       AnalyticsEventLogger analyticsEventLogger,
       SettingsDataProvider settingsDataProvider) {
     this.context = context;
@@ -312,7 +310,7 @@ class CrashlyticsController {
       this.reportUploaderProvider = defaultReportUploader();
     }
     this.nativeComponent = nativeComponent;
-    this.unityVersion = unityVersionProvider.getUnityVersion();
+    this.unityVersion = appData.unityVersionProvider.getUnityVersion();
     this.analyticsEventLogger = analyticsEventLogger;
 
     this.userMetadata = new UserMetadata();

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -134,8 +134,9 @@ public class CrashlyticsCore {
 
       final HttpRequestFactory httpRequestFactory = new HttpRequestFactory();
 
-      final AppData appData = AppData.create(context, idManager, googleAppId, mappingFileId);
       final UnityVersionProvider unityVersionProvider = new ResourceUnityVersionProvider(context);
+      final AppData appData =
+          AppData.create(context, idManager, googleAppId, mappingFileId, unityVersionProvider);
 
       Logger.getLogger().d("Installer package name is: " + appData.installerPackageName);
 
@@ -152,7 +153,6 @@ public class CrashlyticsCore {
               null,
               null,
               nativeComponent,
-              unityVersionProvider,
               analyticsEventLogger,
               settingsProvider);
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
@@ -137,12 +137,20 @@ public class CrashlyticsReportDataCapture {
   }
 
   private CrashlyticsReport.Session.Application populateSessionApplicationData() {
-    return CrashlyticsReport.Session.Application.builder()
-        .setIdentifier(idManager.getAppIdentifier())
-        .setVersion(appData.versionCode)
-        .setDisplayVersion(appData.versionName)
-        .setInstallationUuid(idManager.getCrashlyticsInstallId())
-        .build();
+    CrashlyticsReport.Session.Application.Builder builder =
+        CrashlyticsReport.Session.Application.builder()
+            .setIdentifier(idManager.getAppIdentifier())
+            .setVersion(appData.versionCode)
+            .setDisplayVersion(appData.versionName)
+            .setInstallationUuid(idManager.getCrashlyticsInstallId());
+
+    final String unityVersion = appData.unityVersionProvider.getUnityVersion();
+    if (unityVersion != null) {
+      builder
+          .setDevelopmentPlatform(CrashlyticsReport.DEVELOPMENT_PLATFORM_UNITY)
+          .setDevelopmentPlatformVersion(unityVersion);
+    }
+    return builder.build();
   }
 
   private CrashlyticsReport.Session.OperatingSystem populateSessionOperatingSystemData() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
@@ -137,7 +137,7 @@ public class CrashlyticsReportDataCapture {
   }
 
   private CrashlyticsReport.Session.Application populateSessionApplicationData() {
-    CrashlyticsReport.Session.Application.Builder builder =
+    final CrashlyticsReport.Session.Application.Builder builder =
         CrashlyticsReport.Session.Application.builder()
             .setIdentifier(idManager.getAppIdentifier())
             .setVersion(appData.versionCode)

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -63,6 +63,8 @@ public abstract class CrashlyticsReport {
     NATIVE
   }
 
+  public static final String DEVELOPMENT_PLATFORM_UNITY = "Unity";
+
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   @NonNull
@@ -416,6 +418,12 @@ public abstract class CrashlyticsReport {
       @Nullable
       public abstract String getInstallationUuid();
 
+      @Nullable
+      public abstract String getDevelopmentPlatform();
+
+      @Nullable
+      public abstract String getDevelopmentPlatformVersion();
+
       @NonNull
       protected abstract Builder toBuilder();
 
@@ -445,6 +453,13 @@ public abstract class CrashlyticsReport {
 
         @NonNull
         public abstract Builder setInstallationUuid(@NonNull String installationUuid);
+
+        @NonNull
+        public abstract Builder setDevelopmentPlatform(@Nullable String developmentPlatform);
+
+        @NonNull
+        public abstract Builder setDevelopmentPlatformVersion(
+            @Nullable String developmentPlatformVersion);
 
         @NonNull
         public abstract Application build();

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
@@ -254,6 +254,12 @@ public class CrashlyticsReportJsonTransform {
         case "installationUuid":
           builder.setInstallationUuid(jsonReader.nextString());
           break;
+        case "developmentPlatform":
+          builder.setDevelopmentPlatform(jsonReader.nextString());
+          break;
+        case "developmentPlatformVersion":
+          builder.setDevelopmentPlatformVersion(jsonReader.nextString());
+          break;
         default:
           jsonReader.skipValue();
           break;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/proto/SessionProtobufHelper.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/proto/SessionProtobufHelper.java
@@ -16,6 +16,7 @@ package com.google.firebase.crashlytics.internal.proto;
 
 import android.app.ActivityManager;
 import com.google.firebase.crashlytics.internal.Logger;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.stacktrace.TrimmedThrowableData;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +31,8 @@ public class SessionProtobufHelper {
   private static final ByteString SIGNAL_DEFAULT_BYTE_STRING =
       ByteString.copyFromUtf8(SIGNAL_DEFAULT);
 
-  private static final ByteString UNITY_PLATFORM_BYTE_STRING = ByteString.copyFromUtf8("Unity");
+  private static final ByteString UNITY_PLATFORM_BYTE_STRING =
+      ByteString.copyFromUtf8(CrashlyticsReport.DEVELOPMENT_PLATFORM_UNITY);
 
   private SessionProtobufHelper() {}
 


### PR DESCRIPTION
Crashlytics reports sent via DataTransport erroneously did not set the
development_platform field for Unity apps. This results in incorrect
internal metrics for Unity apps. b/171214452