### PR TITLE
RTDB Query get method must be public

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/Query.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/Query.java
@@ -167,7 +167,7 @@ public class Query {
    * connected, fall back to a locally-cached value.
    */
   @NonNull
-  Task<DataSnapshot> get() {
+  public Task<DataSnapshot> get() {
     return repo.getValue(this);
   }
 


### PR DESCRIPTION
This is a typo that slipped through in the original PR https://github.com/firebase/firebase-android-sdk/pull/2087