### PR TITLE
Updating `firebase-perf` external documentation as part of Open Sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ dependencies:
   * `firebase-inappmessaging-display`
   * `firebase-inappmessaging-display-ktx`
   * `firebase-perf`
+  * `firebase-perf-ktx`
   * `firebase-remote-config`
   * `firebase-remote-config-ktx`
   * `firebase-storage`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ dependencies:
   * `firebase-inappmessaging-ktx`
   * `firebase-inappmessaging-display`
   * `firebase-inappmessaging-display-ktx`
+  * `firebase-perf`
   * `firebase-remote-config`
   * `firebase-remote-config-ktx`
   * `firebase-storage`

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This repository includes the following Firebase SDKs for Android:
   * `firebase-firestore`
   * `firebase-functions`
   * `firebase-inappmessaging-display`
+  * `firebase-perf`
   * `firebase-storage`
 
 For more information on building the SDKs from source or contributing,
@@ -30,6 +31,7 @@ in your app:
   * [`firebase-functions`](ktx/functions.md)
   * [`firebase-inappmessaging`](ktx/inappmessaging.md)
   * [`firebase-inappmessaging-display`](ktx/inappmessaging-display.md)
+  * [`firebase-perf`](ktx/perf.md)
   * [`firebase-remote-config`](ktx/remote-config.md)
   * [`firebase-storage`](ktx/storage.md)
   * [`firebase-database`](ktx/database.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,6 @@ in your app:
   * [`firebase-functions`](ktx/functions.md)
   * [`firebase-inappmessaging`](ktx/inappmessaging.md)
   * [`firebase-inappmessaging-display`](ktx/inappmessaging-display.md)
-  * [`firebase-perf`](ktx/perf.md)
   * [`firebase-remote-config`](ktx/remote-config.md)
   * [`firebase-storage`](ktx/storage.md)
   * [`firebase-database`](ktx/database.md)


### PR DESCRIPTION
Preparing `firebase-perf` to be OSS ready. 
  - Updating main README to include `firebase-perf`
  - Updating [firebaseopensource](https://firebaseopensource.com/projects/firebase/firebase-android-sdk/) to include `firebase-perf`

**Note:** Merge only after `firebase-perf` have been Open Sourced.