### PR TITLE
Clean up and clarify Crashlytics logging.

### DIFF
--- a/firebase-crashlytics-ndk/src/androidTest/java/com/google/firebase/crashlytics/ndk/CrashpadControllerTest.java
+++ b/firebase-crashlytics-ndk/src/androidTest/java/com/google/firebase/crashlytics/ndk/CrashpadControllerTest.java
@@ -24,9 +24,9 @@ import java.io.IOException;
 import java.util.UUID;
 import junit.framework.TestCase;
 
-public class BreakpadControllerTest extends TestCase {
+public class CrashpadControllerTest extends TestCase {
 
-  private BreakpadController controller;
+  private CrashpadController controller;
 
   private Context context;
   private NativeApi mockNativeApi;
@@ -40,7 +40,7 @@ public class BreakpadControllerTest extends TestCase {
     context = ApplicationProvider.getApplicationContext();
     mockNativeApi = mock(NativeApi.class);
     mockFilesManager = mock(CrashFilesManager.class);
-    controller = new BreakpadController(context, mockNativeApi, mockFilesManager);
+    controller = new CrashpadController(context, mockNativeApi, mockFilesManager);
   }
 
   @Override

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashpadController.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashpadController.java
@@ -55,7 +55,7 @@ class CrashpadController implements NativeComponentController {
         initSuccess = nativeApi.initialize(crashReportPath, context.getAssets());
       }
     } catch (IOException e) {
-      Logger.getLogger().e("Error initializing CrashlyticsNdk", e);
+      Logger.getLogger().e("Error initializing Crashlytics NDK", e);
     }
     return initSuccess;
   }
