### PR TITLE
Android Support Library / AndroidX problem. Fix: Upgrade Picasso to avoid android support library dep

### DIFF
--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
 
-    implementation "com.squareup.picasso:picasso:2.71828"
+    implementation "com.squareup.picasso:picasso:2.8"
     implementation "com.squareup.okhttp:okhttp:2.7.5"
 
     vendor ('com.google.dagger:dagger:2.27') {


### PR DESCRIPTION
**PROBLEM**

Firebase In App Messaging still has a dependency on the support library, when this can clash with AndroidX.

```
  /home/blundell/.../build.gradle: 
  Error: 
  
  Dependencies using groupId com.android.support and androidx.* can not be combined but found

  IdeMavenCoordinates
  {
	  myGroupId='com.android.support', 
	  myArtifactId='exifinterface', 
	  myVersion='27.1.0', 
	  myPacking='aar', 
	  myClassifier='null'
  } 

  and 
  
  IdeMavenCoordinates
  {
	  myGroupId='androidx.localbroadcastmanager', 
	  myArtifactId='localbroadcastmanager', 
	  myVersion='1.0.0', 
	  myPacking='aar', 
	  myClassifier='null'
  } 

  incompatible dependencies [GradleCompatible]

```
**INVESTIGATION**

Getting the dependency graph for the module that I had imported Firebase In App Messaging into (`./gradlew libraries:remoteMessaging:dependencies`) shows how FIAM depends on FIAM-display, which depends on Picasso, which depends on a android.support library. Seen here:

```
+--- com.google.firebase:firebase-inappmessaging-display-ktx:19.1.4
|    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0-alpha01
|    +--- com.google.firebase:firebase-common:19.5.0 (*)
|    +--- com.google.firebase:firebase-common-ktx:19.5.0 (*)
|    +--- com.google.firebase:firebase-components:16.1.0 (*)
|    +--- com.google.firebase:firebase-inappmessaging:19.1.4
...
|    +--- com.google.firebase:firebase-inappmessaging-display:19.1.4
|    |    +--- androidx.appcompat:appcompat:1.1.0 -> 1.2.0
|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0-alpha01
|    |    |    +--- androidx.core:core:1.3.0 -> 1.5.0-alpha04 (*)
|    |    |    +--- androidx.cursoradapter:cursoradapter:1.0.0
|    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.2.0-alpha01
|    |    |    +--- androidx.fragment:fragment:1.1.0 (*)
|    |    |    +--- androidx.appcompat:appcompat-resources:1.2.0
...
|    |    +--- com.squareup.picasso:picasso:2.71828
|    |    |    +--- com.squareup.okhttp3:okhttp:3.10.0 -> 4.4.1 (*)
|    |    |    +--- com.android.support:support-annotations:27.1.0
|    |    |    \--- com.android.support:exifinterface:27.1.0                     // HERE IS THE PROBLEM
|    |    |         \--- com.android.support:support-annotations:27.1.0
|    |    \--- javax.inject:javax.inject:1
|    +--- com.google.firebase:firebase-inappmessaging-ktx:19.1.4
|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0-alpha01
|    |    +--- com.google.android.gms:play-services-tasks:17.0.0 -> 17.1.0 (*)
|    |    +--- com.google.firebase:firebase-common:19.5.0 (*)
|    |    +--- com.google.firebase:firebase-common-ktx:19.5.0 (*)
|    |    +--- com.google.firebase:firebase-components:16.1.0 (*)
|    |    +--- com.google.firebase:firebase-inappmessaging:19.1.4 (*)
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.4.20 (*)
|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.4.20 (*)
```
### **WorkAround**

A temporary fix for my project was to force a Picasso upgrade:

```
configurations.all {
    resolutionStrategy.dependencySubstitution {
        // Ensure the firebase-inappmessaging-display library gets the picasso version that supports androidx
        substitute module("com.squareup.picasso:picasso") using module("com.squareup.picasso:picasso:2.8")
    }
}
```

This gives the dependency graph:

```
+--- com.google.firebase:firebase-inappmessaging-display-ktx:19.1.4
|    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0-alpha01
|    +--- com.google.firebase:firebase-common:19.5.0 (*)
|    +--- com.google.firebase:firebase-common-ktx:19.5.0 (*)
|    +--- com.google.firebase:firebase-components:16.1.0 (*)
|    +--- com.google.firebase:firebase-inappmessaging:19.1.4
...
|    +--- com.google.firebase:firebase-inappmessaging-display:19.1.4
|    |    +--- androidx.appcompat:appcompat:1.1.0 -> 1.2.0
|    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0-alpha01
|    |    |    +--- androidx.core:core:1.3.0 -> 1.5.0-alpha04 (*)
|    |    |    +--- androidx.cursoradapter:cursoradapter:1.0.0
|    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.2.0-alpha01
|    |    |    +--- androidx.fragment:fragment:1.1.0 (*)
|    |    |    +--- androidx.appcompat:appcompat-resources:1.2.0
...
|    |    +--- com.squareup.picasso:picasso:2.71828 -> 2.8         // HERE IS THE FIX
|    |    |    +--- com.squareup.okhttp3:okhttp:3.10.0 -> 4.4.1 (*)
|    |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.2.0-alpha01
|    |    |    \--- androidx.exifinterface:exifinterface:1.0.0               // ENSURING THIS IS NOW ANDROIDX
|    |    |         \--- androidx.annotation:annotation:1.0.0 -> 1.2.0-alpha01
|    |    \--- javax.inject:javax.inject:1
|    +--- com.google.firebase:firebase-inappmessaging-ktx:19.1.4
|    |    +--- androidx.annotation:annotation:1.1.0 -> 1.2.0-alpha01
|    |    +--- com.google.android.gms:play-services-tasks:17.0.0 -> 17.1.0 (*)
|    |    +--- com.google.firebase:firebase-common:19.5.0 (*)
|    |    +--- com.google.firebase:firebase-common-ktx:19.5.0 (*)
|    |    +--- com.google.firebase:firebase-components:16.1.0 (*)
|    |    +--- com.google.firebase:firebase-inappmessaging:19.1.4 (*)
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.4.20 (*)
|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.4.20 (*)

```

The real fix is to update the libraries dependencies.

**SOLUTION**

- Move from Picasso 2.7 to 2.8
- Changelog: https://github.com/square/picasso/releases/tag/2.8

This 2.8 release is literally the migration to androix. :+1:

