### PR TITLE
Make the Crashlytics isEmulator check much more robust.

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -52,6 +52,7 @@ import java.util.regex.Pattern;
 public class CommonUtils {
 
   private static final String SHA1_INSTANCE = "SHA-1";
+  private static final String SDK = "sdk";
 
   public static final String SHARED_PREFS_NAME = "com.google.firebase.crashlytics";
   public static final String LEGACY_SHARED_PREFS_NAME = "com.crashlytics.prefs";
@@ -401,23 +402,7 @@ public class CommonUtils {
    */
   public static boolean isEmulator(Context context) {
     final String androidId = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
-    return androidId == null
-        || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
-        || Build.FINGERPRINT.startsWith("generic")
-        || Build.FINGERPRINT.startsWith("unknown")
-        || Build.HARDWARE.contains("goldfish")
-        || Build.HARDWARE.contains("ranchu")
-        || Build.MODEL.contains("google_sdk")
-        || Build.MODEL.contains("Emulator")
-        || Build.MODEL.contains("Android SDK built for x86")
-        || Build.MANUFACTURER.contains("Genymotion")
-        || Build.PRODUCT.contains("sdk_google")
-        || Build.PRODUCT.contains("google_sdk")
-        || Build.PRODUCT.contains("sdk")
-        || Build.PRODUCT.contains("sdk_x86")
-        || Build.PRODUCT.contains("vbox86p")
-        || Build.PRODUCT.contains("emulator")
-        || Build.PRODUCT.contains("simulator");
+    return Build.PRODUCT.contains(SDK) || androidId == null;
   }
 
   public static boolean isRooted(Context context) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -52,6 +52,8 @@ import java.util.regex.Pattern;
 public class CommonUtils {
 
   private static final String SHA1_INSTANCE = "SHA-1";
+  private static final String GOLDFISH = "goldfish";
+  private static final String RANCHU = "ranchu";
   private static final String SDK = "sdk";
 
   public static final String SHARED_PREFS_NAME = "com.google.firebase.crashlytics";
@@ -402,7 +404,10 @@ public class CommonUtils {
    */
   public static boolean isEmulator(Context context) {
     final String androidId = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
-    return Build.PRODUCT.contains(SDK) || androidId == null;
+    return Build.PRODUCT.contains(SDK)
+        || Build.HARDWARE.contains(GOLDFISH)
+        || Build.HARDWARE.contains(RANCHU)
+        || androidId == null;
   }
 
   public static boolean isRooted(Context context) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -33,6 +33,7 @@ import android.os.StatFs;
 import android.provider.Settings.Secure;
 import android.text.TextUtils;
 import com.google.firebase.crashlytics.internal.Logger;
+import com.google.firebase.crashlytics.internal.model.ImmutableList;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
@@ -52,8 +53,6 @@ import java.util.regex.Pattern;
 public class CommonUtils {
 
   private static final String SHA1_INSTANCE = "SHA-1";
-  private static final String GOOGLE_SDK = "google_sdk";
-  private static final String SDK = "sdk";
 
   public static final String SHARED_PREFS_NAME = "com.google.firebase.crashlytics";
   public static final String LEGACY_SHARED_PREFS_NAME = "com.crashlytics.prefs";
@@ -403,7 +402,23 @@ public class CommonUtils {
    */
   public static boolean isEmulator(Context context) {
     final String androidId = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
-    return SDK.equals(Build.PRODUCT) || GOOGLE_SDK.equals(Build.PRODUCT) || androidId == null;
+    return androidId == null
+        || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+        || Build.FINGERPRINT.startsWith("generic")
+        || Build.FINGERPRINT.startsWith("unknown")
+        || Build.HARDWARE.contains("goldfish")
+        || Build.HARDWARE.contains("ranchu")
+        || Build.MODEL.contains("google_sdk")
+        || Build.MODEL.contains("Emulator")
+        || Build.MODEL.contains("Android SDK built for x86")
+        || Build.MANUFACTURER.contains("Genymotion")
+        || Build.PRODUCT.contains("sdk_google")
+        || Build.PRODUCT.contains("google_sdk")
+        || Build.PRODUCT.contains("sdk")
+        || Build.PRODUCT.contains("sdk_x86")
+        || Build.PRODUCT.contains("vbox86p")
+        || Build.PRODUCT.contains("emulator")
+        || Build.PRODUCT.contains("simulator");
   }
 
   public static boolean isRooted(Context context) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -33,7 +33,6 @@ import android.os.StatFs;
 import android.provider.Settings.Secure;
 import android.text.TextUtils;
 import com.google.firebase.crashlytics.internal.Logger;
-import com.google.firebase.crashlytics.internal.model.ImmutableList;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;


### PR DESCRIPTION
Make the Crashlytics isEmulator check much more robust.

This is based on Flutter's isEmulator check for Android. This should also fix #2495.