### PR TITLE
Improve Fireperf SDK startup time.

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -50,11 +50,6 @@ public class PerfSession implements Parcelable {
     PerfSession session = new PerfSession(sessionId, new Clock());
     session.setGaugeAndEventCollectionEnabled(shouldCollectGaugesAndEvents());
 
-    AndroidLogger.getInstance()
-        .debug(
-            "Creating a new %s Session: %s",
-            session.isVerbose() ? "Verbose" : "Non Verbose", sessionId);
-
     return session;
   }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -20,7 +20,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.perf.config.ConfigResolver;
-import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.SessionVerbosity;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -101,7 +101,7 @@ public class TransportManager implements AppStateCallback {
   private FlgTransport flgTransport;
 
   private ExecutorService executorService;
-  private final ApplicationInfo.Builder applicationInfoBuilder;
+  private ApplicationInfo.Builder applicationInfoBuilder;
   private Context appContext;
   private ConfigResolver configResolver;
   private RateLimiter rateLimiter;
@@ -135,8 +135,6 @@ public class TransportManager implements AppStateCallback {
             /* keepAliveTime= */ 10,
             TimeUnit.SECONDS,
             new LinkedBlockingQueue<>());
-
-    this.applicationInfoBuilder = ApplicationInfo.newBuilder();
 
     cacheMap = new ConcurrentHashMap<>();
     cacheMap.put(KEY_AVAILABLE_TRACES_FOR_CACHING, MAX_TRACE_METRICS_CACHE_SIZE);
@@ -219,6 +217,7 @@ public class TransportManager implements AppStateCallback {
   private void finishInitialization() {
     appStateMonitor.registerForAppState(new WeakReference<>(instance));
 
+    applicationInfoBuilder = ApplicationInfo.newBuilder();
     applicationInfoBuilder
         .setGoogleAppId(firebaseApp.getOptions().getApplicationId())
         .setAndroidAppInfo(


### PR DESCRIPTION
 - Removed console logging in `PerfSession.create()`, which reduces the startup time by 15 ms (~25% of total startup time)
   - Side effect: There will no logging for logging verbose/non-verbose session. However, the logging provides little value to developers and developers can easily add logging by themselves.
 - Delay the initialization of `applicationInfoBuilder`, which reduces the startup time by 8 ms (~20% of total startup time)
   - Side effect: None 