### PR TITLE
Include runtimeOnly dependencies in javadocClasspath.

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Dokka.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Dokka.java
@@ -62,6 +62,10 @@ final class Dokka {
           .attribute(
               BuildTypeAttr.ATTRIBUTE, project.getObjects().named(BuildTypeAttr.class, "release"));
     }
+    Configuration runtimeOnly = project.getConfigurations().findByName("runtimeOnly");
+    if(runtimeOnly != null) {
+      javadocClasspath.extendsFrom(runtimeOnly);
+    }
 
     project.afterEvaluate(
         p -> {


### PR DESCRIPTION
This makes such dependencies' symbols available during javadoc/dokka
runs.