### PR TITLE
Removing the isPerformanceMonitoringEnabled check in FirebasePerfProvider and moving the getSharedPreferences to a separate thread.

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -94,6 +94,11 @@ public class ConfigResolver {
     configResolver = null;
   }
 
+  @VisibleForTesting
+  public void setDeviceCacheManager(DeviceCacheManager deviceCacheManager) {
+    this.deviceCacheManager = deviceCacheManager;
+  }
+
   public void setContentProviderContext(Context context) {
     setApplicationContext(context.getApplicationContext());
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/provider/FirebasePerfProvider.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/provider/FirebasePerfProvider.java
@@ -61,13 +61,11 @@ public class FirebasePerfProvider extends ContentProvider {
     ConfigResolver configResolver = ConfigResolver.getInstance();
     configResolver.setContentProviderContext(getContext());
 
-    if (configResolver.isPerformanceMonitoringEnabled()) {
-      AppStateMonitor.getInstance().registerActivityLifecycleCallbacks(getContext());
-      AppStartTrace appStartTrace = AppStartTrace.getInstance();
-      appStartTrace.registerActivityLifecycleCallbacks(getContext());
+    AppStateMonitor.getInstance().registerActivityLifecycleCallbacks(getContext());
+    AppStartTrace appStartTrace = AppStartTrace.getInstance();
+    appStartTrace.registerActivityLifecycleCallbacks(getContext());
 
-      mHandler.post(new AppStartTrace.StartFromBackgroundRunnable(appStartTrace));
-    }
+    mHandler.post(new AppStartTrace.StartFromBackgroundRunnable(appStartTrace));
 
     // In the case of cold start, we create a session and start collecting gauges as early as
     // possible.

--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
@@ -39,6 +39,7 @@ import com.google.firebase.perf.internal.RemoteConfigManager;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
+import com.google.testing.timing.FakeDirectExecutorService;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Assert;
@@ -67,6 +68,8 @@ public class FirebasePerformanceTest {
   @Nullable private GaugeManager spyGaugeManager = null;
 
   @Rule public MockitoRule initRule = MockitoJUnit.rule();
+
+  private FakeDirectExecutorService fakeDirectExecutorService;
 
   @Before
   public void setUp() throws NameNotFoundException {
@@ -98,6 +101,7 @@ public class FirebasePerformanceTest {
     spyConfigResolver = spy(ConfigResolver.getInstance());
 
     spyGaugeManager = spy(GaugeManager.getInstance());
+    fakeDirectExecutorService = new FakeDirectExecutorService();
   }
 
   @After
@@ -542,8 +546,9 @@ public class FirebasePerformanceTest {
       Provider<RemoteConfigComponent> firebaseRemoteConfigProvider,
       Provider<TransportFactory> transportFactoryProvider) {
     if (sharedPreferencesEnabledDisabledKey != null) {
-      DeviceCacheManager.getInstance()
-          .setValue(Constants.ENABLE_DISABLE, sharedPreferencesEnabledDisabledKey);
+      DeviceCacheManager deviceCacheManager = new DeviceCacheManager(fakeDirectExecutorService);
+      deviceCacheManager.setContext(ApplicationProvider.getApplicationContext());
+      deviceCacheManager.setValue(Constants.ENABLE_DISABLE, sharedPreferencesEnabledDisabledKey);
     }
 
     Bundle bundle = new Bundle();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.testing.timing.FakeScheduledExecutorService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,27 +29,32 @@ import org.robolectric.RobolectricTestRunner;
 public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
 
   private DeviceCacheManager deviceCacheManager;
+  private FakeScheduledExecutorService fakeScheduledExecutorService;
 
   @Before
   public void setUp() {
-    deviceCacheManager = DeviceCacheManager.getInstance();
+    fakeScheduledExecutorService = new FakeScheduledExecutorService();
+    deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
   }
 
   @Test
   public void getBoolean_valueIsNotSet_returnsEmpty() {
     deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
 
     assertThat(deviceCacheManager.getBoolean("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void getBoolean_contextAndValueNotSet_returnsEmpty() {
+    assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
     assertThat(deviceCacheManager.getBoolean("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void getBoolean_valueIsSet_returnsSetValue() {
     deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", true);
 
     assertThat(deviceCacheManager.getBoolean("some_key").get()).isTrue();
@@ -57,7 +63,7 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   @Test
   public void clear_setBooleanThenCleared_returnsEmpty() {
     deviceCacheManager.setContext(context);
-
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", true);
 
     assertThat(deviceCacheManager.getBoolean("some_key").get()).isTrue();
@@ -70,14 +76,17 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   public void getBoolean_firebaseAppNotExist_returnsEmpty() {
     DeviceCacheManager.clearInstance();
     FirebaseApp.clearInstancesForTest();
-    deviceCacheManager = DeviceCacheManager.getInstance();
+    deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
     deviceCacheManager.setValue("some_key", true);
 
+    assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
     assertThat(deviceCacheManager.getBoolean("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueBoolean_setTwice_canGetLatestValue() {
+    deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", true);
     assertThat(deviceCacheManager.getBoolean("some_key").get()).isTrue();
 
@@ -86,10 +95,10 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void setValueBoolean_contextNotSet_canGetValue() {
+  public void setValueBoolean_contextNotSet_returnsEmpty() {
     deviceCacheManager.setValue("some_key", true);
 
-    assertThat(deviceCacheManager.getBoolean("some_key").get()).isTrue();
+    assertThat(deviceCacheManager.getBoolean("some_key").isAvailable()).isFalse();
   }
 
   @Test
@@ -100,6 +109,7 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   @Test
   public void getString_valueIsNotSet_returnsEmpty() {
     deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
 
     assertThat(deviceCacheManager.getString("some_key").isAvailable()).isFalse();
   }
@@ -112,23 +122,26 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   @Test
   public void getString_valueIsSet_returnsSetValue() {
     deviceCacheManager.setContext(context);
-    deviceCacheManager.setValue("some_key", "speicalValue");
+    fakeScheduledExecutorService.runAll();
+    deviceCacheManager.setValue("some_key", "specialValue");
 
-    assertThat(deviceCacheManager.getString("some_key").get()).isEqualTo("speicalValue");
+    assertThat(deviceCacheManager.getString("some_key").get()).isEqualTo("specialValue");
   }
 
   @Test
   public void getString_firebaseAppNotExist_returnsEmpty() {
     DeviceCacheManager.clearInstance();
     FirebaseApp.clearInstancesForTest();
-    deviceCacheManager = DeviceCacheManager.getInstance();
-    deviceCacheManager.setValue("some_key", "speicalValue");
+    deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
+    deviceCacheManager.setValue("some_key", "specialValue");
 
     assertThat(deviceCacheManager.getString("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueString_setTwice_canGetLatestValue() {
+    deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", "EarliestValue");
     assertThat(deviceCacheManager.getString("some_key").get()).isEqualTo("EarliestValue");
 
@@ -137,25 +150,30 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void setValueString_contextNotSet_canGetValue() {
+  public void setValueString_contextNotSet_returnsEmpty() {
     deviceCacheManager.setValue("some_key", "newValue");
-    assertThat(deviceCacheManager.getString("some_key").get()).isEqualTo("newValue");
+    assertThat(deviceCacheManager.getString("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueString_setNullString_returnsEmpty() {
+    deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", null);
     assertThat(deviceCacheManager.getString("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueString_keyIsNull_returnsFalse() {
+    deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     assertThat(deviceCacheManager.setValue(null, "value")).isFalse();
   }
 
   @Test
   public void getFloat_valueIsNotSet_returnsEmpty() {
     deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
 
     assertThat(deviceCacheManager.getFloat("some_key").isAvailable()).isFalse();
   }
@@ -163,14 +181,16 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   @Test
   public void getFloat_contextAndValueNotSet_returnsEmpty() {
     DeviceCacheManager.clearInstance();
-    deviceCacheManager = DeviceCacheManager.getInstance();
+    deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
 
+    assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
     assertThat(deviceCacheManager.getFloat("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void getFloat_valueIsSet_returnsSetValue() {
     deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", 1.2f);
 
     assertThat(deviceCacheManager.getFloat("some_key").get()).isEqualTo(1.2f);
@@ -180,14 +200,17 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   public void getFloat_firebaseAppNotExist_returnsEmpty() {
     DeviceCacheManager.clearInstance();
     FirebaseApp.clearInstancesForTest();
-    deviceCacheManager = DeviceCacheManager.getInstance();
+    deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
     deviceCacheManager.setValue("some_key", 1.2f);
 
+    assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
     assertThat(deviceCacheManager.getFloat("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueFloat_setTwice_canGetLatestValue() {
+    deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", 1.01f);
     assertThat(deviceCacheManager.getFloat("some_key").get()).isEqualTo(1.01f);
 
@@ -196,36 +219,42 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void setValueFloat_contextNotSet_canGetValue() {
+  public void setValueFloat_contextNotSet_returnsEmpty() {
     deviceCacheManager.setValue("some_key", 100.0f);
-    assertThat(deviceCacheManager.getFloat("some_key").get()).isEqualTo(100.0f);
+    assertThat(deviceCacheManager.getFloat("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueFloat_keyIsNull_returnsFalse() {
+    deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     assertThat(deviceCacheManager.setValue(null, 10.0f)).isFalse();
   }
 
   @Test
   public void getLong_valueIsNotSet_returnsEmpty() {
     DeviceCacheManager.clearInstance();
-    deviceCacheManager = DeviceCacheManager.getInstance();
+    deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
     deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
 
+    assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
     assertThat(deviceCacheManager.getLong("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void getLong_contextAndValueNotSet_returnsEmpty() {
     DeviceCacheManager.clearInstance();
-    deviceCacheManager = DeviceCacheManager.getInstance();
+    deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
 
+    assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
     assertThat(deviceCacheManager.getLong("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void getLong_valueIsSet_returnsSetValue() {
     deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", 1L);
 
     assertThat(deviceCacheManager.getLong("some_key").get()).isEqualTo(1L);
@@ -235,7 +264,7 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   public void getLong_firebaseAppNotExist_returnsEmpty() {
     DeviceCacheManager.clearInstance();
     FirebaseApp.clearInstancesForTest();
-    deviceCacheManager = DeviceCacheManager.getInstance();
+    deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
     deviceCacheManager.setValue("some_key", 1L);
 
     assertThat(deviceCacheManager.getLong("some_key").isAvailable()).isFalse();
@@ -243,6 +272,8 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void setValueLong_setTwice_canGetLatestValue() {
+    deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", 2L);
     assertThat(deviceCacheManager.getLong("some_key").get()).isEqualTo(2L);
 
@@ -251,13 +282,16 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void setValueLong_contextNotSet_canGetValue() {
+  public void setValueLong_contextNotSet_returnsEmpty() {
     deviceCacheManager.setValue("some_key", 100L);
-    assertThat(deviceCacheManager.getLong("some_key").get()).isEqualTo(100L);
+    // The key is not set if the shared preference is not fetched and available.
+    assertThat(deviceCacheManager.getLong("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueLong_keyIsNull_returnsFalse() {
+    deviceCacheManager.setContext(context);
+    fakeScheduledExecutorService.runAll();
     assertThat(deviceCacheManager.setValue(null, 10.0f)).isFalse();
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/internal/AppStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/internal/AppStateMonitorTest.java
@@ -44,6 +44,7 @@ import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.TraceMetric;
+import com.google.testing.timing.FakeDirectExecutorService;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
@@ -387,6 +388,7 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
     Activity activityWithNonHardwareAcceleratedView =
         createFakeActivity(/* isHardwareAccelerated =*/ true);
     ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
 
     Bundle bundle = new Bundle();
     bundle.putBoolean("firebase_performance_collection_enabled", false);
@@ -404,6 +406,8 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
     Activity activityWithNonHardwareAcceleratedView =
         createFakeActivity(/* isHardwareAccelerated =*/ true);
     ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
+
     // Developer disables Performance Monitoring during build time.
     Bundle bundle = new Bundle();
     bundle.putBoolean("firebase_performance_collection_enabled", false);
@@ -436,6 +440,8 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
     Activity activityWithNonHardwareAcceleratedView =
         createFakeActivity(/* isHardwareAccelerated =*/ true);
     ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
+
     Bundle bundle = new Bundle();
     bundle.putBoolean("firebase_performance_collection_deactivated", true);
     configResolver.setMetadataBundle(new ImmutableBundle(bundle));
@@ -484,6 +490,8 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
   public void foregroundTrace_perfMonEnabledAtRuntime_traceCreated() {
     AppStateMonitor monitor = new AppStateMonitor(transportManager, mClock);
     ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
+
     // Firebase Performance is disabled at build time.
     Bundle bundle = new Bundle();
     bundle.putBoolean("firebase_performance_collection_enabled", false);
@@ -521,6 +529,8 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
   public void foreGroundTrace_perfMonDeactivated_traceCreated() {
     AppStateMonitor monitor = new AppStateMonitor(transportManager, mClock);
     ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
+
     // Firebase Performance is deactivated at build time.
     Bundle bundle = new Bundle();
     bundle.putBoolean("firebase_performance_collection_deactivated", true);
@@ -589,6 +599,8 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
   public void backgroundTrace_perfMonEnabledAtRuntime_traceCreated() {
     AppStateMonitor monitor = new AppStateMonitor(transportManager, mClock);
     ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
+
     // Firebase Performance is disabled at build time.
     Bundle bundle = new Bundle();
     bundle.putBoolean("firebase_performance_collection_enabled", false);
@@ -627,6 +639,8 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
   public void backgroundTrace_perfMonDeactivated_traceCreated() {
     AppStateMonitor monitor = new AppStateMonitor(transportManager, mClock);
     ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
+
     // Firebase Performance is deactivated at build time.
     Bundle bundle = new Bundle();
     bundle.putBoolean("firebase_performance_collection_deactivated", true);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/TraceTest.java
@@ -41,6 +41,7 @@ import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.TraceMetric;
+import com.google.testing.timing.FakeDirectExecutorService;
 import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
@@ -80,7 +81,9 @@ public class TraceTest extends FirebasePerformanceTestBase {
     ConfigResolver.clearInstance();
 
     context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().commit();
-    ConfigResolver.getInstance().setApplicationContext(context);
+    ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
+    configResolver.setApplicationContext(context);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/testing/timing/FakeDirectExecutorService.java
+++ b/firebase-perf/src/test/java/com/google/testing/timing/FakeDirectExecutorService.java
@@ -1,0 +1,55 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.testing.timing;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/** Fake executor service that simply executes the runnable in the same thread. */
+public class FakeDirectExecutorService extends AbstractExecutorService {
+
+  private boolean shutdown = false;
+
+  public void execute(Runnable command) {
+    command.run();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return true;
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return shutdown;
+  }
+
+  @Override
+  public void shutdown() {
+    shutdown = true;
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    shutdown = true;
+    return Arrays.asList();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return shutdown;
+  }
+}


### PR DESCRIPTION
To address StrictMode violation in b/171411615.