### PR TITLE
Add useEmulator support for Firebase Storage

### DIFF
--- a/firebase-storage/api.txt
+++ b/firebase-storage/api.txt
@@ -43,6 +43,7 @@ package com.google.firebase.storage {
     method public void setMaxDownloadRetryTimeMillis(long);
     method public void setMaxOperationRetryTimeMillis(long);
     method public void setMaxUploadRetryTimeMillis(long);
+    method public void useEmulator(@NonNull String, int);
   }
 
   public final class ListResult {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/DeleteStorageTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/DeleteStorageTask.java
@@ -54,7 +54,7 @@ import com.google.firebase.storage.network.NetworkRequest;
   @Override
   public void run() {
     final NetworkRequest request =
-        new DeleteNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp());
+        new DeleteNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings());
     mSender.sendWithExponentialBackoff(request);
     request.completeTask(mPendingResult, null);
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/DeleteStorageTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/DeleteStorageTask.java
@@ -54,8 +54,7 @@ import com.google.firebase.storage.network.NetworkRequest;
   @Override
   public void run() {
     final NetworkRequest request =
-        new DeleteNetworkRequest(
-            mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings());
+        new DeleteNetworkRequest(mStorageRef.getStorageReferenceUri(), mStorageRef.getApp());
     mSender.sendWithExponentialBackoff(request);
     request.completeTask(mPendingResult, null);
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/DeleteStorageTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/DeleteStorageTask.java
@@ -54,7 +54,8 @@ import com.google.firebase.storage.network.NetworkRequest;
   @Override
   public void run() {
     final NetworkRequest request =
-        new DeleteNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings());
+        new DeleteNetworkRequest(
+            mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings());
     mSender.sendWithExponentialBackoff(request);
     request.completeTask(mPendingResult, null);
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
@@ -195,7 +195,7 @@ public class FileDownloadTask extends StorageTask<FileDownloadTask.TaskSnapshot>
       mException = null;
       mSender.reset();
       final NetworkRequest request =
-          new GetNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp(), mResumeOffset);
+          new GetNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings(), mResumeOffset);
 
       mSender.sendWithExponentialBackoff(request, false);
       mResultCode = request.getResultCode();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
@@ -196,10 +196,7 @@ public class FileDownloadTask extends StorageTask<FileDownloadTask.TaskSnapshot>
       mSender.reset();
       final NetworkRequest request =
           new GetNetworkRequest(
-              mStorageRef.getStorageUri(),
-              mStorageRef.getApp(),
-              mStorageRef.getEmulatorSettings(),
-              mResumeOffset);
+              mStorageRef.getStorageReferenceUri(), mStorageRef.getApp(), mResumeOffset);
 
       mSender.sendWithExponentialBackoff(request, false);
       mResultCode = request.getResultCode();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
@@ -195,7 +195,11 @@ public class FileDownloadTask extends StorageTask<FileDownloadTask.TaskSnapshot>
       mException = null;
       mSender.reset();
       final NetworkRequest request =
-          new GetNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings(), mResumeOffset);
+          new GetNetworkRequest(
+              mStorageRef.getStorageUri(),
+              mStorageRef.getApp(),
+              mStorageRef.getEmulatorSettings(),
+              mResumeOffset);
 
       mSender.sendWithExponentialBackoff(request, false);
       mResultCode = request.getResultCode();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
