### PR TITLE
Cleanup the confusing log message

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -154,7 +154,6 @@ public class ConfigResolver {
     }
 
     // 4. Return null. Because Firebase Performance will read high-level Firebase flag in this case.
-    logger.debug("CollectionEnabled metadata key unknown or value not found in manifest.");
     return null;
   }
 


### PR DESCRIPTION
Remote the debugging log message as that does not serve any information to the developer or us.

This is a fix for the bug b/176250560.