### PR TITLE
Add ability to log multiple key/value pairs at once.

### DIFF
--- a/firebase-crashlytics/api.txt
+++ b/firebase-crashlytics/api.txt
@@ -17,7 +17,7 @@ package com.google.firebase.crashlytics {
     method public void setCustomKey(@NonNull String, int);
     method public void setCustomKey(@NonNull String, long);
     method public void setCustomKey(@NonNull String, @NonNull String);
-    method public void setCustomKeys(@NonNull Map<String, String>);
+    method public void setCustomKeys(@NonNull java.util.Map<java.lang.String,java.lang.String>);
     method public void setUserId(@NonNull String);
   }
 

--- a/firebase-crashlytics/api.txt
+++ b/firebase-crashlytics/api.txt
@@ -17,7 +17,7 @@ package com.google.firebase.crashlytics {
     method public void setCustomKey(@NonNull String, int);
     method public void setCustomKey(@NonNull String, long);
     method public void setCustomKey(@NonNull String, @NonNull String);
-    method public void setCustomKeys(@NonNull java.util.Map<java.lang.String,java.lang.String>);
+    method public void setCustomKeys(@NonNull CustomKeysAndValues>);
     method public void setUserId(@NonNull String);
   }
 

--- a/firebase-crashlytics/api.txt
+++ b/firebase-crashlytics/api.txt
@@ -17,6 +17,7 @@ package com.google.firebase.crashlytics {
     method public void setCustomKey(@NonNull String, int);
     method public void setCustomKey(@NonNull String, long);
     method public void setCustomKey(@NonNull String, @NonNull String);
+    method public void setCustomKeys(@NonNull Map<String, String>);
     method public void setUserId(@NonNull String);
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -179,7 +179,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     // test truncation of custom keys and attributes
     assertNull(metadata.getCustomKeys().get(superLongId));
 
-    assertEquals(booleanValue, metadata.getCustomKeys().get(booleanKey));
+    assertTrue(metadata.getCustomKeys().get(booleanKey), true);
     assertEquals(doubleValue, metadata.getCustomKeys().get(doubleKey));
     assertEquals(floatValue, metadata.getCustomKeys().get(floatKey));
     assertEquals(longValue, metadata.getCustomKeys().get(longKey));
@@ -227,7 +227,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     crashlyticsCore.setCustomKeys(updatedKeysAndValues.getCustomValues());
 
     assertEquals(updatedStringValue, metadata.getCustomKeys().get(stringKey));
-    assertEquals(updatedBooleanValue, metadata.getCustomKeys().get(booleanKey));
+    assertTrue(metadata.getCustomKeys().get(booleanKey), false);
     assertEquals(updatedDoubleValue, metadata.getCustomKeys().get(doubleKey));
     assertEquals(updatedFloatValue, metadata.getCustomKeys().get(floatKey));
     assertEquals(updatedLongValue, metadata.getCustomKeys().get(longKey));

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -26,6 +26,7 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.crashlytics.BuildConfig;
+import com.google.firebase.crashlytics.CustomKeysAndValues;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
 import com.google.firebase.crashlytics.internal.MissingNativeComponent;
@@ -133,7 +134,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final String trimmedKey = "trimmed key";
     final String trimmedValue = "trimmed value";
 
-    final StringBuffer idBuffer = new StringBuffer(id);
+    final StringBuffer idBuffer = new StringBuffer("id012345");
     while (idBuffer.length() < UserMetadata.MAX_ATTRIBUTE_SIZE) {
       idBuffer.append("0");
     }
@@ -170,7 +171,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
             .putInt(intKey, intValue)
             .build();
 
-    crashlyticsCore.setCustomKeys(keysAndValues.getCustomKeys());
+    crashlyticsCore.setCustomKeys(keysAndValues.getCustomValues());
 
     assertEquals(stringValue, metadata.getCustomKeys().get(stringKey));
     assertEquals(trimmedValue, metadata.getCustomKeys().get(trimmedKey));
@@ -191,7 +192,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
       final String value = "value" + i;
       addlKeysAndValues.putString(key, value);
     }
