### PR TITLE
Remove unused baseDoc argument

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -219,8 +219,7 @@ class LocalDocumentsView {
 
         DocumentKey key = mutation.getKey();
         MaybeDocument baseDoc = results.get(key);
-        MaybeDocument mutatedDoc =
-            mutation.applyToLocalView(baseDoc, baseDoc, batch.getLocalWriteTime());
+        MaybeDocument mutatedDoc = mutation.applyToLocalView(baseDoc, batch.getLocalWriteTime());
         if (mutatedDoc instanceof Document) {
           results = results.insert(key, (Document) mutatedDoc);
         } else {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/DeleteMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/DeleteMutation.java
@@ -73,7 +73,7 @@ public final class DeleteMutation extends Mutation {
   @Nullable
   @Override
   public MaybeDocument applyToLocalView(
-      @Nullable MaybeDocument maybeDoc, @Nullable MaybeDocument baseDoc, Timestamp localWriteTime) {
+      @Nullable MaybeDocument maybeDoc, Timestamp localWriteTime) {
     verifyKeyMatches(maybeDoc);
 
     if (!this.getPrecondition().isValidFor(maybeDoc)) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/MutationBatch.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/MutationBatch.java
@@ -124,17 +124,15 @@ public final class MutationBatch {
     for (int i = 0; i < baseMutations.size(); i++) {
       Mutation mutation = baseMutations.get(i);
       if (mutation.getKey().equals(documentKey)) {
-        maybeDoc = mutation.applyToLocalView(maybeDoc, maybeDoc, localWriteTime);
+        maybeDoc = mutation.applyToLocalView(maybeDoc, localWriteTime);
       }
     }
-
-    MaybeDocument baseDoc = maybeDoc;
 
     // Second, apply all user-provided mutations.
     for (int i = 0; i < mutations.size(); i++) {
       Mutation mutation = mutations.get(i);
       if (mutation.getKey().equals(documentKey)) {
-        maybeDoc = mutation.applyToLocalView(maybeDoc, baseDoc, localWriteTime);
+        maybeDoc = mutation.applyToLocalView(maybeDoc, localWriteTime);
       }
     }
     return maybeDoc;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/PatchMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/PatchMutation.java
@@ -130,14 +130,14 @@ public final class PatchMutation extends Mutation {
   @Nullable
   @Override
   public MaybeDocument applyToLocalView(
-      @Nullable MaybeDocument maybeDoc, @Nullable MaybeDocument baseDoc, Timestamp localWriteTime) {
+      @Nullable MaybeDocument maybeDoc, Timestamp localWriteTime) {
     verifyKeyMatches(maybeDoc);
 
     if (!getPrecondition().isValidFor(maybeDoc)) {
       return maybeDoc;
     }
 
-    List<Value> transformResults = localTransformResults(localWriteTime, maybeDoc, baseDoc);
+    List<Value> transformResults = localTransformResults(localWriteTime, maybeDoc);
     SnapshotVersion version = getPostMutationVersion(maybeDoc);
     ObjectValue newData = patchDocument(maybeDoc, transformResults);
     return new Document(getKey(), version, newData, Document.DocumentState.LOCAL_MUTATIONS);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/SetMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/SetMutation.java
@@ -94,14 +94,14 @@ public final class SetMutation extends Mutation {
   @Nullable
   @Override
   public MaybeDocument applyToLocalView(
-      @Nullable MaybeDocument maybeDoc, @Nullable MaybeDocument baseDoc, Timestamp localWriteTime) {
+      @Nullable MaybeDocument maybeDoc, Timestamp localWriteTime) {
     verifyKeyMatches(maybeDoc);
 
     if (!this.getPrecondition().isValidFor(maybeDoc)) {
       return maybeDoc;
     }
 
-    List<Value> transformResults = localTransformResults(localWriteTime, maybeDoc, baseDoc);
+    List<Value> transformResults = localTransformResults(localWriteTime, maybeDoc);
     ObjectValue newData = transformObject(value, transformResults);
 
     SnapshotVersion version = getPostMutationVersion(maybeDoc);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/VerifyMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/VerifyMutation.java
@@ -65,7 +65,7 @@ public final class VerifyMutation extends Mutation {
   @Nullable
   @Override
   public MaybeDocument applyToLocalView(
-      @Nullable MaybeDocument maybeDoc, @Nullable MaybeDocument baseDoc, Timestamp localWriteTime) {
+      @Nullable MaybeDocument maybeDoc, Timestamp localWriteTime) {
     throw Assert.fail("VerifyMutation should only be used in Transactions.");
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutationTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutationTest.java
@@ -63,7 +63,7 @@ public class MutationTest {
     Document baseDoc = doc("collection/key", 0, data);
 
     Mutation set = setMutation("collection/key", map("bar", "bar-value"));
-    MaybeDocument setDoc = set.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
+    MaybeDocument setDoc = set.applyToLocalView(baseDoc, Timestamp.now());
     assertEquals(
         doc("collection/key", 0, map("bar", "bar-value"), Document.DocumentState.LOCAL_MUTATIONS),
         setDoc);
@@ -75,7 +75,7 @@ public class MutationTest {
     Document baseDoc = doc("collection/key", 0, data);
 
     Mutation patch = patchMutation("collection/key", map("foo.bar", "new-bar-value"));
-    MaybeDocument local = patch.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
+    MaybeDocument local = patch.applyToLocalView(baseDoc, Timestamp.now());
     Map<String, Object> expectedData = map("foo", map("bar", "new-bar-value"), "baz", "baz-value");
     assertEquals(
         doc("collection/key", 0, expectedData, Document.DocumentState.LOCAL_MUTATIONS), local);
@@ -87,7 +87,7 @@ public class MutationTest {
     Mutation upsert =
         mergeMutation(
             "collection/key", map("foo.bar", "new-bar-value"), Arrays.asList(field("foo.bar")));
-    MaybeDocument newDoc = upsert.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
+    MaybeDocument newDoc = upsert.applyToLocalView(baseDoc, Timestamp.now());
     Map<String, Object> expectedData = map("foo", map("bar", "new-bar-value"));
     assertEquals(
         doc("collection/key", 0, expectedData, Document.DocumentState.LOCAL_MUTATIONS), newDoc);
@@ -99,7 +99,7 @@ public class MutationTest {
     Mutation upsert =
         mergeMutation(
             "collection/key", map("foo.bar", "new-bar-value"), Arrays.asList(field("foo.bar")));
-    MaybeDocument newDoc = upsert.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
+    MaybeDocument newDoc = upsert.applyToLocalView(baseDoc, Timestamp.now());
     Map<String, Object> expectedData = map("foo", map("bar", "new-bar-value"));
     assertEquals(
         doc("collection/key", 0, expectedData, Document.DocumentState.LOCAL_MUTATIONS), newDoc);
@@ -114,7 +114,7 @@ public class MutationTest {
     FieldMask mask = fieldMask("foo.bar");
     Mutation patch = new PatchMutation(key, ObjectValue.emptyObject(), mask, Precondition.NONE);
 
-    MaybeDocument patchDoc = patch.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
+    MaybeDocument patchDoc = patch.applyToLocalView(baseDoc, Timestamp.now());
     Map<String, Object> expectedData = map("foo", map("baz", "baz-value"));
     assertEquals(
         doc("collection/key", 0, expectedData, Document.DocumentState.LOCAL_MUTATIONS), patchDoc);
@@ -126,7 +126,7 @@ public class MutationTest {
     Document baseDoc = doc("collection/key", 0, data);
 
     Mutation patch = patchMutation("collection/key", map("foo.bar", "new-bar-value"));
-    MaybeDocument patchedDoc = patch.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
+    MaybeDocument patchedDoc = patch.applyToLocalView(baseDoc, Timestamp.now());
     Map<String, Object> expectedData = map("foo", map("bar", "new-bar-value"), "baz", "baz-value");
     assertEquals(
         doc("collection/key", 0, expectedData, Document.DocumentState.LOCAL_MUTATIONS), patchedDoc);
@@ -136,7 +136,7 @@ public class MutationTest {
   public void testPatchingDeletedDocumentsDoesNothing() {
     MaybeDocument baseDoc = deletedDoc("collection/key", 0);
     Mutation patch = patchMutation("collection/key", map("foo", "bar"));
-    MaybeDocument patchedDoc = patch.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
+    MaybeDocument patchedDoc = patch.applyToLocalView(baseDoc, Timestamp.now());
     assertEquals(baseDoc, patchedDoc);
   }
 
@@ -148,7 +148,7 @@ public class MutationTest {
     Timestamp timestamp = Timestamp.now();
     Mutation transform =
         patchMutation("collection/key", map("foo.bar", FieldValue.serverTimestamp()));
-    MaybeDocument transformedDoc = transform.applyToLocalView(baseDoc, baseDoc, timestamp);
+    MaybeDocument transformedDoc = transform.applyToLocalView(baseDoc, timestamp);
 
     // Server timestamps aren't parsed, so we manually insert it.
     ObjectValue expectedData =
@@ -462,7 +462,7 @@ public class MutationTest {
 
     for (Map<String, Object> transformData : transforms) {
       PatchMutation transform = patchMutation("collection/key", transformData);
-      currentDoc = transform.applyToLocalView(currentDoc, currentDoc, Timestamp.now());
+      currentDoc = transform.applyToLocalView(currentDoc, Timestamp.now());
     }
 
     Document expectedDoc =
@@ -544,7 +544,7 @@ public class MutationTest {
     Document baseDoc = doc("collection/key", 0, data);
 
     Mutation delete = deleteMutation("collection/key");
-    MaybeDocument deletedDoc = delete.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
+    MaybeDocument deletedDoc = delete.applyToLocalView(baseDoc, Timestamp.now());
     assertEquals(deletedDoc("collection/key", 0), deletedDoc);
   }
 
@@ -691,8 +691,8 @@ public class MutationTest {
     Map<String, Object> increment = map("sum", FieldValue.increment(1));
     Mutation mutation = patchMutation("collection/key", increment);
 
-    MaybeDocument mutatedDoc = mutation.applyToLocalView(baseDoc, baseDoc, Timestamp.now());
-    mutatedDoc = mutation.applyToLocalView(mutatedDoc, baseDoc, Timestamp.now());
+    MaybeDocument mutatedDoc = mutation.applyToLocalView(baseDoc, Timestamp.now());
+    mutatedDoc = mutation.applyToLocalView(mutatedDoc, Timestamp.now());
 
     assertEquals(wrap(2L), ((Document) mutatedDoc).getField(field("sum")));
   }


### PR DESCRIPTION
Port from iOS https://github.com/firebase/firebase-ios-sdk/pull/7276

This likely needs to be ported to Web too (but I didn't check - just worked on this while verifying the iOS PR).