### PR TITLE
Set TrafficStats tag in FirebaseInstallationServiceClient.createFirebaseInstallation

### DIFF
--- a/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Google LLC
+// Copyright 2019-2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019-2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static com.google.firebase.installations.BuildConfig.VERSION_NAME;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.net.TrafficStats;
 import android.text.TextUtils;
 import android.util.JsonReader;
 import android.util.Log;
@@ -56,6 +57,9 @@ import org.json.JSONObject;
  * @hide
  */
 public class FirebaseInstallationServiceClient {
+
+  public static final int CREATE_INSTALLATION_TRAFFIC_STATS_TAG = 0x00008000;
+
   private static final String FIREBASE_INSTALLATIONS_API_DOMAIN =
       "firebaseinstallations.googleapis.com";
   private static final String CREATE_REQUEST_RESOURCE_NAME_FORMAT = "projects/%s/installations";
@@ -153,6 +157,7 @@ public class FirebaseInstallationServiceClient {
     URL url = getFullyQualifiedRequestUri(resourceName);
     for (int retryCount = 0; retryCount <= MAX_RETRIES; retryCount++) {
 
+      TrafficStats.setThreadStatsTag(CREATE_INSTALLATION_TRAFFIC_STATS_TAG);
       HttpURLConnection httpURLConnection = openHttpURLConnection(url, apiKey);
 
       try {
@@ -193,6 +198,7 @@ public class FirebaseInstallationServiceClient {
       } catch (AssertionError | IOException ignored) {
         continue;
       } finally {
+        TrafficStats.clearThreadStatsTag();
         httpURLConnection.disconnect();
       }
     }

--- a/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
@@ -59,10 +59,13 @@ import org.json.JSONObject;
 public class FirebaseInstallationServiceClient {
 
   // TrafficStats tags must be kept in sync with java/com/google/android/gms/libs/punchclock
-  private static final int TRAFFIC_STATS_TAG = 0x00008000;
-  private static final int CREATE_INSTALLATION_TRAFFIC_STATS_TAG = TRAFFIC_STATS_TAG | 0x1;
-  private static final int DELETE_INSTALLATION_TRAFFIC_STATS_TAG = TRAFFIC_STATS_TAG | 0x2;
-  private static final int GENERATE_AUTH_TOKEN_TRAFFIC_STATS_TAG = TRAFFIC_STATS_TAG | 0x3;
+  private static final int TRAFFIC_STATS_FIREBASE_INSTALLATIONS_TAG = 0x00008000;
+  private static final int TRAFFIC_STATS_CREATE_INSTALLATION_TAG =
+      TRAFFIC_STATS_FIREBASE_INSTALLATIONS_TAG | 0x1;
+  private static final int TRAFFIC_STATS_DELETE_INSTALLATION_TAG =
+      TRAFFIC_STATS_FIREBASE_INSTALLATIONS_TAG | 0x2;
+  private static final int TRAFFIC_STATS_GENERATE_AUTH_TOKEN_TAG =
+      TRAFFIC_STATS_FIREBASE_INSTALLATIONS_TAG | 0x3;
 
   private static final String FIREBASE_INSTALLATIONS_API_DOMAIN =
       "firebaseinstallations.googleapis.com";
@@ -161,7 +164,7 @@ public class FirebaseInstallationServiceClient {
     URL url = getFullyQualifiedRequestUri(resourceName);
     for (int retryCount = 0; retryCount <= MAX_RETRIES; retryCount++) {
 
-      TrafficStats.setThreadStatsTag(CREATE_INSTALLATION_TRAFFIC_STATS_TAG);
+      TrafficStats.setThreadStatsTag(TRAFFIC_STATS_CREATE_INSTALLATION_TAG);
       HttpURLConnection httpURLConnection = openHttpURLConnection(url, apiKey);
 
       try {
@@ -319,7 +322,7 @@ public class FirebaseInstallationServiceClient {
 
     int retryCount = 0;
     while (retryCount <= MAX_RETRIES) {
-      TrafficStats.setThreadStatsTag(DELETE_INSTALLATION_TRAFFIC_STATS_TAG);
+      TrafficStats.setThreadStatsTag(TRAFFIC_STATS_DELETE_INSTALLATION_TAG);
       HttpURLConnection httpURLConnection = openHttpURLConnection(url, apiKey);
       try {
         httpURLConnection.setRequestMethod("DELETE");
@@ -402,7 +405,7 @@ public class FirebaseInstallationServiceClient {
     URL url = getFullyQualifiedRequestUri(resourceName);
     for (int retryCount = 0; retryCount <= MAX_RETRIES; retryCount++) {
 
-      TrafficStats.setThreadStatsTag(GENERATE_AUTH_TOKEN_TRAFFIC_STATS_TAG);
+      TrafficStats.setThreadStatsTag(TRAFFIC_STATS_GENERATE_AUTH_TOKEN_TAG);
       HttpURLConnection httpURLConnection = openHttpURLConnection(url, apiKey);
       try {
         httpURLConnection.setRequestMethod("POST");
@@ -633,7 +636,8 @@ public class FirebaseInstallationServiceClient {
         response.append(input).append('\n');
       }
       return String.format(
-          "Error when communicating with the Firebase Installations server API. HTTP response: [%d %s: %s]",
+          "Error when communicating with the Firebase Installations server API. HTTP response: [%d"
+              + " %s: %s]",
           conn.getResponseCode(), conn.getResponseMessage(), response);
     } catch (IOException ignored) {
       return null;

--- a/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/remote/FirebaseInstallationServiceClient.java
@@ -58,7 +58,11 @@ import org.json.JSONObject;
  */
 public class FirebaseInstallationServiceClient {
 
-  public static final int CREATE_INSTALLATION_TRAFFIC_STATS_TAG = 0x00008000;
+  // TrafficStats tags must be kept in sync with java/com/google/android/gms/libs/punchclock
+  private static final int TRAFFIC_STATS_TAG = 0x00008000;
+  private static final int CREATE_INSTALLATION_TRAFFIC_STATS_TAG = TRAFFIC_STATS_TAG | 0x1;
+  private static final int DELETE_INSTALLATION_TRAFFIC_STATS_TAG = TRAFFIC_STATS_TAG | 0x2;
+  private static final int GENERATE_AUTH_TOKEN_TRAFFIC_STATS_TAG = TRAFFIC_STATS_TAG | 0x3;
 
   private static final String FIREBASE_INSTALLATIONS_API_DOMAIN =
       "firebaseinstallations.googleapis.com";
@@ -198,8 +202,8 @@ public class FirebaseInstallationServiceClient {
       } catch (AssertionError | IOException ignored) {
         continue;
       } finally {
-        TrafficStats.clearThreadStatsTag();
         httpURLConnection.disconnect();
+        TrafficStats.clearThreadStatsTag();
       }
     }
 
@@ -315,6 +319,7 @@ public class FirebaseInstallationServiceClient {
 
     int retryCount = 0;
     while (retryCount <= MAX_RETRIES) {
+      TrafficStats.setThreadStatsTag(DELETE_INSTALLATION_TRAFFIC_STATS_TAG);
       HttpURLConnection httpURLConnection = openHttpURLConnection(url, apiKey);
       try {
         httpURLConnection.setRequestMethod("DELETE");
@@ -341,6 +346,7 @@ public class FirebaseInstallationServiceClient {
         retryCount++;
       } finally {
         httpURLConnection.disconnect();
+        TrafficStats.clearThreadStatsTag();
       }
     }
 
@@ -396,6 +402,7 @@ public class FirebaseInstallationServiceClient {
     URL url = getFullyQualifiedRequestUri(resourceName);
     for (int retryCount = 0; retryCount <= MAX_RETRIES; retryCount++) {
 
+      TrafficStats.setThreadStatsTag(GENERATE_AUTH_TOKEN_TRAFFIC_STATS_TAG);
       HttpURLConnection httpURLConnection = openHttpURLConnection(url, apiKey);
       try {
         httpURLConnection.setRequestMethod("POST");
@@ -436,6 +443,7 @@ public class FirebaseInstallationServiceClient {
         continue;
       } finally {
         httpURLConnection.disconnect();
+        TrafficStats.clearThreadStatsTag();
       }
     }
     throw new FirebaseInstallationsException(


### PR DESCRIPTION
Fixes #2227

Tested:
I verified that com.google.googlequicksearchbox doesn't have the violation anymore in the e2e test.

Signed-off-by: Régis Décamps <regisd@google.com>