### PR TITLE
Post-Merge cleanup of MutableDocuments

### DIFF
--- a/firebase-firestore/ktx/src/test/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/ktx/src/test/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -76,7 +76,7 @@ public class TestUtil {
   }
 
   public static MutableDocument doc(DocumentKey key, long version, ObjectValue data) {
-    return new MutableDocument(key).convertToFoundDocument(version(version), data);
+    return MutableDocument.newFoundDocument(key, version(version), data);
   }
 
   public static DocumentSet docSet(Comparator<Document> comparator, MutableDocument... documents) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleLoader.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleLoader.java
@@ -73,8 +73,8 @@ public class BundleLoader {
         documents =
             documents.insert(
                 bundledDocumentMetadata.getKey(),
-                new MutableDocument(bundledDocumentMetadata.getKey())
-                    .convertToNoDocument(bundledDocumentMetadata.getReadTime()));
+                MutableDocument.newNoDocument(
+                    bundledDocumentMetadata.getKey(), bundledDocumentMetadata.getReadTime()));
         currentDocument = null;
       }
     } else if (bundleElement instanceof BundleDocument) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/bundle/BundleSerializer.java
@@ -111,9 +111,8 @@ public class BundleSerializer {
     decodeMapValue(value, document.getJSONObject("fields"));
 
     return new BundleDocument(
-        new MutableDocument(key)
-            .convertToFoundDocument(
-                updateTime, ObjectValue.fromMap(value.getMapValue().getFieldsMap())));
+        MutableDocument.newFoundDocument(
+            key, updateTime, ObjectValue.fromMap(value.getMapValue().getFieldsMap())));
   }
 
   private ResourcePath decodeName(String name) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -407,8 +407,7 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
       // It's a limbo doc. Create a synthetic event saying it was deleted. This is kind of a hack.
       // Ideally, we would have a method in the local store to purge a document. However, it would
       // be tricky to keep all of the local store's invariants with another method.
