### PR TITLE
Add build number to Remote Config

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
@@ -44,6 +44,7 @@ public final class RemoteConfigConstants {
     RequestFieldKey.LANGUAGE_CODE,
     RequestFieldKey.PLATFORM_VERSION,
     RequestFieldKey.TIME_ZONE,
+    RequestFieldKey.APP_BUILD,
     RequestFieldKey.APP_VERSION,
     RequestFieldKey.PACKAGE_NAME,
     RequestFieldKey.SDK_VERSION,
@@ -59,6 +60,7 @@ public final class RemoteConfigConstants {
     String PLATFORM_VERSION = "platformVersion";
     String TIME_ZONE = "timeZone";
     String APP_VERSION = "appVersion";
+    String APP_BUILD = "appBuild";
     String PACKAGE_NAME = "packageName";
     String SDK_VERSION = "sdkVersion";
     String ANALYTICS_USER_PROPERTIES = "analyticsUserProperties";

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -17,6 +17,7 @@ package com.google.firebase.remoteconfig.internal;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.TAG;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.FETCH_REGEX_URL;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.ANALYTICS_USER_PROPERTIES;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_BUILD;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_ID;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_VERSION;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.COUNTRY_CODE;
@@ -41,6 +42,7 @@ import android.os.Build;
 import android.util.Log;
 import androidx.annotation.Keep;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.content.pm.PackageInfoCompat;
 import com.google.android.gms.common.util.AndroidUtilsLight;
 import com.google.android.gms.common.util.Hex;
 import com.google.firebase.remoteconfig.BuildConfig;
@@ -322,9 +324,11 @@ public class ConfigFetchHttpClient {
           context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
       if (packageInfo != null) {
         requestBodyMap.put(APP_VERSION, packageInfo.versionName);
+        requestBodyMap.put(
+            APP_BUILD, Long.toString(PackageInfoCompat.getLongVersionCode(packageInfo)));
       }
     } catch (NameNotFoundException e) {
-      // Leave app version blank if package cannot be found.
+      // Leave app version and build number blank if package cannot be found.
     }
 
     requestBodyMap.put(PACKAGE_NAME, context.getPackageName());

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -20,7 +20,9 @@ import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentD
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.VARIANT_ID;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.FETCH_REGEX_URL;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.ANALYTICS_USER_PROPERTIES;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_BUILD;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_ID;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_VERSION;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.COUNTRY_CODE;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.INSTANCE_ID;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.INSTANCE_ID_TOKEN;
@@ -36,6 +38,7 @@ import static com.google.firebase.remoteconfig.testutil.Assert.assertThrows;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
 import android.os.Build;
 import com.google.android.gms.common.util.MockClock;
 import com.google.common.base.Charsets;
@@ -205,6 +208,11 @@ public class ConfigFetchHttpClientTest {
     assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(locale.toLanguageTag());
     assertThat(requestBody.getInt(PLATFORM_VERSION)).isEqualTo(android.os.Build.VERSION.SDK_INT);
     assertThat(requestBody.get(TIME_ZONE)).isEqualTo(TimeZone.getDefault().getID());
+    PackageInfo packageInfo =
+        context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+    assertThat(requestBody.get(APP_VERSION)).isEqualTo(packageInfo.versionName);
+    assertThat(requestBody.get(APP_BUILD))
+        .isEqualTo(Long.toString(packageInfo.getLongVersionCode()));
     assertThat(requestBody.get(PACKAGE_NAME)).isEqualTo(context.getPackageName());
     assertThat(requestBody.get(SDK_VERSION)).isEqualTo(BuildConfig.VERSION_NAME);
     assertThat(requestBody.getJSONObject(ANALYTICS_USER_PROPERTIES).toString())


### PR DESCRIPTION
Allow users to make conditions using build number like they can for iOS apps

Build version is an internal tracking version of an app, not shown to users (in gradle files, this is versionCode)
App version is the external released version of an app shown to users (in gradle files, this is versionName)