### PR TITLE
Revert "smoke tests for ml modeldownloader"

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -73,7 +73,6 @@ dependencies {
   // TODO(yifany): Restore after messaging in github is up to date
   // implementation "com.google.firebase:firebase-messaging"
   implementation "com.google.firebase:firebase-ml-vision"
-  implementation "com.google.firebase:firebase-ml-modeldownloader"
   implementation "com.google.firebase:firebase-perf"
   implementation "com.google.firebase:firebase-storage"
 

--- a/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
@@ -20,7 +20,6 @@ import com.google.firebase.appindexing.FirebaseAppIndex;
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging;
 // import com.google.firebase.messaging.FirebaseMessaging;
 // import com.google.firebase.perf.FirebasePerformance;
-import com.google.firebase.ml.modeldownloader.FirebaseModelDownloader;
 import com.google.firebase.ml.vision.FirebaseVision;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,10 +52,5 @@ public final class BuildOnlyTest {
   @Test
   public void vision_IsNotNull() {
     assertThat(FirebaseVision.getInstance()).isNotNull();
-  }
-
-  @Test
-  public void modelDownloader_IsNotNull() {
-    assertThat(FirebaseModelDownloader.getInstance()).isNotNull();
   }
 }


### PR DESCRIPTION
Reverts firebase/firebase-android-sdk#2453
Turns out this needs to wait until after official release of SDK.