### PR TITLE
Throw IOException for deleted files

### DIFF
--- a/firebase-storage/CHANGELOG.md
+++ b/firebase-storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed an issue that caused the SDK to crash if the download location
+  was deleted before the download completed. Instead, the download now fails.
+
 # 19.0.2
 - [fixed] Fixed an encoding issue in `list()/listAll()` that caused us to miss
   entries for folders that contained special characters.

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
@@ -130,8 +130,7 @@ public class FileDownloadTask extends StorageTask<FileDownloadTask.TaskSnapshot>
       File outputFile = new File(mDestinationFile.getPath());
       if (!outputFile.exists()) {
         if (mResumeOffset > 0) {
-          Log.e(TAG, "The file downloading to has been deleted:" + outputFile.getAbsolutePath());
-          throw new IllegalStateException("expected a file to resume from.");
+          throw new IOException("The file to download to has been deleted.");
         }
         boolean created = outputFile.createNewFile();
         if (!created) {


### PR DESCRIPTION
This fixes a crash in the Storage SDK that occurred when a file was deleted while being written to. By changing the IllegalStateException to an IOException, we no longer crash the app but instead expose the failure as a failed task.

Fixes https://github.com/firebase/firebase-android-sdk/issues/2211