### PR TITLE
Remove special instructions for requiring NDK r17c.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,6 @@ projects may be published as follows.
     publishProjectsToMavenLocal
 ```
 
-**Note:** Firebase Crashlytics NDK requires NDK version r17c to build. Please
-see the [README](firebase-crashlytics-ndk/README.md) for setup instructions.
-Alternatively, if you do not need to build this project, you can safely disable
-it by commenting out its reference in [subprojects.cfg](subprojects.cfg).
-
 ### Code Formatting
 
 Code in this repo is formatted with the google-java-format tool. You can enable

--- a/firebase-crashlytics-ndk/README.md
+++ b/firebase-crashlytics-ndk/README.md
@@ -4,18 +4,10 @@ This component enables NDK crash reporting with Crashlytics.
 
 ## Prerequisites
 
-This project depends on two submodules in the `third_party` directory.
+This project depends on three submodules in the `third_party` directory.
 Initialize them by running the following commands:
 
 `git submodule init && git submodule update`
-
-In addition, **this project requires NDK version r17c to build.**
-
-### Setting up NDK r17c
-
-1. Follow the instructions
-[here](https://developer.android.com/studio/projects/install-ndk#specific-version)
-to install NDK version 17.2.4988734.
 
 ## Building
 


### PR DESCRIPTION
Firebase Crashlytics NDK no longer requires NDK r17c to build.