### PR TITLE
Handle exception when registering too many receivers in Crashlytics.

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/BatteryStateTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/BatteryStateTest.java
@@ -58,6 +58,18 @@ public class BatteryStateTest extends CrashlyticsTestCase {
     assertEquals(1, state.getBatteryVelocity());
   }
 
+  public void testTooManyReceivers() {
+    Context mockContext = mock(Context.class);
+    when(mockContext.registerReceiver(isNull(), any()))
+        .thenThrow(new IllegalStateException("Too many receivers"));
+
+    BatteryState state = BatteryState.get(mockContext);
+
+    assertNull(state.getBatteryLevel());
+    assertFalse(state.isPowerConnected());
+    assertEquals(1, state.getBatteryVelocity());
+  }
+
   public void testEmptyIntent() {
     final Context mockContext = mock(Context.class);
     when(mockContext.registerReceiver(isNull(), any())).thenReturn(new Intent());

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/BatteryState.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/BatteryState.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.BatteryManager;
+import com.google.firebase.crashlytics.internal.Logger;
 
 /** A utility class representing the state of the battery. */
 class BatteryState {
@@ -66,11 +67,16 @@ class BatteryState {
     boolean powerConnected = false;
     Float level = null;
 
-    final IntentFilter ifilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
-    final Intent batteryStatusIntent = context.registerReceiver(null, ifilter);
-    if (batteryStatusIntent != null) {
-      powerConnected = isPowerConnected(batteryStatusIntent);
-      level = getLevel(batteryStatusIntent);
+    try {
+      final IntentFilter ifilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+      final Intent batteryStatusIntent = context.registerReceiver(/*receiver=*/ null, ifilter);
+      if (batteryStatusIntent != null) {
+        powerConnected = isPowerConnected(batteryStatusIntent);
+        level = getLevel(batteryStatusIntent);
+      }
+    } catch (IllegalStateException ex) {
+      // This happens on some devices when the app registers too many receivers.
+      Logger.getLogger().e("An error occurred getting battery state.", ex);
     }
 
     return new BatteryState(level, powerConnected);


### PR DESCRIPTION
Handle exception when registering too many receivers in Crashlytics. This happens when getting the battery state, and it only affects some devices and some versions of Android.

Tested by unit tests, and manually by fudging with the emulator.

Fixes #2171 