### PR TITLE
Clean up/remove failed or completed download attempts.

### DIFF
--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
@@ -300,7 +300,7 @@ public class ModelFileDownloadService {
       fileDescriptor = downloadManager.openDownloadedFile(downloadingId);
     } catch (FileNotFoundException e) {
       // todo replace with FirebaseMlException
-      Log.d(TAG, "Downloaded file is not found" + e);
+      Log.d(TAG, "Downloaded file is not found: " + e);
     }
     return fileDescriptor;
   }
@@ -341,6 +341,7 @@ public class ModelFileDownloadService {
 
     Integer statusCode = getDownloadingModelStatusCode(downloadingId);
     if (statusCode == null) {
+      Log.d(TAG, "Download failed - no download status available.");
       // No status code, it may mean no such download or no download manager.
       removeOrCancelDownload(model.getName(), model.getDownloadId());
       return null;
@@ -360,6 +361,7 @@ public class ModelFileDownloadService {
       // Try to move it to destination folder.
       File newModelFile;
       try {
+        // TODO add logging
         newModelFile = fileManager.moveModelToDestinationFolder(model, fileDescriptor);
       } finally {
         removeOrCancelDownload(model.getName(), model.getDownloadId());

--- a/firebase-ml-modeldownloader/src/test/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadServiceTest.java
+++ b/firebase-ml-modeldownloader/src/test/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadServiceTest.java
@@ -73,10 +73,12 @@ public class ModelFileDownloadServiceTest {
   private static final String MODEL_NAME = "MODEL_NAME_1";
   private static final String MODEL_HASH = "dsf324";
   public static final String MODEL_URL = "https://project.firebase.com/modelName/23424.jpg";
-  private static final long URL_EXPIRATION = 604800L;
+  private static final long URL_EXPIRATION = 1608063572000L;
 
   private static final Long DOWNLOAD_ID = 987923L;
 
+  private static final CustomModel CUSTOM_MODEL_PREVIOUS_LOADED =
+      new CustomModel(MODEL_NAME, MODEL_HASH + "2", 105, 0, "FakeFile/path.tflite");
   private static final CustomModel CUSTOM_MODEL_NO_URL =
       new CustomModel(MODEL_NAME, MODEL_HASH, 100, 0);
   private static final CustomModel CUSTOM_MODEL_URL =
@@ -189,6 +191,7 @@ public class ModelFileDownloadServiceTest {
     Task<Void> task =
         modelFileDownloadService.download(
             CUSTOM_MODEL_URL, new CustomModelDownloadConditions.Builder().requireWifi().build());
+    when(mockDownloadManager.remove(anyLong())).thenReturn(1);
 
     // Complete the download
     Intent downloadCompleteIntent = new Intent(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
@@ -270,6 +273,38 @@ public class ModelFileDownloadServiceTest {
   }
 
   @Test
+  public void ensureModelDownloaded_downloadCompletes_missingModel() throws Exception {
+    when(mockDownloadManager.enqueue(any())).thenReturn(DOWNLOAD_ID);
+    matrixCursor.addRow(new Integer[] {DownloadManager.STATUS_SUCCESSFUL});
+    when(mockDownloadManager.query(any())).thenReturn(matrixCursor);
+
+    TestOnCompleteListener<Void> onCompleteListener = new TestOnCompleteListener<>();
+    Task<Void> task = modelFileDownloadService.ensureModelDownloaded(CUSTOM_MODEL_URL);
+
+    // clear the model before completing the download
+    sharedPreferencesUtil.clearModelDetails(CUSTOM_MODEL_URL.getName());
+
+    // Complete the download
+    Intent downloadCompleteIntent = new Intent(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
+    downloadCompleteIntent.putExtra(DownloadManager.EXTRA_DOWNLOAD_ID, DOWNLOAD_ID);
+    app.getApplicationContext().sendBroadcast(downloadCompleteIntent);
+
+    try {
+      task.addOnCompleteListener(executor, onCompleteListener);
+      onCompleteListener.await();
+    } catch (FirebaseMlException ex) {
+      System.out.println("error: " + ex.getMessage());
+      assertEquals(ex.getCode(), FirebaseMlException.INVALID_ARGUMENT);
+    }
+    assertTrue(task.isComplete());
+    assertFalse(task.isSuccessful());
+    assertTrue(task.getException() instanceof FirebaseMlException);
+
+    verify(mockDownloadManager, times(1)).enqueue(any());
+    verify(mockDownloadManager, atLeastOnce()).query(any());
+  }
+
+  @Test
   public void ensureModelDownloaded_downloadFailed() {
     when(mockDownloadManager.enqueue(any())).thenReturn(DOWNLOAD_ID);
     matrixCursor =
@@ -343,6 +378,119 @@ public class ModelFileDownloadServiceTest {
   }
 
   @Test
+  public void ensureModelDownloaded_alreadyInProgess_Completed() throws Exception {
+    when(mockDownloadManager.enqueue(any())).thenReturn(DOWNLOAD_ID);
+    matrixCursor.addRow(new Integer[] {DownloadManager.STATUS_SUCCESSFUL});
+    when(mockDownloadManager.query(any())).thenReturn(matrixCursor);
+
+    // set up first request
+    TestOnCompleteListener<Void> onCompleteListener = new TestOnCompleteListener<>();
+    Task<Void> task = modelFileDownloadService.ensureModelDownloaded(CUSTOM_MODEL_URL);
+    task.addOnCompleteListener(executor, onCompleteListener);
+    assertEquals(
+        sharedPreferencesUtil.getDownloadingCustomModelDetails(MODEL_NAME),
+        CUSTOM_MODEL_DOWNLOADING);
+
+    // now retry before completing
+    TestOnCompleteListener<Void> onCompleteListener2 = new TestOnCompleteListener<>();
+    Task<Void> task2 = modelFileDownloadService.ensureModelDownloaded(CUSTOM_MODEL_URL);
+    task2.addOnCompleteListener(executor, onCompleteListener2);
+
+    // Complete the download
+    Intent downloadCompleteIntent = new Intent(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
+    downloadCompleteIntent.putExtra(DownloadManager.EXTRA_DOWNLOAD_ID, DOWNLOAD_ID);
+    app.getApplicationContext().sendBroadcast(downloadCompleteIntent);
+
+    onCompleteListener.await();
+    onCompleteListener2.await();
+
+    assertTrue(task.isComplete());
+    assertTrue(task.isSuccessful());
+    assertNull(task.getResult());
+    assertTrue(task2.isComplete());
+    assertTrue(task2.isSuccessful());
+    assertNull(task2.getResult());
+    assertEquals(
+        sharedPreferencesUtil.getDownloadingCustomModelDetails(MODEL_NAME),
+        CUSTOM_MODEL_DOWNLOADING);
+
+    verify(mockDownloadManager, times(1)).enqueue(any());
+    verify(mockDownloadManager, atLeastOnce()).query(any());
+  }
+
+  @Test
+  public void ensureModelDownloaded_alreadyInProgess_UrlExpired() throws Exception {
+    long downloadId2 = 23456L;
+    when(mockDownloadManager.enqueue(any())).thenReturn(DOWNLOAD_ID).thenReturn(downloadId2);
+    matrixCursor.addRow(new Integer[] {DownloadManager.PAUSED_WAITING_FOR_NETWORK});
+    MatrixCursor matrixCursor2 =
+        new MatrixCursor(
+            new String[] {DownloadManager.COLUMN_STATUS, DownloadManager.COLUMN_REASON});
+    matrixCursor2.addRow(new Integer[] {DownloadManager.STATUS_FAILED, 400});
+
+    MatrixCursor matrixCursorRetry = new MatrixCursor(new String[] {DownloadManager.COLUMN_STATUS});
+    matrixCursorRetry.addRow(new Integer[] {DownloadManager.STATUS_SUCCESSFUL});
+    when(mockDownloadManager.query(any()))
+        .thenReturn(matrixCursor) // first download query in progress - get status
+        .thenReturn(matrixCursor2) // first download failure triggered - get status
+        .thenReturn(matrixCursor2) // first download failed - check error cause
+        .thenReturn(matrixCursorRetry); // second download query
+
+    when(mockDownloadManager.remove(eq(DOWNLOAD_ID))).thenReturn(1);
+
+    // set up the first request
+    TestOnCompleteListener<Void> onCompleteListener = new TestOnCompleteListener<>();
+    Task<Void> task = modelFileDownloadService.ensureModelDownloaded(CUSTOM_MODEL_URL);
+    task.addOnCompleteListener(executor, onCompleteListener);
+
+    assertEquals(
+        sharedPreferencesUtil.getDownloadingCustomModelDetails(MODEL_NAME),
+        CUSTOM_MODEL_DOWNLOADING);
+
+    // now retry before completing
+    TestOnCompleteListener<Void> onCompleteListener2 = new TestOnCompleteListener<>();
+    Task<Void> task2 = modelFileDownloadService.ensureModelDownloaded(CUSTOM_MODEL_URL);
+    task2.addOnCompleteListener(executor, onCompleteListener2);
+
+    assertEquals(
+        sharedPreferencesUtil.getDownloadingCustomModelDetails(MODEL_NAME),
+        new CustomModel(MODEL_NAME, MODEL_HASH, 100, downloadId2));
+
+    // Cancel the first download - I'm assuming this sends is a failure
+    when(mockDownloadManager.enqueue(any())).thenReturn(DOWNLOAD_ID).thenReturn(downloadId2);
+
+    Intent downloadCompleteIntent = new Intent(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
+    // cancel/fail the first download
+    try {
+      downloadCompleteIntent.putExtra(DownloadManager.EXTRA_DOWNLOAD_ID, DOWNLOAD_ID);
+      app.getApplicationContext().sendBroadcast(downloadCompleteIntent);
+      onCompleteListener.await();
+    } catch (Exception ex) {
+      System.out.println("Failure message: " + ex);
+      assertTrue(ex.getMessage().contains("Retry: Expired URL"));
+    }
+    assertTrue(task.isComplete());
+    assertFalse(task.isSuccessful());
+    assertTrue(task.getException().getMessage().contains("Retry: Expired URL"));
+
+    // Complete the second download
+    downloadCompleteIntent.putExtra(DownloadManager.EXTRA_DOWNLOAD_ID, downloadId2);
+    app.getApplicationContext().sendBroadcast(downloadCompleteIntent);
+    onCompleteListener2.await();
+
+    assertTrue(task2.isComplete());
+    assertTrue(task2.isSuccessful());
+    assertNull(task2.getResult());
+    assertEquals(
+        sharedPreferencesUtil.getDownloadingCustomModelDetails(MODEL_NAME),
+        new CustomModel(MODEL_NAME, MODEL_HASH, 100, downloadId2));
+
+    verify(mockDownloadManager, times(2)).enqueue(any());
+    verify(mockDownloadManager, times(4)).query(any());
+    verify(mockDownloadManager, times(1)).remove(anyLong());
+  }
+
+  @Test
   public void scheduleModelDownload_success() {
     when(mockDownloadManager.enqueue(any())).thenReturn(DOWNLOAD_ID);
     Long id = modelFileDownloadService.scheduleModelDownload(CUSTOM_MODEL_URL);
@@ -397,6 +545,7 @@ public class ModelFileDownloadServiceTest {
     when(mockDownloadManager.openDownloadedFile(anyLong()))
         .thenReturn(
             ParcelFileDescriptor.open(testTempModelFile, ParcelFileDescriptor.MODE_READ_ONLY));
+    when(mockDownloadManager.remove(eq(DOWNLOAD_ID))).thenReturn(1);
 
     when(mockFileManager.moveModelToDestinationFolder(any(), any())).thenReturn(testAppModelFile);
 
@@ -405,6 +554,49 @@ public class ModelFileDownloadServiceTest {
     assertEquals(
         sharedPreferencesUtil.getCustomModelDetails(MODEL_NAME), customModelDownloadComplete);
     verify(mockDownloadManager, times(3)).query(any());
+    verify(mockDownloadManager, times(1)).remove(anyLong());
+  }
+
+  @Test
+  public void maybeCheckDownloadingComplete_downloadFailed() throws Exception {
+    sharedPreferencesUtil.setDownloadingCustomModelDetails(CUSTOM_MODEL_DOWNLOADING);
+    assertNull(modelFileDownloadService.getDownloadingModelStatusCode(0L));
+    matrixCursor.addRow(new Integer[] {DownloadManager.STATUS_FAILED});
+    when(mockDownloadManager.query(any())).thenReturn(matrixCursor);
+    when(mockDownloadManager.openDownloadedFile(anyLong()))
+        .thenReturn(
+            ParcelFileDescriptor.open(testTempModelFile, ParcelFileDescriptor.MODE_READ_ONLY));
+    when(mockDownloadManager.remove(eq(DOWNLOAD_ID))).thenReturn(1);
+
+    when(mockFileManager.moveModelToDestinationFolder(any(), any())).thenReturn(testAppModelFile);
+
+    modelFileDownloadService.maybeCheckDownloadingComplete();
+
+    assertNull(sharedPreferencesUtil.getCustomModelDetails(MODEL_NAME));
+    verify(mockDownloadManager, times(3)).query(any());
+    verify(mockDownloadManager, times(1)).remove(anyLong());
+  }
+
+  @Test
+  public void maybeCheckDownloadingComplete_secondDownloadFailed() throws Exception {
+    sharedPreferencesUtil.setUploadedCustomModelDetails(CUSTOM_MODEL_PREVIOUS_LOADED);
+    sharedPreferencesUtil.setDownloadingCustomModelDetails(CUSTOM_MODEL_DOWNLOADING);
+    assertNull(modelFileDownloadService.getDownloadingModelStatusCode(0L));
+    matrixCursor.addRow(new Integer[] {DownloadManager.STATUS_FAILED});
+    when(mockDownloadManager.query(any())).thenReturn(matrixCursor);
+    when(mockDownloadManager.openDownloadedFile(anyLong()))
+        .thenReturn(
+            ParcelFileDescriptor.open(testTempModelFile, ParcelFileDescriptor.MODE_READ_ONLY));
+    when(mockDownloadManager.remove(eq(DOWNLOAD_ID))).thenReturn(1);
+
+    when(mockFileManager.moveModelToDestinationFolder(any(), any())).thenReturn(testAppModelFile);
+
+    modelFileDownloadService.maybeCheckDownloadingComplete();
+
+    assertEquals(
+        sharedPreferencesUtil.getCustomModelDetails(MODEL_NAME), CUSTOM_MODEL_PREVIOUS_LOADED);
+    verify(mockDownloadManager, times(3)).query(any());
+    verify(mockDownloadManager, times(1)).remove(anyLong());
   }
 
   @Test
@@ -434,6 +626,7 @@ public class ModelFileDownloadServiceTest {
     when(mockDownloadManager.openDownloadedFile(anyLong()))
         .thenReturn(
             ParcelFileDescriptor.open(testTempModelFile, ParcelFileDescriptor.MODE_READ_ONLY));
+    when(mockDownloadManager.remove(anyLong())).thenReturn(1);
 
     when(mockFileManager.moveModelToDestinationFolder(any(), any())).thenReturn(testAppModelFile);
 
@@ -445,12 +638,14 @@ public class ModelFileDownloadServiceTest {
         sharedPreferencesUtil.getCustomModelDetails(secondModelName),
         new CustomModel(secondModelName, MODEL_HASH, 100, 0, testAppModelFile.getPath()));
     verify(mockDownloadManager, times(5)).query(any());
+    verify(mockDownloadManager, times(2)).remove(anyLong());
   }
 
   @Test
   public void maybeCheckDownloadingComplete_noDownloadsInProgress() throws Exception {
     modelFileDownloadService.maybeCheckDownloadingComplete();
     verify(mockDownloadManager, never()).query(any());
+    verify(mockDownloadManager, never()).remove(anyLong());
   }
 
   @Test
@@ -463,6 +658,7 @@ public class ModelFileDownloadServiceTest {
     when(mockDownloadManager.openDownloadedFile(anyLong()))
         .thenReturn(
             ParcelFileDescriptor.open(testTempModelFile, ParcelFileDescriptor.MODE_READ_ONLY));
+    when(mockDownloadManager.remove(anyLong())).thenReturn(1);
 
     when(mockFileManager.moveModelToDestinationFolder(any(), any())).thenReturn(testAppModelFile);
 
@@ -472,6 +668,7 @@ public class ModelFileDownloadServiceTest {
 
     CustomModel retrievedModel = sharedPreferencesUtil.getCustomModelDetails(MODEL_NAME);
     assertEquals(retrievedModel, customModelDownloadComplete);
+    verify(mockDownloadManager, times(1)).remove(anyLong());
   }
 
   @Test
@@ -484,9 +681,11 @@ public class ModelFileDownloadServiceTest {
     doThrow(new FileNotFoundException("File not found."))
         .when(mockDownloadManager)
         .openDownloadedFile(anyLong());
+    when(mockDownloadManager.remove(anyLong())).thenReturn(1);
 
     assertNull(modelFileDownloadService.loadNewlyDownloadedModelFile(CUSTOM_MODEL_DOWNLOADING));
     assertNull(sharedPreferencesUtil.getDownloadingCustomModelDetails(MODEL_NAME));
+    verify(mockDownloadManager, times(1)).remove(anyLong());
   }
 
   @Test
@@ -497,6 +696,7 @@ public class ModelFileDownloadServiceTest {
     when(mockDownloadManager.query(any())).thenReturn(matrixCursor);
     assertNull(modelFileDownloadService.loadNewlyDownloadedModelFile(CUSTOM_MODEL_DOWNLOADING));
     assertNull(sharedPreferencesUtil.getCustomModelDetails(MODEL_NAME));
+    verify(mockDownloadManager, never()).remove(anyLong());
   }
 
   @Test
@@ -505,7 +705,10 @@ public class ModelFileDownloadServiceTest {
     assertNull(modelFileDownloadService.getDownloadingModelStatusCode(0L));
     matrixCursor.addRow(new Integer[] {DownloadManager.STATUS_FAILED});
     when(mockDownloadManager.query(any())).thenReturn(matrixCursor);
+    when(mockDownloadManager.remove(anyLong())).thenReturn(1);
+
     assertNull(modelFileDownloadService.loadNewlyDownloadedModelFile(CUSTOM_MODEL_DOWNLOADING));
     assertNull(sharedPreferencesUtil.getCustomModelDetails(MODEL_NAME));
+    verify(mockDownloadManager, times(1)).remove(anyLong());
   }
 }


### PR DESCRIPTION
Removes old download attempts from the download managers and resets the models in shared preferences.