### PR TITLE
Define javadoc-only dependencies in projects gradle files.

### DIFF
--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -68,6 +68,7 @@ dependencies {
 
     // FirebaseApp references storage, so storage needs to be on classpath when dokka runs.
     javadocClasspath project(path: ':firebase-storage')
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'

--- a/firebase-config/firebase-config.gradle
+++ b/firebase-config/firebase-config.gradle
@@ -60,6 +60,8 @@ dependencies {
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'com.google.truth:truth:0.44'
     testImplementation 'junit:junit:4.12'

--- a/firebase-database/firebase-database.gradle
+++ b/firebase-database/firebase-database.gradle
@@ -82,6 +82,8 @@ dependencies {
         exclude group: "com.google.firebase", module: "firebase-common"
     }
 
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -64,6 +64,9 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
     }
 
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'com.android.support.test:runner:1.0.1'

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -117,6 +117,8 @@ dependencies {
     //To provide @Generated annotations
     compileOnly 'javax.annotation:jsr250-api:1.0'
 
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "io.grpc:grpc-stub:$grpcVersion"
     implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"

--- a/firebase-functions/firebase-functions.gradle
+++ b/firebase-functions/firebase-functions.gradle
@@ -66,6 +66,10 @@ dependencies {
 
     annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
 
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    javadocClasspath 'org.codehaus.mojo:animal-sniffer-annotations:1.19'
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.google.android.gms:play-services-tasks:17.0.0'
 
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"

--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -73,6 +73,8 @@ dependencies {
     testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'
     testAnnotationProcessor "com.google.auto.value:auto-value:1.6.3"
 
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'

--- a/firebase-segmentation/firebase-segmentation.gradle
+++ b/firebase-segmentation/firebase-segmentation.gradle
@@ -47,6 +47,7 @@ dependencies {
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'junit:junit:4.12'

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -85,6 +85,8 @@ dependencies {
         exclude group: "com.google.firebase", module: "firebase-common"
     }
 
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'


### PR DESCRIPTION
This will allow us to remove some of the custom logic for generating javadocs we depend on.