### PR TITLE
Fix repeated field encoding.

### DIFF
--- a/encoders/firebase-encoders-proto/src/main/java/com/google/firebase/encoders/proto/ProtobufValueEncoderContext.java
+++ b/encoders/firebase-encoders-proto/src/main/java/com/google/firebase/encoders/proto/ProtobufValueEncoderContext.java
@@ -18,18 +18,23 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.encoders.EncodingException;
 import com.google.firebase.encoders.FieldDescriptor;
-import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.ValueEncoderContext;
 import java.io.IOException;
 
 class ProtobufValueEncoderContext implements ValueEncoderContext {
   private boolean encoded = false;
-  private final FieldDescriptor field;
-  private final ObjectEncoderContext objEncoderCtx;
+  private boolean skipDefault = false;
+  private FieldDescriptor field;
+  private final ProtobufDataEncoderContext objEncoderCtx;
 
-  ProtobufValueEncoderContext(FieldDescriptor field, ObjectEncoderContext objEncoderCtx) {
-    this.field = field;
+  ProtobufValueEncoderContext(ProtobufDataEncoderContext objEncoderCtx) {
     this.objEncoderCtx = objEncoderCtx;
+  }
+
+  void resetContext(FieldDescriptor field, boolean skipDefault) {
+    this.encoded = false;
+    this.field = field;
+    this.skipDefault = skipDefault;
   }
 
   private void checkNotUsed() {
@@ -43,7 +48,7 @@ class ProtobufValueEncoderContext implements ValueEncoderContext {
   @Override
   public ValueEncoderContext add(@Nullable String value) throws IOException {
     checkNotUsed();
-    objEncoderCtx.add(field, value);
+    objEncoderCtx.add(field, value, skipDefault);
     return this;
   }
 
@@ -51,7 +56,7 @@ class ProtobufValueEncoderContext implements ValueEncoderContext {
   @Override
   public ValueEncoderContext add(float value) throws IOException {
     checkNotUsed();
-    objEncoderCtx.add(field, value);
+    objEncoderCtx.add(field, value, skipDefault);
     return this;
   }
 
@@ -59,7 +64,7 @@ class ProtobufValueEncoderContext implements ValueEncoderContext {
   @Override
   public ValueEncoderContext add(double value) throws IOException {
     checkNotUsed();
-    objEncoderCtx.add(field, value);
+    objEncoderCtx.add(field, value, skipDefault);
     return this;
   }
 
@@ -67,7 +72,7 @@ class ProtobufValueEncoderContext implements ValueEncoderContext {
   @Override
   public ValueEncoderContext add(int value) throws IOException {
     checkNotUsed();
-    objEncoderCtx.add(field, value);
+    objEncoderCtx.add(field, value, skipDefault);
     return this;
   }
 
@@ -75,7 +80,7 @@ class ProtobufValueEncoderContext implements ValueEncoderContext {
   @Override
   public ValueEncoderContext add(long value) throws IOException {
     checkNotUsed();
-    objEncoderCtx.add(field, value);
+    objEncoderCtx.add(field, value, skipDefault);
     return this;
   }
 
@@ -83,7 +88,7 @@ class ProtobufValueEncoderContext implements ValueEncoderContext {
   @Override
   public ValueEncoderContext add(boolean value) throws IOException {
     checkNotUsed();
-    objEncoderCtx.add(field, value);
+    objEncoderCtx.add(field, value, skipDefault);
     return this;
   }
 
@@ -91,7 +96,7 @@ class ProtobufValueEncoderContext implements ValueEncoderContext {
   @Override
   public ValueEncoderContext add(@NonNull byte[] bytes) throws IOException {
     checkNotUsed();
-    objEncoderCtx.add(field, bytes);
+    objEncoderCtx.add(field, bytes, skipDefault);
     return this;
   }
 }

--- a/encoders/firebase-encoders-proto/src/test/java/com/google/firebase/encoders/proto/WithCollectionsTests.java
+++ b/encoders/firebase-encoders-proto/src/test/java/com/google/firebase/encoders/proto/WithCollectionsTests.java
@@ -50,10 +50,12 @@ public class WithCollectionsTests {
                 ImmutableMap.<String, Fixed>builder()
                     .put("noValue", new Fixed())
                     .put("value", new Fixed(1, 2, 3, 4))
+                    .put("", new Fixed())
                     .build(),
                 ImmutableList.of(
                     new OtherTypes("hello", new byte[0], false, true),
-                    new OtherTypes("", new byte[] {42}, true, false)))
+                    new OtherTypes("", new byte[] {42}, true, false),
+                    new OtherTypes("", new byte[0], false, false)))
             .encode();
 
     WithCollectionsProto parsed = WithCollectionsProto.parseFrom(result);
@@ -66,6 +68,7 @@ public class WithCollectionsTests {
                 .putMyMap(
                     "value",
                     FixedProto.newBuilder().setF32(1).setSf32(2).setF64(3).setSf64(4).build())
+                .putMyMap("", FixedProto.getDefaultInstance())
                 .addOtherTypes(
                     OtherTypesProto.newBuilder().setStr("hello").setWrappedBool(true).build())
                 .addOtherTypes(
@@ -73,6 +76,7 @@ public class WithCollectionsTests {
                         .setBts(ByteString.copyFrom(new byte[] {42}))
                         .setBl(true)
                         .build())
+                .addOtherTypes(OtherTypesProto.getDefaultInstance())
                 .build());
   }
 }


### PR DESCRIPTION
This change addresses the issue where repeated fields with ["default"](https://developers.google.com/protocol-buffers/docs/proto3#default)
values would not be encoded which would result in such values missing
when decoded back instead of being present as default values.

For example encoding [0,0] would incorrectly decode as [].