-      MutableDocument result =
-          new MutableDocument(limboKey).convertToNoDocument(SnapshotVersion.NONE);
+      MutableDocument result = MutableDocument.newNoDocument(limboKey, SnapshotVersion.NONE);
       Map<DocumentKey, MutableDocument> documentUpdates =
           Collections.singletonMap(limboKey, result);
       Set<DocumentKey> limboDocuments = Collections.singleton(limboKey);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -206,7 +206,7 @@ class LocalDocumentsView {
         MutableDocument document = remoteDocuments.get(key);
         if (document == null) {
           // Create invalid document to apply mutations on top of
-          document = new MutableDocument(key);
+          document = MutableDocument.newInvalidDocument(key);
           remoteDocuments = remoteDocuments.insert(key, document);
         }
         mutation.applyToLocalView(document, batch.getLocalWriteTime());

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
@@ -101,8 +101,8 @@ public final class LocalSerializer {
     DocumentKey key = rpcSerializer.decodeKey(document.getName());
     SnapshotVersion version = rpcSerializer.decodeVersion(document.getUpdateTime());
     MutableDocument result =
-        new MutableDocument(key)
-            .convertToFoundDocument(version, ObjectValue.fromMap(document.getFieldsMap()));
+        MutableDocument.newFoundDocument(
+            key, version, ObjectValue.fromMap(document.getFieldsMap()));
     return hasCommittedMutations ? result.setHasCommittedMutations() : result;
   }
 
@@ -121,7 +121,7 @@ public final class LocalSerializer {
       com.google.firebase.firestore.proto.NoDocument proto, boolean hasCommittedMutations) {
     DocumentKey key = rpcSerializer.decodeKey(proto.getName());
     SnapshotVersion version = rpcSerializer.decodeVersion(proto.getReadTime());
-    MutableDocument result = new MutableDocument(key).convertToNoDocument(version);
+    MutableDocument result = MutableDocument.newNoDocument(key, version);
     return hasCommittedMutations ? result.setHasCommittedMutations() : result;
   }
 
@@ -140,7 +140,7 @@ public final class LocalSerializer {
       com.google.firebase.firestore.proto.UnknownDocument proto) {
     DocumentKey key = rpcSerializer.decodeKey(proto.getName());
     SnapshotVersion version = rpcSerializer.decodeVersion(proto.getVersion());
-    return new MutableDocument(key).convertToUnknownDocument(version);
+    return MutableDocument.newUnknownDocument(key, version);
   }
 
   /** Encodes a MutationBatch model for local storage in the mutation queue. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -776,7 +776,7 @@ public final class LocalStore implements BundleCallback {
       hardAssert(ackVersion != null, "docVersions should contain every doc in the write.");
 
       if (doc.getVersion().compareTo(ackVersion) < 0) {
-        batch.applyToRemoteDocument(docKey, doc, batchResult);
+        batch.applyToRemoteDocument(doc, batchResult);
         if (doc.isValidDocument()) {
           remoteDocuments.add(doc, batchResult.getCommitVersion());
         }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -60,7 +60,7 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
   @Override
   public MutableDocument get(DocumentKey key) {
     Pair<MutableDocument, SnapshotVersion> entry = docs.get(key);
-    return entry != null ? entry.first.clone() : new MutableDocument(key);
+    return entry != null ? entry.first.clone() : MutableDocument.newInvalidDocument(key);
   }
 
   @Override

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -82,7 +82,7 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
         db.query("SELECT contents FROM remote_documents WHERE path = ?")
             .binding(path)
             .firstValue(row -> decodeMaybeDocument(row.getBlob(0)));
-    return document != null ? document : new MutableDocument(documentKey);
+    return document != null ? document : MutableDocument.newInvalidDocument(documentKey);
   }
 
   @Override
@@ -96,7 +96,7 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
     for (DocumentKey key : documentKeys) {
       // Make sure each key has a corresponding entry, which is null in case the document is not
       // found.
-      results.put(key, new MutableDocument(key));
+      results.put(key, MutableDocument.newInvalidDocument(key));
     }
 
     SQLitePersistence.LongQuery longQuery =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Document.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Document.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/MutableDocument.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/MutableDocument.java
@@ -21,11 +21,10 @@ import com.google.firestore.v1.Value;
  * Represents a document in Firestore with a key, version, data and whether it has local mutations
  * applied to it.
  *
- * <p>Documents can transition between states via {@link
- * #convertToFoundDocument(SnapshotVersion,ObjectValue)}, {@link
- * #convertToNoDocument(SnapshotVersion)} and {@link #convertToUnknownDocument(SnapshotVersion)}. If
- * a document does not transition to one of these states even after all mutations have been applied,
- * {@link #isValidDocument()} returns false and the document should be removed from all views.
+ * <p>Documents can transition between states via {@link #convertToFoundDocument}, {@link
+ * #convertToNoDocument} and {@link #convertToUnknownDocument}. If a document does not transition to
+ * one of these states even after all mutations have been applied, {@link #isValidDocument} returns
+ * false and the document should be removed from all views.
  */
 public final class MutableDocument implements Document, Cloneable {
 
@@ -66,6 +65,10 @@ public final class MutableDocument implements Document, Cloneable {
   private ObjectValue value;
   private DocumentState documentState;
 
+  private MutableDocument(DocumentKey key) {
+    this.key = key;
+  }
+
   private MutableDocument(
       DocumentKey key,
       DocumentType documentType,
@@ -95,14 +98,12 @@ public final class MutableDocument implements Document, Cloneable {
   /** Creates a new document that is known to exist with the given data at the given version. */
   public static MutableDocument newFoundDocument(
       DocumentKey documentKey, SnapshotVersion version, ObjectValue value) {
-    return new MutableDocument(
-        documentKey, DocumentType.FOUND_DOCUMENT, version, value, DocumentState.SYNCED);
+    return new MutableDocument(documentKey).convertToFoundDocument(version, value);
   }
 
   /** Creates a new document that is known to not exisr at the given version. */
   public static MutableDocument newNoDocument(DocumentKey documentKey, SnapshotVersion version) {
-    return new MutableDocument(
-        documentKey, DocumentType.NO_DOCUMENT, version, new ObjectValue(), DocumentState.SYNCED);
+    return new MutableDocument(documentKey).convertToNoDocument(version);
   }
 
   /**
@@ -111,12 +112,7 @@ public final class MutableDocument implements Document, Cloneable {
    */
   public static MutableDocument newUnknownDocument(
       DocumentKey documentKey, SnapshotVersion version) {
-    return new MutableDocument(
-        documentKey,
-        DocumentType.UNKNOWN_DOCUMENT,
-        version,
-        new ObjectValue(),
-        DocumentState.HAS_COMMITTED_MUTATIONS);
+    return new MutableDocument(documentKey).convertToUnknownDocument(version);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/MutableDocument.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/MutableDocument.java
@@ -19,12 +19,13 @@ import com.google.firestore.v1.Value;
 
 /**
  * Represents a document in Firestore with a key, version, data and whether it has local mutations
- * applied to it. Documents can start out as {@link DocumentType#INVALID} and transition to a valid
- * states via {@link #convertToFoundDocument(SnapshotVersion,ObjectValue)}, {@link
- * #convertToNoDocument(SnapshotVersion)} and {@link #convertToUnknownDocument(SnapshotVersion)}.
+ * applied to it.
  *
- * <p>Invalid documents serve as base documents for mutations. If a document remains invalid even
- * after all mutations have been applied, it should be removed from all views.
+ * <p>Documents can transition between states via {@link
+ * #convertToFoundDocument(SnapshotVersion,ObjectValue)}, {@link
+ * #convertToNoDocument(SnapshotVersion)} and {@link #convertToUnknownDocument(SnapshotVersion)}. If
+ * a document does not transition to one of these states even after all mutations have been applied,
+ * {@link #isValidDocument()} returns false and the document should be removed from all views.
  */
 public final class MutableDocument implements Document, Cloneable {
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/MutationBatch.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/MutationBatch.java
@@ -76,18 +76,10 @@ public final class MutationBatch {
    * Applies all the mutations in this MutationBatch to the specified document to create a new
    * remote document.
    *
-   * @param documentKey The key of the document to apply mutations to.
    * @param document The document to apply mutations to.
    * @param batchResult The result of applying the MutationBatch to the backend.
    */
-  public void applyToRemoteDocument(
-      DocumentKey documentKey, MutableDocument document, MutationBatchResult batchResult) {
-    hardAssert(
-        document.getKey().equals(documentKey),
-        "applyToRemoteDocument: key %s doesn't match document key %s",
-        documentKey,
-        document.getKey());
-
+  public void applyToRemoteDocument(MutableDocument document, MutationBatchResult batchResult) {
     int size = mutations.size();
     List<MutationResult> mutationResults = batchResult.getMutationResults();
     hardAssert(
@@ -98,7 +90,7 @@ public final class MutationBatch {
 
     for (int i = 0; i < size; i++) {
       Mutation mutation = mutations.get(i);
-      if (mutation.getKey().equals(documentKey)) {
+      if (mutation.getKey().equals(document.getKey())) {
         MutationResult mutationResult = mutationResults.get(i);
         mutation.applyToRemoteDocument(document, mutationResult);
       }
@@ -129,7 +121,7 @@ public final class MutationBatch {
   public ImmutableSortedMap<DocumentKey, Document> applyToLocalDocumentSet(
       ImmutableSortedMap<DocumentKey, Document> documentMap) {
     // TODO(mrschmidt): This implementation is O(n^2). If we iterate through the mutations first
-    // (as done in `applyToLocalView(DocumentKey k, MaybeDoc d)`), we can reduce the complexity to
+    // (as done in `applyToLocalView(MutableDocument d)`), we can reduce the complexity to
     // O(n).
     for (DocumentKey key : getKeys()) {
       // TODO(mutabledocuments): This method should take a map of MutableDocuments and we should

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteSerializer.java
@@ -246,7 +246,7 @@ public final class RemoteSerializer {
     SnapshotVersion version = decodeVersion(response.getFound().getUpdateTime());
     hardAssert(
         !version.equals(SnapshotVersion.NONE), "Got a document response with no snapshot version");
-    return new MutableDocument(key).convertToFoundDocument(version, value);
+    return MutableDocument.newFoundDocument(key, version, value);
   }
 
   private MutableDocument decodeMissingDocument(BatchGetDocumentsResponse response) {
@@ -258,7 +258,7 @@ public final class RemoteSerializer {
     hardAssert(
         !version.equals(SnapshotVersion.NONE),
         "Got a no document response with no snapshot version");
-    return new MutableDocument(key).convertToNoDocument(version);
+    return MutableDocument.newNoDocument(key, version);
   }
 
   // Mutations
@@ -874,7 +874,7 @@ public final class RemoteSerializer {
         hardAssert(
             !version.equals(SnapshotVersion.NONE), "Got a document change without an update time");
         ObjectValue data = ObjectValue.fromMap(docChange.getDocument().getFieldsMap());
-        MutableDocument document = new MutableDocument(key).convertToFoundDocument(version, data);
+        MutableDocument document = MutableDocument.newFoundDocument(key, version, data);
         watchChange = new WatchChange.DocumentChange(added, removed, document.getKey(), document);
         break;
       case DOCUMENT_DELETE:
@@ -883,7 +883,7 @@ public final class RemoteSerializer {
         key = decodeKey(docDelete.getDocument());
         // Note that version might be unset in which case we use SnapshotVersion.NONE
         version = decodeVersion(docDelete.getReadTime());
-        MutableDocument doc = new MutableDocument(key).convertToNoDocument(version);
+        MutableDocument doc = MutableDocument.newNoDocument(key, version);
         watchChange =
             new WatchChange.DocumentChange(Collections.emptyList(), removed, doc.getKey(), doc);
         break;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/WatchChangeAggregator.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/WatchChangeAggregator.java
@@ -189,8 +189,7 @@ public class WatchChangeAggregator {
           // deleted document there might be another query that will raise this document as part of
           // a snapshot  until it is resolved, essentially exposing inconsistency between queries.
           DocumentKey key = DocumentKey.fromPath(target.getPath());
-          MutableDocument result =
-              new MutableDocument(key).convertToNoDocument(SnapshotVersion.NONE);
+          MutableDocument result = MutableDocument.newNoDocument(key, SnapshotVersion.NONE);
           removeDocumentFromTarget(targetId, key, result);
         } else {
           hardAssert(
@@ -228,7 +227,7 @@ public class WatchChangeAggregator {
           // limboDocumentRefs.
           DocumentKey key = DocumentKey.fromPath(targetData.getTarget().getPath());
           if (pendingDocumentUpdates.get(key) == null && !targetContainsDocument(targetId, key)) {
-            MutableDocument result = new MutableDocument(key).convertToNoDocument(snapshotVersion);
+            MutableDocument result = MutableDocument.newNoDocument(key, snapshotVersion);
             removeDocumentFromTarget(targetId, key, result);
           }
         }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/bundle/BundleSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/bundle/BundleSerializerTest.java
@@ -698,13 +698,13 @@ public class BundleSerializerTest {
     BundleDocument actualDocument = serializer.decodeDocument(new JSONObject(documentJson));
     BundleDocument expectedDocument =
         new BundleDocument(
-            new MutableDocument(DocumentKey.fromName(TEST_DOCUMENT))
-                .convertToFoundDocument(
-                    new SnapshotVersion(new com.google.firebase.Timestamp(1577836802, 2)),
-                    new ObjectValue(
-                        Value.newBuilder()
-                            .setMapValue(MapValue.newBuilder().putFields("foo", proto))
-                            .build())));
+            MutableDocument.newFoundDocument(
+                DocumentKey.fromName(TEST_DOCUMENT),
+                new SnapshotVersion(new com.google.firebase.Timestamp(1577836802, 2)),
+                new ObjectValue(
+                    Value.newBuilder()
+                        .setMapValue(MapValue.newBuilder().putFields("foo", proto))
+                        .build())));
 
     assertEquals(expectedDocument, actualDocument);
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LruGarbageCollectorTestCase.java
@@ -576,7 +576,7 @@ public abstract class LruGarbageCollectorTestCase {
         () -> {
           SnapshotVersion newVersion = version(3);
           MutableDocument doc =
-              new MutableDocument(middleDocToUpdate).convertToFoundDocument(newVersion, testValue);
+              MutableDocument.newFoundDocument(middleDocToUpdate, newVersion, testValue);
           documentCache.add(doc, newVersion);
           updateTargetInTransaction(middleTarget);
         });

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
@@ -107,8 +107,7 @@ abstract class RemoteDocumentCacheTestCase {
 
     List<String> keys = new ArrayList<>(Arrays.asList(paths));
     keys.add("foo/nonexistent");
-    written.put(
-        key("foo/nonexistent"), new MutableDocument(key("foo/nonexistent"))); // Add invalid doc
+    written.put(key("foo/nonexistent"), MutableDocument.newInvalidDocument(key("foo/nonexistent")));
     Map<DocumentKey, MutableDocument> read = getAll(keys);
     assertEquals(written, read);
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/DocumentTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/DocumentTest.java
@@ -36,8 +36,7 @@ public class DocumentTest {
   @Test
   public void testInstantiation() {
     MutableDocument document =
-        new MutableDocument(key("messages/first"))
-            .convertToFoundDocument(version(1), wrapObject("a", 1));
+        MutableDocument.newFoundDocument(key("messages/first"), version(1), wrapObject("a", 1));
 
     assertEquals(key("messages/first"), document.getKey());
     assertEquals(version(1), document.getVersion());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutableObjectValueTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutableObjectValueTest.java
@@ -29,7 +29,7 @@ import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
-public class ObjectValueBuilderTest {
+public class MutableObjectValueTest {
   private String fooString = "foo";
   private Value fooValue = wrap(fooString);
   private String barString = "bar";
@@ -37,7 +37,7 @@ public class ObjectValueBuilderTest {
   private Value emptyObject = Value.newBuilder().setMapValue(MapValue.getDefaultInstance()).build();
 
   @Test
-  public void supportsEmptyobjectValues() {
+  public void supportsEmptyObjectValues() {
     ObjectValue objectValue = new ObjectValue();
     assertEquals(new ObjectValue(), objectValue);
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutationTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutationTest.java
@@ -91,7 +91,7 @@ public class MutationTest {
 
   @Test
   public void testAppliesPatchToNullDocWithMergeToDocuments() {
-    MutableDocument mergeDoc = new MutableDocument(key("collection/key"));
+    MutableDocument mergeDoc = MutableDocument.newInvalidDocument(key("collection/key"));
     Mutation upsert =
         mergeMutation(
             "collection/key", map("foo.bar", "new-bar-value"), Arrays.asList(field("foo.bar")));
@@ -582,17 +582,26 @@ public class MutationTest {
     assertVersionTransitions(set, docV3, mutationResult, docV7Committed);
     assertVersionTransitions(set, deletedV3, mutationResult, docV7Committed);
     assertVersionTransitions(
-        set, new MutableDocument(key("collection/key")), mutationResult, docV7Committed);
+        set,
+        MutableDocument.newInvalidDocument(key("collection/key")),
+        mutationResult,
+        docV7Committed);
 
     assertVersionTransitions(patch, docV3, mutationResult, docV7Committed);
     assertVersionTransitions(patch, deletedV3, mutationResult, docV7Unknown);
     assertVersionTransitions(
-        patch, new MutableDocument(key("collection/key")), mutationResult, docV7Unknown);
+        patch,
+        MutableDocument.newInvalidDocument(key("collection/key")),
+        mutationResult,
+        docV7Unknown);
 
     assertVersionTransitions(delete, docV3, mutationResult, docV7Deleted);
     assertVersionTransitions(delete, deletedV3, mutationResult, docV7Deleted);
     assertVersionTransitions(
-        delete, new MutableDocument(key("collection/key")), mutationResult, docV7Deleted);
+        delete,
+        MutableDocument.newInvalidDocument(key("collection/key")),
+        mutationResult,
+        docV7Deleted);
   }
 
   @Test

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -195,15 +195,15 @@ public class TestUtil {
   }
 
   public static MutableDocument doc(DocumentKey key, long version, ObjectValue data) {
-    return new MutableDocument(key).convertToFoundDocument(version(version), data);
+    return MutableDocument.newFoundDocument(key, version(version), data);
   }
 
   public static MutableDocument deletedDoc(String key, long version) {
-    return new MutableDocument(key(key)).convertToNoDocument(version(version));
+    return MutableDocument.newNoDocument(key(key), version(version));
   }
 
   public static MutableDocument unknownDoc(String key, long version) {
-    return new MutableDocument(key(key)).convertToUnknownDocument(version(version));
+    return MutableDocument.newUnknownDocument(key(key), version(version));
   }
 
   public static ImmutableSortedMap<DocumentKey, MutableDocument> docMap(


### PR DESCRIPTION
Some small fixes to MutableDocuments that I noticed while porting to JS (more likely coming). I also added the often asked for factory functions since it helps with readability (otherwise the reader does not know what `new MutableDocument` means).