### PR TITLE
Make Api Information task comment the diff on the PR

### DIFF
--- a/ci/fireci/fireci/commands.py
+++ b/ci/fireci/fireci/commands.py
@@ -72,12 +72,7 @@ def smoke_tests(app_build_variant, test_apps_dir):
 def api_information(auth_token, repo_name, issue_number):
   """Comments the api information on the pr"""
 
-  try:
-  	gradle.run('apiInformation')
-  except:
-  	# apiInformation task fails when there is a diff in api surface.
-  	# Even if this fails we would need to comment information on github PR
-  	pass
+  gradle.run('apiInformation', '--continue', check=False)
 
   dir_suffix = 'build/apiinfo'
   comment_string = ""

--- a/ci/fireci/fireci/commands.py
+++ b/ci/fireci/fireci/commands.py
@@ -72,7 +72,13 @@ def smoke_tests(app_build_variant, test_apps_dir):
 def api_information(auth_token, repo_name, issue_number):
   """Comments the api information on the pr"""
 
-  gradle.run('apiInformation')
+  try:
+  	gradle.run('apiInformation')
+  except:
+  	# apiInformation task fails when there is a diff in api surface.
+  	# Even if this fails we would need to comment information on github PR
+  	pass
+
   dir_suffix = 'build/apiinfo'
   comment_string = ""
   for filename in os.listdir(dir_suffix):
@@ -85,7 +91,7 @@ def api_information(auth_token, repo_name, issue_number):
           formatted_output_lines.append(line[line.find('error:'):])
         elif 'warning' in line:
           formatted_output_lines.append(line[line.find('warning:'):])
-          
+    
     if formatted_output_lines:
       comment_string += 'The public api surface has changed for the subproject {}:\n'.format(subproject)
       comment_string += ''.join(formatted_output_lines)


### PR DESCRIPTION
Tested at https://github.com/firebase/firebase-android-sdk/pull/1831 
apiInformation task would still show failure status since we are doing exit(1) before posting the comment