### PR TITLE
Implement LoadBundleTask

### DIFF
--- a/firebase-common/src/main/java/com/google/firebase/internal/ActivityLifecycleListener.java
+++ b/firebase-common/src/main/java/com/google/firebase/internal/ActivityLifecycleListener.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.storage.internal;
+package com.google.firebase.internal;
 
 import android.app.Activity;
 import android.util.Log;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTaskProgress.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTaskProgress.java
@@ -15,8 +15,19 @@
 package com.google.firebase.firestore;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
+/** Represents a progress update or a final state from loading bundles. */
 /* package */ final class LoadBundleTaskProgress {
+  static final LoadBundleTaskProgress INITIAL =
+      new LoadBundleTaskProgress(0, 0, 0, 0, null, TaskState.SUCCESS);
+
+  /**
+   * Represents the state of bundle loading tasks.
+   *
+   * <p>Both {@link TaskState#SUCCESS} and {@link TaskState#ERROR} are final states: task will abort
+   * or complete and there will be no more updates after they are reported.
+   */
   public enum TaskState {
     ERROR,
     RUNNING,
@@ -27,39 +38,79 @@ import androidx.annotation.NonNull;
   private int totalDocuments;
   private long bytesLoaded;
   private long totalBytes;
-  private TaskState taskState;
+  @NonNull private final TaskState taskState;
+  @Nullable private final Exception exception;
 
   public LoadBundleTaskProgress(
       int documentsLoaded,
       int totalDocuments,
       long bytesLoaded,
       long totalBytes,
+      @Nullable Exception exception,
       @NonNull TaskState taskState) {
     this.documentsLoaded = documentsLoaded;
     this.totalDocuments = totalDocuments;
     this.bytesLoaded = bytesLoaded;
     this.totalBytes = totalBytes;
     this.taskState = taskState;
+    this.exception = exception;
   }
 
+  /** Returns how many documents have been loaded. */
   public int getDocumentsLoaded() {
     return documentsLoaded;
   }
 
+  /**
+   * Returns the total number of documents in the bundle. Returns 0 if the bundle failed to parse.
+   */
   public int getTotalDocuments() {
     return totalDocuments;
   }
 
+  /** Returns how many bytes have been loaded. */
   public long getBytesLoaded() {
     return bytesLoaded;
   }
 
+  /** Returns the total number of bytes in the bundle. Returns 0 if the bundle failed to parse. */
   public long getTotalBytes() {
     return totalBytes;
   }
 
+  /** Returns the current state of the task. */
   @NonNull
   public TaskState getTaskState() {
     return taskState;
+  }
+
+  /** If the task failed, returns the exception. Otherwise, returns null. */
+  @Nullable
+  public Exception getError() {
+    return exception;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    LoadBundleTaskProgress that = (LoadBundleTaskProgress) o;
+
+    if (documentsLoaded != that.documentsLoaded) return false;
+    if (totalDocuments != that.totalDocuments) return false;
+    if (bytesLoaded != that.bytesLoaded) return false;
+    if (totalBytes != that.totalBytes) return false;
+    return taskState == that.taskState;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = documentsLoaded;
+    result = 31 * result + totalDocuments;
+    result = 31 * result + (int) (bytesLoaded ^ (bytesLoaded >>> 32));
+    result = 31 * result + (int) (totalBytes ^ (totalBytes >>> 32));
+    result = 31 * result + taskState.hashCode();
+    return result;
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTaskProgress.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTaskProgress.java
@@ -34,10 +34,10 @@ import androidx.annotation.Nullable;
     SUCCESS
   }
 
-  private int documentsLoaded;
-  private int totalDocuments;
-  private long bytesLoaded;
-  private long totalBytes;
+  private final int documentsLoaded;
+  private final int totalDocuments;
+  private final long bytesLoaded;
+  private final long totalBytes;
   @NonNull private final TaskState taskState;
   @Nullable private final Exception exception;
 
@@ -86,7 +86,7 @@ import androidx.annotation.Nullable;
 
   /** If the task failed, returns the exception. Otherwise, returns null. */
   @Nullable
-  public Exception getError() {
+  public Exception getException() {
     return exception;
   }
 
@@ -101,7 +101,8 @@ import androidx.annotation.Nullable;
     if (totalDocuments != that.totalDocuments) return false;
     if (bytesLoaded != that.bytesLoaded) return false;
     if (totalBytes != that.totalBytes) return false;
-    return taskState == that.taskState;
+    if (taskState != that.taskState) return false;
+    return exception != null ? exception.equals(that.exception) : that.exception == null;
   }
 
   @Override
@@ -111,6 +112,7 @@ import androidx.annotation.Nullable;
     result = 31 * result + (int) (bytesLoaded ^ (bytesLoaded >>> 32));
     result = 31 * result + (int) (totalBytes ^ (totalBytes >>> 32));
     result = 31 * result + taskState.hashCode();
+    result = 31 * result + (exception != null ? exception.hashCode() : 0);
     return result;
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/OnProgressListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/OnProgressListener.java
@@ -1,0 +1,22 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore;
+
+import androidx.annotation.NonNull;
+
+/** A listener that is called periodically during execution of a {@link LoadBundleTask}. */
+/* package */ interface OnProgressListener<ProgressT> {
+  void onProgress(@NonNull ProgressT snapshot);
+}

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/LoadBundleTaskTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/LoadBundleTaskTest.java
@@ -150,7 +150,7 @@ public class LoadBundleTaskTest {
     task.addOnProgressListener(
         p -> {
           try {
-            collector.checkThat(TEST_THREAD_NAME, not(equalTo(Thread.currentThread().getName())));
+            collector.checkThat(Thread.currentThread().getName(), not(equalTo(TEST_THREAD_NAME)));
           } finally {
             latch.countDown();
           }
@@ -159,7 +159,7 @@ public class LoadBundleTaskTest {
         testExecutor,
         p -> {
           try {
-            collector.checkThat(TEST_THREAD_NAME, equalTo(Thread.currentThread().getName()));
+            collector.checkThat(Thread.currentThread().getName(), equalTo(TEST_THREAD_NAME));
           } finally {
             latch.countDown();
           }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/LoadBundleTaskTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/LoadBundleTaskTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import android.app.Activity;
-import androidx.annotation.NonNull;
 import com.google.android.gms.tasks.Task;
 import java.lang.reflect.Method;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -29,7 +28,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -47,11 +45,11 @@ public class LoadBundleTaskTest {
 
   Executor testExecutor =
       Executors.newSingleThreadExecutor(
-              r -> {
-                Thread t = new Thread(r);
-                t.setName(TEST_THREAD_NAME);
-                return t;
-              });
+          r -> {
+            Thread t = new Thread(r);
+            t.setName(TEST_THREAD_NAME);
+            return t;
+          });
   ActivityController<Activity> activityController =
       Robolectric.buildActivity(Activity.class).create();
   Activity activity = activityController.get();

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/LoadBundleTaskTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/LoadBundleTaskTest.java
@@ -14,18 +14,38 @@
 
 package com.google.firebase.firestore;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import android.app.Activity;
 import com.google.android.gms.tasks.Task;
 import java.lang.reflect.Method;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class LoadBundleTaskTest {
+  static final LoadBundleTaskProgress SUCCESS_RESULT =
+      new LoadBundleTaskProgress(0, 0, 0, 0, null, LoadBundleTaskProgress.TaskState.SUCCESS);
+  static final Exception TEST_EXCEPTION = new Exception("Test Exception");
+
+  Executor testExecutor = Executors.newSingleThreadExecutor();
+  ActivityController<Activity> activityController =
+      Robolectric.buildActivity(Activity.class).create();
+  Activity activity = activityController.get();
+
   @Test
   public void testImplementsAllTaskInterface() {
     for (Method method : Task.class.getDeclaredMethods()) {
@@ -37,5 +57,209 @@ public class LoadBundleTaskTest {
                 + method.toGenericString());
       }
     }
+  }
+
+  @Test
+  public void testSuccessListener() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(3);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.addOnSuccessListener(progress -> latch.countDown());
+    task.addOnSuccessListener(testExecutor, progress -> latch.countDown());
+    task.addOnSuccessListener(activity, progress -> latch.countDown());
+
+    task.setResult(SUCCESS_RESULT);
+
+    latch.await();
+  }
+
+  @Test
+  public void testFailureListener() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(3);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.addOnFailureListener(progress -> latch.countDown());
+    task.addOnFailureListener(testExecutor, progress -> latch.countDown());
+    task.addOnFailureListener(activity, progress -> latch.countDown());
+
+    task.setException(TEST_EXCEPTION);
+
+    latch.await();
+  }
+
+  @Test
+  public void testCompleteListener() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(3);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.addOnCompleteListener(progress -> latch.countDown());
+    task.addOnCompleteListener(testExecutor, progress -> latch.countDown());
+    task.addOnCompleteListener(activity, progress -> latch.countDown());
+
+    task.setResult(SUCCESS_RESULT);
+
+    latch.await();
+  }
+
+  @Test
+  public void testProgressListener() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(3);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.addOnProgressListener(progress -> latch.countDown());
+    task.addOnProgressListener(testExecutor, progress -> latch.countDown());
+    task.addOnProgressListener(activity, progress -> latch.countDown());
+
+    task.updateProgress(SUCCESS_RESULT);
+
+    latch.await();
+  }
+
+  @Test
+  public void testProgressListenerWithSuccess() throws InterruptedException {
+    BlockingQueue<LoadBundleTaskProgress> actualSnapshots = new ArrayBlockingQueue<>(3);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.addOnProgressListener(actualSnapshots::add);
+
+    LoadBundleTaskProgress initialProgress =
+        new LoadBundleTaskProgress(
+            0, 10, 0, 10, /* exception= */ null, LoadBundleTaskProgress.TaskState.RUNNING);
+    task.updateProgress(initialProgress);
+    assertEquals(initialProgress, actualSnapshots.take());
+
+    LoadBundleTaskProgress partialProgress =
+        new LoadBundleTaskProgress(
+            5, 10, 5, 10, /* exception= */ null, LoadBundleTaskProgress.TaskState.RUNNING);
+    task.updateProgress(partialProgress);
+    assertEquals(partialProgress, actualSnapshots.take());
+
+    LoadBundleTaskProgress successProgress =
+        new LoadBundleTaskProgress(
+            10, 10, 10, 10, /* exception= */ null, LoadBundleTaskProgress.TaskState.SUCCESS);
+    task.setResult(successProgress);
+    assertEquals(successProgress, actualSnapshots.take());
+  }
+
+  @Test
+  public void testProgressListenerWithException() throws InterruptedException {
+    BlockingQueue<LoadBundleTaskProgress> actualSnapshots = new ArrayBlockingQueue<>(3);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.addOnProgressListener(actualSnapshots::add);
+
+    LoadBundleTaskProgress initialProgress =
+        new LoadBundleTaskProgress(
+            0, 10, 0, 10, /* exception= */ null, LoadBundleTaskProgress.TaskState.RUNNING);
+    task.updateProgress(initialProgress);
+    assertEquals(initialProgress, actualSnapshots.take());
+
+    LoadBundleTaskProgress partialProgress =
+        new LoadBundleTaskProgress(
+            5, 10, 5, 10, /* exception= */ null, LoadBundleTaskProgress.TaskState.RUNNING);
+    task.updateProgress(partialProgress);
+    assertEquals(partialProgress, actualSnapshots.take());
+
+    LoadBundleTaskProgress failureProgress =
+        new LoadBundleTaskProgress(
+            5, 10, 5, 10, TEST_EXCEPTION, LoadBundleTaskProgress.TaskState.ERROR);
+    task.setException(TEST_EXCEPTION);
+    assertEquals(failureProgress, actualSnapshots.take());
+  }
+
+  @Test
+  public void testProgressListenerWithInitialException() throws InterruptedException {
+    BlockingQueue<LoadBundleTaskProgress> actualSnapshots = new ArrayBlockingQueue<>(3);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.addOnProgressListener(actualSnapshots::add);
+
+    LoadBundleTaskProgress failureProgress =
+        new LoadBundleTaskProgress(
+            0, 0, 0, 0, TEST_EXCEPTION, LoadBundleTaskProgress.TaskState.ERROR);
+    task.setException(TEST_EXCEPTION);
+    assertEquals(failureProgress, actualSnapshots.take());
+  }
+
+  @Test
+  public void testContinueWith() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.continueWith(
+        task1 -> {
+          latch.countDown();
+          return null;
+        });
+    task.continueWith(
+        testExecutor,
+        task1 -> {
+          latch.countDown();
+          return null;
+        });
+
+    task.setResult(SUCCESS_RESULT);
+
+    latch.await();
+  }
+
+  @Test
+  public void testContinueWithTask() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    LoadBundleTask task = new LoadBundleTask();
+    task.continueWithTask(
+        task1 -> {
+          latch.countDown();
+          return null;
+        });
+    task.continueWithTask(
+        testExecutor,
+        task1 -> {
+          latch.countDown();
+          return null;
+        });
+
+    task.setResult(SUCCESS_RESULT);
+
+    latch.await();
+  }
+
+  @Test
+  public void testIsSuccessful() {
+    LoadBundleTask task = new LoadBundleTask();
+    assertFalse(task.isSuccessful());
+    task.setResult(SUCCESS_RESULT);
+    assertTrue(task.isSuccessful());
+  }
+
+  @Test
+  public void testIsCompleteWithSuccess() {
+    LoadBundleTask task = new LoadBundleTask();
+    assertFalse(task.isComplete());
+    task.setResult(SUCCESS_RESULT);
+    assertTrue(task.isComplete());
+  }
+
+  @Test
+  public void testIsCompleteWithFailure() {
+    LoadBundleTask task = new LoadBundleTask();
+    assertFalse(task.isComplete());
+    task.setException(new Exception());
+    assertTrue(task.isComplete());
+  }
+
+  @Test
+  public void testGetResult() {
+    LoadBundleTask task = new LoadBundleTask();
+    task.setResult(SUCCESS_RESULT);
+    assertEquals(SUCCESS_RESULT, task.getResult());
+  }
+
+  @Test
+  public void testGetException() {
+    LoadBundleTask task = new LoadBundleTask();
+    task.setException(TEST_EXCEPTION);
+    assertEquals(TEST_EXCEPTION, task.getException());
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageTask.java
@@ -318,7 +318,7 @@ public abstract class StorageTask<ResultT extends StorageTask.ProvideError>
 
   /**
    * Returns the current state of the task. This method will return state at any point of the tasks
-   * execution and may not be the final result..
+   * execution and may not be the final result.
    */
   @NonNull
   public ResultT getSnapshot() {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/TaskListenerImpl.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/TaskListenerImpl.java
@@ -19,7 +19,7 @@ import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.common.internal.Preconditions;
-import com.google.firebase.storage.internal.ActivityLifecycleListener;
+import com.google.firebase.internal.ActivityLifecycleListener;
 import com.google.firebase.storage.internal.SmartHandler;
 import java.util.HashMap;
 import java.util.Queue;


### PR DESCRIPTION
This implements the logic for LoadBundleTask. It's basically a super advanced copy/paste job:

- It takes some API comments from the Web implementation (https://github.com/firebase/firebase-js-sdk/blob/master/packages/firebase/index.d.ts#L8374)
- It relies on the Android Task API whenever possible. For progress updates, the implementation is inspired by cs/piper///depot/google3/java/com/google/android/gmscore/integ/client/tasks/src/com/google/android/gms/tasks/TaskImpl.java
- Most Task API comments are copied from StorageTask (https://github.com/firebase/firebase-android-sdk/blob/master/firebase-storage/src/main/java/com/google/firebase/storage/StorageTask.java)