### PR TITLE
Add Proguard rule for Crashlytics NDK

### DIFF
--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk-proguard.txt
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk-proguard.txt
@@ -16,3 +16,4 @@
 # native libraries call FirebaseCrashlytics public methods dynamically via JNI.
 -keep public class com.google.firebase.crashlytics.FirebaseCrashlytics { public *; }
 -keep public class com.google.firebase.crashlytics.ndk.CrashpadMain { public *; }
+-keep public class com.google.firebase.crashlytics.ndk.JniNativeApi { native <methods>; }


### PR DESCRIPTION
Prevents aggressive stripping of native methods in the JniNativeApi class.