### PR TITLE
update scheduling alogirthm to handle reschedules

### DIFF
--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/TestWorkScheduler.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/TestWorkScheduler.java
@@ -33,4 +33,12 @@ public class TestWorkScheduler implements WorkScheduler {
     }
     uploader.get().upload(transportContext, attemptNumber, () -> {});
   }
+
+  @Override
+  public void schedule(TransportContext transportContext, int attemptNumber, boolean force) {
+    if (attemptNumber > 2) {
+      return;
+    }
+    uploader.get().upload(transportContext, attemptNumber, () -> {});
+  }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -77,15 +77,16 @@ public class AlarmManagerScheduler implements WorkScheduler {
     return (PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_NO_CREATE) != null);
   }
 
-   @Override
-   public void schedule(TransportContext transportContext, int attemptNumber) {
+  @Override
+  public void schedule(TransportContext transportContext, int attemptNumber) {
     schedule(transportContext, attemptNumber, false);
-   }
-   /**
+  }
+  /**
    * Schedules the AlarmManager service.
    *
    * @param transportContext Contains information about the backend and the priority.
    * @param attemptNumber Number of times the AlarmManager has tried to log for this backend.
+   * @param force When set to true the scheduler is forced to schedule the job.
    */
   @Override
   public void schedule(TransportContext transportContext, int attemptNumber, boolean force) {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -77,14 +77,18 @@ public class AlarmManagerScheduler implements WorkScheduler {
     return (PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_NO_CREATE) != null);
   }
 
-  /**
+   @Override
+   public void schedule(TransportContext transportContext, int attemptNumber) {
+    schedule(transportContext, attemptNumber, false);
+   }
+   /**
    * Schedules the AlarmManager service.
    *
    * @param transportContext Contains information about the backend and the priority.
    * @param attemptNumber Number of times the AlarmManager has tried to log for this backend.
    */
   @Override
-  public void schedule(TransportContext transportContext, int attemptNumber) {
+  public void schedule(TransportContext transportContext, int attemptNumber, boolean force) {
     Uri.Builder intentDataBuilder = new Uri.Builder();
     intentDataBuilder.appendQueryParameter(BACKEND_NAME, transportContext.getBackendName());
     intentDataBuilder.appendQueryParameter(
@@ -97,7 +101,7 @@ public class AlarmManagerScheduler implements WorkScheduler {
     intent.setData(intentDataBuilder.build());
     intent.putExtra(ATTEMPT_NUMBER, attemptNumber);
 
-    if (isJobServiceOn(intent)) {
+    if (!force && isJobServiceOn(intent)) {
       Logging.d(
           LOG_TAG, "Upload for context %s is already scheduled. Returning...", transportContext);
       return;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
@@ -83,15 +83,23 @@ public class JobInfoScheduler implements WorkScheduler {
     return false;
   }
 
-  @Override
-  public void schedule(TransportContext transportContext, int attemptNumber) {
-    schedule(transportContext, attemptNumber, false);
-  }
   /**
    * Schedules the JobScheduler service.
    *
    * @param transportContext Contains information about the backend and the priority.
    * @param attemptNumber Number of times the JobScheduler has tried to log for this backend.
+   */
+  @Override
+  public void schedule(TransportContext transportContext, int attemptNumber) {
+    schedule(transportContext, attemptNumber, false);
+  }
+
+  /**
+   * Schedules the JobScheduler service.
+   *
+   * @param transportContext Contains information about the backend and the priority.
+   * @param attemptNumber Number of times the JobScheduler has tried to log for this backend.
+   * @param force When set to true the scheduler is forced to schedule the job.
    */
   @Override
   public void schedule(TransportContext transportContext, int attemptNumber, boolean force) {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
@@ -83,6 +83,10 @@ public class JobInfoScheduler implements WorkScheduler {
     return false;
   }
 
+  @Override
+  public void schedule(TransportContext transportContext, int attemptNumber) {
+    schedule(transportContext, attemptNumber, false);
+  }
   /**
    * Schedules the JobScheduler service.
    *
@@ -90,13 +94,13 @@ public class JobInfoScheduler implements WorkScheduler {
    * @param attemptNumber Number of times the JobScheduler has tried to log for this backend.
    */
   @Override
-  public void schedule(TransportContext transportContext, int attemptNumber) {
+  public void schedule(TransportContext transportContext, int attemptNumber, boolean force) {
     ComponentName serviceComponent = new ComponentName(context, JobInfoSchedulerService.class);
     JobScheduler jobScheduler =
         (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
     int jobId = getJobId(transportContext);
     // Check if there exists a job scheduled for this backend name.
-    if (isJobServiceOn(jobScheduler, jobId, attemptNumber)) {
+    if (!force && isJobServiceOn(jobScheduler, jobId, attemptNumber)) {
       Logging.d(
           LOG_TAG, "Upload for context %s is already scheduled. Returning...", transportContext);
       return;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -137,7 +137,7 @@ public class Uploader {
                   transportContext, clock.getTime() + response.getNextRequestWaitMillis());
             }
             if (eventStore.hasPendingEventsFor(transportContext)) {
-              workScheduler.schedule(transportContext, 1);
+              workScheduler.schedule(transportContext, 1, true);
             }
           }
           return null;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/WorkScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/WorkScheduler.java
@@ -19,5 +19,6 @@ import com.google.android.datatransport.runtime.TransportContext;
 /** Schedules the services to be able to eventually log events to their respective backends. */
 public interface WorkScheduler {
   void schedule(TransportContext transportContext, int attemptNumber);
+
   void schedule(TransportContext transportContext, int attemptNumber, boolean force);
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/WorkScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/WorkScheduler.java
@@ -19,4 +19,5 @@ import com.google.android.datatransport.runtime.TransportContext;
 /** Schedules the services to be able to eventually log events to their respective backends. */
 public interface WorkScheduler {
   void schedule(TransportContext transportContext, int attemptNumber);
+  void schedule(TransportContext transportContext, int attemptNumber, boolean force);
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerSchedulerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerSchedulerTest.java
@@ -18,6 +18,7 @@ import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.AdditionalMatchers.gt;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -121,6 +122,18 @@ public class AlarmManagerSchedulerTest {
             eq(AlarmManager.ELAPSED_REALTIME),
             eq(INITIAL_TIMESTAMP + THIRTY_SECONDS),
             any()); // 2^0*DELTA
+  }
+
+  @Test
+  public void schedule_secondAttemptThenForce() {
+    Intent intent = getIntent(TRANSPORT_CONTEXT);
+    store.recordNextCallTime(TRANSPORT_CONTEXT, 5);
+    assertThat(scheduler.isJobServiceOn(intent)).isFalse();
+    scheduler.schedule(TRANSPORT_CONTEXT, 2);
+    assertThat(scheduler.isJobServiceOn(intent)).isTrue();
+    scheduler.schedule(TRANSPORT_CONTEXT, 1, true);
+    // When you force the schedule it gets scheduled again.
+    verify(alarmManager, times(2)).set(eq(AlarmManager.ELAPSED_REALTIME), anyLong(), any());
   }
 
   @Test

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoSchedulerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoSchedulerTest.java
@@ -55,7 +55,7 @@ public class JobInfoSchedulerTest {
   private final JobInfoScheduler scheduler = new JobInfoScheduler(context, store, config);
 
   @Test
-  public void schedule_firstAttemptThenForce() {
+  public void schedule_secondAttemptThenForce() {
     store.recordNextCallTime(TRANSPORT_CONTEXT, 5);
     scheduler.schedule(TRANSPORT_CONTEXT, 2);
     int jobId = scheduler.getJobId(TRANSPORT_CONTEXT);

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoSchedulerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoSchedulerTest.java
@@ -55,6 +55,31 @@ public class JobInfoSchedulerTest {
   private final JobInfoScheduler scheduler = new JobInfoScheduler(context, store, config);
 
   @Test
+  public void schedule_firstAttemptThenForce() {
+    store.recordNextCallTime(TRANSPORT_CONTEXT, 5);
+    scheduler.schedule(TRANSPORT_CONTEXT, 2);
+    int jobId = scheduler.getJobId(TRANSPORT_CONTEXT);
+    assertThat(jobScheduler.getAllPendingJobs()).isNotEmpty();
+    assertThat(jobScheduler.getAllPendingJobs().size()).isEqualTo(1);
+    JobInfo jobInfo = jobScheduler.getAllPendingJobs().get(0);
+    PersistableBundle bundle = jobInfo.getExtras();
+    assertThat(jobInfo.getId()).isEqualTo(jobId);
+    assertThat(bundle.get(JobInfoScheduler.BACKEND_NAME))
+        .isEqualTo(TRANSPORT_CONTEXT.getBackendName());
+    assertThat(bundle.get(JobInfoScheduler.ATTEMPT_NUMBER)).isEqualTo(2);
+    // Schedule again with force set to true.
+    scheduler.schedule(TRANSPORT_CONTEXT, 1, true);
+    assertThat(jobScheduler.getAllPendingJobs().size()).isEqualTo(1);
+    jobInfo = jobScheduler.getAllPendingJobs().get(0);
+    bundle = jobInfo.getExtras();
+    assertThat(jobInfo.getId()).isEqualTo(jobId);
+    assertThat(bundle.get(JobInfoScheduler.BACKEND_NAME))
+        .isEqualTo(TRANSPORT_CONTEXT.getBackendName());
+    //  Earlier job should be overwritten with the newly scheduled job.
+    assertThat(bundle.get(JobInfoScheduler.ATTEMPT_NUMBER)).isEqualTo(1);
+  }
+
+  @Test
   public void schedule_longWaitTimeFirstAttempt() {
     store.recordNextCallTime(TRANSPORT_CONTEXT, 1000000);
     scheduler.schedule(TRANSPORT_CONTEXT, 1);

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
@@ -141,6 +141,6 @@ public class UploaderTest {
                 });
     Iterable<PersistedEvent> persistedEvents = store.loadBatch(TRANSPORT_CONTEXT);
     uploader.logAndUpdateState(TRANSPORT_CONTEXT, 1);
-    verify(mockScheduler, times(1)).schedule(TRANSPORT_CONTEXT, 1);
+    verify(mockScheduler, times(1)).schedule(TRANSPORT_CONTEXT, 1, true);
   }
 }


### PR DESCRIPTION
As per https://developer.android.com/reference/android/app/job/JobScheduler#getAllPendingJobs() this also returns the jobs which we are currently running. This results in the job never being rescheduled if there are more pending events. This pr fixes it.
Also as per https://stackoverflow.com/questions/37059315/android-jobscheduler-if-you-schedule-the-same-job-with-periodic-time-does-it-s if you schedule the same job and the same job is running then its killed and the new job is scheduled.