### PR TITLE
Depend on IllegalArgumentException or NullPointerException to check if corrrect firelog support exists - allowing this to not import com.google.android.datatransport.cct.CCTDestination

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingRegistrar.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingRegistrar.java
@@ -74,20 +74,12 @@ public class FirebaseMessagingRegistrar implements ComponentRegistrar {
     // in 1p context there is no dependency on firebase-datatransport, so the factory may be
     // missing. Note that it is possible for it to be present if another SDK(e.g. fiam) is used in
     // the 1p app.
-    if (realFactory == null || !isFirelogJsonAvailable()) {
-      return new DevNullTransportFactory();
-    }
-
-    return realFactory;
-  }
-
-  static boolean isFirelogJsonAvailable() {
     try {
-      Class<?> clazz = Class.forName("com.google.android.datatransport.cct.CCTDestination");
-      Set<Encoding> encodingSet = (Set<Encoding>) clazz.getField("SUPPORTED_ENCODINGS").get(null);
-      return encodingSet.contains(Encoding.of("json"));
-    } catch (Exception e) {
-      return false;
+      // TODO: make sure this statement does not get proguarded away.
+      realFactory.getTransport("test", String.class, Encoding.of("json"), String::getBytes);
+      return realFactory;
+    } catch (IllegalArgumentException | NullPointerException e) {
+      return new DevNullTransportFactory();
     }
   }
 

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingRegistrar.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingRegistrar.java
@@ -33,7 +33,6 @@ import com.google.firebase.platforminfo.LibraryVersionComponent;
 import com.google.firebase.platforminfo.UserAgentPublisher;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 
 /**
  * {@link ComponentRegistrar} for FirebaseMessaging - see

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingRegistrar.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingRegistrar.java
@@ -21,7 +21,6 @@ import com.google.android.datatransport.Transformer;
 import com.google.android.datatransport.Transport;
 import com.google.android.datatransport.TransportFactory;
 import com.google.android.datatransport.TransportScheduleCallback;
-import com.google.android.datatransport.cct.CCTDestination;
 import com.google.android.gms.common.annotation.KeepForSdk;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.components.Component;
@@ -34,6 +33,7 @@ import com.google.firebase.platforminfo.LibraryVersionComponent;
 import com.google.firebase.platforminfo.UserAgentPublisher;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * {@link ComponentRegistrar} for FirebaseMessaging - see
@@ -74,12 +74,21 @@ public class FirebaseMessagingRegistrar implements ComponentRegistrar {
     // in 1p context there is no dependency on firebase-datatransport, so the factory may be
     // missing. Note that it is possible for it to be present if another SDK(e.g. fiam) is used in
     // the 1p app.
-    if (realFactory == null
-        || !CCTDestination.LEGACY_INSTANCE.getSupportedEncodings().contains(Encoding.of("json"))) {
+    if (realFactory == null || !isFirelogJsonAvailable()) {
       return new DevNullTransportFactory();
     }
 
     return realFactory;
+  }
+
+  static boolean isFirelogJsonAvailable() {
+    try {
+      Class<?> clazz = Class.forName("com.google.android.datatransport.cct.CCTDestination");
+      Set<Encoding> encodingSet = (Set<Encoding>) clazz.getField("SUPPORTED_ENCODINGS").get(null);
+      return encodingSet.contains(Encoding.of("json"));
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   /** Produces Transports that don't send events anywhere. */

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CCTDestination.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CCTDestination.java
@@ -40,6 +40,7 @@ public final class CCTDestination implements EncodedDestination {
   private static final String EXTRAS_VERSION_MARKER = "1$";
   private static final String EXTRAS_DELIMITER = "\\";
 
+  // This is private, but is used in reflection by firebase messaging, so changing it will break it.
   private static final Set<Encoding> SUPPORTED_ENCODINGS =
       Collections.unmodifiableSet(
           new HashSet<>(Arrays.asList(Encoding.of("proto"), Encoding.of("json"))));

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CCTDestination.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CCTDestination.java
@@ -40,7 +40,6 @@ public final class CCTDestination implements EncodedDestination {
   private static final String EXTRAS_VERSION_MARKER = "1$";
   private static final String EXTRAS_DELIMITER = "\\";
 
-  // This is private, but is used by reflection in firebase messaging, so changing it will break it.
   private static final Set<Encoding> SUPPORTED_ENCODINGS =
       Collections.unmodifiableSet(
           new HashSet<>(Arrays.asList(Encoding.of("proto"), Encoding.of("json"))));

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CCTDestination.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CCTDestination.java
@@ -40,7 +40,7 @@ public final class CCTDestination implements EncodedDestination {
   private static final String EXTRAS_VERSION_MARKER = "1$";
   private static final String EXTRAS_DELIMITER = "\\";
 
-  // This is private, but is used in reflection by firebase messaging, so changing it will break it.
+  // This is private, but is used by reflection in firebase messaging, so changing it will break it.
   private static final Set<Encoding> SUPPORTED_ENCODINGS =
       Collections.unmodifiableSet(
           new HashSet<>(Arrays.asList(Encoding.of("proto"), Encoding.of("json"))));


### PR DESCRIPTION
This check conflicts with Firebase Crashlytics internally - and this is a *potential* solution. Let me know if I'm missing any better ideas!