### PR TITLE
Enabling Test Orchestrator 

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/device/FirebaseTestServer.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/device/FirebaseTestServer.java
@@ -62,6 +62,7 @@ public class FirebaseTestServer extends TestServer {
         "--type=instrumentation",
         "--app=" + testedApkPath,
         "--test=" + testApk,
+        "--use-orchestrator",
         "--no-auto-google-login",
         "--no-record-video",
         "--no-performance-metrics",


### PR DESCRIPTION
b/174660554

Enabling Test Orchestrator to run each of app's instrumentation tests independently without accumulating shared states.

References:
  - https://firebase.google.com/docs/test-lab/android/firebase-console#new_instrumentation_tests_with_orchestrator
 - http://cloud/sdk/gcloud/reference/firebase/test/android/run#--use-orchestrator