### PR TITLE
Remove KTX docs from firebaseopensource.com

### DIFF
--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -5,6 +5,9 @@
         "Android"
     ],
     "content": "docs/README.md",
+    "pages": {	
+        "README.md": "Development Guide"
+    },
     "related": [
         "firebase/quickstart-android"
     ],

--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -5,19 +5,6 @@
         "Android"
     ],
     "content": "docs/README.md",
-    "pages": {
-        "README.md": "Development Guide",
-        "docs/ktx/common.md": "Common KTX",
-        "docs/ktx/crashlytics.md": "Crashlytics KTX",
-        "docs/ktx/dynamic-links.md": "Dynamic Links KTX",
-        "docs/ktx/firestore.md": "Firestore KTX",
-        "docs/ktx/functions.md": "Functions KTX",
-        "docs/ktx/inappmessaging.md": "In-App Messaging KTX",
-        "docs/ktx/inappmessaging-display.md": "In-App Messaging Display KTX",
-        "docs/ktx/remote-config.md": "Remote Config KTX",
-        "docs/ktx/storage.md": "Storage KTX",
-        "docs/ktx/database.md": "Realtime Database KTX"
-    },
     "related": [
         "firebase/quickstart-android"
     ],
@@ -25,10 +12,6 @@
         {
             "title": "Main Reference",
             "href": "https://firebase.google.com/docs/reference/android/"
-        },
-        {
-            "title": "KTX Reference",
-            "href": "https://firebase.github.io/firebase-android-sdk/reference/kotlin/firebase-ktx/"
         }
     ]
 }


### PR DESCRIPTION
This will remove the sidebar from this page:
https://firebaseopensource.com/projects/firebase/firebase-android-sdk/

Someone else can decide if we actually want to delete all the individual md files listed here:
https://github.com/firebase/firebase-android-sdk/tree/master/docs#kotlin-extensions