-    crashlyticsCore.setCustomKeys(addlKeysAndValues.build().getCustomKeys());
+    crashlyticsCore.setCustomKeys(addlKeysAndValues.build().getCustomValues());
 
     // Make sure the first MAX_ATTRIBUTES - 8 keys were set
     for (int i = 9; i < UserMetadata.MAX_ATTRIBUTES; ++i) {
@@ -206,7 +207,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     // Check updating existing keys and setting to null
     final String updatedStringValue = "string value 1";
-    final boolean updatedBooleanValue = true;
+    final boolean updatedBooleanValue = false;
     final double updatedDoubleValue = -1.000000000000001;
     final float updatedFloatValue = -2.000002f;
     final long updatedLongValue = -3;
@@ -223,7 +224,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
             .putInt(intKey, updatedIntValue)
             .build();
 
-    crashlyticsCore.setCustomKeys(updatedKeysAndValues.build().getCustomKeys());
+    crashlyticsCore.setCustomKeys(updatedKeysAndValues.getCustomValues());
 
     assertEquals(updatedStringValue, metadata.getCustomKeys().get(stringKey));
     assertEquals(updatedBooleanValue, metadata.getCustomKeys().get(booleanKey));

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -38,6 +38,7 @@ import com.google.firebase.crashlytics.internal.settings.TestSettingsData;
 import com.google.firebase.crashlytics.internal.settings.model.SettingsData;
 import com.google.firebase.crashlytics.internal.unity.UnityVersionProvider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
 
@@ -135,8 +136,8 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     final String longId = idBuffer.toString();
     final String superLongId = longId + "more chars";
-    final String longValue = longId.replaceAll("0", "x");
-    final String superLongValue = longValue + "some more chars";
+    final String longStringValue = longId.replaceAll("0", "x");
+    final String superLongValue = longStringValue + "some more chars";
 
     final String booleanKey = "boolean key";
     final Boolean booleanValue = true;
@@ -145,7 +146,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final double doubleValue = 1.000000000000001;
 
     final String floatKey = "float key";
-    final float floatValue = 2.000002;
+    final float floatValue = 2.000002f;
 
     final String longKey = "long key";
     final long longValue = 3;
@@ -156,7 +157,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     Map<String, String> keysAndValues = new CustomKeysAndValues.Builder()
       .putString(stringKey, stringValue)
       .putString(" " + trimmedKey + " ", " " + trimmedValue + " ")
-      .putString(longId, longValue)
+      .putString(longId, longStringValue)
       .putString(superLongId, superLongValue)
       .putBoolean(booleanKey, booleanValue)
       .putDouble(doubleKey, doubleValue)
@@ -169,7 +170,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     assertEquals(stringValue, metadata.getCustomKeys().get(stringKey));
     assertEquals(trimmedValue, metadata.getCustomKeys().get(trimmedKey));
-    assertEquals(longValue, metadata.getCustomKeys().get(longId));
+    assertEquals(longStringValue, metadata.getCustomKeys().get(longId));
     // test truncation of custom keys and attributes
     assertNull(metadata.getCustomKeys().get(superLongId));
 
@@ -203,7 +204,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final String updatedStringValue = "string value 1";
     final Boolean updatedBooleanValue = true;
     final double updatedDoubleValue = -1.000000000000001;
-    final float updatedFloatValue = -2.000002;
+    final float updatedFloatValue = -2.000002f;
     final long updatedLongValue = -3;
     final int updatedIntValue = -4;
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -165,7 +165,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
       .putInt(intKey, intValue)
       .build();
 
-    crashlyticsCore.setCustomKeys(keysAndValues.getCustomKeys);
+    crashlyticsCore.setCustomKeys(keysAndValues.getCustomKeys());
 
     assertEquals(stringValue, metadata.getCustomKeys().get(stringKey));
     assertEquals(trimmedValue, metadata.getCustomKeys().get(trimmedKey));
@@ -186,7 +186,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
       final String value = "value" + i;
       addlKeysAndValues.putString(key, value);
     }
