### PR TITLE
Key comparison for RTDB queries should correctly handle boundary sentinels

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/snapshot/ChildKey.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/snapshot/ChildKey.java
@@ -113,6 +113,12 @@ public class ChildKey implements Comparable<ChildKey> {
 
   public static ChildKey fromString(String key) {
     Integer intValue = Utilities.tryParseInt(key);
+    if (key.equals(MIN_KEY_NAME)) {
+      return MIN_KEY;
+    }
+    if (key.equals(MAX_KEY_NAME)) {
+      return MAX_KEY;
+    }
     if (intValue != null) {
       return new IntegerChildKey(key, intValue);
     } else if (key.equals(".priority")) {

--- a/firebase-database/src/main/java/com/google/firebase/database/snapshot/ChildKey.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/snapshot/ChildKey.java
@@ -71,9 +71,9 @@ public class ChildKey implements Comparable<ChildKey> {
   public int compareTo(ChildKey other) {
     if (this == other) {
       return 0;
-    } else if (this == MIN_KEY || other == MAX_KEY) {
+    } else if (this.key.equals(MIN_KEY_NAME) || other.key.equals(MAX_KEY_NAME)) {
       return -1;
-    } else if (other == MIN_KEY || this == MAX_KEY) {
+    } else if (other.key.equals(MIN_KEY_NAME) || this.key.equals(MAX_KEY_NAME)) {
       return 1;
     } else if (this.isInt()) {
       if (other.isInt()) {
@@ -113,12 +113,6 @@ public class ChildKey implements Comparable<ChildKey> {
 
   public static ChildKey fromString(String key) {
     Integer intValue = Utilities.tryParseInt(key);
-    if (key.equals(MIN_KEY_NAME)) {
-      return MIN_KEY;
-    }
-    if (key.equals(MAX_KEY_NAME)) {
-      return MAX_KEY;
-    }
     if (intValue != null) {
       return new IntegerChildKey(key, intValue);
     } else if (key.equals(".priority")) {


### PR DESCRIPTION
In order for `startAfter` and `endBefore` to have the correct ordering semantics, we need to return the objects `MAX_KEY` and `MIN_KEY`. Otherwise, the comparison function won't work properly in all cases:

https://github.com/firebase/firebase-android-sdk/blob/master/firebase-database/src/main/java/com/google/firebase/database/snapshot/ChildKey.java#L74-L76