### PR TITLE
Don't crash SDK is socket.close() fails

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 19.5.1 (Unreleased)
+# Unreleased
+- [fixed] Fixed a crash on some Pixel devices that occurred when closing the
+  network connection.
+
+# 19.5.1
 - [fixed] Fixes a regression in v19.4 that may cause assertion failures,
   especially when persistence is enabled.
 

--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 - [fixed] Fixed a crash on some Pixel devices that occurred when closing the
   network connection.
+- [added] Added `Query.get()`, which allows users to receive a single data
+  snapshot. `Query.get()` returns the latest value even if an older value
+  already exists in cache.
 
 # 19.5.1
 - [fixed] Fixes a regression in v19.4 that may cause assertion failures,

--- a/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
@@ -261,8 +261,8 @@ public class WebSocket {
     if (socket != null) {
       try {
         socket.close();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
+      } catch (Throwable e) {
+        eventHandler.onError(new WebSocketException("Failed to close", e));
       }
     }
     state = State.DISCONNECTED;

--- a/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/tubesock/WebSocket.java
@@ -261,7 +261,7 @@ public class WebSocket {
     if (socket != null) {
       try {
         socket.close();
-      } catch (Throwable e) {
+      } catch (Exception e) {
         eventHandler.onError(new WebSocketException("Failed to close", e));
       }
     }


### PR DESCRIPTION
On some Pixel devices, `socket.close()` throws an NPE (might be related to https://github.com/google/conscrypt/issues/331).

Fixes b/164528104