-    crashlyticsCore.setCustomKeys(addlKeysAndValues.build().getCustomKeys);
+    crashlyticsCore.setCustomKeys(addlKeysAndValues.build().getCustomKeys());
 
     // Make sure the first MAX_ATTRIBUTES - 8 keys were set
     for (int i = 9; i < UserMetadata.MAX_ATTRIBUTES; ++i) {
@@ -217,7 +217,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
       .putInt(intKey, updatedIntValue)
       .build();
 
-    crashlyticsCore.setCustomKeys(updatedKeysAndValues.build().getCustomKeys);
+    crashlyticsCore.setCustomKeys(updatedKeysAndValues.build().getCustomKeys());
 
     assertEquals(updatedStringValue, metadata.getCustomKeys().get(stringKey));
     assertEquals(updatedBooleanValue, metadata.getCustomKeys().get(booleanKey));

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -202,7 +202,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     // Check updating existing keys and setting to null
     final String updatedStringValue = "string value 1";
-    final Boolean updatedBooleanValue = true;
+    final boolean updatedBooleanValue = true;
     final double updatedDoubleValue = -1.000000000000001;
     final float updatedFloatValue = -2.000002f;
     final long updatedLongValue = -3;

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -38,7 +38,6 @@ import com.google.firebase.crashlytics.internal.settings.TestSettingsData;
 import com.google.firebase.crashlytics.internal.settings.model.SettingsData;
 import com.google.firebase.crashlytics.internal.unity.UnityVersionProvider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
 
@@ -134,6 +133,10 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final String trimmedKey = "trimmed key";
     final String trimmedValue = "trimmed value";
 
+    final StringBuffer idBuffer = new StringBuffer(id);
+    while (idBuffer.length() < UserMetadata.MAX_ATTRIBUTE_SIZE) {
+      idBuffer.append("0");
+    }
     final String longId = idBuffer.toString();
     final String superLongId = longId + "more chars";
     final String longStringValue = longId.replaceAll("0", "x");
@@ -154,7 +157,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final String intKey = "int key";
     final int intValue = 4;
 
-    Map<String, String> keysAndValues =
+    CustomKeysAndValues keysAndValues =
         new CustomKeysAndValues.Builder()
             .putString(stringKey, stringValue)
             .putString(" " + trimmedKey + " ", " " + trimmedValue + " ")
@@ -182,7 +185,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     assertEquals(intValue, metadata.getCustomKeys().get(intKey));
 
     // test the max number of attributes. We've already set 8.
-    Map<String, String> addlKeysAndValues = new CustomKeysAndValues.Builder();
+    CustomKeysAndValues.Builder addlKeysAndValues = new CustomKeysAndValues.Builder();
     for (int i = 9; i < UserMetadata.MAX_ATTRIBUTES + 1; ++i) {
       final String key = "key" + i;
       final String value = "value" + i;
@@ -209,7 +212,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final long updatedLongValue = -3;
     final int updatedIntValue = -4;
 
-    Map<String, String> updatedKeysAndValues =
+    CustomKeysAndValues updatedKeysAndValues =
         new CustomKeysAndValues.Builder()
             .putString(stringKey, updatedStringValue)
             .putString(longId, null)

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -127,6 +127,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
   }
 
   public void testBulkCustomKeys() throws Exception {
+    final double DELTA = 1e-15;
     UserMetadata metadata = crashlyticsCore.getController().getUserMetadata();
 
     final String stringKey = "string key";
@@ -180,10 +181,10 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     assertNull(metadata.getCustomKeys().get(superLongId));
 
     assertTrue(metadata.getCustomKeys().get(booleanKey), true);
-    assertEquals(doubleValue, metadata.getCustomKeys().get(doubleKey));
-    assertEquals(floatValue, metadata.getCustomKeys().get(floatKey));
-    assertEquals(longValue, metadata.getCustomKeys().get(longKey));
-    assertEquals(intValue, metadata.getCustomKeys().get(intKey));
+    assertEquals(doubleValue, metadata.getCustomKeys().get(doubleKey), DELTA);
+    assertEquals(floatValue, metadata.getCustomKeys().get(floatKey), DELTA);
+    assertEquals(longValue, metadata.getCustomKeys().get(longKey), DELTA);
+    assertEquals(intValue, metadata.getCustomKeys().get(intKey), DELTA);
 
     // test the max number of attributes. We've already set 8.
     CustomKeysAndValues.Builder addlKeysAndValues = new CustomKeysAndValues.Builder();
@@ -228,10 +229,10 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     assertEquals(updatedStringValue, metadata.getCustomKeys().get(stringKey));
     assertTrue(metadata.getCustomKeys().get(booleanKey), false);
-    assertEquals(updatedDoubleValue, metadata.getCustomKeys().get(doubleKey));
-    assertEquals(updatedFloatValue, metadata.getCustomKeys().get(floatKey));
-    assertEquals(updatedLongValue, metadata.getCustomKeys().get(longKey));
-    assertEquals(updatedIntValue, metadata.getCustomKeys().get(intKey));
+    assertEquals(updatedDoubleValue, metadata.getCustomKeys().get(doubleKey), DELTA);
+    assertEquals(updatedFloatValue, metadata.getCustomKeys().get(floatKey), DELTA);
+    assertEquals(updatedLongValue, metadata.getCustomKeys().get(longKey), DELTA);
+    assertEquals(updatedIntValue, metadata.getCustomKeys().get(intKey), DELTA);
     assertEquals("", metadata.getCustomKeys().get(longId));
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -154,17 +154,18 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final String intKey = "int key";
     final int intValue = 4;
 
-    Map<String, String> keysAndValues = new CustomKeysAndValues.Builder()
-      .putString(stringKey, stringValue)
-      .putString(" " + trimmedKey + " ", " " + trimmedValue + " ")
-      .putString(longId, longStringValue)
-      .putString(superLongId, superLongValue)
-      .putBoolean(booleanKey, booleanValue)
-      .putDouble(doubleKey, doubleValue)
-      .putFloat(floatKey, floatValue)
-      .putLong(longKey, longValue)
-      .putInt(intKey, intValue)
-      .build();
+    Map<String, String> keysAndValues =
+        new CustomKeysAndValues.Builder()
+            .putString(stringKey, stringValue)
+            .putString(" " + trimmedKey + " ", " " + trimmedValue + " ")
+            .putString(longId, longStringValue)
+            .putString(superLongId, superLongValue)
+            .putBoolean(booleanKey, booleanValue)
+            .putDouble(doubleKey, doubleValue)
+            .putFloat(floatKey, floatValue)
+            .putLong(longKey, longValue)
+            .putInt(intKey, intValue)
+            .build();
 
     crashlyticsCore.setCustomKeys(keysAndValues.getCustomKeys());
 
@@ -208,15 +209,16 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final long updatedLongValue = -3;
     final int updatedIntValue = -4;
 
-    Map<String, String> updatedKeysAndValues = new CustomKeysAndValues.Builder()
-      .putString(stringKey, updatedStringValue)
-      .putString(longId, null)
-      .putBoolean(booleanKey, updatedBooleanValue)
-      .putDouble(doubleKey, updatedDoubleValue)
-      .putFloat(floatKey, updatedFloatValue)
-      .putLong(longKey, updatedLongValue)
-      .putInt(intKey, updatedIntValue)
-      .build();
+    Map<String, String> updatedKeysAndValues =
+        new CustomKeysAndValues.Builder()
+            .putString(stringKey, updatedStringValue)
+            .putString(longId, null)
+            .putBoolean(booleanKey, updatedBooleanValue)
+            .putDouble(doubleKey, updatedDoubleValue)
+            .putFloat(floatKey, updatedFloatValue)
+            .putLong(longKey, updatedLongValue)
+            .putInt(intKey, updatedIntValue)
+            .build();
 
     crashlyticsCore.setCustomKeys(updatedKeysAndValues.build().getCustomKeys());
 
@@ -227,7 +229,6 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     assertEquals(updatedLongValue, metadata.getCustomKeys().get(longKey));
     assertEquals(updatedIntValue, metadata.getCustomKeys().get(intKey));
     assertEquals("", metadata.getCustomKeys().get(longId));
-
   }
 
   public void testGetVersion() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/CustomKeysAndValues.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/CustomKeysAndValues.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.crashlytics.internal.common;
+package com.google.firebase.crashlytics;
 
 import androidx.annotation.NonNull;
 import java.util.HashMap;
@@ -26,38 +26,44 @@ public class CustomKeysAndValues {
 
   private final Map<String, String> keysAndValues;
 
-  static class Builder {
+  public static class Builder {
 
     // Holds the converted pairs of custom keys and values.
     private Map<String, String> keysAndValues = new HashMap<String, String>();
 
     // Methods to accept keys and values and convert values to strings.
 
+    @NonNull
     public Builder putString(@NonNull String key, @NonNull String value) {
       keysAndValues.put(key, value);
       return this;
     }
 
+    @NonNull
     public Builder putBoolean(@NonNull String key, boolean value) {
       keysAndValues.put(key, Boolean.toString(value));
       return this;
     }
 
+    @NonNull
     public Builder putDouble(@NonNull String key, double value) {
       keysAndValues.put(key, Double.toString(value));
       return this;
     }
 
+    @NonNull
     public Builder putFloat(@NonNull String key, float value) {
       keysAndValues.put(key, Float.toString(value));
       return this;
     }
 
+    @NonNull
     public Builder putLong(@NonNull String key, long value) {
       keysAndValues.put(key, Long.toString(value));
       return this;
     }
 
+    @NonNull
     public Builder putInt(@NonNull String key, int value) {
       keysAndValues.put(key, Integer.toString(value));
       return this;
@@ -69,10 +75,11 @@ public class CustomKeysAndValues {
     }
   }
 
-  private CustomKeysAndValues(Builder builder) {
+  protected CustomKeysAndValues(@NonNull Builder builder) {
     this.keysAndValues = builder.keysAndValues;
   }
 
+  @NonNull
   public Map<String, String> getCustomValues() {
     return keysAndValues;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -37,7 +37,6 @@ import com.google.firebase.crashlytics.internal.breadcrumbs.DisabledBreadcrumbSo
 import com.google.firebase.crashlytics.internal.common.AppData;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.common.CrashlyticsCore;
-import com.google.firebase.crashlytics.internal.common.CustomKeysAndValues;
 import com.google.firebase.crashlytics.internal.common.DataCollectionArbiter;
 import com.google.firebase.crashlytics.internal.common.ExecutorUtils;
 import com.google.firebase.crashlytics.internal.common.IdManager;
@@ -46,6 +45,7 @@ import com.google.firebase.crashlytics.internal.settings.SettingsController;
 import com.google.firebase.crashlytics.internal.unity.ResourceUnityVersionProvider;
 import com.google.firebase.crashlytics.internal.unity.UnityVersionProvider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -442,6 +442,27 @@ public class FirebaseCrashlytics {
     core.setCustomKey(key, value);
   }
 
+  /**
+     * Sets custom keys and values that are associated with subsequent fatal and non-fatal
+     * reports.
+     *
+     * <p>Multiple calls to this method with the same key update the value for that key.
+     *
+     * <p>The value of any key at the time of a fatal or non-fatal event is associated with that
+     * event.
+     *
+     * <p>Keys and associated values are visible in the session view on the Firebase Crashlytics
+     * console.
+     *
+     * <p>Accepts a maximum of 64 key/value pairs. New keys beyond that limit are ignored. Keys
+     * or values that exceed 1024 characters are truncated.
+     *
+     * @param keysAndValues A dictionary of keys and the values to associate with each key
+     */
+    public void setCustomKeys(CustomKeysAndValues keysAndValues) {
+      core.setCustomKeys(keysAndValues.keysAndValues);
+    }
+
   // region Unsent report management.
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -462,7 +462,7 @@ public class FirebaseCrashlytics {
      *
      * @param keysAndValues A dictionary of keys and the values to associate with each key
      */
-    public void setCustomKeys(CustomKeysAndValues keysAndValues) {
+    public void setCustomKeys(@NonNull CustomKeysAndValues keysAndValues) {
       core.setCustomKeys(keysAndValues.keysAndValues);
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -37,6 +37,7 @@ import com.google.firebase.crashlytics.internal.breadcrumbs.DisabledBreadcrumbSo
 import com.google.firebase.crashlytics.internal.common.AppData;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.common.CrashlyticsCore;
+import com.google.firebase.crashlytics.internal.common.CustomKeysAndValues;
 import com.google.firebase.crashlytics.internal.common.DataCollectionArbiter;
 import com.google.firebase.crashlytics.internal.common.ExecutorUtils;
 import com.google.firebase.crashlytics.internal.common.IdManager;
@@ -443,8 +444,10 @@ public class FirebaseCrashlytics {
   }
 
   /**
-     * Sets custom keys and values that are associated with subsequent fatal and non-fatal
-     * reports.
+     * Sets multiple custom keys and values that are associated with subsequent
+     * fatal and non-fatal reports. This method is intended as an alternative
+     * to setCustomKey in order to reduce the computational load of writing
+     * out multiple key/value pairs at the same time.
      *
      * <p>Multiple calls to this method with the same key update the value for that key.
      *

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -45,7 +45,6 @@ import com.google.firebase.crashlytics.internal.settings.SettingsController;
 import com.google.firebase.crashlytics.internal.unity.ResourceUnityVersionProvider;
 import com.google.firebase.crashlytics.internal.unity.UnityVersionProvider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -461,8 +460,8 @@ public class FirebaseCrashlytics {
    *
    * @param keysAndValues A dictionary of keys and the values to associate with each key
    */
-  public void setCustomKeys(@NonNull Map<String, String> keysAndValues) {
-    core.setCustomKeys(keysAndValues);
+  public void setCustomKeys(@NonNull CustomKeysAndValues keysAndValues) {
+    core.setCustomKeys(keysAndValues.getCustomValues());
   }
 
   // region Unsent report management.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -444,27 +444,26 @@ public class FirebaseCrashlytics {
   }
 
   /**
-     * Sets multiple custom keys and values that are associated with subsequent
-     * fatal and non-fatal reports. This method is intended as an alternative
-     * to setCustomKey in order to reduce the computational load of writing
-     * out multiple key/value pairs at the same time.
-     *
-     * <p>Multiple calls to this method with the same key update the value for that key.
-     *
-     * <p>The value of any key at the time of a fatal or non-fatal event is associated with that
-     * event.
-     *
-     * <p>Keys and associated values are visible in the session view on the Firebase Crashlytics
-     * console.
-     *
-     * <p>Accepts a maximum of 64 key/value pairs. New keys beyond that limit are ignored. Keys
-     * or values that exceed 1024 characters are truncated.
-     *
-     * @param keysAndValues A dictionary of keys and the values to associate with each key
-     */
-    public void setCustomKeys(@NonNull Map<String, String> keysAndValues) {
-      core.setCustomKeys(keysAndValues);
-    }
+   * Sets multiple custom keys and values that are associated with subsequent fatal and non-fatal
+   * reports. This method is intended as an alternative to setCustomKey in order to reduce the
+   * computational load of writing out multiple key/value pairs at the same time.
+   *
+   * <p>Multiple calls to this method with the same key update the value for that key.
+   *
+   * <p>The value of any key at the time of a fatal or non-fatal event is associated with that
+   * event.
+   *
+   * <p>Keys and associated values are visible in the session view on the Firebase Crashlytics
+   * console.
+   *
+   * <p>Accepts a maximum of 64 key/value pairs. New keys beyond that limit are ignored. Keys or
+   * values that exceed 1024 characters are truncated.
+   *
+   * @param keysAndValues A dictionary of keys and the values to associate with each key
+   */
+  public void setCustomKeys(@NonNull Map<String, String> keysAndValues) {
+    core.setCustomKeys(keysAndValues);
+  }
 
   // region Unsent report management.
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -462,8 +462,8 @@ public class FirebaseCrashlytics {
      *
      * @param keysAndValues A dictionary of keys and the values to associate with each key
      */
-    public void setCustomKeys(@NonNull CustomKeysAndValues keysAndValues) {
-      core.setCustomKeys(keysAndValues.keysAndValues);
+    public void setCustomKeys(@NonNull Map<String, String> keysAndValues) {
+      core.setCustomKeys(keysAndValues);
     }
 
   // region Unsent report management.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -449,7 +449,6 @@ class CrashlyticsController {
           throw ex;
         } else {
           Logger.getLogger().e("Attempting to set custom attribute with null key, ignoring.");
-          return;
         }
       }
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -437,6 +437,24 @@ class CrashlyticsController {
     cacheKeyData(userMetadata.getCustomKeys());
   }
 
+  void setCustomKeys(Map<String, String> keysAndValues) {
+    // Write all the key/value pairs before doing anything computationally expensive.
+    for (Map.Entry<String, String> entry : keysAndValues.entrySet()) {
+      try {
+      userMetadata.setCustomKey(entry.getKey(), entry.getValue());
+      } catch (IllegalArgumentException ex) {
+        if (context != null && CommonUtils.isAppDebuggable(context)) {
+          throw ex;
+        } else {
+          Logger.getLogger().e("Attempting to set custom attribute with null key, ignoring.");
+          return;
+        }
+      }
+    }
+    // Once all the key/value pairs are added, update the cache.
+    cacheKeyData(userMetadata.getCustomKeys());
+  }
+
   /**
    * Cache user metadata asynchronously in case of a non-graceful process exit. Can be reloaded and
    * sent with the previous crash data on app restart. NOTE: Because this is asynchronous, it is

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -215,7 +215,8 @@ class CrashlyticsController {
                             if (appSettingsData == null) {
                               Logger.getLogger()
                                   .w(
-                                      "Received null app settings, cannot send reports at crash time.");
+                                      "Received null app settings, cannot send reports at crash"
+                                          + " time.");
                               return Tasks.forResult(null);
                             }
                             // Data collection is enabled, so it's safe to send the report.
@@ -361,7 +362,8 @@ class CrashlyticsController {
                                 if (appSettingsData == null) {
                                   Logger.getLogger()
                                       .w(
-                                          "Received null app settings at app startup. Cannot send cached reports");
+                                          "Received null app settings at app startup. Cannot send"
+                                              + " cached reports");
                                   return Tasks.forResult(null);
                                 }
                                 logAnalyticsAppExceptionEvents();
@@ -441,7 +443,7 @@ class CrashlyticsController {
     // Write all the key/value pairs before doing anything computationally expensive.
     for (Map.Entry<String, String> entry : keysAndValues.entrySet()) {
       try {
-      userMetadata.setCustomKey(entry.getKey(), entry.getValue());
+        userMetadata.setCustomKey(entry.getKey(), entry.getValue());
       } catch (IllegalArgumentException ex) {
         if (context != null && CommonUtils.isAppDebuggable(context)) {
           throw ex;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -329,6 +329,19 @@ public class CrashlyticsCore {
     controller.setCustomKey(key, value);
   }
 
+  /**
+   * Sets multiple values to be associated with given keys for your crash data. The key/value pairs will be
+   * reported with any crash that occurs in this session. A maximum of 64 key/value pairs can be
+   * stored for any type. New keys added over that limit will be ignored. Keys and values are
+   * trimmed ({@link String#trim()}), and keys or values that exceed 1024 characters will be
+   * truncated.
+   *
+   * @throws NullPointerException if key is null.
+   */
+  public void setCustomKeys(Map<String, String> keysAndValues) {
+    controller.setCustomKeys(keysAndValues);
+  }
+
   // endregion
 
   // region Package-protected getters

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -330,7 +330,10 @@ public class CrashlyticsCore {
   }
 
   /**
-   * Sets multiple values to be associated with given keys for your crash data. The key/value pairs will be
+   * Sets multiple values to be associated with given keys for your crash data.
+   * This method should be used instead of setCustomKey when many different
+   * key/value pairs are to be set at the same time in order to optimize the
+   * process of writing out the data. The key/value pairs will be
    * reported with any crash that occurs in this session. A maximum of 64 key/value pairs can be
    * stored for any type. New keys added over that limit will be ignored. Keys and values are
    * trimmed ({@link String#trim()}), and keys or values that exceed 1024 characters will be

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -339,7 +339,7 @@ public class CrashlyticsCore {
    * trimmed ({@link String#trim()}), and keys or values that exceed 1024 characters will be
    * truncated.
    *
-   * @throws NullPointerException if key is null.
+   * @throws NullPointerException if any key in keysAndValues is null.
    */
   public void setCustomKeys(Map<String, String> keysAndValues) {
     controller.setCustomKeys(keysAndValues);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.Map;
 
 @SuppressWarnings("PMD.NullAssignment")
 public class CrashlyticsCore {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -36,13 +36,13 @@ import com.google.firebase.crashlytics.internal.stacktrace.MiddleOutFallbackStra
 import com.google.firebase.crashlytics.internal.stacktrace.RemoveRepeatsStrategy;
 import com.google.firebase.crashlytics.internal.stacktrace.StackTraceTrimmingStrategy;
 import java.io.File;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.Map;
 
 @SuppressWarnings("PMD.NullAssignment")
 public class CrashlyticsCore {
@@ -331,10 +331,9 @@ public class CrashlyticsCore {
   }
 
   /**
-   * Sets multiple values to be associated with given keys for your crash data.
-   * This method should be used instead of setCustomKey when many different
-   * key/value pairs are to be set at the same time in order to optimize the
-   * process of writing out the data. The key/value pairs will be
+   * Sets multiple values to be associated with given keys for your crash data. This method should
+   * be used instead of setCustomKey when many different key/value pairs are to be set at the same
+   * time in order to optimize the process of writing out the data. The key/value pairs will be
    * reported with any crash that occurs in this session. A maximum of 64 key/value pairs can be
    * stored for any type. New keys added over that limit will be ignored. Keys and values are
    * trimmed ({@link String#trim()}), and keys or values that exceed 1024 characters will be

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
@@ -1,0 +1,60 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.common;
+
+/**
+ * Helper class which handles the accumluation of multiple key/value pairs with
+ * heterogenous value types.
+ */
+public class CustomKeysAndValues {
+
+  static final Map<String, String> keysAndValues;
+
+  static class Builder {
+
+    // Holds the pairs of custom keys and values to associate with the
+    // crash data while accumulating adding pairs.
+    Map<String, String> keysAndValues = new HashMap<String, String>();
+
+    Builder setValueForKey(@NonNull String key, @NonNull String value) {
+      stringValues.put(key, value);
+    }
+    Builder setValueForKey(@NonNull String key, boolean value) {
+      stringValues.put(key, Boolean.toString(value));
+    }
+    Builder setValueForKey(@NonNull String key, double value) {
+      stringValues.put(key, Double.toString(value));
+    }
+    Builder setValueForKey(@NonNull String key, float value) {
+      stringValues.put(key, Float.toString(value));
+    }
+    Builder setValueForKey(@NonNull String key, long value){
+      stringValues.put(key, Long.toString(value));
+    }
+    Builder setValueForKey(@NonNull String key, int value){
+      stringValues.put(key, Integer.toString(value));
+    }
+
+    @NonNull
+    public CustomKeysAndValues build() {
+      return new CustomKeysAndValues(this);
+    }
+  }
+
+  private CustomKeysAndValues(Builder builder) {
+    keysAndValues = builder.keysAndValues;
+  }
+
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
@@ -14,13 +14,13 @@
 
 package com.google.firebase.crashlytics.internal.common;
 
+import androidx.annotation.NonNull;
 import java.util.HashMap;
 import java.util.Map;
-import androidx.annotation.NonNull;
 
 /**
- * Helper class which handles the storage and conversion to strings of key/value
- * pairs with heterogenous value types.
+ * Helper class which handles the storage and conversion to strings of key/value pairs with
+ * heterogenous value types.
  */
 public class CustomKeysAndValues {
 
@@ -37,23 +37,28 @@ public class CustomKeysAndValues {
       keysAndValues.put(key, value);
       return this;
     }
+
     public Builder putBoolean(@NonNull String key, boolean value) {
       keysAndValues.put(key, Boolean.toString(value));
       return this;
     }
+
     public Builder putDouble(@NonNull String key, double value) {
       keysAndValues.put(key, Double.toString(value));
       return this;
     }
+
     public Builder putFloat(@NonNull String key, float value) {
       keysAndValues.put(key, Float.toString(value));
       return this;
     }
-    public Builder putLong(@NonNull String key, long value){
+
+    public Builder putLong(@NonNull String key, long value) {
       keysAndValues.put(key, Long.toString(value));
       return this;
     }
-    public Builder putInt(@NonNull String key, int value){
+
+    public Builder putInt(@NonNull String key, int value) {
       keysAndValues.put(key, Integer.toString(value));
       return this;
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
@@ -35,21 +35,27 @@ public class CustomKeysAndValues {
 
     Builder setValueForKey(@NonNull String key, @NonNull String value) {
       keysAndValues.put(key, value);
+      return this;
     }
     Builder setValueForKey(@NonNull String key, boolean value) {
       keysAndValues.put(key, Boolean.toString(value));
+      return this;
     }
     Builder setValueForKey(@NonNull String key, double value) {
       keysAndValues.put(key, Double.toString(value));
+      return this;
     }
     Builder setValueForKey(@NonNull String key, float value) {
       keysAndValues.put(key, Float.toString(value));
+      return this;
     }
     Builder setValueForKey(@NonNull String key, long value){
       keysAndValues.put(key, Long.toString(value));
+      return this;
     }
     Builder setValueForKey(@NonNull String key, int value){
       keysAndValues.put(key, Integer.toString(value));
+      return this;
     }
 
     @NonNull

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
@@ -14,9 +14,12 @@
 
 package com.google.firebase.crashlytics.internal.common;
 
+import java.util.Map;
+import androidx.annotation.NonNull;
+
 /**
- * Helper class which handles the accumluation of multiple key/value pairs with
- * heterogenous value types.
+ * Helper class which handles the storage and conversion to strings of key/value
+ * pairs with heterogenous value types.
  */
 public class CustomKeysAndValues {
 
@@ -24,9 +27,10 @@ public class CustomKeysAndValues {
 
   static class Builder {
 
-    // Holds the pairs of custom keys and values to associate with the
-    // crash data while accumulating adding pairs.
+    // Holds the converted pairs of custom keys and values.
     Map<String, String> keysAndValues = new HashMap<String, String>();
+
+    // Methods to accept keys and values and convert values to strings.
 
     Builder setValueForKey(@NonNull String key, @NonNull String value) {
       stringValues.put(key, value);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 package com.google.firebase.crashlytics.internal.common;
 
+import java.util.HashMap;
 import java.util.Map;
 import androidx.annotation.NonNull;
 
@@ -23,7 +24,7 @@ import androidx.annotation.NonNull;
  */
 public class CustomKeysAndValues {
 
-  static final Map<String, String> keysAndValues;
+  public static final Map<String, String> keysAndValues;
 
   static class Builder {
 
@@ -33,22 +34,22 @@ public class CustomKeysAndValues {
     // Methods to accept keys and values and convert values to strings.
 
     Builder setValueForKey(@NonNull String key, @NonNull String value) {
-      stringValues.put(key, value);
+      keysAndValues.put(key, value);
     }
     Builder setValueForKey(@NonNull String key, boolean value) {
-      stringValues.put(key, Boolean.toString(value));
+      keysAndValues.put(key, Boolean.toString(value));
     }
     Builder setValueForKey(@NonNull String key, double value) {
-      stringValues.put(key, Double.toString(value));
+      keysAndValues.put(key, Double.toString(value));
     }
     Builder setValueForKey(@NonNull String key, float value) {
-      stringValues.put(key, Float.toString(value));
+      keysAndValues.put(key, Float.toString(value));
     }
     Builder setValueForKey(@NonNull String key, long value){
-      stringValues.put(key, Long.toString(value));
+      keysAndValues.put(key, Long.toString(value));
     }
     Builder setValueForKey(@NonNull String key, int value){
-      stringValues.put(key, Integer.toString(value));
+      keysAndValues.put(key, Integer.toString(value));
     }
 
     @NonNull
@@ -58,7 +59,6 @@ public class CustomKeysAndValues {
   }
 
   private CustomKeysAndValues(Builder builder) {
-    keysAndValues = builder.keysAndValues;
+    this.keysAndValues = builder.keysAndValues;
   }
-
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
@@ -24,7 +24,7 @@ import androidx.annotation.NonNull;
  */
 public class CustomKeysAndValues {
 
-  public static final Map<String, String> keysAndValues;
+  public final Map<String, String> keysAndValues;
 
   static class Builder {
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CustomKeysAndValues.java
@@ -24,36 +24,36 @@ import androidx.annotation.NonNull;
  */
 public class CustomKeysAndValues {
 
-  public final Map<String, String> keysAndValues;
+  private final Map<String, String> keysAndValues;
 
   static class Builder {
 
     // Holds the converted pairs of custom keys and values.
-    Map<String, String> keysAndValues = new HashMap<String, String>();
+    private Map<String, String> keysAndValues = new HashMap<String, String>();
 
     // Methods to accept keys and values and convert values to strings.
 
-    Builder setValueForKey(@NonNull String key, @NonNull String value) {
+    public Builder putString(@NonNull String key, @NonNull String value) {
       keysAndValues.put(key, value);
       return this;
     }
-    Builder setValueForKey(@NonNull String key, boolean value) {
+    public Builder putBoolean(@NonNull String key, boolean value) {
       keysAndValues.put(key, Boolean.toString(value));
       return this;
     }
-    Builder setValueForKey(@NonNull String key, double value) {
+    public Builder putDouble(@NonNull String key, double value) {
       keysAndValues.put(key, Double.toString(value));
       return this;
     }
-    Builder setValueForKey(@NonNull String key, float value) {
+    public Builder putFloat(@NonNull String key, float value) {
       keysAndValues.put(key, Float.toString(value));
       return this;
     }
-    Builder setValueForKey(@NonNull String key, long value){
+    public Builder putLong(@NonNull String key, long value){
       keysAndValues.put(key, Long.toString(value));
       return this;
     }
-    Builder setValueForKey(@NonNull String key, int value){
+    public Builder putInt(@NonNull String key, int value){
       keysAndValues.put(key, Integer.toString(value));
       return this;
     }
@@ -66,5 +66,9 @@ public class CustomKeysAndValues {
 
   private CustomKeysAndValues(Builder builder) {
     this.keysAndValues = builder.keysAndValues;
+  }
+
+  public Map<String, String> getCustomValues() {
+    return keysAndValues;
   }
 }


### PR DESCRIPTION
Bulk key/value logging will improve the performance of the SDK for developers who write out many custom keys and values at any given time by doing computationally expensive operations once for all pairs. 