### PR TITLE
Use custom tab only for web actions

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -534,7 +534,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   }
 
   private void launchUriIntent(Activity activity, Uri uri) {
-    if (supportsCustomTabs(activity)) {
+    if (shouldOpenWeb(uri) && supportsCustomTabs(activity)) {
       // If we can launch a chrome view, try that.
       CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
       Intent intent = customTabsIntent.intent;
@@ -562,5 +562,10 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     List<ResolveInfo> resolveInfos =
         activity.getPackageManager().queryIntentServices(customTabIntent, 0);
     return resolveInfos != null && !resolveInfos.isEmpty();
+  }
+
+  private boolean shouldOpenWeb(Uri uri) {
+    String scheme = uri.getScheme();
+    return scheme != null && (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"));
   }
 }

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -534,7 +534,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   }
 
   private void launchUriIntent(Activity activity, Uri uri) {
-    if (shouldOpenWeb(uri) && supportsCustomTabs(activity)) {
+    if (ishttpOrHttpsUri(uri) && supportsCustomTabs(activity)) {
       // If we can launch a chrome view, try that.
       CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
       Intent intent = customTabsIntent.intent;
@@ -564,7 +564,10 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     return resolveInfos != null && !resolveInfos.isEmpty();
   }
 
-  private boolean shouldOpenWeb(Uri uri) {
+  private boolean ishttpOrHttpsUri(Uri uri) {
+    if (uri == null) {
+      return false;
+    }
     String scheme = uri.getScheme();
     return scheme != null && (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"));
   }

--- a/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
+++ b/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
@@ -21,8 +21,10 @@ import static com.google.firebase.inappmessaging.testutil.TestData.BANNER_MESSAG
 import static com.google.firebase.inappmessaging.testutil.TestData.CARD_MESSAGE_MODEL;
 import static com.google.firebase.inappmessaging.testutil.TestData.IMAGE_MESSAGE_MODEL;
 import static com.google.firebase.inappmessaging.testutil.TestData.IMAGE_MESSAGE_MODEL_WITHOUT_ACTION;
+import static com.google.firebase.inappmessaging.testutil.TestData.IMAGE_MESSAGE_WEB_ACTION_MODEL;
 import static com.google.firebase.inappmessaging.testutil.TestData.IMAGE_URL_STRING;
 import static com.google.firebase.inappmessaging.testutil.TestData.MODAL_MESSAGE_MODEL;
+import static com.google.firebase.inappmessaging.testutil.TestData.WEB_ACTION_URL_STRING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -589,12 +591,15 @@ public class FirebaseInAppMessagingDisplayTest {
     customTabIntent.setPackage("com.android.chrome");
     shadowPackageManager.addResolveInfoForIntent(customTabIntent, resolveInfo);
     resumeActivity(activity);
-    listener.displayMessage(IMAGE_MESSAGE_MODEL, callbacks);
+    listener.displayMessage(IMAGE_MESSAGE_WEB_ACTION_MODEL, callbacks);
     verify(imageBindingWrapper)
         .inflate(onClickListenerArgCaptor.capture(), any(OnClickListener.class));
-    onClickListenerArgCaptor.getValue().get(IMAGE_MESSAGE_MODEL.getAction()).onClick(null);
+    onClickListenerArgCaptor
+        .getValue()
+        .get(IMAGE_MESSAGE_WEB_ACTION_MODEL.getAction())
+        .onClick(null);
     assertThat(shadowActivity.getNextStartedActivity().getData())
-        .isEqualTo(Uri.parse(ACTION_URL_STRING));
+        .isEqualTo(Uri.parse(WEB_ACTION_URL_STRING));
   }
 
   @Test

--- a/firebase-inappmessaging/src/testData/inappmessaging/testutil/TestData.java
+++ b/firebase-inappmessaging/src/testData/inappmessaging/testutil/TestData.java
@@ -77,7 +77,8 @@ public class TestData {
       Button.builder().setText(BUTTON_TEXT_MODEL).setButtonHexColor(BUTTON_BG_STRING).build();
 
   // ************************* ACTION *************************
-  public static final String ACTION_URL_STRING = "action_url";
+  public static final String ACTION_URL_STRING = "fiam://action_url";
+  public static final String WEB_ACTION_URL_STRING = "http://action_url";
   public static final String SECONDARY_ACTION_URL_STRING = "secondary_action";
   public static final Action ACTION_MODEL_WITHOUT_BUTTON =
       Action.builder().setActionUrl(ACTION_URL_STRING).build();
@@ -89,6 +90,8 @@ public class TestData {
       Action.builder().setActionUrl(ACTION_URL_STRING).setButton(BUTTON_MODEL).build();
   public static final Action SECONDARY_ACTION_MODEL_WITH_BUTTON =
       Action.builder().setActionUrl(SECONDARY_ACTION_URL_STRING).setButton(BUTTON_MODEL).build();
+  public static final Action WEB_ACTION_MODEL_WITHOUT_BUTTON =
+      Action.builder().setActionUrl(WEB_ACTION_URL_STRING).build();
 
   // ************************* BANNER *************************
   public static final BannerMessage BANNER_MESSAGE_MODEL =
@@ -153,6 +156,12 @@ public class TestData {
   public static final ImageOnlyMessage IMAGE_MESSAGE_MODEL =
       ImageOnlyMessage.builder()
           .setAction(ACTION_MODEL_WITHOUT_BUTTON)
+          .setImageData(IMAGE_DATA)
+          .build(CAMPAIGN_METADATA_MODEL, DATA);
+
+  public static final ImageOnlyMessage IMAGE_MESSAGE_WEB_ACTION_MODEL =
+      ImageOnlyMessage.builder()
+          .setAction(WEB_ACTION_MODEL_WITHOUT_BUTTON)
           .setImageData(IMAGE_DATA)
           .build(CAMPAIGN_METADATA_MODEL, DATA);
 


### PR DESCRIPTION
Currently, FIAM uses Custom Tabs to open every action URI and results in errors for deep links.

Refering to [iOS SDK's implementation](https://github.com/firebase/firebase-ios-sdk/blob/b41a1273368e8af2af26d1dfcb135fc2307b94b3/FirebaseInAppMessaging/Sources/Runtime/FIRIAMActionURLFollower.m#L107-L129), which checks whether URI schems is http/https, I implemented a similar logic in this PR.

Not pretty sure if my test change is sufficient as this is my first time to contribute to the project. 
So please let me know if there's anything missing.