@@ -82,12 +82,14 @@ class CrashpadController implements NativeComponentController {
     final File sessionFileDirectoryForMinidump = new File(sessionFileDirectory, "pending");
 
     Logger.getLogger()
-        .d("Minidump directory: " + sessionFileDirectoryForMinidump.getAbsolutePath());
+        .v("Minidump directory: " + sessionFileDirectoryForMinidump.getAbsolutePath());
 
     File minidump = getSingleFileWithExtension(sessionFileDirectoryForMinidump, ".dmp");
 
     Logger.getLogger()
-        .d("Minidump " + (minidump != null && minidump.exists() ? "exists" : "does not exist"));
+        .v(
+            "Minidump file "
+                + (minidump != null && minidump.exists() ? "exists" : "does not exist"));
 
     final SessionFiles.Builder builder = new SessionFiles.Builder();
     if (sessionFileDirectory != null

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashpadController.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashpadController.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 
-class BreakpadController implements NativeComponentController {
+class CrashpadController implements NativeComponentController {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
   private static final String SESSION_METADATA_FILE = "session.json";
@@ -39,7 +39,7 @@ class BreakpadController implements NativeComponentController {
   private final NativeApi nativeApi;
   private final CrashFilesManager filesManager;
 
-  BreakpadController(Context context, NativeApi nativeApi, CrashFilesManager filesManager) {
+  CrashpadController(Context context, NativeApi nativeApi, CrashFilesManager filesManager) {
     this.context = context;
     this.nativeApi = nativeApi;
     this.filesManager = filesManager;

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/FirebaseCrashlyticsNdk.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/FirebaseCrashlyticsNdk.java
@@ -31,7 +31,7 @@ class FirebaseCrashlyticsNdk implements CrashlyticsNativeComponent {
     final File rootDir = new File(context.getFilesDir(), FILES_PATH);
 
     final NativeComponentController controller =
-        new BreakpadController(
+        new CrashpadController(
             context, new JniNativeApi(context), new NdkCrashFilesManager(rootDir));
     return new FirebaseCrashlyticsNdk(controller);
   }

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/FirebaseCrashlyticsNdk.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/FirebaseCrashlyticsNdk.java
@@ -50,8 +50,9 @@ class FirebaseCrashlyticsNdk implements CrashlyticsNativeComponent {
   @Override
   public boolean openSession(String sessionId) {
     final boolean initSuccess = controller.initialize(sessionId);
-    Logger.getLogger()
-        .i("Crashlytics NDK initialization " + (initSuccess ? "successful" : "FAILED"));
+    if (!initSuccess) {
+      Logger.getLogger().w("Failed to initialize Crashlytics NDK for session " + sessionId);
+    }
     return initSuccess;
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCallTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCallTest.java
@@ -186,7 +186,13 @@ public class DefaultSettingsSpiCallTest extends CrashlyticsTestCase {
 
     assertNull(defaultSettingsSpiCall.handleResponse(mockHttpResponse));
     verify(mockHttpResponse, never()).body();
-    verify(mockLogger, times(1)).e(eq("Failed to retrieve settings from " + TEST_URL));
+    verify(mockLogger, times(1))
+        .e(
+            eq(
+                "Settings request failed; (status: "
+                    + HttpURLConnection.HTTP_INTERNAL_ERROR
+                    + ") from "
+                    + TEST_URL));
   }
 
   public void testRequestWasSuccessful_successfulStatusCodes() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/CrashlyticsAnalyticsListener.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/CrashlyticsAnalyticsListener.java
@@ -20,6 +20,7 @@ import androidx.annotation.Nullable;
 import com.google.firebase.analytics.connector.AnalyticsConnector.AnalyticsConnectorListener;
 import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.analytics.AnalyticsEventReceiver;
+import java.util.Locale;
 
 /**
  * Crashlytics listener for Firebase Analytics events. Processes incoming events and passes those
@@ -46,7 +47,10 @@ class CrashlyticsAnalyticsListener implements AnalyticsConnectorListener {
 
   @Override
   public void onMessageTriggered(int id, @Nullable Bundle extras) {
-    Logger.getLogger().d("Received Analytics message: " + id + " " + extras);
+    Logger.getLogger()
+        .v(
+            String.format(
+                Locale.US, "Analytics listener received message. ID: %d, Extras: %s", id, extras));
 
     if (extras == null) {
       return;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -92,7 +92,6 @@ public class FirebaseCrashlytics {
 
     if (analyticsConnector != null) {
       // If FA is available, create a logger to log events from the Crashlytics origin.
-      Logger.getLogger().d("Firebase Analytics is available.");
       final CrashlyticsOriginAnalyticsEventLogger directAnalyticsEventLogger =
           new CrashlyticsOriginAnalyticsEventLogger(analyticsConnector);
 
@@ -107,7 +106,7 @@ public class FirebaseCrashlytics {
           subscribeToAnalyticsEvents(analyticsConnector, crashlyticsAnalyticsListener);
 
       if (analyticsConnectorHandle != null) {
-        Logger.getLogger().d("Firebase Analytics listener registered successfully.");
+        Logger.getLogger().d("Registered Firebase Analytics listener.");
         // Create the event receiver which will supply breadcrumb events to Crashlytics
         final BreadcrumbAnalyticsEventReceiver breadcrumbReceiver =
             new BreadcrumbAnalyticsEventReceiver();
@@ -132,7 +131,8 @@ public class FirebaseCrashlytics {
         // Set the blocking analytics event logger for Crashlytics.
         analyticsEventLogger = blockingAnalyticsEventLogger;
       } else {
-        Logger.getLogger().d("Firebase Analytics listener registration failed.");
+        Logger.getLogger()
+            .w("Could not register Firebase Analytics listener; a listener is already registered.");
         // FA is enabled, but the listener was not registered successfully.
         // We cannot listen for breadcrumbs.
         breadcrumbSource = new DisabledBreadcrumbSource();
@@ -142,7 +142,7 @@ public class FirebaseCrashlytics {
       }
     } else {
       // FA is entirely unavailable. We cannot listen for breadcrumbs or send events.
-      Logger.getLogger().d("Firebase Analytics is unavailable.");
+      Logger.getLogger().d("Firebase Analytics is not available.");
       breadcrumbSource = new DisabledBreadcrumbSource();
       analyticsEventLogger = new UnavailableAnalyticsEventLogger();
     }
@@ -161,7 +161,7 @@ public class FirebaseCrashlytics {
 
     final String googleAppId = app.getOptions().getApplicationId();
     final String mappingFileId = CommonUtils.getMappingFileId(context);
-    Logger.getLogger().d("Mapping file ID is: " + mappingFileId);
+    Logger.getLogger().v("Mapping file ID is: " + mappingFileId);
 
     final UnityVersionProvider unityVersionProvider = new ResourceUnityVersionProvider(context);
 
@@ -170,11 +170,11 @@ public class FirebaseCrashlytics {
       appData =
           AppData.create(context, idManager, googleAppId, mappingFileId, unityVersionProvider);
     } catch (PackageManager.NameNotFoundException e) {
-      Logger.getLogger().e("Could not retrieve app info, initialization failed.", e);
+      Logger.getLogger().e("Error retrieving app package info.", e);
       return null;
     }
 
-    Logger.getLogger().d("Installer package name is: " + appData.installerPackageName);
+    Logger.getLogger().v("Installer package name is: " + appData.installerPackageName);
 
     final ExecutorService threadPoolExecutor =
         ExecutorUtils.buildSingleThreadExecutorService("com.google.firebase.crashlytics.startup");
@@ -282,7 +282,7 @@ public class FirebaseCrashlytics {
    */
   public void recordException(@NonNull Throwable throwable) {
     if (throwable == null) { // Users could call this with null despite the annotation.
-      Logger.getLogger().w("Crashlytics is ignoring a request to log a null exception.");
+      Logger.getLogger().v("A null value was passed to recordException. Ignoring.");
       return;
     }
     core.logException(throwable);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -161,7 +161,7 @@ public class FirebaseCrashlytics {
 
     final String googleAppId = app.getOptions().getApplicationId();
     final String mappingFileId = CommonUtils.getMappingFileId(context);
-    Logger.getLogger().v("Mapping file ID is: " + mappingFileId);
+    Logger.getLogger().d("Mapping file ID is: " + mappingFileId);
 
     final UnityVersionProvider unityVersionProvider = new ResourceUnityVersionProvider(context);
 
@@ -282,7 +282,7 @@ public class FirebaseCrashlytics {
    */
   public void recordException(@NonNull Throwable throwable) {
     if (throwable == null) { // Users could call this with null despite the annotation.
-      Logger.getLogger().v("A null value was passed to recordException. Ignoring.");
+      Logger.getLogger().w("A null value was passed to recordException. Ignoring.");
       return;
     }
     core.logException(throwable);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/analytics/BlockingAnalyticsEventLogger.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/analytics/BlockingAnalyticsEventLogger.java
@@ -51,23 +51,25 @@ public class BlockingAnalyticsEventLogger implements AnalyticsEventReceiver, Ana
   @Override
   public void logEvent(@NonNull String name, @Nullable Bundle params) {
     synchronized (latchLock) {
-      Logger.getLogger().d("Logging Crashlytics event to Firebase");
+      Logger.getLogger()
+          .v("Logging event " + name + " to Firebase Analytics with params " + params);
       this.eventLatch = new CountDownLatch(1);
       this.callbackReceived = false;
 
       baseAnalyticsEventLogger.logEvent(name, params);
 
-      Logger.getLogger().d("Awaiting app exception callback from FA...");
+      Logger.getLogger().v("Awaiting app exception callback from Analytics...");
       try {
         if (eventLatch.await(timeout, timeUnit)) {
           callbackReceived = true;
-          Logger.getLogger().d("App exception callback received from FA listener.");
+          Logger.getLogger().v("App exception callback received from Analytics listener.");
         } else {
           Logger.getLogger()
-              .d("Timeout exceeded while awaiting app exception callback from FA listener.");
+              .w("Timeout exceeded while awaiting app exception callback from Analytics listener.");
         }
       } catch (InterruptedException ie) {
-        Logger.getLogger().d("Interrupted while awaiting app exception callback from FA listener.");
+        Logger.getLogger()
+            .e("Interrupted while awaiting app exception callback from Analytics listener.");
       }
 
       this.eventLatch = null;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -158,7 +158,7 @@ public class CommonUtils {
       String arch = Build.CPU_ABI;
 
       if (TextUtils.isEmpty(arch)) {
-        Logger.getLogger().d("Architecture#getValue()::Build.CPU_ABI returned null or empty");
+        Logger.getLogger().v("Architecture#getValue()::Build.CPU_ABI returned null or empty");
         return UNKNOWN;
       }
 
@@ -195,7 +195,7 @@ public class CommonUtils {
             // leave in this handling since we don't know for certain it isn't.
             bytes = convertMemInfoToBytes(result, "GB", BYTES_IN_A_GIGABYTE);
           } else {
-            Logger.getLogger().d("Unexpected meminfo format while computing RAM: " + result);
+            Logger.getLogger().w("Unexpected meminfo format while computing RAM: " + result);
           }
         } catch (NumberFormatException e) {
           Logger.getLogger().e("Unexpected meminfo format while computing RAM: " + result, e);
@@ -606,7 +606,7 @@ public class CommonUtils {
     final int id = CommonUtils.getResourcesIdentifier(context, UNITY_EDITOR_VERSION, "string");
     if (id != 0) {
       version = context.getResources().getString(id);
-      Logger.getLogger().d("Unity Editor version is: " + version);
+      Logger.getLogger().v("Unity Editor version is: " + version);
     }
     return version;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -767,7 +767,8 @@ class CrashlyticsController {
             Long.parseLong(markerFile.getName().substring(APP_EXCEPTION_MARKER_PREFIX.length()));
         events.add(logAnalyticsAppExceptionEvent(timestamp));
       } catch (NumberFormatException nfe) {
-        Logger.getLogger().w("Could not parse timestamp from file " + markerFile.getName());
+        Logger.getLogger()
+            .w("Could not parse app exception timestamp from file " + markerFile.getName());
       }
       markerFile.delete();
     }
@@ -777,7 +778,7 @@ class CrashlyticsController {
 
   private Task<Void> logAnalyticsAppExceptionEvent(long timestamp) {
     if (firebaseCrashExists()) {
-      Logger.getLogger().v("Skipping logging Crashlytics event to Firebase, FirebaseCrash exists");
+      Logger.getLogger().d("Skipping logging Crashlytics event to Firebase, FirebaseCrash exists");
       return Tasks.forResult(null);
     }
     Logger.getLogger().d("Logging app exception event to Firebase Analytics");

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -778,7 +778,7 @@ class CrashlyticsController {
 
   private Task<Void> logAnalyticsAppExceptionEvent(long timestamp) {
     if (firebaseCrashExists()) {
-      Logger.getLogger().d("Skipping logging Crashlytics event to Firebase, FirebaseCrash exists");
+      Logger.getLogger().w("Skipping logging Crashlytics event to Firebase, FirebaseCrash exists");
       return Tasks.forResult(null);
     }
     Logger.getLogger().d("Logging app exception event to Firebase Analytics");

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -165,12 +165,7 @@ class CrashlyticsController {
       @NonNull final Throwable ex) {
 
     Logger.getLogger()
-        .d(
-            "Crashlytics is handling uncaught "
-                + "exception \""
-                + ex
-                + "\" from thread "
-                + thread.getName());
+        .d("Handling uncaught " + "exception \"" + ex + "\" from thread " + thread.getName());
 
     // Capture the time that the crash occurs and close over it so that the time doesn't
     // reflect when we get around to executing the task later.
@@ -258,7 +253,7 @@ class CrashlyticsController {
     }
 
     Logger.getLogger().d("Automatic data collection is disabled.");
-    Logger.getLogger().d("Notifying that unsent reports are available.");
+    Logger.getLogger().v("Notifying that unsent reports are available.");
     unsentReportsAvailable.trySetResult(true);
 
     // If data collection gets enabled while we are waiting for an action, go ahead and send the
@@ -289,7 +284,7 @@ class CrashlyticsController {
       return sessionId != null && nativeComponent.hasCrashDataForSession(sessionId);
     }
 
-    Logger.getLogger().d("Found previous crash marker.");
+    Logger.getLogger().v("Found previous crash marker.");
     crashMarker.remove();
 
     return Boolean.TRUE;
@@ -302,7 +297,7 @@ class CrashlyticsController {
     // and 2) when there's a fatal crash. So no new reports will become available while the app is
     // running.
     if (!checkForUnsentReportsCalled.compareAndSet(false, true)) {
-      Logger.getLogger().d("checkForUnsentReports should only be called once per execution.");
+      Logger.getLogger().w("checkForUnsentReports should only be called once per execution.");
       return Tasks.forResult(false);
     }
     return unsentReportsAvailable.getTask();
@@ -321,11 +316,11 @@ class CrashlyticsController {
   Task<Void> submitAllReports(Task<AppSettingsData> appSettingsDataTask) {
     if (!reportingCoordinator.hasReportsToSend()) {
       // Just notify the user that there are no reports and stop.
-      Logger.getLogger().d("No reports are available.");
+      Logger.getLogger().v("No crash reports are available to be sent.");
       unsentReportsAvailable.trySetResult(false);
       return Tasks.forResult(null);
     }
-    Logger.getLogger().d("Unsent reports are available.");
+    Logger.getLogger().v("Crash reports are available to be sent.");
 
     return waitForReportAction()
         .onSuccessTask(
@@ -339,14 +334,14 @@ class CrashlyticsController {
                       @Override
                       public Task<Void> call() throws Exception {
                         if (!send) {
-                          Logger.getLogger().d("Reports are being deleted.");
+                          Logger.getLogger().v("Deleting cached crash reports...");
                           deleteFiles(listAppExceptionMarkerFiles());
                           reportingCoordinator.removeAllReports();
                           unsentReportsHandled.trySetResult(null);
                           return Tasks.forResult(null);
                         }
 
-                        Logger.getLogger().d("Reports are being sent.");
+                        Logger.getLogger().d("Sending cached crash reports...");
 
                         // waitForReportAction guarantees we got user permission.
                         boolean dataCollectionToken = send;
@@ -367,7 +362,7 @@ class CrashlyticsController {
                                 if (appSettingsData == null) {
                                   Logger.getLogger()
                                       .w(
-                                          "Received null app settings, cannot send reports during app startup.");
+                                          "Received null app settings at app startup. Cannot send cached reports");
                                   return Tasks.forResult(null);
                                 }
                                 logAnalyticsAppExceptionEvents();
@@ -414,7 +409,7 @@ class CrashlyticsController {
               final String currentSessionId = getCurrentSessionId();
               if (currentSessionId == null) {
                 Logger.getLogger()
-                    .d("Tried to write a non-fatal exception while no session was open.");
+                    .w("Tried to write a non-fatal exception while no session was open.");
                 return;
               }
               reportingCoordinator.persistNonFatalEvent(
@@ -526,18 +521,18 @@ class CrashlyticsController {
     backgroundWorker.checkRunningOnThread();
 
     if (isHandlingException()) {
-      Logger.getLogger().d("Skipping session finalization because a crash has already occurred.");
+      Logger.getLogger().w("Skipping session finalization because a crash has already occurred.");
       return Boolean.FALSE;
     }
 
-    Logger.getLogger().d("Finalizing previously open sessions.");
+    Logger.getLogger().v("Finalizing previously open sessions.");
     try {
       doCloseSessions(true);
     } catch (Exception e) {
       Logger.getLogger().e("Unable to finalize previously open sessions.", e);
       return false;
     }
-    Logger.getLogger().d("Closed all previously open sessions");
+    Logger.getLogger().v("Closed all previously open sessions.");
 
     return true;
   }
@@ -577,7 +572,7 @@ class CrashlyticsController {
     List<String> sortedOpenSessions = reportingCoordinator.listSortedOpenSessionIds();
 
     if (sortedOpenSessions.size() <= offset) {
-      Logger.getLogger().d("No open sessions to be closed.");
+      Logger.getLogger().v("No open sessions to be closed.");
       return;
     }
 
@@ -588,7 +583,7 @@ class CrashlyticsController {
       // data when we aren't including current.
       finalizePreviousNativeSession(mostRecentSessionIdToClose);
       if (!nativeComponent.finalizeSession(mostRecentSessionIdToClose)) {
-        Logger.getLogger().d("Could not finalize native session: " + mostRecentSessionIdToClose);
+        Logger.getLogger().w("Could not finalize native session: " + mostRecentSessionIdToClose);
       }
     }
 
@@ -627,7 +622,7 @@ class CrashlyticsController {
   // endregion
 
   private void finalizePreviousNativeSession(String previousSessionId) {
-    Logger.getLogger().d("Finalizing native report for session " + previousSessionId);
+    Logger.getLogger().v("Finalizing native report for session " + previousSessionId);
     NativeSessionFileProvider nativeSessionFileProvider =
         nativeComponent.getSessionFileProvider(previousSessionId);
     File minidumpFile = nativeSessionFileProvider.getMinidumpFile();
@@ -643,7 +638,7 @@ class CrashlyticsController {
     final File nativeSessionDirectory = new File(getNativeSessionFilesDir(), previousSessionId);
 
     if (!nativeSessionDirectory.mkdirs()) {
-      Logger.getLogger().d("Couldn't create native sessions directory");
+      Logger.getLogger().w("Couldn't create directory to store native session files, aborting.");
       return;
     }
 
@@ -673,7 +668,7 @@ class CrashlyticsController {
     try {
       new File(getFilesDir(), APP_EXCEPTION_MARKER_PREFIX + eventTime).createNewFile();
     } catch (IOException e) {
-      Logger.getLogger().d("Could not write app exception marker.");
+      Logger.getLogger().w("Could not create app exception marker file.", e);
     }
   }
 
@@ -772,7 +767,7 @@ class CrashlyticsController {
             Long.parseLong(markerFile.getName().substring(APP_EXCEPTION_MARKER_PREFIX.length()));
         events.add(logAnalyticsAppExceptionEvent(timestamp));
       } catch (NumberFormatException nfe) {
-        Logger.getLogger().d("Could not parse timestamp from file " + markerFile.getName());
+        Logger.getLogger().w("Could not parse timestamp from file " + markerFile.getName());
       }
       markerFile.delete();
     }
@@ -782,9 +777,10 @@ class CrashlyticsController {
 
   private Task<Void> logAnalyticsAppExceptionEvent(long timestamp) {
     if (firebaseCrashExists()) {
-      Logger.getLogger().d("Skipping logging Crashlytics event to Firebase, FirebaseCrash exists");
+      Logger.getLogger().v("Skipping logging Crashlytics event to Firebase, FirebaseCrash exists");
       return Tasks.forResult(null);
     }
+    Logger.getLogger().d("Logging app exception event to Firebase Analytics");
     final ThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
     return Tasks.call(
         executor,

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -193,7 +193,7 @@ public class CrashlyticsCore {
       return false;
     }
 
-    Logger.getLogger().d("Exception handling initialization successful");
+    Logger.getLogger().d("Successfully configured exception handler.");
     return true;
   }
 
@@ -228,7 +228,7 @@ public class CrashlyticsCore {
       }
 
       if (!controller.finalizeSessions()) {
-        Logger.getLogger().d("Could not finalize previous sessions.");
+        Logger.getLogger().w("Previous sessions could not be finalized.");
       }
 
       // TODO: Move this call out of this method, so that the return value merely indicates
@@ -367,7 +367,7 @@ public class CrashlyticsCore {
     } catch (InterruptedException e) {
       Logger.getLogger().e("Crashlytics was interrupted during initialization.", e);
     } catch (ExecutionException e) {
-      Logger.getLogger().e("Problem encountered during Crashlytics initialization.", e);
+      Logger.getLogger().e("Crashlytics encountered a problem during initialization.", e);
     } catch (TimeoutException e) {
       Logger.getLogger().e("Crashlytics timed out during initialization.", e);
     }
@@ -380,7 +380,7 @@ public class CrashlyticsCore {
     // Create the Crashlytics initialization marker file, which is used to determine
     // whether the app crashed before initialization could complete.
     initializationMarker.create();
-    Logger.getLogger().d("Initialization marker file created.");
+    Logger.getLogger().v("Initialization marker file was created.");
   }
 
   /** Enqueues a job to remove the Crashlytics initialization marker file */
@@ -391,7 +391,9 @@ public class CrashlyticsCore {
           public Boolean call() throws Exception {
             try {
               final boolean removed = initializationMarker.remove();
-              Logger.getLogger().d("Initialization marker file removed: " + removed);
+              if (!removed) {
+                Logger.getLogger().w("Initialization marker file was not properly removed.");
+              }
               return removed;
             } catch (Exception e) {
               Logger.getLogger()
@@ -440,7 +442,7 @@ public class CrashlyticsCore {
 
   static boolean isBuildIdValid(String buildId, boolean requiresBuildId) {
     if (!requiresBuildId) {
-      Logger.getLogger().d("Configured not to require a build ID.");
+      Logger.getLogger().v("Configured not to require a build ID.");
       return true;
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsUncaughtExceptionHandler.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsUncaughtExceptionHandler.java
@@ -56,8 +56,7 @@ class CrashlyticsUncaughtExceptionHandler implements Thread.UncaughtExceptionHan
     } catch (Exception e) {
       Logger.getLogger().e("An error occurred in the uncaught exception handler", e);
     } finally {
-      Logger.getLogger()
-          .d("Completed exception processing." + " Invoking default exception handler.");
+      Logger.getLogger().d("Completed exception processing. Invoking default exception handler.");
       defaultHandler.uncaughtException(thread, ex);
       isHandlingException.set(false);
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsUncaughtExceptionHandler.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsUncaughtExceptionHandler.java
@@ -57,9 +57,7 @@ class CrashlyticsUncaughtExceptionHandler implements Thread.UncaughtExceptionHan
       Logger.getLogger().e("An error occurred in the uncaught exception handler", e);
     } finally {
       Logger.getLogger()
-          .d(
-              "Crashlytics completed exception processing."
-                  + " Invoking default exception handler.");
+          .d("Completed exception processing." + " Invoking default exception handler.");
       defaultHandler.uncaughtException(thread, ex);
       isHandlingException.set(false);
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
@@ -142,7 +142,7 @@ public class DataCollectionArbiter {
             ? "global Firebase setting"
             : setInManifest ? FIREBASE_CRASHLYTICS_COLLECTION_ENABLED + " manifest flag" : "API";
     Logger.getLogger()
-        .d(
+        .v(
             String.format(
                 "Crashlytics automatic data collection %s by %s.", stateString, fromString));
   }
@@ -186,7 +186,7 @@ public class DataCollectionArbiter {
     } catch (PackageManager.NameNotFoundException e) {
       // This shouldn't happen since it's this app's package, but fall through to default
       // if so.
-      Logger.getLogger().d("Unable to get PackageManager. Falling through", e);
+      Logger.getLogger().e("Could not read data collection permission from manifest", e);
     }
     return null;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
@@ -142,7 +142,7 @@ public class DataCollectionArbiter {
             ? "global Firebase setting"
             : setInManifest ? FIREBASE_CRASHLYTICS_COLLECTION_ENABLED + " manifest flag" : "API";
     Logger.getLogger()
-        .v(
+        .d(
             String.format(
                 "Crashlytics automatic data collection %s by %s.", stateString, fromString));
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -111,13 +111,13 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
 
   public void persistFatalEvent(
       @NonNull Throwable event, @NonNull Thread thread, @NonNull String sessionId, long timestamp) {
-    Logger.getLogger().d("Persisting fatal event for session " + sessionId);
+    Logger.getLogger().v("Persisting fatal event for session " + sessionId);
     persistEvent(event, thread, sessionId, EVENT_TYPE_CRASH, timestamp, true);
   }
 
   public void persistNonFatalEvent(
       @NonNull Throwable event, @NonNull Thread thread, @NonNull String sessionId, long timestamp) {
-    Logger.getLogger().d("Persisting non-fatal event for session " + sessionId);
+    Logger.getLogger().v("Persisting non-fatal event for session " + sessionId);
     persistEvent(event, thread, sessionId, EVENT_TYPE_LOGGED, timestamp, false);
   }
 
@@ -138,7 +138,7 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
   public void persistUserId(@NonNull String sessionId) {
     final String userId = reportMetadata.getUserId();
     if (userId == null) {
-      Logger.getLogger().d("Could not persist user ID; no user ID available");
+      Logger.getLogger().v("Could not persist user ID; no user ID available");
       return;
     }
     reportPersistence.persistUserIdForSession(userId, sessionId);
@@ -212,7 +212,7 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
       eventBuilder.setLog(
           CrashlyticsReport.Session.Event.Log.builder().setContent(content).build());
     } else {
-      Logger.getLogger().d("No log data to include with this event.");
+      Logger.getLogger().v("No log data to include with this event.");
     }
 
     // TODO: Put this back once support for reports endpoint is removed.
@@ -235,8 +235,6 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
 
   private boolean onReportSendComplete(@NonNull Task<CrashlyticsReportWithSessionId> task) {
     if (task.isSuccessful()) {
-      // TODO: Consolidate sending analytics event here, which will capture both native and
-      // non-native fatal reports
       final CrashlyticsReportWithSessionId report = task.getResult();
       Logger.getLogger()
           .d("Crashlytics report successfully enqueued to DataTransport: " + report.getSessionId());
@@ -244,7 +242,7 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
       return true;
     }
     Logger.getLogger()
-        .d("Crashlytics report could not be enqueued to DataTransport", task.getException());
+        .w("Crashlytics report could not be enqueued to DataTransport", task.getException());
     return false;
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/UserMetadata.java
@@ -55,7 +55,7 @@ public class UserMetadata {
     key = sanitizeAttribute(key);
 
     if (attributes.size() >= MAX_ATTRIBUTES && !attributes.containsKey(key)) {
-      Logger.getLogger().d("Exceeded maximum number of custom attributes (" + MAX_ATTRIBUTES + ")");
+      Logger.getLogger().v("Exceeded maximum number of custom attributes (" + MAX_ATTRIBUTES + ")");
       return;
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
@@ -151,7 +151,7 @@ public class CrashlyticsReportPersistence {
     try {
       writeTextFile(new File(sessionDirectory, fileName), json);
     } catch (IOException e) {
-      Logger.getLogger().d("Could not persist event for session " + sessionId, e);
+      Logger.getLogger().w("Could not persist event for session " + sessionId, e);
     }
     trimEvents(sessionDirectory, maxEventsToKeep);
   }
@@ -162,7 +162,7 @@ public class CrashlyticsReportPersistence {
       writeTextFile(new File(sessionDirectory, USER_FILE_NAME), userId);
     } catch (IOException e) {
       // Session directory is not guaranteed to exist
-      Logger.getLogger().d("Could not persist user ID for session " + sessionId, e);
+      Logger.getLogger().w("Could not persist user ID for session " + sessionId, e);
     }
   }
 
@@ -209,7 +209,7 @@ public class CrashlyticsReportPersistence {
   public void finalizeReports(@Nullable String currentSessionId, long sessionEndTime) {
     final List<File> sessionDirectories = capAndGetOpenSessions(currentSessionId);
     for (File sessionDirectory : sessionDirectories) {
-      Logger.getLogger().d("Finalizing report for session " + sessionDirectory.getName());
+      Logger.getLogger().v("Finalizing report for session " + sessionDirectory.getName());
       synthesizeReport(sessionDirectory, sessionEndTime);
       recursiveDelete(sessionDirectory);
     }
@@ -237,7 +237,7 @@ public class CrashlyticsReportPersistence {
         CrashlyticsReport jsonReport = TRANSFORM.reportFromJson(readTextFile(reportFile));
         allReports.add(CrashlyticsReportWithSessionId.create(jsonReport, reportFile.getName()));
       } catch (IOException e) {
-        Logger.getLogger().d("Could not load report file " + reportFile + "; deleting", e);
+        Logger.getLogger().w("Could not load report file " + reportFile + "; deleting", e);
         reportFile.delete();
       }
     }
@@ -304,7 +304,7 @@ public class CrashlyticsReportPersistence {
 
     // Only process the session if it has associated events
     if (eventFiles.isEmpty()) {
-      Logger.getLogger().d("Session " + sessionDirectory.getName() + " has no events.");
+      Logger.getLogger().v("Session " + sessionDirectory.getName() + " has no events.");
       return;
     }
 
@@ -317,13 +317,13 @@ public class CrashlyticsReportPersistence {
         events.add(TRANSFORM.eventFromJson(readTextFile(eventFile)));
         isHighPriorityReport = isHighPriorityReport || isHighPriorityEventFile(eventFile.getName());
       } catch (IOException e) {
-        Logger.getLogger().d("Could not add event to report for " + eventFile, e);
+        Logger.getLogger().w("Could not add event to report for " + eventFile, e);
       }
     }
 
     // b/168902195
     if (events.isEmpty()) {
-      Logger.getLogger().d("Could not parse event files for session " + sessionDirectory.getName());
+      Logger.getLogger().w("Could not parse event files for session " + sessionDirectory.getName());
       return;
     }
 
@@ -333,7 +333,7 @@ public class CrashlyticsReportPersistence {
       try {
         userId = readTextFile(userIdFile);
       } catch (IOException e) {
-        Logger.getLogger().d("Could not read user ID file in " + sessionDirectory.getName(), e);
+        Logger.getLogger().w("Could not read user ID file in " + sessionDirectory.getName(), e);
       }
     }
 
@@ -356,7 +356,7 @@ public class CrashlyticsReportPersistence {
           new File(prepareDirectory(outputDirectory), previousSessionId),
           TRANSFORM.reportToJson(report));
     } catch (IOException e) {
-      Logger.getLogger().d("Could not synthesize final native report file for " + reportFile, e);
+      Logger.getLogger().w("Could not synthesize final native report file for " + reportFile, e);
     }
   }
 
@@ -385,7 +385,7 @@ public class CrashlyticsReportPersistence {
           new File(prepareDirectory(outputDirectory), session.getIdentifier()),
           TRANSFORM.reportToJson(report));
     } catch (IOException e) {
-      Logger.getLogger().d("Could not synthesize final report file for " + reportFile, e);
+      Logger.getLogger().w("Could not synthesize final report file for " + reportFile, e);
     }
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStoreImpl.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStoreImpl.java
@@ -46,7 +46,7 @@ public class FileStoreImpl implements FileStore {
         Logger.getLogger().w("Couldn't create file");
       }
     } else {
-      Logger.getLogger().d("Null File");
+      Logger.getLogger().w("Null File");
     }
     return null;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/CachedSettingsIo.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/CachedSettingsIo.java
@@ -45,7 +45,7 @@ public class CachedSettingsIo {
    *     cached data could be found, or an error occurred.
    */
   public JSONObject readCachedSettings() {
-    Logger.getLogger().d("Reading cached settings...");
+    Logger.getLogger().d("Checking for cached settings...");
 
     FileInputStream fis = null;
     JSONObject toReturn = null;
@@ -59,7 +59,7 @@ public class CachedSettingsIo {
 
         toReturn = new JSONObject(settingsStr);
       } else {
-        Logger.getLogger().d("No cached settings found.");
+        Logger.getLogger().v("Settings file does not exist.");
       }
     } catch (Exception e) {
       Logger.getLogger().e("Failed to fetch cached settings", e);
@@ -78,7 +78,7 @@ public class CachedSettingsIo {
    * @param settingsJson JSON data to write to the cache
    */
   public void writeCachedSettings(long expiresAtMillis, JSONObject settingsJson) {
-    Logger.getLogger().d("Writing settings to cache file...");
+    Logger.getLogger().v("Writing settings to cache file...");
 
     if (settingsJson != null) {
       FileWriter writer = null;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsController.java
@@ -243,9 +243,9 @@ public class SettingsController implements SettingsDataProvider {
             if (SettingsCacheBehavior.IGNORE_CACHE_EXPIRATION.equals(cacheBehavior)
                 || !settingsData.isExpired(currentTimeMillis)) {
               toReturn = settingsData;
-              Logger.getLogger().d("Returning cached settings.");
+              Logger.getLogger().v("Returning cached settings.");
             } else {
-              Logger.getLogger().d("Cached settings have expired.");
+              Logger.getLogger().v("Cached settings have expired.");
             }
           } else {
             Logger.getLogger().e("Failed to parse cached settings data.", null);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCall.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCall.java
@@ -128,7 +128,7 @@ public class DefaultSettingsSpiCall implements SettingsSpiCall {
     if (requestWasSuccessful(statusCode)) {
       toReturn = getJsonObjectFrom(httpResponse.body());
     } else {
-      logger.e("Failed to retrieve settings from " + url);
+      logger.e("Settings request failed; (status: " + statusCode + ") from " + url);
       toReturn = null;
     }
     return toReturn;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCall.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/network/DefaultSettingsSpiCall.java
@@ -108,7 +108,7 @@ public class DefaultSettingsSpiCall implements SettingsSpiCall {
       httpRequest = applyHeadersTo(httpRequest, requestData);
 
       logger.d("Requesting settings from " + url);
-      logger.d("Settings query params were: " + queryParams);
+      logger.v("Settings query params were: " + queryParams);
 
       final HttpResponse httpResponse = httpRequest.execute();
       toReturn = handleResponse(httpResponse);
@@ -122,7 +122,7 @@ public class DefaultSettingsSpiCall implements SettingsSpiCall {
   /** package private for testing */
   JSONObject handleResponse(HttpResponse httpResponse) {
     final int statusCode = httpResponse.code();
-    logger.d("Settings result was: " + statusCode);
+    logger.v("Settings response code was: " + statusCode);
 
     final JSONObject toReturn;
     if (requestWasSuccessful(statusCode)) {
@@ -150,8 +150,8 @@ public class DefaultSettingsSpiCall implements SettingsSpiCall {
     try {
       return new JSONObject(httpRequestBody);
     } catch (Exception e) {
-      logger.d("Failed to parse settings JSON from " + url, e);
-      logger.d("Settings response " + httpRequestBody);
+      logger.w("Failed to parse settings JSON from " + url, e);
+      logger.w("Settings response " + httpRequestBody);
       return null;
     }
   }


### PR DESCRIPTION
Made some log messages clearer and easier to understand, also
reduced noise by changing the log level on existing logs to:

E: Unexpected/error state, not recoverable. Crashlytics will not function.

W: Unexpected/error state, but recoverable.

D: SDK lifecycle logs ("what" is happening).
   - Unix-style "no news is good news" logging, if something goes
     wrong, it will appear in W or E logs.

V: Finer-grained logging ("how" things are happening).
   - "Success" logs, as well as logging of internally-stored values
     (e.g. current mapping file ID) are logged at this level.

Also modified a few logs to *only* print in an error case.