### PR TITLE
Add Bundle API

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,12 +1,21 @@
-# Unreleased
-- [fixed] Removed excess validation of null and NaN values in query filters.
-  This more closely aligns the SDK with the Firestore backend, which has always
-  accepted null and NaN for all operators, even though this isn't necessarily
-  useful.
+# Unreleased (22.1.0)
+- [feature] Added support for Firestore Bundles via
+  `FirebaseFirestore.loadBundle()` and `FirebaseFirestore.getNamedQuery()`.
+  Bundles contain pre-packaged data produced with the NodeJS Server SDK and
+  can be used to populate Firestore's cache without directly reading documents
+  from the backend.
+
+# (22.0.2)
 - [changed] A write to a document that contains FieldValue transforms is no
   longer split up into two separate operations. This reduces the number of
   writes the backend performs and allows each WriteBatch to hold 500 writes
   regardless of how many FieldValue transformations are attached.
+
+# (22.0.1)
+- [fixed] Removed excess validation of null and NaN values in query filters.
+  This more closely aligns the SDK with the Firestore backend, which has always
+  accepted null and NaN for all operators, even though this isn't necessarily
+  useful.
 
 # (22.0.0)
 - [changed] Removed the deprecated `timestampsInSnapshotsEnabled` setting.

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -281,7 +281,7 @@ package com.google.firebase.firestore {
   }
 
   public @interface OnProgressListener<ProgessT> {
-    method public abstract void onProgress(@NonNull ProgressT snapshot);
+    method public abstract void onProgress(@NonNull ProgressT);
   }
 
   @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME) @java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD}) public @interface PropertyName {

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -280,6 +280,10 @@ package com.google.firebase.firestore {
     enum_constant public static final com.google.firebase.firestore.MetadataChanges INCLUDE;
   }
 
+  public @interface OnProgressListener<ProgessT> {
+    method public abstract void onProgress(@NonNull ProgressT snapshot);
+  }
+
   @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME) @java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD}) public @interface PropertyName {
     method public abstract String value();
   }

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -146,6 +146,10 @@ package com.google.firebase.firestore {
     method @NonNull public com.google.firebase.firestore.FirebaseFirestoreSettings getFirestoreSettings();
     method @NonNull public static com.google.firebase.firestore.FirebaseFirestore getInstance();
     method @NonNull public static com.google.firebase.firestore.FirebaseFirestore getInstance(@NonNull com.google.firebase.FirebaseApp);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.Query> getNamedQuery(@NonNull String);
+    method @NonNull public com.google.firebase.firestore.LoadBundleTask loadBundle(@NonNull java.io.InputStream);
+    method @NonNull public com.google.firebase.firestore.LoadBundleTask loadBundle(@NonNull byte[]);
+    method @NonNull public com.google.firebase.firestore.LoadBundleTask loadBundle(@NonNull java.nio.ByteBuffer);
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> runBatch(@NonNull com.google.firebase.firestore.WriteBatch.Function);
     method @NonNull public <TResult> com.google.android.gms.tasks.Task<TResult> runTransaction(@NonNull com.google.firebase.firestore.Transaction.Function<TResult>);
     method public void setFirestoreSettings(@NonNull com.google.firebase.firestore.FirebaseFirestoreSettings);
@@ -219,8 +223,44 @@ package com.google.firebase.firestore {
     method public void remove();
   }
 
+  public class LoadBundleTask extends com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> {
+    ctor @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public LoadBundleTask();
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCanceledListener(@NonNull com.google.android.gms.tasks.OnCanceledListener);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCanceledListener(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.OnCanceledListener);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCanceledListener(@NonNull android.app.Activity, @NonNull com.google.android.gms.tasks.OnCanceledListener);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCompleteListener(@NonNull com.google.android.gms.tasks.OnCompleteListener<com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCompleteListener(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.OnCompleteListener<com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCompleteListener(@NonNull android.app.Activity, @NonNull com.google.android.gms.tasks.OnCompleteListener<com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnFailureListener(@NonNull com.google.android.gms.tasks.OnFailureListener);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnFailureListener(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.OnFailureListener);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnFailureListener(@NonNull android.app.Activity, @NonNull com.google.android.gms.tasks.OnFailureListener);
+    method @NonNull public com.google.firebase.firestore.LoadBundleTask addOnProgressListener(@NonNull com.google.firebase.firestore.OnProgressListener<com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public com.google.firebase.firestore.LoadBundleTask addOnProgressListener(@NonNull java.util.concurrent.Executor, @NonNull com.google.firebase.firestore.OnProgressListener<com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public com.google.firebase.firestore.LoadBundleTask addOnProgressListener(@NonNull android.app.Activity, @NonNull com.google.firebase.firestore.OnProgressListener<com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnSuccessListener(@NonNull com.google.android.gms.tasks.OnSuccessListener<? super com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnSuccessListener(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.OnSuccessListener<? super com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnSuccessListener(@NonNull android.app.Activity, @NonNull com.google.android.gms.tasks.OnSuccessListener<? super com.google.firebase.firestore.LoadBundleTaskProgress>);
+    method @NonNull public <TContinuationResult> com.google.android.gms.tasks.Task<TContinuationResult> continueWith(@NonNull com.google.android.gms.tasks.Continuation<com.google.firebase.firestore.LoadBundleTaskProgress,TContinuationResult>);
+    method @NonNull public <TContinuationResult> com.google.android.gms.tasks.Task<TContinuationResult> continueWith(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.Continuation<com.google.firebase.firestore.LoadBundleTaskProgress,TContinuationResult>);
+    method @NonNull public <TContinuationResult> com.google.android.gms.tasks.Task<TContinuationResult> continueWithTask(@NonNull com.google.android.gms.tasks.Continuation<com.google.firebase.firestore.LoadBundleTaskProgress,com.google.android.gms.tasks.Task<TContinuationResult>>);
+    method @NonNull public <TContinuationResult> com.google.android.gms.tasks.Task<TContinuationResult> continueWithTask(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.Continuation<com.google.firebase.firestore.LoadBundleTaskProgress,com.google.android.gms.tasks.Task<TContinuationResult>>);
+    method @Nullable public Exception getException();
+    method @NonNull public com.google.firebase.firestore.LoadBundleTaskProgress getResult();
+    method @NonNull public <X extends java.lang.Throwable> com.google.firebase.firestore.LoadBundleTaskProgress getResult(@NonNull Class<X>) throws X;
+    method public boolean isCanceled();
+    method public boolean isComplete();
+    method public boolean isSuccessful();
+    method @NonNull public <TContinuationResult> com.google.android.gms.tasks.Task<TContinuationResult> onSuccessTask(@NonNull com.google.android.gms.tasks.SuccessContinuation<com.google.firebase.firestore.LoadBundleTaskProgress,TContinuationResult>);
+    method @NonNull public <TContinuationResult> com.google.android.gms.tasks.Task<TContinuationResult> onSuccessTask(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.SuccessContinuation<com.google.firebase.firestore.LoadBundleTaskProgress,TContinuationResult>);
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public void setException(@NonNull Exception);
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public void setResult(@NonNull com.google.firebase.firestore.LoadBundleTaskProgress);
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public void updateProgress(@NonNull com.google.firebase.firestore.LoadBundleTaskProgress);
+  }
+
   public final class LoadBundleTaskProgress {
     ctor @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public LoadBundleTaskProgress(int, int, long, long, @Nullable Exception, @NonNull com.google.firebase.firestore.LoadBundleTaskProgress.TaskState);
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) @NonNull public static com.google.firebase.firestore.LoadBundleTaskProgress forInitial(@NonNull com.google.firebase.firestore.bundle.BundleMetadata);
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) @NonNull public static com.google.firebase.firestore.LoadBundleTaskProgress forSuccess(@NonNull com.google.firebase.firestore.bundle.BundleMetadata);
     method public long getBytesLoaded();
     method public int getDocumentsLoaded();
     method @Nullable public Exception getException();

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -224,7 +224,6 @@ package com.google.firebase.firestore {
   }
 
   public class LoadBundleTask extends com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> {
-    ctor @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public LoadBundleTask();
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCanceledListener(@NonNull com.google.android.gms.tasks.OnCanceledListener);
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCanceledListener(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.OnCanceledListener);
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.firestore.LoadBundleTaskProgress> addOnCanceledListener(@NonNull android.app.Activity, @NonNull com.google.android.gms.tasks.OnCanceledListener);
@@ -252,15 +251,9 @@ package com.google.firebase.firestore {
     method public boolean isSuccessful();
     method @NonNull public <TContinuationResult> com.google.android.gms.tasks.Task<TContinuationResult> onSuccessTask(@NonNull com.google.android.gms.tasks.SuccessContinuation<com.google.firebase.firestore.LoadBundleTaskProgress,TContinuationResult>);
     method @NonNull public <TContinuationResult> com.google.android.gms.tasks.Task<TContinuationResult> onSuccessTask(@NonNull java.util.concurrent.Executor, @NonNull com.google.android.gms.tasks.SuccessContinuation<com.google.firebase.firestore.LoadBundleTaskProgress,TContinuationResult>);
-    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public void setException(@NonNull Exception);
-    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public void setResult(@NonNull com.google.firebase.firestore.LoadBundleTaskProgress);
-    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public void updateProgress(@NonNull com.google.firebase.firestore.LoadBundleTaskProgress);
   }
 
   public final class LoadBundleTaskProgress {
-    ctor @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) public LoadBundleTaskProgress(int, int, long, long, @Nullable Exception, @NonNull com.google.firebase.firestore.LoadBundleTaskProgress.TaskState);
-    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) @NonNull public static com.google.firebase.firestore.LoadBundleTaskProgress forInitial(@NonNull com.google.firebase.firestore.bundle.BundleMetadata);
-    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP) @NonNull public static com.google.firebase.firestore.LoadBundleTaskProgress forSuccess(@NonNull com.google.firebase.firestore.bundle.BundleMetadata);
     method public long getBytesLoaded();
     method public int getDocumentsLoaded();
     method @Nullable public Exception getException();
@@ -280,8 +273,8 @@ package com.google.firebase.firestore {
     enum_constant public static final com.google.firebase.firestore.MetadataChanges INCLUDE;
   }
 
-  public @interface OnProgressListener<ProgessT> {
-    method public abstract void onProgress(@NonNull ProgressT);
+  public interface OnProgressListener<ProgressT> {
+    method public void onProgress(@NonNull ProgressT);
   }
 
   @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME) @java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD}) public @interface PropertyName {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
@@ -1,0 +1,298 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore;
+
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.querySnapshotToValues;
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testFirestore;
+import static com.google.firebase.firestore.testutil.TestUtil.map;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.android.gms.tasks.RuntimeExecutionException;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.firestore.testutil.EventAccumulator;
+import com.google.firebase.firestore.testutil.IntegrationTestUtil;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class BundleTest {
+  private static String[] BUNDLE_TEMPLATES =
+      new String[] {
+        "{\"metadata\":{\"id\":\"test-bundle\",\"createTime\":{\"seconds\":1001,\"nanos\":9999},"
+            + "\"version\":1,\"totalDocuments\":2,\"totalBytes\":{totalBytes}}}",
+        "{\"namedQuery\":{\"name\":\"limit\",\"readTime\":{\"seconds\":1000,\"nanos\":9999},"
+            + "\"bundledQuery\":{\"parent\":\"projects/{projectId}/databases/(default)/documents\","
+            + "\"structuredQuery\":{\"from\":[{\"collectionId\":\"coll-1\"}],\"orderBy\":"
+            + "[{\"field\":{\"fieldPath\":\"bar\"},\"direction\":\"DESCENDING\"},{\"field\":"
+            + "{\"fieldPath\":\"__name__\"},\"direction\":\"DESCENDING\"}],\"limit\":"
+            + "{\"value\":1}},\"limitType\":\"FIRST\"}}}",
+        "{\"namedQuery\":{\"name\":\"limit-to-last\",\"readTime\":{\"seconds\":1000,\"nanos\":9999},"
+            + "\"bundledQuery\":{\"parent\":\"projects/{projectId}/databases/(default)/documents\","
+            + "\"structuredQuery\":{\"from\":[{\"collectionId\":\"coll-1\"}],\"orderBy\":"
+            + "[{\"field\":{\"fieldPath\":\"bar\"},\"direction\":\"DESCENDING\"},{\"field\":"
+            + "{\"fieldPath\":\"__name__\"},\"direction\":\"DESCENDING\"}],\"limit\":"
+            + "{\"value\":1}},\"limitType\":\"LAST\"}}}",
+        "{\"documentMetadata\":{\"name\":"
+            + "\"projects/{projectId}/databases/(default)/documents/coll-1/a\",\"readTime\":"
+            + "{\"seconds\":1000,\"nanos\":9999},\"exists\":true}}",
+        "{\"document\":{\"name\":\"projects/{projectId}/databases/(default)/documents/coll-1/a\","
+            + "\"createTime\":{\"seconds\":1,\"nanos\":9},\"updateTime\":{\"seconds\":1,"
+            + "\"nanos\":9},\"fields\":{\"k\":{\"stringValue\":\"a\"},\"bar\":"
+            + "{\"integerValue\":1}}}}",
+        "{\"documentMetadata\":{\"name\":"
+            + "\"projects/{projectId}/databases/(default)/documents/coll-1/b\",\"readTime\":"
+            + "{\"seconds\":1000,\"nanos\":9999},\"exists\":true}}",
+        "{\"document\":{\"name\":\"projects/{projectId}/databases/(default)/documents/coll-1/b\","
+            + "\"createTime\":{\"seconds\":1,\"nanos\":9},\"updateTime\":{\"seconds\":1,"
+            + "\"nanos\":9},\"fields\":{\"k\":{\"stringValue\":\"b\"},\"bar\":"
+            + "{\"integerValue\":2}}}}"
+      };
+
+  private FirebaseFirestore db;
+
+  @Before
+  public void setUp() {
+    FirebaseFirestore.setLoggingEnabled(true);
+    db = testFirestore();
+  }
+
+  @After
+  public void tearDown() {
+    IntegrationTestUtil.tearDown();
+  }
+
+  @Test
+  public void testLoadDocumentsWithProgressUpdates() throws Exception {
+    List<LoadBundleTaskProgress> progressEvents = new ArrayList<>();
+
+    byte[] bundle = createBundle(db.getDatabaseId().getProjectId());
+    LoadBundleTask bundleTask = db.loadBundle(bundle);
+    bundleTask.addOnProgressListener(progressEvents::add);
+
+    LoadBundleTaskProgress result = awaitCompletion(bundleTask);
+
+    assertEquals(4, progressEvents.size());
+    verifyProgress(progressEvents.get(0), 0);
+    verifyProgress(progressEvents.get(1), 1);
+    verifyProgress(progressEvents.get(2), 2);
+    verifySuccessProgress(progressEvents.get(3));
+    assertEquals(progressEvents.get(3), result);
+
+    verifyQueryResults();
+  }
+
+  @Test
+  public void testLoadForASecondTimeSkips() throws Exception {
+    byte[] bundle = createBundle(db.getDatabaseId().getProjectId());
+    LoadBundleTask initialLoad = db.loadBundle(bundle);
+    Tasks.await(initialLoad);
+
+    List<LoadBundleTaskProgress> progressEvents = new ArrayList<>();
+    LoadBundleTask secondLoad = db.loadBundle(bundle);
+    secondLoad.addOnProgressListener(progressEvents::add);
+    awaitCompletion(secondLoad);
+
+    // No loading actually happened in the second `loadBundle` call only the success progress is
+    // recorded.
+    assertEquals(1, progressEvents.size());
+    verifySuccessProgress(progressEvents.get(0));
+
+    verifyQueryResults();
+  }
+
+  @Test
+  public void testLoadWithDocumentsThatAreAlreadyPulledFromBackend() throws Exception {
+    Task<Void> docA = db.document("coll-1/a").set(map("bar", "newValueA"));
+    Tasks.await(docA);
+    Task<Void> docB = db.document("coll-1/b").set(map("bar", "newValueB"));
+    Tasks.await(docB);
+
+    EventAccumulator<QuerySnapshot> accumulator = new EventAccumulator<>();
+
+    ListenerRegistration listenerRegistration = null;
+    try {
+      listenerRegistration = db.collection("coll-1").addSnapshotListener(accumulator.listener());
+      accumulator.awaitRemoteEvent();
+
+      ByteBuffer bundle = ByteBuffer.wrap(createBundle(db.getDatabaseId().getProjectId()));
+      LoadBundleTask bundleTask = db.loadBundle(bundle); // Test the ByteBuffer overload
+      LoadBundleTaskProgress result = Tasks.await(bundleTask);
+      verifySuccessProgress(result);
+
+      // The test bundle is holding ancient documents, so no events are generated as a result.
+      // The case where a bundle has newer doc than cache can only be tested in spec tests.
+      accumulator.assertNoAdditionalEvents();
+
+      CollectionReference collectionQuery = db.collection("coll-1");
+      QuerySnapshot collectionSnapshot = Tasks.await(collectionQuery.get(Source.CACHE));
+      assertEquals(
+          asList(map("bar", "newValueA"), map("bar", "newValueB")),
+          querySnapshotToValues(collectionSnapshot));
+
+      Query limitQuery = Tasks.await(db.getNamedQuery("limit"));
+      QuerySnapshot limitSnapshot = Tasks.await(limitQuery.get(Source.CACHE));
+      assertEquals(1, limitSnapshot.size());
+
+      Query limitToLastQuery = Tasks.await(db.getNamedQuery("limit-to-last"));
+      QuerySnapshot limitToLastSnapshot = Tasks.await(limitToLastQuery.get(Source.CACHE));
+      assertEquals(1, limitToLastSnapshot.size());
+    } finally {
+      if (listenerRegistration != null) {
+        listenerRegistration.remove();
+      }
+    }
+  }
+
+  @Test
+  public void testLoadedDocumentsShouldNotBeGarbageCollectedRightAway() throws Exception {
+    // This test really only makes sense with memory persistence, as SQLite persistence only ever
+    // lazily deletes data
+    db.setFirestoreSettings(
+        new FirebaseFirestoreSettings.Builder().setPersistenceEnabled(false).build());
+
+    InputStream bundle = new ByteArrayInputStream(createBundle(db.getDatabaseId().getProjectId()));
+    LoadBundleTask bundleTask = db.loadBundle(bundle); // Test the InputStream overload
+    LoadBundleTaskProgress result = Tasks.await(bundleTask);
+    verifySuccessProgress(result);
+
+    // Read a different collection, this will trigger GC.
+    Tasks.await(db.collection("coll-other").get());
+
+    // Read the loaded documents, expecting document in cache. With memory GC, the documents would
+    // get GC-ed if we did not hold the document keys  in a "umbrella" target. See local_store.ts
+    // for details.
+    verifyQueryResults();
+  }
+
+  @Test
+  public void testLoadWithDocumentsFromOtherProjectFails() throws Exception {
+    List<LoadBundleTaskProgress> progressEvents = new ArrayList<>();
+
+    byte[] bundle = createBundle("other-project");
+    LoadBundleTask bundleTask = db.loadBundle(bundle);
+
+    bundleTask.addOnProgressListener(progressEvents::add);
+
+    try {
+      awaitCompletion(bundleTask);
+      fail();
+    } catch (RuntimeExecutionException e) {
+      assertEquals(
+          "Resource name is not valid for current instance: "
+              + "projects/other-project/databases/(default)/documents",
+          e.getCause().getCause().getMessage());
+    }
+
+    assertEquals(2, progressEvents.size());
+    verifyProgress(progressEvents.get(0), 0);
+    verifyErrorProgress(progressEvents.get(1));
+
+    // Verify Firestore still functions, despite loaded a problematic bundle.
+    Tasks.await(db.collection("coll-1").get());
+  }
+
+  /**
+   * Waits for the completion handler to be invoked.
+   *
+   * <p>Tasks.await() in combination with progress updates can be racy, as the Task can resolve just
+   * before the final progress even is raised. We use listeners here as their order is
+   * deterministic.
+   */
+  private LoadBundleTaskProgress awaitCompletion(LoadBundleTask bundleTask)
+      throws InterruptedException {
+    Semaphore success = new Semaphore(0);
+    bundleTask.addOnCompleteListener(v -> success.release());
+    success.acquire();
+    return bundleTask.getResult();
+  }
+
+  private void verifyQueryResults() throws ExecutionException, InterruptedException {
+    // Read from cache. These documents do not exist in backend, so they can only be read from
+    // cache.
+    CollectionReference collectionQuery = db.collection("coll-1");
+    QuerySnapshot collectionSnapshot = Tasks.await(collectionQuery.get(Source.CACHE));
+    assertEquals(
+        asList(map("bar", 1L, "k", "a"), map("bar", 2L, "k", "b")),
+        querySnapshotToValues(collectionSnapshot));
+
+    Query limitQuery = Tasks.await(db.getNamedQuery("limit"));
+    QuerySnapshot limitSnapshot = Tasks.await(limitQuery.get(Source.CACHE));
+    assertEquals(asList(map("bar", 2L, "k", "b")), querySnapshotToValues(limitSnapshot));
+
+    Query limitToLastQuery = Tasks.await(db.getNamedQuery("limit-to-last"));
+    QuerySnapshot limitToLastSnapshot = Tasks.await(limitToLastQuery.get(Source.CACHE));
+    assertEquals(asList(map("bar", 1L, "k", "a")), querySnapshotToValues(limitToLastSnapshot));
+  }
+
+  /**
+   * Returns a valid bundle by replacing project id in `BUNDLE_TEMPLATES` with the given db project
+   * id (also recalculate length prefixes).
+   */
+  private byte[] createBundle(String projectId) throws UnsupportedEncodingException {
+    StringBuilder bundle = new StringBuilder();
+
+    // Prepare non-metadata elements since we need the total length of these elements before
+    // generating the metadata.
+    for (int i = 1; i < BUNDLE_TEMPLATES.length; ++i) {
+      // Extract elements from BUNDLE_TEMPLATE and replace the project ID.
+      String element = BUNDLE_TEMPLATES[i].replaceAll("\\{projectId\\}", projectId);
+      bundle.append(element.length());
+      bundle.append(element);
+    }
+
+    String bundleString = bundle.toString();
+
+    // Update BundleMetadata with new totalBytes.
+    String metadata =
+        BUNDLE_TEMPLATES[0].replace(
+            "{totalBytes}", Integer.toString(bundleString.getBytes("UTF-8").length));
+
+    return (metadata.length() + metadata + bundleString).getBytes("UTF-8");
+  }
+
+  private void verifySuccessProgress(LoadBundleTaskProgress progress) {
+    assertEquals(LoadBundleTaskProgress.TaskState.SUCCESS, progress.getTaskState());
+    assertEquals(progress.getTotalBytes(), progress.getBytesLoaded());
+    assertEquals(progress.getTotalDocuments(), progress.getDocumentsLoaded());
+  }
+
+  private void verifyErrorProgress(LoadBundleTaskProgress progress) {
+    assertEquals(LoadBundleTaskProgress.TaskState.ERROR, progress.getTaskState());
+    assertEquals(0, progress.getBytesLoaded());
+    assertEquals(0, progress.getDocumentsLoaded());
+  }
+
+  private void verifyProgress(LoadBundleTaskProgress progress, int expectedDocuments) {
+    assertEquals(LoadBundleTaskProgress.TaskState.RUNNING, progress.getTaskState());
+    assertTrue(progress.getBytesLoaded() <= progress.getTotalBytes());
+    assertTrue(progress.getDocumentsLoaded() <= progress.getTotalDocuments());
+    assertEquals(expectedDocuments, progress.getDocumentsLoaded());
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -43,10 +43,14 @@ import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.remote.FirestoreChannel;
 import com.google.firebase.firestore.remote.GrpcMetadataProvider;
 import com.google.firebase.firestore.util.AsyncQueue;
+import com.google.firebase.firestore.util.ByteBufferInputStream;
 import com.google.firebase.firestore.util.Executors;
 import com.google.firebase.firestore.util.Function;
 import com.google.firebase.firestore.util.Logger;
 import com.google.firebase.firestore.util.Logger.Level;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.concurrent.Executor;
 
 /**
@@ -579,6 +583,67 @@ public class FirebaseFirestore {
   public ListenerRegistration addSnapshotsInSyncListener(
       @NonNull Executor executor, @NonNull Runnable runnable) {
     return addSnapshotsInSyncListener(executor, null, runnable);
+  }
+
+  /**
+   * Loads a Firestore Bundle into the local cache.
+   *
+   * @param bundleData A stream representing the Bundle to be loaded.
+   * @return A {@link LoadBundleTask}, which notifies callers with progress updates, and completion
+   *     or error events.
+   */
+  @NonNull
+  public LoadBundleTask loadBundle(@NonNull InputStream bundleData) {
+    ensureClientConfigured();
+    LoadBundleTask resultTask = new LoadBundleTask();
+    client.loadBundle(bundleData, resultTask);
+    return resultTask;
+  }
+
+  /**
+   * Loads a Firestore Bundle into the local cache.
+   *
+   * @param bundleData A byte array representing the Bundle to be loaded.
+   * @return A {@link LoadBundleTask}, which notifies callers with progress updates, and completion
+   *     or error events.
+   */
+  @NonNull
+  public LoadBundleTask loadBundle(@NonNull byte[] bundleData) {
+    return loadBundle(new ByteArrayInputStream(bundleData));
+  }
+
+  /**
+   * Loads a Firestore Bundle into the local cache.
+   *
+   * @param bundleData A ByteBuffer representing the Bundle to be loaded.
+   * @return A {@link LoadBundleTask}, which notifies callers with progress updates, and completion
+   *     or error events.
+   */
+  @NonNull
+  public LoadBundleTask loadBundle(@NonNull ByteBuffer bundleData) {
+    return loadBundle(new ByteBufferInputStream(bundleData));
+  }
+
+  /**
+   * Reads a Firestore {@link Query} from local cache, identified by the given name.
+   *
+   * <p>The named queries are packaged into bundles on the server side (along with resulting
+   * documents), and loaded to local cache using {@link #loadBundle(byte[])}. Once in local cache,
+   * you can use this method to extract a query by name.
+   */
+  public @NonNull Task<Query> getNamedQuery(@NonNull String name) {
+    ensureClientConfigured();
+    return client
+        .getNamedQuery(name)
+        .continueWith(
+            task -> {
+              com.google.firebase.firestore.core.Query query = task.getResult();
+              if (query != null) {
+                return new Query(query, FirebaseFirestore.this);
+              } else {
+                return null;
+              }
+            });
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTask.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTask.java
@@ -63,6 +63,7 @@ public class LoadBundleTask extends Task<LoadBundleTaskProgress> {
   @GuardedBy("lock")
   private final Queue<ManagedListener> progressListeners;
 
+  /* @hide */
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public LoadBundleTask() {
     snapshot = LoadBundleTaskProgress.INITIAL;
@@ -500,6 +501,7 @@ public class LoadBundleTask extends Task<LoadBundleTaskProgress> {
     }
   }
 
+  /** @hide */
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public void setResult(@NonNull LoadBundleTaskProgress result) {
     hardAssert(
@@ -516,6 +518,7 @@ public class LoadBundleTask extends Task<LoadBundleTaskProgress> {
     completionSource.setResult(result);
   }
 
+  /** @hide */
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public void setException(@NonNull Exception exception) {
     LoadBundleTaskProgress snapshot;
@@ -538,6 +541,7 @@ public class LoadBundleTask extends Task<LoadBundleTaskProgress> {
     completionSource.setException(exception);
   }
 
+  /** @hide */
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public void updateProgress(@NonNull LoadBundleTaskProgress progressUpdate) {
     synchronized (lock) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTask.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTask.java
@@ -63,7 +63,7 @@ public class LoadBundleTask extends Task<LoadBundleTaskProgress> {
   @GuardedBy("lock")
   private final Queue<ManagedListener> progressListeners;
 
-  /* @hide */
+  /** @hide */
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public LoadBundleTask() {
     snapshot = LoadBundleTaskProgress.INITIAL;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTask.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTask.java
@@ -14,10 +14,13 @@
 
 package com.google.firebase.firestore;
 
+import static com.google.firebase.firestore.util.Assert.hardAssert;
+
 import android.app.Activity;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 import com.google.android.gms.common.api.internal.ActivityLifecycleObserver;
 import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.OnCanceledListener;
@@ -37,7 +40,7 @@ import java.util.concurrent.Executor;
  * Represents the task of loading a Firestore bundle. It provides progress of bundle loading, as
  * well as task completion and error events.
  */
-/* package */ class LoadBundleTask extends Task<LoadBundleTaskProgress> {
+public class LoadBundleTask extends Task<LoadBundleTaskProgress> {
   private final Object lock = new Object();
 
   /** The last progress update, or {@code null} if not yet available. */
@@ -60,6 +63,7 @@ import java.util.concurrent.Executor;
   @GuardedBy("lock")
   private final Queue<ManagedListener> progressListeners;
 
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public LoadBundleTask() {
     snapshot = LoadBundleTaskProgress.INITIAL;
     completionSource = new TaskCompletionSource<>();
@@ -496,7 +500,11 @@ import java.util.concurrent.Executor;
     }
   }
 
-  void setResult(@Nullable LoadBundleTaskProgress result) {
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+  public void setResult(@NonNull LoadBundleTaskProgress result) {
+    hardAssert(
+        result.getTaskState().equals(LoadBundleTaskProgress.TaskState.SUCCESS),
+        "Expected success, but was " + result.getTaskState());
     synchronized (lock) {
       snapshot = result;
       for (ManagedListener listener : progressListeners) {
@@ -504,10 +512,12 @@ import java.util.concurrent.Executor;
       }
       progressListeners.clear();
     }
+
     completionSource.setResult(result);
   }
 
-  void setException(@NonNull Exception exception) {
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+  public void setException(@NonNull Exception exception) {
     LoadBundleTaskProgress snapshot;
     synchronized (lock) {
       snapshot =
@@ -528,7 +538,8 @@ import java.util.concurrent.Executor;
     completionSource.setException(exception);
   }
 
-  void updateProgress(LoadBundleTaskProgress progressUpdate) {
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+  public void updateProgress(@NonNull LoadBundleTaskProgress progressUpdate) {
     synchronized (lock) {
       snapshot = progressUpdate;
       for (ManagedListener listener : progressListeners) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTaskProgress.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTaskProgress.java
@@ -43,6 +43,7 @@ public final class LoadBundleTaskProgress {
   @NonNull private final TaskState taskState;
   @Nullable private final Exception exception;
 
+  /** @hide */
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public LoadBundleTaskProgress(
       int documentsLoaded,
@@ -62,6 +63,7 @@ public final class LoadBundleTaskProgress {
   /**
    * Creates an "initial" status update from a bundle's metadata. The initial status sets all
    * loading indicators to 0.
+   * @hide
    */
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public static @NonNull LoadBundleTaskProgress forInitial(@NonNull BundleMetadata bundleMetadata) {
@@ -77,6 +79,7 @@ public final class LoadBundleTaskProgress {
   /**
    * Creates a "success" status update from a bundle's metadata. The initial status sets all loading
    * indicators to their maximum values.
+   * @hide
    */
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   public static @NonNull LoadBundleTaskProgress forSuccess(@NonNull BundleMetadata bundleMetadata) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTaskProgress.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/LoadBundleTaskProgress.java
@@ -17,6 +17,7 @@ package com.google.firebase.firestore;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
+import com.google.firebase.firestore.bundle.BundleMetadata;
 
 /** Represents a progress update or a final state from loading bundles. */
 public final class LoadBundleTaskProgress {
@@ -56,6 +57,36 @@ public final class LoadBundleTaskProgress {
     this.totalBytes = totalBytes;
     this.taskState = taskState;
     this.exception = exception;
+  }
+
+  /**
+   * Creates an "initial" status update from a bundle's metadata. The initial status sets all
+   * loading indicators to 0.
+   */
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+  public static @NonNull LoadBundleTaskProgress forInitial(@NonNull BundleMetadata bundleMetadata) {
+    return new LoadBundleTaskProgress(
+        0,
+        bundleMetadata.getTotalDocuments(),
+        0,
+        bundleMetadata.getTotalBytes(),
+        /* exception= */ null,
+        TaskState.RUNNING);
+  }
+
+  /**
+   * Creates a "success" status update from a bundle's metadata. The initial status sets all loading
+   * indicators to their maximum values.
+   */
+  @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+  public static @NonNull LoadBundleTaskProgress forSuccess(@NonNull BundleMetadata bundleMetadata) {
+    return new LoadBundleTaskProgress(
+        bundleMetadata.getTotalDocuments(),
+        bundleMetadata.getTotalDocuments(),
+        bundleMetadata.getTotalBytes(),
+        bundleMetadata.getTotalBytes(),
+        /* exception= */ null,
+        LoadBundleTaskProgress.TaskState.SUCCESS);
   }
 
   /** Returns how many documents have been loaded. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/OnProgressListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/OnProgressListener.java
@@ -17,6 +17,6 @@ package com.google.firebase.firestore;
 import androidx.annotation.NonNull;
 
 /** A listener that is called periodically during execution of a {@link LoadBundleTask}. */
-/* package */ interface OnProgressListener<ProgressT> {
+public interface OnProgressListener<ProgressT> {
   void onProgress(@NonNull ProgressT snapshot);
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleLoader.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleLoader.java
@@ -36,8 +36,6 @@ import java.util.Map;
 public class BundleLoader {
   private final BundleListener bundleListener;
   private final BundleMetadata bundleMetadata;
-  private final int totalDocuments;
-  private final long totalBytes;
   private final List<NamedQuery> queries;
   private final Map<DocumentKey, BundledDocumentMetadata> documentsMetadata;
 
@@ -45,15 +43,9 @@ public class BundleLoader {
   private long bytesLoaded;
   @Nullable private DocumentKey currentDocument;
 
-  public BundleLoader(
-      BundleListener bundleListener,
-      BundleMetadata bundleMetadata,
-      int totalDocuments,
-      long totalBytes) {
+  public BundleLoader(BundleListener bundleListener, BundleMetadata bundleMetadata) {
     this.bundleListener = bundleListener;
     this.bundleMetadata = bundleMetadata;
-    this.totalDocuments = totalDocuments;
-    this.totalBytes = totalBytes;
     this.queries = new ArrayList<>();
     this.documents = emptyMaybeDocumentMap();
     this.documentsMetadata = new HashMap<>();
@@ -104,9 +96,9 @@ public class BundleLoader {
     return updateProgress
         ? new LoadBundleTaskProgress(
             documents.size(),
-            totalDocuments,
+            bundleMetadata.getTotalDocuments(),
             bytesLoaded,
-            totalBytes,
+            bundleMetadata.getTotalBytes(),
             null,
             LoadBundleTaskProgress.TaskState.RUNNING)
         : null;
@@ -119,9 +111,9 @@ public class BundleLoader {
         "Bundled documents end with a document metadata element instead of a document.");
     Preconditions.checkArgument(bundleMetadata.getBundleId() != null, "Bundle ID must be set");
     Preconditions.checkArgument(
-        documents.size() == totalDocuments,
+        documents.size() == bundleMetadata.getTotalDocuments(),
         "Expected %s documents, but loaded %s.",
-        totalDocuments,
+        bundleMetadata.getTotalDocuments(),
         documents.size());
 
     ImmutableSortedMap<DocumentKey, MaybeDocument> changes =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleMetadata.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleMetadata.java
@@ -21,11 +21,20 @@ public class BundleMetadata implements BundleElement {
   private final String bundleId;
   private final int schemaVersion;
   private final SnapshotVersion createTime;
+  private final int totalDocuments;
+  private final long totalBytes;
 
-  public BundleMetadata(String bundleId, int schemaVersion, SnapshotVersion createTime) {
+  public BundleMetadata(
+      String bundleId,
+      int schemaVersion,
+      SnapshotVersion createTime,
+      int totalDocuments,
+      long totalBytes) {
     this.bundleId = bundleId;
     this.schemaVersion = schemaVersion;
     this.createTime = createTime;
+    this.totalDocuments = totalDocuments;
+    this.totalBytes = totalBytes;
   }
 
   /**
@@ -49,6 +58,16 @@ public class BundleMetadata implements BundleElement {
     return createTime;
   }
 
+  /** Returns the number of documents in the bundle. */
+  public int getTotalDocuments() {
+    return totalDocuments;
+  }
+
+  /** Returns the size of the bundle in bytes, excluding this BundleMetadata. */
+  public long getTotalBytes() {
+    return totalBytes;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -57,6 +76,8 @@ public class BundleMetadata implements BundleElement {
     BundleMetadata that = (BundleMetadata) o;
 
     if (schemaVersion != that.schemaVersion) return false;
+    if (totalDocuments != that.totalDocuments) return false;
+    if (totalBytes != that.totalBytes) return false;
     if (!bundleId.equals(that.bundleId)) return false;
     return createTime.equals(that.createTime);
   }
@@ -65,6 +86,8 @@ public class BundleMetadata implements BundleElement {
   public int hashCode() {
     int result = bundleId.hashCode();
     result = 31 * result + schemaVersion;
+    result = 31 * result + totalDocuments;
+    result = 31 * result + (int) (totalBytes ^ (totalBytes >>> 32));
     result = 31 * result + createTime.hashCode();
     return result;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleReader.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleReader.java
@@ -15,6 +15,7 @@
 package com.google.firebase.firestore.bundle;
 
 import androidx.annotation.Nullable;
+import com.google.firebase.firestore.util.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -56,8 +57,7 @@ public class BundleReader {
     }
     BundleElement element = readNextElement();
     if (!(element instanceof BundleMetadata)) {
-      throw new IllegalArgumentException(
-          "Expected first element in bundle to be a metadata object");
+      raiseError("Expected first element in bundle to be a metadata object");
     }
     metadata = (BundleMetadata) element;
     // We don't consider the metadata as part ot the bundle size, as it used to encode the size of
@@ -164,7 +164,7 @@ public class BundleReader {
 
     int remaining = length;
     while (remaining > 0) {
-      if (!pullMoreData()) {
+      if (buffer.remaining() == 0 && !pullMoreData()) {
         raiseError("Reached the end of bundle when more data was expected.");
       }
 
@@ -181,15 +181,13 @@ public class BundleReader {
   /**
    * Pulls more data from underlying stream into the internal buffer.
    *
-   * @return whether more data is available
+   * @return whether more data was read.
    */
   private boolean pullMoreData() throws IOException {
-    if (buffer.remaining() == 0) {
-      buffer.compact();
-      dataReader.read(buffer);
-      buffer.flip();
-    }
-    return buffer.remaining() > 0;
+    buffer.compact();
+    int read = dataReader.read(buffer);
+    buffer.flip();
+    return read > 0;
   }
 
   /** Converts a JSON-encoded bundle element into its model class. */
@@ -197,13 +195,22 @@ public class BundleReader {
     JSONObject object = new JSONObject(json);
 
     if (object.has("metadata")) {
-      return serializer.decodeBundleMetadata(object.getJSONObject("metadata"));
+      BundleMetadata metadata = serializer.decodeBundleMetadata(object.getJSONObject("metadata"));
+      Logger.debug("BundleElement", "BundleMetadata element loaded");
+      return metadata;
     } else if (object.has("namedQuery")) {
-      return serializer.decodeNamedQuery(object.getJSONObject("namedQuery"));
+      NamedQuery namedQuery = serializer.decodeNamedQuery(object.getJSONObject("namedQuery"));
+      Logger.debug("BundleElement", "Query loaded: " + namedQuery.getName());
+      return namedQuery;
     } else if (object.has("documentMetadata")) {
-      return serializer.decodeBundledDocumentMetadata(object.getJSONObject("documentMetadata"));
+      BundledDocumentMetadata documentMetadata =
+          serializer.decodeBundledDocumentMetadata(object.getJSONObject("documentMetadata"));
+      Logger.debug("BundleElement", "Document metadata loaded: " + documentMetadata.getKey());
+      return documentMetadata;
     } else if (object.has("document")) {
-      return serializer.decodeDocument(object.getJSONObject("document"));
+      BundleDocument document = serializer.decodeDocument(object.getJSONObject("document"));
+      Logger.debug("BundleElement", "Document loaded: " + document.getKey());
+      return document;
     } else {
       throw new IllegalArgumentException("Cannot decode unknown Bundle element: " + json);
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleReader.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleReader.java
@@ -57,7 +57,7 @@ public class BundleReader {
     }
     BundleElement element = readNextElement();
     if (!(element instanceof BundleMetadata)) {
-      raiseError("Expected first element in bundle to be a metadata object");
+      throw abort("Expected first element in bundle to be a metadata object");
     }
     metadata = (BundleMetadata) element;
     // We don't consider the metadata as part ot the bundle size, as it used to encode the size of
@@ -130,7 +130,7 @@ public class BundleReader {
     // We broke out of the loop because underlying stream is closed, but still cannot find an
     // open bracket.
     if (nextOpenBracket == -1) {
-      raiseError("Reached the end of bundle when a length string is expected.");
+      throw abort("Reached the end of bundle when a length string is expected.");
     }
 
     char[] c = new char[nextOpenBracket];
@@ -165,7 +165,7 @@ public class BundleReader {
     int remaining = length;
     while (remaining > 0) {
       if (buffer.remaining() == 0 && !pullMoreData()) {
-        raiseError("Reached the end of bundle when more data was expected.");
+        throw abort("Reached the end of bundle when more data was expected.");
       }
 
       int read = Math.min(remaining, buffer.remaining());
@@ -191,7 +191,7 @@ public class BundleReader {
   }
 
   /** Converts a JSON-encoded bundle element into its model class. */
-  private BundleElement decodeBundleElement(String json) throws JSONException {
+  private BundleElement decodeBundleElement(String json) throws JSONException, IOException {
     JSONObject object = new JSONObject(json);
 
     if (object.has("metadata")) {
@@ -212,13 +212,13 @@ public class BundleReader {
       Logger.debug("BundleElement", "Document loaded: " + document.getKey());
       return document;
     } else {
-      throw new IllegalArgumentException("Cannot decode unknown Bundle element: " + json);
+      throw abort("Cannot decode unknown Bundle element: " + json);
     }
   }
 
   /** Closes the underlying stream and raises an IllegalArgumentException. */
-  private void raiseError(String message) throws IOException {
+  private IllegalArgumentException abort(String message) throws IOException {
     close();
-    throw new IllegalArgumentException("Invalid bundle format: " + message);
+    throw new IllegalArgumentException("Invalid bundle: " + message);
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleSerializer.java
@@ -51,7 +51,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 /** A JSON serializer to deserialize Firestore Bundles. */
-class BundleSerializer {
+public class BundleSerializer {
 
   private static final long MILLIS_PER_SECOND = 1000;
 
@@ -80,7 +80,9 @@ class BundleSerializer {
     String bundleId = bundleMetadata.getString("id");
     int version = bundleMetadata.getInt("version");
     SnapshotVersion createTime = decodeSnapshotVersion(bundleMetadata.get("createTime"));
-    return new BundleMetadata(bundleId, version, createTime);
+    int totalDocuments = bundleMetadata.getInt("totalDocuments");
+    long totalBytes = bundleMetadata.getLong("totalBytes");
+    return new BundleMetadata(bundleId, version, createTime, totalDocuments, totalBytes);
   }
 
   public BundledDocumentMetadata decodeBundledDocumentMetadata(JSONObject bundledDocumentMetadata)

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -25,8 +25,12 @@ import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.FirebaseFirestoreException.Code;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;
+import com.google.firebase.firestore.LoadBundleTask;
 import com.google.firebase.firestore.auth.CredentialsProvider;
 import com.google.firebase.firestore.auth.User;
+import com.google.firebase.firestore.bundle.BundleReader;
+import com.google.firebase.firestore.bundle.BundleSerializer;
+import com.google.firebase.firestore.bundle.NamedQuery;
 import com.google.firebase.firestore.core.EventManager.ListenOptions;
 import com.google.firebase.firestore.local.GarbageCollectionScheduler;
 import com.google.firebase.firestore.local.LocalStore;
@@ -39,10 +43,12 @@ import com.google.firebase.firestore.model.NoDocument;
 import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.remote.Datastore;
 import com.google.firebase.firestore.remote.GrpcMetadataProvider;
+import com.google.firebase.firestore.remote.RemoteSerializer;
 import com.google.firebase.firestore.remote.RemoteStore;
 import com.google.firebase.firestore.util.AsyncQueue;
 import com.google.firebase.firestore.util.Function;
 import com.google.firebase.firestore.util.Logger;
+import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -59,13 +65,14 @@ public final class FirestoreClient {
   private final DatabaseInfo databaseInfo;
   private final CredentialsProvider credentialsProvider;
   private final AsyncQueue asyncQueue;
+  private final BundleSerializer bundleSerializer;
+  private final GrpcMetadataProvider metadataProvider;
 
   private Persistence persistence;
   private LocalStore localStore;
   private RemoteStore remoteStore;
   private SyncEngine syncEngine;
   private EventManager eventManager;
-  private final GrpcMetadataProvider metadataProvider;
 
   // LRU-related
   @Nullable private GarbageCollectionScheduler gcScheduler;
@@ -81,6 +88,8 @@ public final class FirestoreClient {
     this.credentialsProvider = credentialsProvider;
     this.asyncQueue = asyncQueue;
     this.metadataProvider = metadataProvider;
+    this.bundleSerializer =
+        new BundleSerializer(new RemoteSerializer(databaseInfo.getDatabaseId()));
 
     TaskCompletionSource<User> firstUser = new TaskCompletionSource<>();
     final AtomicBoolean initialized = new AtomicBoolean(false);
@@ -262,6 +271,37 @@ public final class FirestoreClient {
   public void addSnapshotsInSyncListener(EventListener<Void> listener) {
     verifyNotTerminated();
     asyncQueue.enqueueAndForget(() -> eventManager.addSnapshotsInSyncListener(listener));
+  }
+
+  public void loadBundle(InputStream bundleData, LoadBundleTask resultTask) {
+    verifyNotTerminated();
+    BundleReader bundleReader = new BundleReader(bundleSerializer, bundleData);
+    asyncQueue.enqueueAndForget(() -> syncEngine.loadBundle(bundleReader, resultTask));
+  }
+
+  public Task<Query> getNamedQuery(String queryName) {
+    verifyNotTerminated();
+    TaskCompletionSource<Query> completionSource = new TaskCompletionSource<>();
+    asyncQueue.enqueueAndForget(
+        () -> {
+          NamedQuery namedQuery = localStore.getNamedQuery(queryName);
+          if (namedQuery != null) {
+            Target target = namedQuery.getBundledQuery().getTarget();
+            completionSource.setResult(
+                new Query(
+                    target.getPath(),
+                    target.getCollectionGroup(),
+                    target.getFilters(),
+                    target.getOrderBy(),
+                    target.getLimit(),
+                    namedQuery.getBundledQuery().getLimitType(),
+                    target.getStartAt(),
+                    target.getEndAt()));
+          } else {
+            completionSource.setResult(null);
+          }
+        });
+    return completionSource.getTask();
   }
 
   public void removeSnapshotsInSyncListener(EventListener<Void> listener) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -24,7 +24,13 @@ import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.LoadBundleTask;
+import com.google.firebase.firestore.LoadBundleTaskProgress;
 import com.google.firebase.firestore.auth.User;
+import com.google.firebase.firestore.bundle.BundleElement;
+import com.google.firebase.firestore.bundle.BundleLoader;
+import com.google.firebase.firestore.bundle.BundleMetadata;
+import com.google.firebase.firestore.bundle.BundleReader;
 import com.google.firebase.firestore.core.ViewSnapshot.SyncState;
 import com.google.firebase.firestore.local.LocalStore;
 import com.google.firebase.firestore.local.LocalViewChanges;
@@ -48,6 +54,7 @@ import com.google.firebase.firestore.util.Function;
 import com.google.firebase.firestore.util.Logger;
 import com.google.firebase.firestore.util.Util;
 import io.grpc.Status;
+import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -505,6 +512,54 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
     }
 
     pendingWritesCallbacks.clear();
+  }
+
+  public void loadBundle(BundleReader bundleReader, LoadBundleTask resultTask) {
+    try {
+      BundleMetadata bundleMetadata = bundleReader.getBundleMetadata();
+      boolean hasNewerBundle = localStore.hasNewerBundle(bundleMetadata);
+      if (hasNewerBundle) {
+        resultTask.setResult(LoadBundleTaskProgress.forSuccess(bundleMetadata));
+        return;
+      }
+
+      @Nullable LoadBundleTaskProgress progress = LoadBundleTaskProgress.forInitial(bundleMetadata);
+      resultTask.updateProgress(progress);
+
+      BundleLoader bundleLoader = new BundleLoader(localStore, bundleMetadata);
+
+      long bytesRead = 0;
+      BundleElement bundleElement;
+      while ((bundleElement = bundleReader.getNextElement()) != null) {
+        long oldBytesRead = bytesRead;
+        bytesRead = bundleReader.getBytesRead();
+        progress = bundleLoader.addElement(bundleElement, bytesRead - oldBytesRead);
+        if (progress != null) {
+          resultTask.updateProgress(progress);
+        }
+      }
+
+      ImmutableSortedMap<DocumentKey, MaybeDocument> changes = bundleLoader.applyChanges();
+
+      // TODO(b/160876443): This currently raises snapshots with `fromCache=false` if users already
+      // listen to some queries and bundles has newer version.
+      emitNewSnapsAndNotifyLocalStore(changes, /* remoteEvent= */ null);
+
+      // Save metadata, so loading the same bundle will skip.
+      localStore.saveBundle(bundleMetadata);
+      resultTask.setResult(LoadBundleTaskProgress.forSuccess(bundleMetadata));
+    } catch (Exception e) {
+      Logger.warn("Firestore", "Loading bundle failed : %s", e);
+      resultTask.setException(
+          new FirebaseFirestoreException(
+              "Bundle failed to load", FirebaseFirestoreException.Code.INVALID_ARGUMENT, e));
+    } finally {
+      try {
+        bundleReader.close();
+      } catch (IOException e) {
+        Logger.warn("SyncEngine", "Exception while closing bundle", e);
+      }
+    }
   }
 
   /** Resolves the task corresponding to this write result. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -14,8 +14,6 @@
 
 package com.google.firebase.firestore.core;
 
-import static com.google.firebase.firestore.util.Assert.hardAssert;
-
 import androidx.annotation.Nullable;
 import com.google.firebase.firestore.core.OrderBy.Direction;
 import com.google.firebase.firestore.model.DocumentKey;
@@ -90,12 +88,8 @@ public final class Target {
     return filters;
   }
 
-  /**
-   * The maximum number of results to return. If there is no limit on the query, then this will
-   * cause an assertion failure.
-   */
+  /** The maximum number of results to return. Returns -1 if there is no limit on the query. */
   public long getLimit() {
-    hardAssert(hasLimit(), "Called getLimit when no limit was set");
     return limit;
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -611,16 +611,16 @@ public final class LocalStore implements BundleListener {
 
   /**
    * Returns a boolean indicating if the given bundle has already been loaded and its create time is
-   * newer than the currently loading bundle.
+   * newer or equal to the currently loading bundle.
    */
   public boolean hasNewerBundle(BundleMetadata bundleMetadata) {
     return persistence.runTransaction(
         "Has newer bundle",
         () -> {
-          BundleMetadata existingMetadata =
+          BundleMetadata cachedMetadata =
               bundleCache.getBundleMetadata(bundleMetadata.getBundleId());
-          return existingMetadata != null
-              && existingMetadata.getCreateTime().compareTo(bundleMetadata.getCreateTime()) > 0;
+          return cachedMetadata != null
+              && cachedMetadata.getCreateTime().compareTo(bundleMetadata.getCreateTime()) >= 0;
         });
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteBundleCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteBundleCache.java
@@ -37,8 +37,8 @@ class SQLiteBundleCache implements BundleCache {
   @Override
   public BundleMetadata getBundleMetadata(String bundleId) {
     return db.query(
-            "SELECT schema_version, create_time_seconds, create_time_nanos "
-                + "FROM bundles WHERE bundle_id = ?")
+            "SELECT schema_version, create_time_seconds, create_time_nanos, total_documents, "
+                + " total_bytes FROM bundles WHERE bundle_id = ?")
         .binding(bundleId)
         .firstValue(
             row ->
@@ -47,19 +47,23 @@ class SQLiteBundleCache implements BundleCache {
                     : new BundleMetadata(
                         bundleId,
                         row.getInt(0),
-                        new SnapshotVersion(new Timestamp(row.getLong(1), row.getInt(2)))));
+                        new SnapshotVersion(new Timestamp(row.getLong(1), row.getInt(2))),
+                        row.getInt(3),
+                        row.getLong(4)));
   }
 
   @Override
   public void saveBundleMetadata(BundleMetadata metadata) {
     db.execute(
         "INSERT OR REPLACE INTO bundles "
-            + "(bundle_id, schema_version, create_time_seconds, create_time_nanos) "
-            + "VALUES (?, ?, ?, ?)",
+            + "(bundle_id, schema_version, create_time_seconds, create_time_nanos, "
+            + "total_documents, total_bytes) VALUES (?, ?, ?, ?, ?, ?)",
         metadata.getBundleId(),
         metadata.getSchemaVersion(),
         metadata.getCreateTime().getTimestamp().getSeconds(),
-        metadata.getCreateTime().getTimestamp().getNanoseconds());
+        metadata.getCreateTime().getTimestamp().getNanoseconds(),
+        metadata.getTotalDocuments(),
+        metadata.getTotalBytes());
   }
 
   @Override

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -23,11 +23,11 @@ import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 import android.text.TextUtils;
-import android.util.Log;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.proto.Target;
 import com.google.firebase.firestore.util.Consumer;
+import com.google.firebase.firestore.util.Logger;
 import com.google.firebase.firestore.util.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
@@ -207,7 +207,8 @@ class SQLiteSchema {
     if (!tablesFound) {
       fn.run();
     } else {
-      Log.d("SQLiteSchema", "Skipping migration because all of " + allTables + " already exist");
+      Logger.debug(
+          "SQLiteSchema", "Skipping migration because all of " + allTables + " already exist");
     }
   }
 
@@ -569,7 +570,9 @@ class SQLiteSchema {
                   + "bundle_id TEXT PRIMARY KEY, "
                   + "create_time_seconds INTEGER, "
                   + "create_time_nanos INTEGER, "
-                  + "schema_version INTEGER)");
+                  + "schema_version INTEGER, "
+                  + "total_documents INTEGER, "
+                  + "total_bytes INTEGER)");
 
           db.execSQL(
               "CREATE TABLE named_queries ("

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
@@ -495,7 +495,14 @@ public final class RemoteSerializer {
     }
 
     builder.setTargetId(targetData.getTargetId());
-    builder.setResumeToken(targetData.getResumeToken());
+
+    if (!targetData.getResumeToken().isEmpty()) {
+      builder.setResumeToken(targetData.getResumeToken());
+    } else if (targetData.getSnapshotVersion().compareTo(SnapshotVersion.NONE) > 0) {
+      // TODO(wuandy): Consider removing above check because it is most likely true. Right now, many
+      // tests depend on this behaviour though (leaving min() out of serialization).
+      builder.setReadTime(encodeTimestamp(targetData.getSnapshotVersion().getTimestamp()));
+    }
 
     return builder.build();
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/bundle/BundleSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/bundle/BundleSerializerTest.java
@@ -620,11 +620,17 @@ public class BundleSerializerTest {
         "{\n"
             + "id: 'bundle-1',\n"
             + "version: 1,\n"
-            + "createTime: '2020-01-01T00:00:01.000000001Z' \n"
+            + "createTime: { seconds: 2, nanos: 3 },\n"
+            + "totalDocuments: 4,\n"
+            + "totalBytes: 5\n"
             + "}";
     BundleMetadata expectedMetadata =
         new BundleMetadata(
-            "bundle-1", 1, new SnapshotVersion(new com.google.firebase.Timestamp(1577836801, 1)));
+            "bundle-1",
+            /* schemaVersion= */ 1,
+            new SnapshotVersion(new com.google.firebase.Timestamp(2, 3)),
+            /* totalDocuments= */ 4,
+            /* totalBytes= */ 5);
     BundleMetadata actualMetadata = serializer.decodeBundleMetadata(new JSONObject(json));
     assertEquals(expectedMetadata, actualMetadata);
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/BundleCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/BundleCacheTestCase.java
@@ -70,7 +70,12 @@ public abstract class BundleCacheTestCase {
   @Test
   public void testReturnsSavedBundle() {
     BundleMetadata expectedBundleMetadata =
-        new BundleMetadata("bundle-1", 1, new SnapshotVersion(Timestamp.now()));
+        new BundleMetadata(
+            "bundle-1",
+            1,
+            new SnapshotVersion(Timestamp.now()),
+            /* totalDocuments= */ 1,
+            /* totalBytes= */ 10);
     bundleCache.saveBundleMetadata(expectedBundleMetadata);
     BundleMetadata actualBundleMetadata = bundleCache.getBundleMetadata("bundle-1");
 
@@ -78,7 +83,12 @@ public abstract class BundleCacheTestCase {
 
     // Overwrite
     expectedBundleMetadata =
-        new BundleMetadata("bundle-1", 2, new SnapshotVersion(Timestamp.now()));
+        new BundleMetadata(
+            "bundle-1",
+            2,
+            new SnapshotVersion(Timestamp.now()),
+            /* totalDocuments= */ 1,
+            /* totalBytes= */ 10);
     bundleCache.saveBundleMetadata(expectedBundleMetadata);
     actualBundleMetadata = bundleCache.getBundleMetadata("bundle-1");
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -192,7 +192,13 @@ public abstract class LocalStoreTestCase {
   }
 
   private void saveBundle(String bundleId, int createTime) {
-    localStore.saveBundle(new BundleMetadata(bundleId, /* version= */ 1, version(createTime)));
+    localStore.saveBundle(
+        new BundleMetadata(
+            bundleId,
+            /* version= */ 1,
+            version(createTime),
+            /* totalDocuments= */ 1,
+            /* totalBytes= */ 10));
   }
 
   private void bundleDocuments(MaybeDocument... expected) {
@@ -269,14 +275,24 @@ public abstract class LocalStoreTestCase {
   private void assertHasNewerBundle(String bundleId, int createTime) {
     boolean hasNewerBundle =
         localStore.hasNewerBundle(
-            new BundleMetadata(bundleId, /* version= */ 1, version(createTime)));
+            new BundleMetadata(
+                bundleId,
+                /* version= */ 1,
+                version(createTime),
+                /* totalDocuments= */ 1,
+                /* totalBytes= */ 10));
     assertTrue(hasNewerBundle);
   }
 
   private void assertNoNewerBundle(String bundleId, int createTime) {
     boolean hasNewerBundle =
         localStore.hasNewerBundle(
-            new BundleMetadata(bundleId, /* version= */ 1, version(createTime)));
+            new BundleMetadata(
+                bundleId,
+                /* version= */ 1,
+                version(createTime),
+                /* totalDocuments= */ 1,
+                /* totalBytes= */ 10));
     assertFalse(hasNewerBundle);
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/PersistenceTestHelpers.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/PersistenceTestHelpers.java
@@ -31,7 +31,7 @@ public final class PersistenceTestHelpers {
 
   public static DatabaseInfo nextDatabaseInfo() {
     return new DatabaseInfo(
-        DatabaseId.forDatabase("project", "database"),
+        DatabaseId.forProject("test-project"),
         nextSQLiteDatabaseName(),
         "localhost",
         /* sslEnabled= */ false);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/spec/SpecTestCase.java
@@ -40,7 +40,10 @@ import com.google.firebase.database.collection.ImmutableSortedSet;
 import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;
+import com.google.firebase.firestore.LoadBundleTask;
 import com.google.firebase.firestore.auth.User;
+import com.google.firebase.firestore.bundle.BundleReader;
+import com.google.firebase.firestore.bundle.BundleSerializer;
 import com.google.firebase.firestore.core.ComponentProvider;
 import com.google.firebase.firestore.core.DatabaseInfo;
 import com.google.firebase.firestore.core.DocumentViewChange;
@@ -66,6 +69,7 @@ import com.google.firebase.firestore.model.mutation.MutationResult;
 import com.google.firebase.firestore.remote.ExistenceFilter;
 import com.google.firebase.firestore.remote.MockDatastore;
 import com.google.firebase.firestore.remote.RemoteEvent;
+import com.google.firebase.firestore.remote.RemoteSerializer;
 import com.google.firebase.firestore.remote.RemoteStore;
 import com.google.firebase.firestore.remote.RemoteStore.RemoteStoreCallback;
 import com.google.firebase.firestore.remote.WatchChange;
@@ -97,6 +101,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.apache.tools.ant.filters.StringInputStream;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -501,6 +506,20 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
     queue.runSync(() -> eventManager.removeQueryListener(listener));
   }
 
+  private void doLoadBundle(String json) throws Exception {
+    BundleReader bundleReader =
+        new BundleReader(
+            new BundleSerializer(new RemoteSerializer(databaseInfo.getDatabaseId())),
+            new StringInputStream(json));
+    LoadBundleTask bundleTask = new LoadBundleTask();
+    queue.runSync(
+        () -> {
+          syncEngine.loadBundle(bundleReader, bundleTask);
+          bundleTask.addOnFailureListener(e -> log("Loading bundle failed with " + e));
+        });
+    assertTrue(bundleTask.isSuccessful());
+  }
+
   private void doMutation(Mutation mutation) throws Exception {
     DocumentKey documentKey = mutation.getKey();
     TaskCompletionSource<Void> callback = new TaskCompletionSource<>();
@@ -799,6 +818,8 @@ public abstract class SpecTestCase implements RemoteStoreCallback {
       doRemoveSnapshotsInSyncListener();
     } else if (step.has("drainQueue")) {
       doDrainQueue();
+    } else if (step.has("loadBundle")) {
+      doLoadBundle(step.getString("loadBundle"));
     } else if (step.has("watchAck")) {
       doWatchAck(step.getJSONArray("watchAck"));
     } else if (step.has("watchCurrent")) {

--- a/firebase-firestore/src/test/resources/json/bundle_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/bundle_spec_test.json
@@ -4,8 +4,7 @@
     "itName": "Bundles query can be loaded and resumed from different tabs",
     "tags": [
       "multi-client",
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 2,
@@ -224,8 +223,7 @@
     "describeName": "Bundles:",
     "itName": "Bundles query can be resumed from same query.",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -298,8 +296,7 @@
     "itName": "Load and observe from same secondary client",
     "tags": [
       "multi-client",
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 2,
@@ -508,8 +505,7 @@
     "itName": "Load from primary client and observe from secondary",
     "tags": [
       "multi-client",
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 2,
@@ -753,8 +749,7 @@
     "itName": "Load from secondary clients and observe from primary",
     "tags": [
       "multi-client",
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 2,
@@ -910,8 +905,7 @@
     "describeName": "Bundles:",
     "itName": "Newer deleted docs from bundles should delete cached docs",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -1049,8 +1043,7 @@
     "describeName": "Bundles:",
     "itName": "Newer docs from bundles might lead to limbo doc",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -1269,8 +1262,7 @@
     "describeName": "Bundles:",
     "itName": "Newer docs from bundles should keep not raise snapshot if there are unacknowledged writes",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -1416,8 +1408,7 @@
     "describeName": "Bundles:",
     "itName": "Newer docs from bundles should overwrite cache",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -1555,8 +1546,7 @@
     "describeName": "Bundles:",
     "itName": "Newer docs from bundles should raise snapshot only when Watch catches up with acknowledged writes",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -1746,8 +1736,7 @@
     "describeName": "Bundles:",
     "itName": "Older deleted docs from bundles should do nothing",
     "tags": [
-      "no-ios",
-      "no-android"
+      "no-ios"
     ],
     "config": {
       "numClients": 1,


### PR DESCRIPTION
WE HAVE REACHED THE END!

This PR adds the API endpoints, the SyncEngine logic and the integration tests for Bundles.

Some notable changes:
- I rewrote EventAccumulator to support assertNoAdditionalEvents().
- I added totalBytes/totalDocuments back to BundleMetadata as it made plumbing these values through much easier.