@@ -166,7 +166,6 @@ public class FirebaseStorage {
    * @param port the emulator port (for example, 9000)
    */
   public void useEmulator(@NonNull String host, int port) {
-    // TODO(samstern): Throw if used already?
     this.emulatorSettings = new EmulatedServiceSettings(host, port);
   }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
@@ -24,6 +24,7 @@ import com.google.android.gms.common.internal.Preconditions;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.auth.internal.InternalAuthProvider;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.inject.Provider;
 import com.google.firebase.storage.internal.Util;
 import java.io.UnsupportedEncodingException;
@@ -50,6 +51,8 @@ public class FirebaseStorage {
   private long sMaxUploadRetry = 10 * DateUtils.MINUTE_IN_MILLIS; //  10 * 60 * 1000
   private long sMaxDownloadRetry = 10 * DateUtils.MINUTE_IN_MILLIS; //  10 * 60 * 1000
   private long sMaxQueryRetry = 2 * DateUtils.MINUTE_IN_MILLIS; //  2 * 60 * 1000
+
+  @Nullable private EmulatedServiceSettings emulatorSettings;
 
   FirebaseStorage(
       @Nullable String bucketName,
@@ -152,6 +155,19 @@ public class FirebaseStorage {
       Log.e(TAG, "Unable to parse url:" + url, e);
       throw new IllegalArgumentException(STORAGE_URI_PARSE_EXCEPTION);
     }
+  }
+
+  /**
+   * Modifies this FirebaseStorage instance to communicate with the Storage emulator.
+   *
+   * <p>Note: Call this method before using the instance to do any storage operations.
+   *
+   * @param host the emulator host (for example, 10.0.2.2)
+   * @param port the emulator port (for example, 9000)
+   */
+  public void useEmulator(@NonNull String host, int port) {
+    // TODO(samstern): Throw if used already?
+    this.emulatorSettings = new EmulatedServiceSettings(host, port);
   }
 
   /**
@@ -306,5 +322,10 @@ public class FirebaseStorage {
   @Nullable
   InternalAuthProvider getAuthProvider() {
     return mAuthProvider != null ? mAuthProvider.get() : null;
+  }
+
+  @Nullable
+  EmulatedServiceSettings getEmulatorSettings() {
+    return emulatorSettings;
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
@@ -59,7 +59,9 @@ class GetDownloadUrlTask implements Runnable {
 
     if (!TextUtils.isEmpty(downloadTokens)) {
       String downloadToken = downloadTokens.split(",", -1)[0];
-      Uri.Builder uriBuilder = NetworkRequest.getDefaultURL(storageRef.getStorageUri(), storageRef.getEmulatorSettings()).buildUpon();
+      Uri.Builder uriBuilder =
+          NetworkRequest.getDefaultURL(storageRef.getStorageUri(), storageRef.getEmulatorSettings())
+              .buildUpon();
       uriBuilder.appendQueryParameter("alt", "media");
       uriBuilder.appendQueryParameter("token", downloadToken);
       return uriBuilder.build();
@@ -71,7 +73,8 @@ class GetDownloadUrlTask implements Runnable {
   @Override
   public void run() {
     final NetworkRequest request =
-        new GetMetadataNetworkRequest(storageRef.getStorageUri(), storageRef.getApp(), storageRef.getEmulatorSettings());
+        new GetMetadataNetworkRequest(
+            storageRef.getStorageUri(), storageRef.getApp(), storageRef.getEmulatorSettings());
 
     sender.sendWithExponentialBackoff(request);
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
@@ -59,7 +59,7 @@ class GetDownloadUrlTask implements Runnable {
 
     if (!TextUtils.isEmpty(downloadTokens)) {
       String downloadToken = downloadTokens.split(",", -1)[0];
-      Uri.Builder uriBuilder = NetworkRequest.getDefaultURL(storageRef.getStorageUri()).buildUpon();
+      Uri.Builder uriBuilder = NetworkRequest.getDefaultURL(storageRef.getStorageUri(), storageRef.getEmulatorSettings()).buildUpon();
       uriBuilder.appendQueryParameter("alt", "media");
       uriBuilder.appendQueryParameter("token", downloadToken);
       return uriBuilder.build();
@@ -71,7 +71,7 @@ class GetDownloadUrlTask implements Runnable {
   @Override
   public void run() {
     final NetworkRequest request =
-        new GetMetadataNetworkRequest(storageRef.getStorageUri(), storageRef.getApp());
+        new GetMetadataNetworkRequest(storageRef.getStorageUri(), storageRef.getApp(), storageRef.getEmulatorSettings());
 
     sender.sendWithExponentialBackoff(request);
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetDownloadUrlTask.java
@@ -59,9 +59,7 @@ class GetDownloadUrlTask implements Runnable {
 
     if (!TextUtils.isEmpty(downloadTokens)) {
       String downloadToken = downloadTokens.split(",", -1)[0];
-      Uri.Builder uriBuilder =
-          NetworkRequest.getDefaultURL(storageRef.getStorageUri(), storageRef.getEmulatorSettings())
-              .buildUpon();
+      Uri.Builder uriBuilder = storageRef.getStorageReferenceUri().getHttpUri().buildUpon();
       uriBuilder.appendQueryParameter("alt", "media");
       uriBuilder.appendQueryParameter("token", downloadToken);
       return uriBuilder.build();
@@ -73,8 +71,7 @@ class GetDownloadUrlTask implements Runnable {
   @Override
   public void run() {
     final NetworkRequest request =
-        new GetMetadataNetworkRequest(
-            storageRef.getStorageUri(), storageRef.getApp(), storageRef.getEmulatorSettings());
+        new GetMetadataNetworkRequest(storageRef.getStorageReferenceUri(), storageRef.getApp());
 
     sender.sendWithExponentialBackoff(request);
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
@@ -56,8 +56,7 @@ class GetMetadataTask implements Runnable {
   @Override
   public void run() {
     final NetworkRequest request =
-        new GetMetadataNetworkRequest(
-            mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings());
+        new GetMetadataNetworkRequest(mStorageRef.getStorageReferenceUri(), mStorageRef.getApp());
 
     mSender.sendWithExponentialBackoff(request);
     if (request.isResultSuccess()) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
@@ -56,7 +56,8 @@ class GetMetadataTask implements Runnable {
   @Override
   public void run() {
     final NetworkRequest request =
-        new GetMetadataNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings());
+        new GetMetadataNetworkRequest(
+            mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings());
 
     mSender.sendWithExponentialBackoff(request);
     if (request.isResultSuccess()) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/GetMetadataTask.java
@@ -56,7 +56,7 @@ class GetMetadataTask implements Runnable {
   @Override
   public void run() {
     final NetworkRequest request =
-        new GetMetadataNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp());
+        new GetMetadataNetworkRequest(mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings());
 
     mSender.sendWithExponentialBackoff(request);
     if (request.isResultSuccess()) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/ListTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/ListTask.java
@@ -59,7 +59,11 @@ class ListTask implements Runnable {
   public void run() {
     final NetworkRequest request =
         new ListNetworkRequest(
-            storageRef.getStorageUri(), storageRef.getApp(), storageRef.getEmulatorSettings(), maxResults, pageToken);
+            storageRef.getStorageUri(),
+            storageRef.getApp(),
+            storageRef.getEmulatorSettings(),
+            maxResults,
+            pageToken);
 
     sender.sendWithExponentialBackoff(request);
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/ListTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/ListTask.java
@@ -59,7 +59,7 @@ class ListTask implements Runnable {
   public void run() {
     final NetworkRequest request =
         new ListNetworkRequest(
-            storageRef.getStorageUri(), storageRef.getApp(), maxResults, pageToken);
+            storageRef.getStorageUri(), storageRef.getApp(), storageRef.getEmulatorSettings(), maxResults, pageToken);
 
     sender.sendWithExponentialBackoff(request);
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/ListTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/ListTask.java
@@ -59,11 +59,7 @@ class ListTask implements Runnable {
   public void run() {
     final NetworkRequest request =
         new ListNetworkRequest(
-            storageRef.getStorageUri(),
-            storageRef.getApp(),
-            storageRef.getEmulatorSettings(),
-            maxResults,
-            pageToken);
+            storageRef.getStorageReferenceUri(), storageRef.getApp(), maxResults, pageToken);
 
     sender.sendWithExponentialBackoff(request);
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageReference.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageReference.java
@@ -28,8 +28,8 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.storage.internal.Slashes;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -688,8 +688,8 @@ public class StorageReference implements Comparable<StorageReference> {
     return mStorageUri.compareTo(other.mStorageUri);
   }
 
-  @Nullable
-  EmulatedServiceSettings getEmulatorSettings() {
-    return mFirebaseStorage.getEmulatorSettings();
+  @NonNull
+  StorageReferenceUri getStorageReferenceUri() {
+    return new StorageReferenceUri(mStorageUri, mFirebaseStorage.getEmulatorSettings());
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageReference.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageReference.java
@@ -28,6 +28,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.storage.internal.Slashes;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -685,5 +686,10 @@ public class StorageReference implements Comparable<StorageReference> {
     // mStorageUri contains a reference to the GCS bucket as well as the fully qualified path
     // of this reference.
     return mStorageUri.compareTo(other.mStorageUri);
+  }
+
+  @Nullable
+  EmulatedServiceSettings getEmulatorSettings() {
+    return mFirebaseStorage.getEmulatorSettings();
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
@@ -117,7 +117,11 @@ public class StreamDownloadTask extends StorageTask<StreamDownloadTask.TaskSnaps
     }
 
     request =
-        new GetNetworkRequest(storageRef.getStorageUri(), storageRef.getApp(), storageRef.getEmulatorSettings(), bytesDownloaded);
+        new GetNetworkRequest(
+            storageRef.getStorageUri(),
+            storageRef.getApp(),
+            storageRef.getEmulatorSettings(),
+            bytesDownloaded);
 
     sender.sendWithExponentialBackoff(request, false);
     resultCode = request.getResultCode();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
@@ -118,10 +118,7 @@ public class StreamDownloadTask extends StorageTask<StreamDownloadTask.TaskSnaps
 
     request =
         new GetNetworkRequest(
-            storageRef.getStorageUri(),
-            storageRef.getApp(),
-            storageRef.getEmulatorSettings(),
-            bytesDownloaded);
+            storageRef.getStorageReferenceUri(), storageRef.getApp(), bytesDownloaded);
 
     sender.sendWithExponentialBackoff(request, false);
     resultCode = request.getResultCode();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
@@ -117,7 +117,7 @@ public class StreamDownloadTask extends StorageTask<StreamDownloadTask.TaskSnaps
     }
 
     request =
-        new GetNetworkRequest(storageRef.getStorageUri(), storageRef.getApp(), bytesDownloaded);
+        new GetNetworkRequest(storageRef.getStorageUri(), storageRef.getApp(), storageRef.getEmulatorSettings(), bytesDownloaded);
 
     sender.sendWithExponentialBackoff(request, false);
     resultCode = request.getResultCode();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
@@ -52,9 +52,8 @@ class UpdateMetadataTask implements Runnable {
   public void run() {
     final NetworkRequest request =
         new UpdateMetadataNetworkRequest(
-            mStorageRef.getStorageUri(),
+            mStorageRef.getStorageReferenceUri(),
             mStorageRef.getApp(),
-            mStorageRef.getEmulatorSettings(),
             mNewMetadata.createJSONObject());
 
     mSender.sendWithExponentialBackoff(request);

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
@@ -52,7 +52,7 @@ class UpdateMetadataTask implements Runnable {
   public void run() {
     final NetworkRequest request =
         new UpdateMetadataNetworkRequest(
-            mStorageRef.getStorageUri(), mStorageRef.getApp(), mNewMetadata.createJSONObject());
+            mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings(), mNewMetadata.createJSONObject());
 
     mSender.sendWithExponentialBackoff(request);
     if (request.isResultSuccess()) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UpdateMetadataTask.java
@@ -52,7 +52,10 @@ class UpdateMetadataTask implements Runnable {
   public void run() {
     final NetworkRequest request =
         new UpdateMetadataNetworkRequest(
-            mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings(), mNewMetadata.createJSONObject());
+            mStorageRef.getStorageUri(),
+            mStorageRef.getApp(),
+            mStorageRef.getEmulatorSettings(),
+            mNewMetadata.createJSONObject());
 
     mSender.sendWithExponentialBackoff(request);
     if (request.isResultSuccess()) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -262,6 +262,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
         new ResumableUploadStartRequest(
             mStorageRef.getStorageUri(),
             mStorageRef.getApp(),
+            mStorageRef.getEmulatorSettings(),
             mMetadata != null ? mMetadata.createJSONObject() : null,
             mimeType);
 
@@ -345,7 +346,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
   private boolean recoverStatus(boolean withRetry) {
     NetworkRequest queryRequest =
         new ResumableUploadQueryRequest(
-            mStorageRef.getStorageUri(), mStorageRef.getApp(), mUploadUri);
+            mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings(), mUploadUri);
 
     if (RESUMABLE_FINAL_STATUS.equals(mServerStatus)) {
       return false;
@@ -411,6 +412,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
           new ResumableUploadByteRequest(
               mStorageRef.getStorageUri(),
               mStorageRef.getApp(),
+              mStorageRef.getEmulatorSettings(),
               mUploadUri,
               mStreamBuffer.get(),
               mBytesUploaded.get(),
@@ -484,7 +486,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
     if (mUploadUri != null) {
       cancelRequest =
           new ResumableUploadCancelRequest(
-              mStorageRef.getStorageUri(), mStorageRef.getApp(), mUploadUri);
+              mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings(), mUploadUri);
     }
 
     if (cancelRequest != null) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -346,7 +346,10 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
   private boolean recoverStatus(boolean withRetry) {
     NetworkRequest queryRequest =
         new ResumableUploadQueryRequest(
-            mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings(), mUploadUri);
+            mStorageRef.getStorageUri(),
+            mStorageRef.getApp(),
+            mStorageRef.getEmulatorSettings(),
+            mUploadUri);
 
     if (RESUMABLE_FINAL_STATUS.equals(mServerStatus)) {
       return false;
@@ -486,7 +489,10 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
     if (mUploadUri != null) {
       cancelRequest =
           new ResumableUploadCancelRequest(
-              mStorageRef.getStorageUri(), mStorageRef.getApp(), mStorageRef.getEmulatorSettings(), mUploadUri);
+              mStorageRef.getStorageUri(),
+              mStorageRef.getApp(),
+              mStorageRef.getEmulatorSettings(),
+              mUploadUri);
     }
 
     if (cancelRequest != null) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -260,9 +260,8 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
     }
     NetworkRequest startRequest =
         new ResumableUploadStartRequest(
-            mStorageRef.getStorageUri(),
+            mStorageRef.getStorageReferenceUri(),
             mStorageRef.getApp(),
-            mStorageRef.getEmulatorSettings(),
             mMetadata != null ? mMetadata.createJSONObject() : null,
             mimeType);
 
@@ -346,10 +345,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
   private boolean recoverStatus(boolean withRetry) {
     NetworkRequest queryRequest =
         new ResumableUploadQueryRequest(
-            mStorageRef.getStorageUri(),
-            mStorageRef.getApp(),
-            mStorageRef.getEmulatorSettings(),
-            mUploadUri);
+            mStorageRef.getStorageReferenceUri(), mStorageRef.getApp(), mUploadUri);
 
     if (RESUMABLE_FINAL_STATUS.equals(mServerStatus)) {
       return false;
@@ -413,9 +409,8 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
 
       NetworkRequest uploadRequest =
           new ResumableUploadByteRequest(
-              mStorageRef.getStorageUri(),
+              mStorageRef.getStorageReferenceUri(),
               mStorageRef.getApp(),
-              mStorageRef.getEmulatorSettings(),
               mUploadUri,
               mStreamBuffer.get(),
               mBytesUploaded.get(),
@@ -489,10 +484,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
     if (mUploadUri != null) {
       cancelRequest =
           new ResumableUploadCancelRequest(
-              mStorageRef.getStorageUri(),
-              mStorageRef.getApp(),
-              mStorageRef.getEmulatorSettings(),
-              mUploadUri);
+              mStorageRef.getStorageReferenceUri(), mStorageRef.getApp(), mUploadUri);
     }
 
     if (cancelRequest != null) {

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/StorageReferenceUri.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/StorageReferenceUri.java
@@ -20,11 +20,7 @@ import androidx.annotation.Nullable;
 import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.storage.network.NetworkRequest;
 
-/**
- * Utility class to encapsulate the two "views" of a storage URI in a single object.
- *
- * @hide
- */
+/** Utility class to encapsulate the two "views" of a storage URI in a single object. */
 public class StorageReferenceUri {
 
   private final Uri httpBaseUri;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/StorageReferenceUri.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/StorageReferenceUri.java
@@ -52,8 +52,7 @@ public class StorageReferenceUri {
     // Add /o/path (if there is a path)
     String path = Slashes.normalizeSlashes(gsUri.getPath());
     if (path.length() > 0 && !"/".equals(path)) {
-      httpBuilder =
-          httpBuilder.appendPath("o").appendEncodedPath(Slashes.preserveSlashEncode(path));
+      httpBuilder = httpBuilder.appendPath("o").appendPath(path);
     }
 
     this.httpUri = httpBuilder.build();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/StorageReferenceUri.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/StorageReferenceUri.java
@@ -1,0 +1,76 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.storage.internal;
+
+import android.net.Uri;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.network.NetworkRequest;
+
+/**
+ * Utility class to encapsulate the two "views" of a storage URI in a single object.
+ *
+ * @hide
+ */
+public class StorageReferenceUri {
+
+  private final Uri httpBaseUri;
+  private final Uri httpUri;
+  private final Uri gsUri;
+
+  public StorageReferenceUri(@NonNull Uri gsUri) {
+    this(gsUri, null);
+  }
+
+  public StorageReferenceUri(
+      @NonNull Uri gsUri, @Nullable EmulatedServiceSettings emulatorSettings) {
+    // We assume this has already come from Util.normalize()
+    this.gsUri = gsUri;
+    this.httpBaseUri =
+        emulatorSettings == null
+            ? NetworkRequest.PROD_BASE_URL
+            : Uri.parse(
+                "http://" + emulatorSettings.getHost() + ":" + emulatorSettings.getPort() + "/v0");
+
+    // Add /b/bucket
+    String bucket = gsUri.getAuthority();
+    Uri.Builder httpBuilder = httpBaseUri.buildUpon().appendPath("b").appendEncodedPath(bucket);
+
+    // Add /o/path (if there is a path)
+    String path = Slashes.normalizeSlashes(gsUri.getPath());
+    if (path.length() > 0 && !"/".equals(path)) {
+      httpBuilder =
+          httpBuilder.appendPath("o").appendEncodedPath(Slashes.preserveSlashEncode(path));
+    }
+
+    this.httpUri = httpBuilder.build();
+  }
+
+  @NonNull
+  public Uri getHttpBaseUri() {
+    return httpBaseUri;
+  }
+
+  @NonNull
+  public Uri getHttpUri() {
+    return httpUri;
+  }
+
+  @NonNull
+  public Uri getGsUri() {
+    return gsUri;
+  }
+}

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
@@ -27,6 +27,7 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.GetTokenResult;
 import com.google.firebase.auth.internal.InternalAuthProvider;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.storage.network.NetworkRequest;
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
@@ -70,10 +71,6 @@ public class Util {
     return Objects.equal(a, b);
   }
 
-  private static String getAuthority() throws RemoteException {
-    return NetworkRequest.getAuthority();
-  }
-
   /**
    * Normalizes a Firebase Storage uri into its "gs://" format and strips any trailing slash.
    *
@@ -91,6 +88,8 @@ public class Util {
         "Firebase Storage URLs must point to an object in your Storage Bucket. Please "
             + "obtain a URL using the Firebase Console or getDownloadUrl().";
 
+    Uri baseUrl = NetworkRequest.getBaseUrl(/* emulatorSettings= */ null);
+
     String trimmedInput = s.toLowerCase();
     String bucket;
     String encodedPath;
@@ -104,13 +103,7 @@ public class Util {
       if (scheme != null
           && (equals(scheme.toLowerCase(), "http") || equals(scheme.toLowerCase(), "https"))) {
         String lowerAuthority = uri.getAuthority().toLowerCase();
-        int indexOfAuth;
-        try {
-          indexOfAuth = lowerAuthority.indexOf(getAuthority());
-        } catch (RemoteException e) {
-          throw new UnsupportedEncodingException(
-              "Could not parse Url because the Storage network layer did not load");
-        }
+        int indexOfAuth = lowerAuthority.indexOf(baseUrl.getAuthority());
         encodedPath = Slashes.slashize(uri.getEncodedPath());
         if (indexOfAuth == 0 && encodedPath.startsWith("/")) {
           int firstBSlash = encodedPath.indexOf("/b/", 0); // /v0/b/bucket.storage

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
@@ -86,8 +86,7 @@ public class Util {
         "Firebase Storage URLs must point to an object in your Storage Bucket. Please "
             + "obtain a URL using the Firebase Console or getDownloadUrl().";
 
-    Uri baseUrl = NetworkRequest.getBaseUrl(/* emulatorSettings= */ null);
-
+    Uri baseUrl = NetworkRequest.PROD_BASE_URL;
     String trimmedInput = s.toLowerCase();
     String bucket;
     String encodedPath;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/internal/Util.java
@@ -15,7 +15,6 @@
 package com.google.firebase.storage.internal;
 
 import android.net.Uri;
-import android.os.RemoteException;
 import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -27,7 +26,6 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.GetTokenResult;
 import com.google.firebase.auth.internal.InternalAuthProvider;
-import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.storage.network.NetworkRequest;
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/DeleteNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/DeleteNetworkRequest.java
@@ -14,19 +14,15 @@
 
 package com.google.firebase.storage.network;
 
-import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 
 /** A network request that deletes a gcs object. */
 public class DeleteNetworkRequest extends NetworkRequest {
   public DeleteNetworkRequest(
-      @NonNull Uri gsUri,
-      @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings) {
-    super(gsUri, app, emulatorSettings);
+      @NonNull StorageReferenceUri storageReferenceUri, @NonNull FirebaseApp app) {
+    super(storageReferenceUri, app);
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/DeleteNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/DeleteNetworkRequest.java
@@ -16,12 +16,15 @@ package com.google.firebase.storage.network;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 
 /** A network request that deletes a gcs object. */
 public class DeleteNetworkRequest extends NetworkRequest {
-  public DeleteNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app) {
-    super(gsUri, app);
+  public DeleteNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings) {
+    super(gsUri, app, emulatorSettings);
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/DeleteNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/DeleteNetworkRequest.java
@@ -17,13 +17,15 @@ package com.google.firebase.storage.network;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.emulators.EmulatedServiceSettings;
 
 /** A network request that deletes a gcs object. */
 public class DeleteNetworkRequest extends NetworkRequest {
-  public DeleteNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings) {
+  public DeleteNetworkRequest(
+      @NonNull Uri gsUri,
+      @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings) {
     super(gsUri, app, emulatorSettings);
   }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetMetadataNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetMetadataNetworkRequest.java
@@ -16,12 +16,15 @@ package com.google.firebase.storage.network;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 
 /** A network request that returns metadata on a gcs object. */
 public class GetMetadataNetworkRequest extends NetworkRequest {
-  public GetMetadataNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app) {
-    super(gsUri, app);
+  public GetMetadataNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings) {
+    super(gsUri, app, emulatorSettings);
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetMetadataNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetMetadataNetworkRequest.java
@@ -17,13 +17,15 @@ package com.google.firebase.storage.network;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.emulators.EmulatedServiceSettings;
 
 /** A network request that returns metadata on a gcs object. */
 public class GetMetadataNetworkRequest extends NetworkRequest {
-  public GetMetadataNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings) {
+  public GetMetadataNetworkRequest(
+      @NonNull Uri gsUri,
+      @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings) {
     super(gsUri, app, emulatorSettings);
   }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetMetadataNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetMetadataNetworkRequest.java
@@ -14,19 +14,15 @@
 
 package com.google.firebase.storage.network;
 
-import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 
 /** A network request that returns metadata on a gcs object. */
 public class GetMetadataNetworkRequest extends NetworkRequest {
   public GetMetadataNetworkRequest(
-      @NonNull Uri gsUri,
-      @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings) {
-    super(gsUri, app, emulatorSettings);
+      @NonNull StorageReferenceUri storageReferenceUri, @NonNull FirebaseApp app) {
+    super(storageReferenceUri, app);
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
@@ -17,10 +17,8 @@ package com.google.firebase.storage.network;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.emulators.EmulatedServiceSettings;
-
 import java.util.Collections;
 import java.util.Map;
 
@@ -29,7 +27,11 @@ public class GetNetworkRequest extends NetworkRequest {
   @SuppressWarnings("unused")
   private static final String TAG = "GetNetworkRequest";
 
-  public GetNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings, long startByte) {
+  public GetNetworkRequest(
+      @NonNull Uri gsUri,
+      @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings,
+      long startByte) {
     super(gsUri, app, emulatorSettings);
     if (startByte != 0) {
       super.setCustomHeader("Range", "bytes=" + startByte + "-");

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
@@ -16,7 +16,11 @@ package com.google.firebase.storage.network;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
+
 import java.util.Collections;
 import java.util.Map;
 
@@ -25,8 +29,8 @@ public class GetNetworkRequest extends NetworkRequest {
   @SuppressWarnings("unused")
   private static final String TAG = "GetNetworkRequest";
 
-  public GetNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, long startByte) {
-    super(gsUri, app);
+  public GetNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings, long startByte) {
+    super(gsUri, app, emulatorSettings);
     if (startByte != 0) {
       super.setCustomHeader("Range", "bytes=" + startByte + "-");
     }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/GetNetworkRequest.java
@@ -14,11 +14,9 @@
 
 package com.google.firebase.storage.network;
 
-import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 import java.util.Collections;
 import java.util.Map;
 
@@ -28,11 +26,8 @@ public class GetNetworkRequest extends NetworkRequest {
   private static final String TAG = "GetNetworkRequest";
 
   public GetNetworkRequest(
-      @NonNull Uri gsUri,
-      @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings,
-      long startByte) {
-    super(gsUri, app, emulatorSettings);
+      @NonNull StorageReferenceUri storageReferenceUri, @NonNull FirebaseApp app, long startByte) {
+    super(storageReferenceUri, app);
     if (startByte != 0) {
       super.setCustomHeader("Range", "bytes=" + startByte + "-");
     }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -48,7 +48,7 @@ public class ListNetworkRequest extends NetworkRequest {
   @NonNull
   public Uri getURL() {
     String bucketName = getStorageReferenceUri().getGsUri().getAuthority();
-    return Uri.parse(getBaseUrl() + "/b/" + bucketName + "/o");
+    return Uri.parse(getStorageReferenceUri().getHttpBaseUri() + "/b/" + bucketName + "/o");
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -19,7 +19,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,12 +29,11 @@ public class ListNetworkRequest extends NetworkRequest {
   @Nullable private final String nextPageToken;
 
   public ListNetworkRequest(
-      @NonNull Uri gsUri,
+      @NonNull StorageReferenceUri storageReferenceUri,
       @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings,
       @Nullable Integer maxPageSize,
       @Nullable String nextPageToken) {
-    super(gsUri, app, emulatorSettings);
+    super(storageReferenceUri, app);
     this.maxPageSize = maxPageSize;
     this.nextPageToken = nextPageToken;
   }
@@ -48,7 +47,8 @@ public class ListNetworkRequest extends NetworkRequest {
   @Override
   @NonNull
   public Uri getURL() {
-    return Uri.parse(getBaseUrl() + "/b/" + mGsUri.getAuthority() + "/o");
+    String bucketName = getStorageReferenceUri().getGsUri().getAuthority();
+    return Uri.parse(getBaseUrl() + "/b/" + bucketName + "/o");
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -47,7 +47,7 @@ public class ListNetworkRequest extends NetworkRequest {
 
   @Override
   @NonNull
-  protected Uri getURL() {
+  public Uri getURL() {
     return Uri.parse(getBaseUrl() + "/b/" + mGsUri.getAuthority() + "/o");
   }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -20,7 +20,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.emulators.EmulatedServiceSettings;
-
 import java.util.HashMap;
 import java.util.Map;
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ListNetworkRequest.java
@@ -19,6 +19,8 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,9 +32,10 @@ public class ListNetworkRequest extends NetworkRequest {
   public ListNetworkRequest(
       @NonNull Uri gsUri,
       @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings,
       @Nullable Integer maxPageSize,
       @Nullable String nextPageToken) {
-    super(gsUri, app);
+    super(gsUri, app, emulatorSettings);
     this.maxPageSize = maxPageSize;
     this.nextPageToken = nextPageToken;
   }
@@ -46,7 +49,7 @@ public class ListNetworkRequest extends NetworkRequest {
   @Override
   @NonNull
   protected Uri getURL() {
-    return Uri.parse(sNetworkRequestUrl + "/b/" + mGsUri.getAuthority() + "/o");
+    return Uri.parse(getBaseUrl() + "/b/" + mGsUri.getAuthority() + "/o");
   }
 
   @Override

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
@@ -23,6 +23,7 @@ import android.text.TextUtils;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.FirebaseApp;
@@ -161,7 +162,8 @@ public abstract class NetworkRequest {
    * @return Url for the target REST call in string form.
    */
   @NonNull
-  protected Uri getURL() {
+  @VisibleForTesting
+  public Uri getURL() {
     return targetUrl;
   }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
@@ -187,11 +187,6 @@ public abstract class NetworkRequest {
   }
 
   @NonNull
-  protected Uri getBaseUrl() {
-    return storageReferenceUri.getHttpBaseUri();
-  }
-
-  @NonNull
   protected StorageReferenceUri getStorageReferenceUri() {
     return storageReferenceUri;
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/NetworkRequest.java
@@ -88,9 +88,9 @@ public abstract class NetworkRequest {
   private final Uri targetUrl;
 
   public NetworkRequest(
-          @NonNull Uri gsUri,
-          @NonNull FirebaseApp app,
-          @Nullable EmulatedServiceSettings emulatorSettings) {
+      @NonNull Uri gsUri,
+      @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings) {
     Preconditions.checkNotNull(gsUri);
     Preconditions.checkNotNull(app);
     this.mGsUri = gsUri;
@@ -104,7 +104,8 @@ public abstract class NetworkRequest {
   @NonNull
   public static Uri getBaseUrl(@Nullable EmulatedServiceSettings emulatorSettings) {
     if (emulatorSettings != null) {
-      return Uri.parse("http://" + emulatorSettings.getHost() + ":" + emulatorSettings.getPort() + "/v0");
+      return Uri.parse(
+          "http://" + emulatorSettings.getHost() + ":" + emulatorSettings.getPort() + "/v0");
     } else {
       return Uri.parse("https://firebasestorage.googleapis.com/v0");
     }
@@ -116,7 +117,8 @@ public abstract class NetworkRequest {
    * @return Url for the target REST call in string form.
    */
   @NonNull
-  public static Uri getDefaultURL(@NonNull Uri gsUri, @Nullable EmulatedServiceSettings emulatorSettings) {
+  public static Uri getDefaultURL(
+      @NonNull Uri gsUri, @Nullable EmulatedServiceSettings emulatorSettings) {
     Preconditions.checkNotNull(gsUri);
     String pathWithoutBucket = getPathWithoutBucket(gsUri);
     Uri.Builder uriBuilder = getBaseUrl(emulatorSettings).buildUpon();

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableNetworkRequest.java
@@ -14,11 +14,9 @@
 
 package com.google.firebase.storage.network;
 
-import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 
 /** Encapsulates a single resumable network request and response */
 abstract class ResumableNetworkRequest extends NetworkRequest {
@@ -29,9 +27,7 @@ abstract class ResumableNetworkRequest extends NetworkRequest {
   @NonNull static final String OFFSET = "X-Goog-Upload-Offset";
 
   ResumableNetworkRequest(
-      @NonNull Uri gsUri,
-      @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings) {
-    super(gsUri, app, emulatorSettings);
+      @NonNull StorageReferenceUri storageReferenceUri, @NonNull FirebaseApp app) {
+    super(storageReferenceUri, app);
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableNetworkRequest.java
@@ -16,7 +16,10 @@ package com.google.firebase.storage.network;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 
 /** Encapsulates a single resumable network request and response */
 abstract class ResumableNetworkRequest extends NetworkRequest {
@@ -26,7 +29,7 @@ abstract class ResumableNetworkRequest extends NetworkRequest {
   @NonNull static final String CONTENT_TYPE = "X-Goog-Upload-Header-Content-Type";
   @NonNull static final String OFFSET = "X-Goog-Upload-Offset";
 
-  ResumableNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app) {
-    super(gsUri, app);
+  ResumableNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings) {
+    super(gsUri, app, emulatorSettings);
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableNetworkRequest.java
@@ -17,7 +17,6 @@ package com.google.firebase.storage.network;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.emulators.EmulatedServiceSettings;
 
@@ -29,7 +28,10 @@ abstract class ResumableNetworkRequest extends NetworkRequest {
   @NonNull static final String CONTENT_TYPE = "X-Goog-Upload-Header-Content-Type";
   @NonNull static final String OFFSET = "X-Goog-Upload-Offset";
 
-  ResumableNetworkRequest(@NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings) {
+  ResumableNetworkRequest(
+      @NonNull Uri gsUri,
+      @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings) {
     super(gsUri, app, emulatorSettings);
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadByteRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadByteRequest.java
@@ -69,7 +69,7 @@ public class ResumableUploadByteRequest extends ResumableNetworkRequest {
 
   @Override
   @NonNull
-  protected Uri getURL() {
+  public Uri getURL() {
     return uploadURL;
   }
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadByteRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadByteRequest.java
@@ -18,6 +18,7 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 
 /** A request to upload a single chunk of a large blob. */
 public class ResumableUploadByteRequest extends ResumableNetworkRequest {
@@ -30,12 +31,13 @@ public class ResumableUploadByteRequest extends ResumableNetworkRequest {
   public ResumableUploadByteRequest(
       @NonNull Uri gsUri,
       @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulattorSettings,
       @NonNull Uri uploadURL,
       @Nullable byte[] chunk,
       long offset,
       int bytesToWrite,
       boolean isFinal) {
-    super(gsUri, app);
+    super(gsUri, app, emulattorSettings);
     if (chunk == null && bytesToWrite != -1) {
       super.mException = new IllegalArgumentException("contentType is null or empty");
     }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadByteRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadByteRequest.java
@@ -18,7 +18,7 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 
 /** A request to upload a single chunk of a large blob. */
 public class ResumableUploadByteRequest extends ResumableNetworkRequest {
@@ -29,15 +29,14 @@ public class ResumableUploadByteRequest extends ResumableNetworkRequest {
   private final int bytesToWrite;
 
   public ResumableUploadByteRequest(
-      @NonNull Uri gsUri,
+      @NonNull StorageReferenceUri storageReferenceUri,
       @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulattorSettings,
       @NonNull Uri uploadURL,
       @Nullable byte[] chunk,
       long offset,
       int bytesToWrite,
       boolean isFinal) {
-    super(gsUri, app, emulattorSettings);
+    super(storageReferenceUri, app);
     if (chunk == null && bytesToWrite != -1) {
       super.mException = new IllegalArgumentException("contentType is null or empty");
     }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
@@ -16,8 +16,10 @@ package com.google.firebase.storage.network;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 
 /** Cancels an upload request in progress. */
 public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
@@ -26,8 +28,8 @@ public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
   private final Uri uploadURL;
 
   public ResumableUploadCancelRequest(
-      @NonNull Uri gsUri, @NonNull FirebaseApp app, @NonNull Uri uploadURL) {
-    super(gsUri, app);
+          @NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings, @NonNull Uri uploadURL) {
+    super(gsUri, app, emulatorSettings);
     cancelCalled = true;
     this.uploadURL = uploadURL;
     super.setCustomHeader(PROTOCOL, "resumable");

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
@@ -28,7 +28,10 @@ public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
   private final Uri uploadURL;
 
   public ResumableUploadCancelRequest(
-          @NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings, @NonNull Uri uploadURL) {
+      @NonNull Uri gsUri,
+      @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings,
+      @NonNull Uri uploadURL) {
     super(gsUri, app, emulatorSettings);
     cancelCalled = true;
     this.uploadURL = uploadURL;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
@@ -47,7 +47,7 @@ public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
 
   @NonNull
   @Override
-  protected Uri getURL() {
+  public Uri getURL() {
     return uploadURL;
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadCancelRequest.java
@@ -16,10 +16,9 @@ package com.google.firebase.storage.network;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 
 /** Cancels an upload request in progress. */
 public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
@@ -28,11 +27,10 @@ public class ResumableUploadCancelRequest extends ResumableNetworkRequest {
   private final Uri uploadURL;
 
   public ResumableUploadCancelRequest(
-      @NonNull Uri gsUri,
+      @NonNull StorageReferenceUri storageReferenceUri,
       @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings,
       @NonNull Uri uploadURL) {
-    super(gsUri, app, emulatorSettings);
+    super(storageReferenceUri, app);
     cancelCalled = true;
     this.uploadURL = uploadURL;
     super.setCustomHeader(PROTOCOL, "resumable");

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
@@ -44,7 +44,7 @@ public class ResumableUploadQueryRequest extends ResumableNetworkRequest {
 
   @NonNull
   @Override
-  protected Uri getURL() {
+  public Uri getURL() {
     return uploadURL;
   }
 }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
@@ -17,7 +17,6 @@ package com.google.firebase.storage.network;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.emulators.EmulatedServiceSettings;
 
@@ -26,7 +25,10 @@ public class ResumableUploadQueryRequest extends ResumableNetworkRequest {
   private final Uri uploadURL;
 
   public ResumableUploadQueryRequest(
-          @NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings, @NonNull Uri uploadURL) {
+      @NonNull Uri gsUri,
+      @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings,
+      @NonNull Uri uploadURL) {
     super(gsUri, app, emulatorSettings);
     this.uploadURL = uploadURL;
 

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
@@ -16,15 +16,18 @@ package com.google.firebase.storage.network;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 
 /** Queries the current status of a resumable upload session. */
 public class ResumableUploadQueryRequest extends ResumableNetworkRequest {
   private final Uri uploadURL;
 
   public ResumableUploadQueryRequest(
-      @NonNull Uri gsUri, @NonNull FirebaseApp app, @NonNull Uri uploadURL) {
-    super(gsUri, app);
+          @NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings, @NonNull Uri uploadURL) {
+    super(gsUri, app, emulatorSettings);
     this.uploadURL = uploadURL;
 
     super.setCustomHeader(PROTOCOL, "resumable");

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadQueryRequest.java
@@ -16,20 +16,18 @@ package com.google.firebase.storage.network;
 
 import android.net.Uri;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 
 /** Queries the current status of a resumable upload session. */
 public class ResumableUploadQueryRequest extends ResumableNetworkRequest {
   private final Uri uploadURL;
 
   public ResumableUploadQueryRequest(
-      @NonNull Uri gsUri,
+      @NonNull StorageReferenceUri storageReferenceUri,
       @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings,
       @NonNull Uri uploadURL) {
-    super(gsUri, app, emulatorSettings);
+    super(storageReferenceUri, app);
     this.uploadURL = uploadURL;
 
     super.setCustomHeader(PROTOCOL, "resumable");

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
@@ -49,7 +49,7 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
   @NonNull
   public Uri getURL() {
     String bucket = getStorageReferenceUri().getGsUri().getAuthority();
-    Uri.Builder uriBuilder = getBaseUrl().buildUpon();
+    Uri.Builder uriBuilder = getStorageReferenceUri().getHttpBaseUri().buildUpon();
     uriBuilder.appendPath("b");
     uriBuilder.appendPath(bucket);
     uriBuilder.appendPath("o");

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
@@ -19,7 +19,7 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
@@ -30,12 +30,11 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
   private final String contentType;
 
   public ResumableUploadStartRequest(
-      @NonNull Uri gsUri,
+      @NonNull StorageReferenceUri storageReferenceUri,
       @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings,
       @Nullable JSONObject metadata,
       @NonNull String contentType) {
-    super(gsUri, app, emulatorSettings);
+    super(storageReferenceUri, app);
     this.metadata = metadata;
     this.contentType = contentType;
     if (TextUtils.isEmpty(this.contentType)) {
@@ -49,9 +48,10 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
   @Override
   @NonNull
   public Uri getURL() {
+    String bucket = getStorageReferenceUri().getGsUri().getAuthority();
     Uri.Builder uriBuilder = getBaseUrl().buildUpon();
     uriBuilder.appendPath("b");
-    uriBuilder.appendPath(mGsUri.getAuthority());
+    uriBuilder.appendPath(bucket);
     uriBuilder.appendPath("o");
     return uriBuilder.build();
   }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
@@ -20,7 +20,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.emulators.EmulatedServiceSettings;
-
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
@@ -19,6 +19,8 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
+
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
@@ -31,9 +33,10 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
   public ResumableUploadStartRequest(
       @NonNull Uri gsUri,
       @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings,
       @Nullable JSONObject metadata,
       @NonNull String contentType) {
-    super(gsUri, app);
+    super(gsUri, app, emulatorSettings);
     this.metadata = metadata;
     this.contentType = contentType;
     if (TextUtils.isEmpty(this.contentType)) {
@@ -47,7 +50,7 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
   @Override
   @NonNull
   protected Uri getURL() {
-    Uri.Builder uriBuilder = sNetworkRequestUrl.buildUpon();
+    Uri.Builder uriBuilder = getBaseUrl().buildUpon();
     uriBuilder.appendPath("b");
     uriBuilder.appendPath(mGsUri.getAuthority());
     uriBuilder.appendPath("o");

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/ResumableUploadStartRequest.java
@@ -48,7 +48,7 @@ public class ResumableUploadStartRequest extends ResumableNetworkRequest {
 
   @Override
   @NonNull
-  protected Uri getURL() {
+  public Uri getURL() {
     Uri.Builder uriBuilder = getBaseUrl().buildUpon();
     uriBuilder.appendPath("b");
     uriBuilder.appendPath(mGsUri.getAuthority());

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/UpdateMetadataNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/UpdateMetadataNetworkRequest.java
@@ -19,7 +19,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.emulators.EmulatedServiceSettings;
-
 import org.json.JSONObject;
 
 /** Represents a request to update metadata on a GCS blob. */
@@ -27,7 +26,10 @@ public class UpdateMetadataNetworkRequest extends NetworkRequest {
   private final JSONObject metadata;
 
   public UpdateMetadataNetworkRequest(
-          @NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings, @Nullable JSONObject metadata) {
+      @NonNull Uri gsUri,
+      @NonNull FirebaseApp app,
+      @Nullable EmulatedServiceSettings emulatorSettings,
+      @Nullable JSONObject metadata) {
     super(gsUri, app, emulatorSettings);
     this.metadata = metadata;
     // On kitkat and below, patch is not supported.

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/UpdateMetadataNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/UpdateMetadataNetworkRequest.java
@@ -14,11 +14,10 @@
 
 package com.google.firebase.storage.network;
 
-import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.emulators.EmulatedServiceSettings;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 import org.json.JSONObject;
 
 /** Represents a request to update metadata on a GCS blob. */
@@ -26,11 +25,10 @@ public class UpdateMetadataNetworkRequest extends NetworkRequest {
   private final JSONObject metadata;
 
   public UpdateMetadataNetworkRequest(
-      @NonNull Uri gsUri,
+      @NonNull StorageReferenceUri storageReferenceUri,
       @NonNull FirebaseApp app,
-      @Nullable EmulatedServiceSettings emulatorSettings,
       @Nullable JSONObject metadata) {
-    super(gsUri, app, emulatorSettings);
+    super(storageReferenceUri, app);
     this.metadata = metadata;
     // On kitkat and below, patch is not supported.
     this.setCustomHeader("X-HTTP-Method-Override", PATCH);

--- a/firebase-storage/src/main/java/com/google/firebase/storage/network/UpdateMetadataNetworkRequest.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/network/UpdateMetadataNetworkRequest.java
@@ -18,6 +18,8 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.emulators.EmulatedServiceSettings;
+
 import org.json.JSONObject;
 
 /** Represents a request to update metadata on a GCS blob. */
@@ -25,8 +27,8 @@ public class UpdateMetadataNetworkRequest extends NetworkRequest {
   private final JSONObject metadata;
 
   public UpdateMetadataNetworkRequest(
-      @NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable JSONObject metadata) {
-    super(gsUri, app);
+          @NonNull Uri gsUri, @NonNull FirebaseApp app, @Nullable EmulatedServiceSettings emulatorSettings, @Nullable JSONObject metadata) {
+    super(gsUri, app, emulatorSettings);
     this.metadata = metadata;
     // On kitkat and below, patch is not supported.
     this.setCustomHeader("X-HTTP-Method-Override", PATCH);

--- a/firebase-storage/src/test/java/com/google/firebase/storage/NetworkRequestTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/NetworkRequestTest.java
@@ -1,0 +1,107 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.storage;
+
+import android.os.Build;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.storage.internal.MockClockHelper;
+import com.google.firebase.storage.internal.RobolectricThreadFix;
+import com.google.firebase.storage.network.GetNetworkRequest;
+import com.google.firebase.storage.network.ListNetworkRequest;
+import com.google.firebase.storage.network.NetworkRequest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+public class NetworkRequestTest {
+
+  private FirebaseApp app;
+
+  @Before
+  public void setUp() throws Exception {
+    RobolectricThreadFix.install();
+    MockClockHelper.install();
+    app = TestUtil.createApp();
+  }
+
+  @After
+  public void tearDown() {
+    FirebaseStorageComponent component = app.get(FirebaseStorageComponent.class);
+    component.clearInstancesForTesting();
+    app.delete();
+  }
+
+  @Test
+  public void getRequest_returnsProductionUrl() {
+    FirebaseStorage storage = FirebaseStorage.getInstance(app);
+
+    StorageReference reference = storage.getReference("child");
+    NetworkRequest request =
+        new GetNetworkRequest(
+            reference.getStorageUri(), reference.getApp(), reference.getEmulatorSettings(), 0);
+
+    Assert.assertEquals(
+        "https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o/child",
+        request.getURL().toString());
+  }
+
+  @Test
+  public void getRequest_returnsEmulatorUrl() {
+    FirebaseStorage storage = FirebaseStorage.getInstance(app);
+    storage.useEmulator("10.0.2.2", 9199);
+
+    StorageReference reference = storage.getReference("child");
+    NetworkRequest request =
+        new GetNetworkRequest(
+            reference.getStorageUri(), reference.getApp(), reference.getEmulatorSettings(), 0);
+
+    Assert.assertEquals(
+        "http://10.0.2.2:9199/v0/b/fooey.appspot.com/o/child", request.getURL().toString());
+  }
+
+  @Test
+  public void listRequest_returnsProductionUrl() {
+    FirebaseStorage storage = FirebaseStorage.getInstance(app);
+
+    StorageReference ref = storage.getReference();
+    NetworkRequest request =
+        new ListNetworkRequest(
+            ref.getStorageUri(), ref.getApp(), ref.getEmulatorSettings(), 1, null);
+
+    Assert.assertEquals(
+        "https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o",
+        request.getURL().toString());
+  }
+
+  @Test
+  public void listRequest_returnsEmulatorUrl() {
+    FirebaseStorage storage = FirebaseStorage.getInstance(app);
+    storage.useEmulator("10.0.2.2", 9199);
+
+    StorageReference ref = storage.getReference();
+    NetworkRequest request =
+        new ListNetworkRequest(
+            ref.getStorageUri(), ref.getApp(), ref.getEmulatorSettings(), 1, null);
+
+    Assert.assertEquals(
+        "http://10.0.2.2:9199/v0/b/fooey.appspot.com/o", request.getURL().toString());
+  }
+}

--- a/firebase-storage/src/test/java/com/google/firebase/storage/NetworkRequestTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/NetworkRequestTest.java
@@ -55,8 +55,7 @@ public class NetworkRequestTest {
 
     StorageReference reference = storage.getReference("child");
     NetworkRequest request =
-        new GetNetworkRequest(
-            reference.getStorageUri(), reference.getApp(), reference.getEmulatorSettings(), 0);
+        new GetNetworkRequest(reference.getStorageReferenceUri(), reference.getApp(), 0);
 
     Assert.assertEquals(
         "https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o/child",
@@ -70,8 +69,7 @@ public class NetworkRequestTest {
 
     StorageReference reference = storage.getReference("child");
     NetworkRequest request =
-        new GetNetworkRequest(
-            reference.getStorageUri(), reference.getApp(), reference.getEmulatorSettings(), 0);
+        new GetNetworkRequest(reference.getStorageReferenceUri(), reference.getApp(), 0);
 
     Assert.assertEquals(
         "http://10.0.2.2:9199/v0/b/fooey.appspot.com/o/child", request.getURL().toString());
@@ -83,8 +81,7 @@ public class NetworkRequestTest {
 
     StorageReference ref = storage.getReference();
     NetworkRequest request =
-        new ListNetworkRequest(
-            ref.getStorageUri(), ref.getApp(), ref.getEmulatorSettings(), 1, null);
+        new ListNetworkRequest(ref.getStorageReferenceUri(), ref.getApp(), 1, null);
 
     Assert.assertEquals(
         "https://firebasestorage.googleapis.com/v0/b/fooey.appspot.com/o",
@@ -98,8 +95,7 @@ public class NetworkRequestTest {
 
     StorageReference ref = storage.getReference();
     NetworkRequest request =
-        new ListNetworkRequest(
-            ref.getStorageUri(), ref.getApp(), ref.getEmulatorSettings(), 1, null);
+        new ListNetworkRequest(ref.getStorageReferenceUri(), ref.getApp(), 1, null);
 
     Assert.assertEquals(
         "http://10.0.2.2:9199/v0/b/fooey.appspot.com/o", request.getURL().toString());

--- a/firebase-storage/src/test/java/com/google/firebase/storage/StorageReferenceTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/StorageReferenceTest.java
@@ -20,6 +20,7 @@ import android.os.Build;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.storage.internal.MockClockHelper;
 import com.google.firebase.storage.internal.RobolectricThreadFix;
 import com.google.firebase.storage.network.MockConnectionFactory;
@@ -70,6 +71,17 @@ public class StorageReferenceTest {
     instance.setMaxUploadRetryTimeMillis(1337);
     Assert.assertEquals(42, instance.getReference().getStorage().getMaxDownloadRetryTimeMillis());
     Assert.assertEquals(1337, instance.getReference().getStorage().getMaxUploadRetryTimeMillis());
+  }
+
+  @Test
+  public void retainsEmulatorProperties() {
+    FirebaseStorage storage = FirebaseStorage.getInstance(app);
+    storage.useEmulator("10.0.2.2", 9199);
+
+    StorageReference ref = storage.getReference();
+    EmulatedServiceSettings emulatorSettings = ref.getEmulatorSettings();
+    Assert.assertEquals("10.0.2.2", emulatorSettings.getHost());
+    Assert.assertEquals(9199, emulatorSettings.getPort());
   }
 
   @Test

--- a/firebase-storage/src/test/java/com/google/firebase/storage/StorageReferenceTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/StorageReferenceTest.java
@@ -20,9 +20,9 @@ import android.os.Build;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.storage.internal.MockClockHelper;
 import com.google.firebase.storage.internal.RobolectricThreadFix;
+import com.google.firebase.storage.internal.StorageReferenceUri;
 import com.google.firebase.storage.network.MockConnectionFactory;
 import com.google.firebase.storage.network.NetworkLayerMock;
 import com.google.firebase.testing.FirebaseAppRule;
@@ -79,9 +79,8 @@ public class StorageReferenceTest {
     storage.useEmulator("10.0.2.2", 9199);
 
     StorageReference ref = storage.getReference();
-    EmulatedServiceSettings emulatorSettings = ref.getEmulatorSettings();
-    Assert.assertEquals("10.0.2.2", emulatorSettings.getHost());
-    Assert.assertEquals(9199, emulatorSettings.getPort());
+    StorageReferenceUri uri = ref.getStorageReferenceUri();
+    Assert.assertEquals("http://10.0.2.2:9199/v0", uri.getHttpBaseUri().toString());
   }
 
   @Test

--- a/firebase-storage/src/test/java/com/google/firebase/storage/internal/StorageReferenceUriTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/internal/StorageReferenceUriTest.java
@@ -1,0 +1,90 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.storage.internal;
+
+import android.net.Uri;
+import android.os.Build;
+import com.google.firebase.emulators.EmulatedServiceSettings;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+public class StorageReferenceUriTest {
+
+  private static final EmulatedServiceSettings EMULATOR_SETTINGS =
+      new EmulatedServiceSettings("10.0.2.2", 1234);
+
+  @Test
+  public void testBucketRootUrl() {
+    StorageReferenceUri uri = new StorageReferenceUri(Uri.parse("gs://bucket"));
+    Assert.assertEquals(uri.getGsUri().toString(), "gs://bucket");
+    Assert.assertEquals(
+        uri.getHttpBaseUri().toString(), "https://firebasestorage.googleapis.com/v0");
+    Assert.assertEquals(
+        uri.getHttpUri().toString(), "https://firebasestorage.googleapis.com/v0/b/bucket");
+  }
+
+  @Test
+  public void testBucketRootUrl_emulator() {
+    StorageReferenceUri uri = new StorageReferenceUri(Uri.parse("gs://bucket"), EMULATOR_SETTINGS);
+    Assert.assertEquals(uri.getGsUri().toString(), "gs://bucket");
+    Assert.assertEquals(uri.getHttpBaseUri().toString(), "http://10.0.2.2:1234/v0");
+    Assert.assertEquals(uri.getHttpUri().toString(), "http://10.0.2.2:1234/v0/b/bucket");
+  }
+
+  @Test
+  public void testBucketObjectUrl_simple() {
+    StorageReferenceUri uri = new StorageReferenceUri(Uri.parse("gs://bucket/object"));
+    Assert.assertEquals(uri.getGsUri().toString(), "gs://bucket/object");
+    Assert.assertEquals(
+        uri.getHttpBaseUri().toString(), "https://firebasestorage.googleapis.com/v0");
+    Assert.assertEquals(
+        uri.getHttpUri().toString(), "https://firebasestorage.googleapis.com/v0/b/bucket/o/object");
+  }
+
+  @Test
+  public void testBucketObjectUrl_simple_emulator() {
+    StorageReferenceUri uri =
+        new StorageReferenceUri(Uri.parse("gs://bucket/object"), EMULATOR_SETTINGS);
+    Assert.assertEquals(uri.getGsUri().toString(), "gs://bucket/object");
+    Assert.assertEquals(uri.getHttpBaseUri().toString(), "http://10.0.2.2:1234/v0");
+    Assert.assertEquals(uri.getHttpUri().toString(), "http://10.0.2.2:1234/v0/b/bucket/o/object");
+  }
+
+  @Test
+  public void testBucketObjectUrl_deep() {
+    StorageReferenceUri uri = new StorageReferenceUri(Uri.parse("gs://bucket/object/path/child"));
+    Assert.assertEquals(uri.getGsUri().toString(), "gs://bucket/object/path/child");
+    Assert.assertEquals(
+        uri.getHttpBaseUri().toString(), "https://firebasestorage.googleapis.com/v0");
+    Assert.assertEquals(
+        uri.getHttpUri().toString(),
+        "https://firebasestorage.googleapis.com/v0/b/bucket/o/object/path/child");
+  }
+
+  @Test
+  public void testBucketObjectUrl_deep_emulator() {
+    StorageReferenceUri uri =
+        new StorageReferenceUri(Uri.parse("gs://bucket/object/path/child"), EMULATOR_SETTINGS);
+    Assert.assertEquals(uri.getGsUri().toString(), "gs://bucket/object/path/child");
+    Assert.assertEquals(uri.getHttpBaseUri().toString(), "http://10.0.2.2:1234/v0");
+    Assert.assertEquals(
+        uri.getHttpUri().toString(), "http://10.0.2.2:1234/v0/b/bucket/o/object/path/child");
+  }
+}

--- a/firebase-storage/src/test/java/com/google/firebase/storage/internal/StorageReferenceUriTest.java
+++ b/firebase-storage/src/test/java/com/google/firebase/storage/internal/StorageReferenceUriTest.java
@@ -75,7 +75,7 @@ public class StorageReferenceUriTest {
         uri.getHttpBaseUri().toString(), "https://firebasestorage.googleapis.com/v0");
     Assert.assertEquals(
         uri.getHttpUri().toString(),
-        "https://firebasestorage.googleapis.com/v0/b/bucket/o/object/path/child");
+        "https://firebasestorage.googleapis.com/v0/b/bucket/o/object%2Fpath%2Fchild");
   }
 
   @Test
@@ -85,6 +85,6 @@ public class StorageReferenceUriTest {
     Assert.assertEquals(uri.getGsUri().toString(), "gs://bucket/object/path/child");
     Assert.assertEquals(uri.getHttpBaseUri().toString(), "http://10.0.2.2:1234/v0");
     Assert.assertEquals(
-        uri.getHttpUri().toString(), "http://10.0.2.2:1234/v0/b/bucket/o/object/path/child");
+        uri.getHttpUri().toString(), "http://10.0.2.2:1234/v0/b/bucket/o/object%2Fpath%2Fchild");
   }
 }

--- a/firebase-storage/test-app/src/main/AndroidManifest.xml
+++ b/firebase-storage/test-app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <activity
             android:name="com.example.storage.MainActivity"
             android:label="@string/app_name"

--- a/firebase-storage/test-app/src/main/java/com/example/storage/MainActivity.java
+++ b/firebase-storage/test-app/src/main/java/com/example/storage/MainActivity.java
@@ -391,6 +391,12 @@ public class MainActivity extends AppCompatActivity {
 
     clickButton = findViewById(R.id.listAll);
     clickButton.setOnClickListener(v -> runTaskTest("listAll", TestCommandHelper::listAllFiles));
+
+    clickButton = findViewById(R.id.useEmulator);
+    clickButton.setOnClickListener(v -> {
+        storage.useEmulator("10.0.2.2", 9199);
+        v.setEnabled(false);
+    });
   }
 
   private void runTaskTest(final String testName, TaskProvider runner) {

--- a/firebase-storage/test-app/src/main/java/com/example/storage/MainActivity.java
+++ b/firebase-storage/test-app/src/main/java/com/example/storage/MainActivity.java
@@ -393,10 +393,11 @@ public class MainActivity extends AppCompatActivity {
     clickButton.setOnClickListener(v -> runTaskTest("listAll", TestCommandHelper::listAllFiles));
 
     clickButton = findViewById(R.id.useEmulator);
-    clickButton.setOnClickListener(v -> {
-        storage.useEmulator("10.0.2.2", 9199);
-        v.setEnabled(false);
-    });
+    clickButton.setOnClickListener(
+        v -> {
+          storage.useEmulator("10.0.2.2", 9199);
+          v.setEnabled(false);
+        });
   }
 
   private void runTaskTest(final String testName, TaskProvider runner) {

--- a/firebase-storage/test-app/src/main/res/layout/content_main.xml
+++ b/firebase-storage/test-app/src/main/res/layout/content_main.xml
@@ -286,13 +286,24 @@
 
     <!-- Tenth Row -->
 
+    <Button
+        android:textSize="7sp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Use Emulator"
+        android:id="@+id/useEmulator"
+        android:layout_below="@+id/listSinglePage"
+        android:layout_alignParentLeft="true" />
+
+    <!-- Eleventh Row -->
+
     <EditText
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:inputType="textMultiLine"
         android:ems="10"
         android:id="@+id/editText"
-        android:layout_below="@+id/listMultplePages"
+        android:layout_below="@+id/useEmulator"
         android:layout_alignParentLeft="true"
         android:layout_alignParentRight="true"/>
 

--- a/firebase-storage/test-app/test-app.gradle
+++ b/firebase-storage/test-app/test-app.gradle
@@ -50,10 +50,10 @@ dependencies {
 
   // We intentionally use an open ended version to pick up any SNAPSHOT
   // versions published to the root project' s build/ directory.
-  implementation 'com.google.firebase:firebase-auth:18+'
-  implementation 'com.google.firebase:firebase-common:18+'
-  implementation 'com.google.android.gms:play-services-basement:17.0.0'
-  implementation 'com.google.android.gms:play-services-base:17.0.0'
+  implementation 'com.google.firebase:firebase-common:19+'
+  implementation 'com.google.firebase:firebase-auth:20+'
+  implementation 'com.google.android.gms:play-services-basement:17.6.0'
+  implementation 'com.google.android.gms:play-services-base:17.6.0'
 
   implementation 'com.google.android.material:material:1.0.0'
   implementation 'androidx.appcompat:appcompat:1.0.2'


### PR DESCRIPTION
Add `useEmulator` method for the Storage SDK

Testing:

- Added some super-basic unit tests
- Modified the test app to support using the emulator, tested against an early build. This seemed to work for most operations, others failed on the emulator side but no issues with the plumbing.

TODO:

- [ ] Decide if `getRefFromUrl()` should accept localhost URLs and check them against emulator setings.

cc @abeisgoat 