### PR TITLE
Specify write id predicates instead of exclusion sets

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/core/ValueProvider.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/ValueProvider.java
@@ -16,7 +16,6 @@ package com.google.firebase.database.core;
 
 import com.google.firebase.database.snapshot.ChildKey;
 import com.google.firebase.database.snapshot.Node;
-import java.util.ArrayList;
 
 /**
  * A ValueProvider defers the calculation of a Node's value until needed.
@@ -73,7 +72,7 @@ abstract class ValueProvider {
 
     @Override
     public Node node() {
-      return syncTree.calcCompleteEventCache(path, new ArrayList<>());
+      return syncTree.calcCompleteEventCache(path, null);
     }
   }
 }

--- a/firebase-database/src/main/java/com/google/firebase/database/core/WriteTree.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/WriteTree.java
@@ -184,20 +184,20 @@ public class WriteTree {
    * include hidden writes), attempt to calculate a complete snapshot for the given path
    */
   public Node calcCompleteEventCache(Path treePath, Node completeServerCache) {
-    return this.calcCompleteEventCache(treePath, completeServerCache, new ArrayList<Long>());
+    return this.calcCompleteEventCache(treePath, completeServerCache, null);
   }
 
   public Node calcCompleteEventCache(
-      Path treePath, Node completeServerCache, List<Long> writeIdsToExclude) {
-    return this.calcCompleteEventCache(treePath, completeServerCache, writeIdsToExclude, false);
+      Path treePath, Node completeServerCache, Predicate<Long> writeIdPred) {
+    return this.calcCompleteEventCache(treePath, completeServerCache, writeIdPred, false);
   }
 
   public Node calcCompleteEventCache(
       final Path treePath,
       Node completeServerCache,
-      final List<Long> writeIdsToExclude,
+      final Predicate<Long> writeIdPred,
       final boolean includeHiddenWrites) {
-    if (writeIdsToExclude.isEmpty() && !includeHiddenWrites) {
+    if (writeIdPred == null && !includeHiddenWrites) {
       Node shadowingNode = this.visibleWrites.getCompleteNode(treePath);
       if (shadowingNode != null) {
         return shadowingNode;
@@ -235,7 +235,7 @@ public class WriteTree {
                 @Override
                 public boolean evaluate(UserWriteRecord write) {
                   return (write.isVisible() || includeHiddenWrites)
-                      && !writeIdsToExclude.contains(write.getWriteId())
+                      && writeIdPred.evaluate(write.getWriteId())
                       && (write.getPath().contains(treePath) || treePath.contains(write.getPath()));
                 }
               };

--- a/firebase-database/src/main/java/com/google/firebase/database/core/WriteTreeRef.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/WriteTreeRef.java
@@ -14,13 +14,12 @@
 
 package com.google.firebase.database.core;
 
+import com.google.firebase.database.core.utilities.Predicate;
 import com.google.firebase.database.core.view.CacheNode;
 import com.google.firebase.database.snapshot.ChildKey;
 import com.google.firebase.database.snapshot.Index;
 import com.google.firebase.database.snapshot.NamedNode;
 import com.google.firebase.database.snapshot.Node;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * A WriteTreeRef wraps a WriteTree and a path, for convenient access to a particular subtree. All
@@ -54,17 +53,17 @@ public class WriteTreeRef {
    * writes. Note that customizing the returned node can lead to a more expensive calculation.
    */
   public Node calcCompleteEventCache(Node completeServerCache) {
-    return this.calcCompleteEventCache(completeServerCache, Collections.<Long>emptyList());
+    return this.calcCompleteEventCache(completeServerCache, null);
   }
 
-  public Node calcCompleteEventCache(Node completeServerCache, List<Long> writeIdsToExclude) {
-    return this.calcCompleteEventCache(completeServerCache, writeIdsToExclude, false);
+  public Node calcCompleteEventCache(Node completeServerCache, Predicate<Long> writeIdPred) {
+    return this.calcCompleteEventCache(completeServerCache, writeIdPred, false);
   }
 
   public Node calcCompleteEventCache(
-      Node completeServerCache, List<Long> writeIdsToExclude, boolean includeHiddenWrites) {
+      Node completeServerCache, Predicate<Long> writeIdPred, boolean includeHiddenWrites) {
     return this.writeTree.calcCompleteEventCache(
-        this.treePath, completeServerCache, writeIdsToExclude, includeHiddenWrites);
+        this.treePath, completeServerCache, writeIdPred, includeHiddenWrites);
   }
 
   /**


### PR DESCRIPTION
Having the ability to pass a predicate to exclude write ids will be useful for transactions (https://github.com/firebase/firebase-android-sdk/pull/2480), where we want to say "exclude all pending writes with id > N." This avoids a larger refactor where we copy a bunch of functions in SyncTree to accomodate that use-case.