### PR TITLE
Fixing issues related with package visibility changes for Android 11.

### DIFF
--- a/firebase-inappmessaging-display/src/main/AndroidManifest.xml
+++ b/firebase-inappmessaging-display/src/main/AndroidManifest.xml
@@ -3,6 +3,14 @@
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />
+
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="https" />
+    </intent>
+  </queries>
+
   <application>
     <service android:name="com.google.firebase.components.ComponentDiscoveryService"
         android:exported="false">


### PR DESCRIPTION
Fixing issues related with package visibility changes for Android 11.

While targeting android 11, querying for activities or services which can handle intent returns 0 results. To support this querying in Android 11 and above we need to have the 'queries' tag mentioned in the manifest. Please see: https://developer.android.com/about/versions/11/privacy/package-visibility for details.