### PR TITLE
Replace gRPC Status#equals() with Status#isOk().

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AbstractStream.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AbstractStream.java
@@ -273,7 +273,7 @@ abstract class AbstractStream<ReqT, RespT, CallbackT extends StreamCallback>
   private void close(State finalState, Status status) {
     hardAssert(isStarted(), "Only started streams should be closed.");
     hardAssert(
-        finalState == State.Error || status.equals(Status.OK),
+        finalState == State.Error || status.isOk(),
         "Can't provide an error when not in an error state.");
     workerQueue.verifyIsCurrentThread();
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
@@ -468,7 +468,7 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
   }
 
   private void handleWatchStreamClose(Status status) {
-    if (Status.OK.equals(status)) {
+    if (status.isOk()) {
       // Graceful stop (due to stop() or idle timeout). Make sure that's desirable.
       hardAssert(
           !shouldStartWatchStream(), "Watch stream was stopped gracefully while still needed.");
@@ -655,7 +655,7 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
   }
 
   private void handleWriteStreamClose(Status status) {
-    if (Status.OK.equals(status)) {
+    if (status.isOk()) {
       // Graceful stop (due to stop() or idle timeout). Make sure that's desirable.
       hardAssert(
           !shouldStartWriteStream(), "Write stream was stopped gracefully while still needed.");


### PR DESCRIPTION
Status#equals() uses reference equality. This will typically work for OK statuses, but will almost always fail for non-OK statuses. Status#isOk() or comparing Status#getCode() is preferred.

See cl/356819841 for additional context and motivation.