### PR TITLE
Initial commit for the probuf compiler plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.14'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
         classpath 'org.jsoup:jsoup:1.13.1'
         classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.9'

--- a/encoders/protoc-gen-firebase-encoders/protoc-gen-firebase-encoders.gradle
+++ b/encoders/protoc-gen-firebase-encoders/protoc-gen-firebase-encoders.gradle
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id "org.jetbrains.kotlin.jvm"
+    id "java-library"
+    id "com.github.johnrengelman.shadow" version "5.2.0"
+}
+
+jar {
+    manifest.attributes "Main-Class": "com.google.firebase.encoders.proto.codegen.MainKt"
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72"
+
+    implementation "com.google.protobuf:protobuf-java:3.11.4"
+    //implementation "com.google.protobuf:protoc-gen-javalite:3.0.0"
+    implementation 'com.squareup:javapoet:1.13.0'
+    implementation 'com.google.guava:guava:30.0-jre'
+}

--- a/encoders/protoc-gen-firebase-encoders/src/main/kotlin/com/google/firebase/encoders/proto/codegen/CodeGenerator.kt
+++ b/encoders/protoc-gen-firebase-encoders/src/main/kotlin/com/google/firebase/encoders/proto/codegen/CodeGenerator.kt
@@ -1,0 +1,22 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.proto.codegen
+
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
+
+class CodeGenerator(val request: CodeGeneratorRequest) {
+    fun generate(): CodeGeneratorResponse = CodeGeneratorResponse.getDefaultInstance()
+}

--- a/encoders/protoc-gen-firebase-encoders/src/main/kotlin/com/google/firebase/encoders/proto/codegen/Main.kt
+++ b/encoders/protoc-gen-firebase-encoders/src/main/kotlin/com/google/firebase/encoders/proto/codegen/Main.kt
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.encoders.proto.codegen
+
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
+import java.io.PrintWriter
+import java.io.StringWriter
+
+/** Main entry point to the executable jar.
+ *
+ * According to protoc plugin spec, this function is invoked with no arguments and receives a
+ * serialized [CodeGeneratorRequest] via `stdin` and must return a [CodeGeneratorResponse] via
+ * `stdout`.
+ */
+fun main(args: Array<String>) {
+    val request = CodeGeneratorRequest.parseFrom(System.`in`)
+    runCatching {
+        CodeGenerator(request).generate().writeTo(System.out)
+    }.onFailure {
+        val stringWriter = StringWriter()
+        it.printStackTrace(PrintWriter(stringWriter))
+        CodeGeneratorResponse.newBuilder()
+                .setError(stringWriter.toString())
+                .build()
+                .writeTo(System.out)
+    }
+}

--- a/encoders/protoc-gen-firebase-encoders/tests/src/main/proto/test.proto
+++ b/encoders/protoc-gen-firebase-encoders/tests/src/main/proto/test.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package com.firebase.testing;
+
+message TestMessage {
+  int32 foo = 1;
+}

--- a/encoders/protoc-gen-firebase-encoders/tests/tests.gradle
+++ b/encoders/protoc-gen-firebase-encoders/tests/tests.gradle
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id "java-library"
+    id 'com.google.protobuf'
+}
+
+
+// add a dependency on the protoc plugin's fat jar to make it available to protobuf below.
+configurations.create("protobuild")
+dependencies {
+    protobuild project(path: ":encoders:protoc-gen-firebase-encoders", configuration: "shadow")
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:$protocVersion"
+    }
+    plugins {
+        firebaseEncoders {
+            path = configurations.protobuild.asPath
+        }
+    }
+    generateProtoTasks {
+        all().each { task ->
+            task.builtins {
+                remove java
+            }
+            task.dependsOn configurations.protobuild
+            task.plugins {
+                firebaseEncoders {}
+            }
+        }
+    }
+}
+
+dependencies {
+
+    implementation project(":encoders:firebase-encoders")
+    implementation project(":encoders:firebase-encoders-proto")
+    annotationProcessor project(":encoders:firebase-encoders-processor")
+}

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -45,6 +45,8 @@ encoders:firebase-encoders-processor
 encoders:firebase-encoders-proto
 encoders:firebase-encoders-reflective
 encoders:firebase-decoders-json
+encoders:protoc-gen-firebase-encoders
+encoders:protoc-gen-firebase-encoders:tests
 
 integ-testing
 


### PR DESCRIPTION
It consists of a fat jar can be used instead or in addition to standard
codegen.

The jar can be consumed via an absolute path to it(as is done in the
`tests` project) or as a maven artifact if available in one of the
configured repositories.