### PR TITLE
Cleaning up unnecessary use of "@hide annotations" (b/177448055)

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
@@ -38,7 +38,6 @@ import java.util.List;
  *
  * @hide
  */
-/** @hide */
 @Keep
 public class FirebasePerfRegistrar implements ComponentRegistrar {
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -266,7 +266,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
    *     collection enablement
    * @hide
    */
-  /** @hide */
   public synchronized void setPerformanceCollectionEnabled(@Nullable Boolean enable) {
     // If FirebaseApp is not initialized, Firebase Performance API is not effective yet.
     try {
@@ -328,7 +327,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
    * @hide
    */
   @Override
-  /** @hide */
   public void putAttribute(@NonNull String attribute, @NonNull String value) {
     boolean noError = true;
     try {
@@ -371,7 +369,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
    * @hide
    */
   @Override
-  /** @hide */
   public void removeAttribute(@NonNull String attribute) {
     mCustomAttributes.remove(attribute);
   }
@@ -385,7 +382,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
    */
   @Override
   @Nullable
-  /** @hide */
   public String getAttribute(@NonNull String attribute) {
     return mCustomAttributes.get(attribute);
   }
@@ -398,7 +394,6 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
    */
   @Override
   @NonNull
-  /** @hide */
   public Map<String, String> getAttributes() {
     return new HashMap<>(mCustomAttributes);
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformanceAttributable.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformanceAttributable.java
@@ -25,7 +25,6 @@ import java.util.Map;
  *
  * @hide
  */
-/** @hide */
 public interface FirebasePerformanceAttributable {
 
   // Redefining some constants for javadoc as Constants class is hidden

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -423,7 +423,6 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   }
 
   /** An interface to be implemented by subscribers which needs to receive app state update. */
-  /** An interface to be implemented by clients which needs to receive app state update. */
   public static interface AppStateCallback {
     public void onUpdateAppState(ApplicationProcessState newState);
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -45,13 +45,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * Trace timer implementation to send foreground and background session log.
- *
- * @hide
- */
-
-/** @hide */
+/** Trace timer implementation to send foreground and background session log. */
 public class AppStateMonitor implements ActivityLifecycleCallbacks {
 
   private static final AndroidLogger logger = AndroidLogger.getInstance();
@@ -125,8 +119,6 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     }
   }
 
-  /** @hide */
-  /** @hide */
   public void incrementCount(@NonNull String name, long value) {
     // This method is called by RateLimiter.java when a log exceeds rate limit and to be dropped
     // It can be on any thread. sendSessionLog() method is called in callback methods from main UI
@@ -141,24 +133,16 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     }
   }
 
-  /** @hide */
-  /** @hide */
   public void incrementTsnsCount(int value) {
     mTsnsCount.addAndGet(value);
   }
 
-  /** @hide */
-  /** @hide */
   @Override
   public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
 
-  /** @hide */
-  /** @hide */
   @Override
   public void onActivityDestroyed(Activity activity) {}
 
-  /** @hide */
-  /** @hide */
   @Override
   public synchronized void onActivityStarted(Activity activity) {
     if (isScreenTraceSupported(activity) && mConfigResolver.isPerformanceMonitoringEnabled()) {
@@ -171,8 +155,6 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     }
   }
 
-  /** @hide */
-  /** @hide */
   @Override
   public synchronized void onActivityStopped(Activity activity) {
     if (isScreenTraceSupported(activity)) {
@@ -192,8 +174,6 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     }
   }
 
-  /** @hide */
-  /** @hide */
   @Override
   public synchronized void onActivityResumed(Activity activity) {
     // cases:
@@ -224,11 +204,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     return mIsColdStart;
   }
 
-  /**
-   * @return current app state.
-   * @hide
-   */
-  /** @hide */
+  /** @return current app state. */
   public ApplicationProcessState getAppState() {
     return mCurrentState;
   }
@@ -237,9 +213,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
    * Register a client to receive app state update.
    *
    * @param client an AppStateCallback instance.
-   * @hide
    */
-  /** @hide */
   public void registerForAppState(WeakReference<AppStateCallback> client) {
     synchronized (mClients) {
       mClients.add(client);
@@ -250,9 +224,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
    * Unregister the client to stop receiving app state update.
    *
    * @param client an AppStateCallback instance.
-   * @hide
    */
-  /** @hide */
   public void unregisterForAppState(WeakReference<AppStateCallback> client) {
     synchronized (mClients) {
       mClients.remove(client);
@@ -424,15 +396,8 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     }
   }
 
-  /**
-   * An interface to be implemented by clients which needs to receive app state update.
-   *
-   * @hide
-   */
-  /** @hide */
+  /** An interface to be implemented by clients which needs to receive app state update. */
   public static interface AppStateCallback {
-    /** @hide */
-    /** @hide */
     public void onUpdateAppState(ApplicationProcessState newState);
   }
 
@@ -441,9 +406,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
    *
    * @param activity activity object.
    * @return screen trace name.
-   * @hide
    */
-  /** @hide */
   public static String getScreenTraceName(Activity activity) {
     return Constants.SCREEN_TRACE_PREFIX + activity.getClass().getSimpleName();
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateUpdateHandler.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateUpdateHandler.java
@@ -22,10 +22,7 @@ import java.lang.ref.WeakReference;
 /**
  * A client that can be registered with AppStateMonitor class to receive foreground/background app
  * state update.
- *
- * @hide
  */
-/** @hide */
 public abstract class AppStateUpdateHandler implements AppStateCallback {
 
   private AppStateMonitor mAppStateMonitor;
@@ -38,21 +35,15 @@ public abstract class AppStateUpdateHandler implements AppStateCallback {
   // the registration in AppStateMonitor will prevent Trace to be deallocated.
   private WeakReference<AppStateCallback> mWeakRef;
 
-  /** @hide */
-  /** @hide */
   protected AppStateUpdateHandler() {
     this(AppStateMonitor.getInstance());
   }
 
-  /** @hide */
-  /** @hide */
   protected AppStateUpdateHandler(@NonNull AppStateMonitor appStateMonitor) {
     mAppStateMonitor = appStateMonitor;
     mWeakRef = new WeakReference<AppStateCallback>(this);
   }
 
-  /** @hide */
-  /** @hide */
   protected void registerForAppState() {
     if (mIsRegisteredForAppState) {
       return;
@@ -62,8 +53,6 @@ public abstract class AppStateUpdateHandler implements AppStateCallback {
     mIsRegisteredForAppState = true;
   }
 
-  /** @hide */
-  /** @hide */
   protected void unregisterForAppState() {
     if (!mIsRegisteredForAppState) {
       return;
@@ -72,14 +61,21 @@ public abstract class AppStateUpdateHandler implements AppStateCallback {
     mIsRegisteredForAppState = false;
   }
 
-  /** @hide */
-  /** @hide */
   protected void incrementTsnsCount(int count) {
     mAppStateMonitor.incrementTsnsCount(count);
   }
 
-  /** @hide */
-  /** @hide */
+  /**
+   * Reason: HIDE_ANNOTATION_REQUIRED_IN_CHILD_CLASS
+   *
+   * <p>Hide annotation is needed here even if the entire package (containing this class) is hidden.
+   * This is because this class is extended by a Public API class and thus any public methods in
+   * this class would then become a part of the Public API transitively. Adding the hide annotation
+   * to the class level does not work either and it has to be added to the concerned public method
+   * specifically.
+   *
+   * @hide
+   */
   @Override
   public void onUpdateAppState(ApplicationProcessState newState) {
     // For Trace and NetworkRequestMetricBuilder, the app state means all app states the app
@@ -94,8 +90,11 @@ public abstract class AppStateUpdateHandler implements AppStateCallback {
     }
   }
 
-  /** @hide */
-  /** @hide */
+  /**
+   * Reason: HIDE_ANNOTATION_REQUIRED_IN_CHILD_CLASS
+   *
+   * @hide
+   */
   public ApplicationProcessState getAppState() {
     return mState;
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/package-info.java
@@ -13,5 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-/** @hide */
 package com.google.firebase.perf.application;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -48,10 +48,7 @@ import com.google.firebase.perf.util.Utils;
  * Retrieves configuration value from various config storage sources and returns resolved
  * configuration value to the caller. This class is the single source of truth for all
  * configurations across Firebase Performance.
- *
- * @hide
  */
-/** @hide */
 public class ConfigResolver {
 
   private static final AndroidLogger logger = AndroidLogger.getInstance();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
@@ -20,12 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Stores all configuration flag names and their constant values.
- *
- * @hide
- */
-/** @hide */
+/** Stores all configuration flag names and their constant values. */
 final class ConfigurationConstants {
 
   protected static final class CollectionDeactivated extends ConfigurationFlag<Boolean> {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationFlag.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationFlag.java
@@ -19,10 +19,7 @@ import androidx.annotation.Nullable;
 /**
  * Parent class to be extended for each configuration flag. Provides basic constant fields and
  * common methods for all flags.
- *
- * @hide
  */
-/** @hide */
 abstract class ConfigurationFlag<T> {
 
   ConfigurationFlag() {}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java
@@ -28,10 +28,7 @@ import java.util.concurrent.Executors;
 /**
  * Utilizes platform supported APIs for storing and retrieving Firebase Performance related
  * configurations.
- *
- * @hide
  */
-/** @hide */
 @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
 public class DeviceCacheManager {
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -38,10 +38,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>The source of Remote config is currently Firebase Remote Config. Read more at
  * go/fireperf-remote-config-android.
- *
- * @hide
  */
-/** @hide */
 @Keep // Needed because of b/117526359.
 public class RemoteConfigManager {
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/package-info.java
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-package com.google.firebase.perf.metrics.resource;
+package com.google.firebase.perf.config;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/components/FirebasePerformanceComponent.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/components/FirebasePerformanceComponent.java
@@ -20,11 +20,7 @@ import com.google.firebase.perf.injection.modules.FirebasePerformanceModule;
 import dagger.Component;
 import javax.inject.Singleton;
 
-/**
- * Dagger component to create FirebasePerformanceComponent Objects.
- *
- * @hide
- */
+/** Dagger component to create FirebasePerformanceComponent Objects. */
 @Component(modules = {FirebasePerformanceModule.class})
 @Singleton
 public interface FirebasePerformanceComponent {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/components/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/components/package-info.java
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-package com.google.firebase.perf.metrics.resource;
+package com.google.firebase.perf.injection.components;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/FirebasePerformanceModule.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/FirebasePerformanceModule.java
@@ -27,11 +27,7 @@ import com.google.firebase.remoteconfig.RemoteConfigComponent;
 import dagger.Module;
 import dagger.Provides;
 
-/**
- * Provider for {@link FirebasePerformance}.
- *
- * @hide
- */
+/** Provider for {@link FirebasePerformance}. */
 @Module
 public class FirebasePerformanceModule {
   private final FirebaseApp firebaseApp;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/injection/modules/package-info.java
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-package com.google.firebase.perf.metrics.resource;
+package com.google.firebase.perf.injection.modules;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/AndroidLogger.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/AndroidLogger.java
@@ -17,12 +17,7 @@ package com.google.firebase.perf.logging;
 import androidx.annotation.VisibleForTesting;
 import java.util.Locale;
 
-/**
- * Firebase Performance logger that writes to logcat.
- *
- * @hide
- */
-/** @hide */
+/** Firebase Performance logger that writes to logcat. */
 public class AndroidLogger {
 
   private static volatile AndroidLogger instance;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/LogWrapper.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/LogWrapper.java
@@ -16,12 +16,7 @@ package com.google.firebase.perf.logging;
 
 import android.util.Log;
 
-/**
- * Wrapper that handles Android logcat logging.
- *
- * @hide
- */
-/** @hide */
+/** Wrapper that handles Android logcat logging. */
 class LogWrapper {
 
   private static final String LOG_TAG = "FirebasePerformance";

--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/package-info.java
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-package com.google.firebase.perf.metrics.resource;
+package com.google.firebase.perf.logging;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -51,7 +51,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @hide
  */
-/** @hide */
 public class AppStartTrace implements ActivityLifecycleCallbacks {
   private static final long MAX_LATENCY_BEFORE_UI_INIT = TimeUnit.MINUTES.toMicros(1);
   private static volatile AppStartTrace sInstance;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Counter.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Counter.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @hide
  */
-/** @hide */
 public class Counter implements Parcelable {
   private final String mName;
   private AtomicLong mCount;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/HttpMetric.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/HttpMetric.java
@@ -50,7 +50,6 @@ public class HttpMetric implements FirebasePerformanceAttributable {
    *
    * @hide
    */
-  /** @hide */
   public HttpMetric(
       String url, @HttpMethod String httpMethod, TransportManager transportManager, Timer timer) {
     mAttributes = new ConcurrentHashMap<>();
@@ -71,7 +70,6 @@ public class HttpMetric implements FirebasePerformanceAttributable {
    *
    * @hide
    */
-  /** @hide */
   public HttpMetric(
       URL url, @HttpMethod String httpMethod, TransportManager transportManager, Timer timer) {
     this(url.toString(), httpMethod, transportManager, timer);
@@ -124,7 +122,6 @@ public class HttpMetric implements FirebasePerformanceAttributable {
    *
    * @hide
    */
-  /** @hide */
   public void markRequestComplete() {
     mMetricBuilder.setTimeToRequestCompletedMicros(mTimer.getDurationMicros());
   }
@@ -134,7 +131,6 @@ public class HttpMetric implements FirebasePerformanceAttributable {
    *
    * @hide
    */
-  /** @hide */
   public void markResponseStart() {
     mMetricBuilder.setTimeToResponseInitiatedMicros(mTimer.getDurationMicros());
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/NetworkRequestMetricBuilder.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/NetworkRequestMetricBuilder.java
@@ -46,8 +46,6 @@ import java.util.Map;
  *
  * @hide
  */
-
-/** @hide */
 public final class NetworkRequestMetricBuilder extends AppStateUpdateHandler
     implements SessionAwareObject {
 
@@ -71,9 +69,7 @@ public final class NetworkRequestMetricBuilder extends AppStateUpdateHandler
 
   private final WeakReference<SessionAwareObject> weakReference = new WeakReference<>(this);
 
-  /** @hide */
   @Override
-  /** @hide */
   public void updateSession(PerfSession session) {
     // Note(b/152218504): Being defensive to fix the NPE
     if (session == null) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
@@ -70,7 +70,6 @@ public class Trace extends AppStateUpdateHandler
 
   /** @hide */
   @Override
-  /** @hide */
   public void updateSession(PerfSession session) {
     // Note(b/152218504): Being defensive to fix the NPE
     if (session == null) {
@@ -89,7 +88,6 @@ public class Trace extends AppStateUpdateHandler
    * @param name name of the trace object
    * @hide
    */
-  /** @hide */
   @NonNull
   public static Trace create(@NonNull String name) {
     // Make a copy of input name so it does not hold onto the reference which is thread-safer.
@@ -117,7 +115,6 @@ public class Trace extends AppStateUpdateHandler
    * @param attributes The map of custom attributes
    * @hide
    */
-  /** @hide */
   private Trace(
       @NonNull Trace parent,
       @NonNull String name,
@@ -145,7 +142,6 @@ public class Trace extends AppStateUpdateHandler
    *
    * @hide
    */
-  /** @hide */
   public Trace(
       @NonNull String name,
       @NonNull TransportManager transportManager,
@@ -160,7 +156,6 @@ public class Trace extends AppStateUpdateHandler
    *
    * @hide
    */
-  /** @hide */
   public Trace(
       @NonNull String name,
       @NonNull TransportManager transportManager,
@@ -293,7 +288,6 @@ public class Trace extends AppStateUpdateHandler
    * @param name Name to be given to the stage.
    * @hide
    */
-  /** @hide */
   void startStage(@NonNull String name) {
     Timer currentTime = clock.getTime();
     setEndTimeOfLastStage(currentTime);
@@ -305,7 +299,6 @@ public class Trace extends AppStateUpdateHandler
    *
    * @hide
    */
-  /** @hide */
   void stopStage() {
     setEndTimeOfLastStage(clock.getTime());
   }
@@ -418,7 +411,6 @@ public class Trace extends AppStateUpdateHandler
    * @return The instance of the {@link Trace}.
    * @hide
    */
-  /** @hide */
   @NonNull
   static synchronized Trace getTrace(@NonNull String traceName) {
     Trace trace = sTraces.get(traceName);
@@ -429,7 +421,6 @@ public class Trace extends AppStateUpdateHandler
     return trace;
   }
 
-  /** @hide */
   /** @hide */
   @VisibleForTesting
   @NonNull
@@ -456,7 +447,6 @@ public class Trace extends AppStateUpdateHandler
    * @return The instance of the {@link Trace} started.
    * @hide
    */
-  /** @hide */
   @Nullable
   static Trace startTrace(@NonNull String traceName) {
     Trace trace = sTraces.get(traceName);
@@ -475,7 +465,6 @@ public class Trace extends AppStateUpdateHandler
    * @return The instance of the {@link Trace} stopped.
    * @hide
    */
-  /** @hide */
   @Nullable
   static Trace stopTrace(@NonNull String traceName) {
     Trace trace = sTraces.get(traceName);
@@ -491,7 +480,6 @@ public class Trace extends AppStateUpdateHandler
    *
    * @hide
    */
-  /** @hide */
   @Override
   protected void finalize() throws Throwable {
     try {
@@ -506,14 +494,12 @@ public class Trace extends AppStateUpdateHandler
   }
 
   /** @hide */
-  /** @hide */
   @VisibleForTesting
   @NonNull
   String getName() {
     return name;
   }
 
-  /** @hide */
   /** @hide */
   @VisibleForTesting
   @NonNull
@@ -522,20 +508,17 @@ public class Trace extends AppStateUpdateHandler
   }
 
   /** @hide */
-  /** @hide */
   @VisibleForTesting
   Timer getStartTime() {
     return startTime;
   }
 
   /** @hide */
-  /** @hide */
   @VisibleForTesting
   Timer getEndTime() {
     return endTime;
   }
 
-  /** @hide */
   /** @hide */
   @VisibleForTesting
   @NonNull
@@ -549,7 +532,6 @@ public class Trace extends AppStateUpdateHandler
    * @return true if trace is stopped. false if not stopped.
    * @hide
    */
-  /** @hide */
   @VisibleForTesting
   boolean isStopped() {
     return endTime != null;
@@ -561,7 +543,6 @@ public class Trace extends AppStateUpdateHandler
    * @return true if trace has started, false if it has not started
    * @hide
    */
-  /** @hide */
   @VisibleForTesting
   boolean hasStarted() {
     return startTime != null;
@@ -573,7 +554,6 @@ public class Trace extends AppStateUpdateHandler
    * @return true if trace has been started but not stopped.
    * @hide
    */
-  /** @hide */
   @VisibleForTesting
   boolean isActive() {
     return hasStarted() && !isStopped();
@@ -717,7 +697,6 @@ public class Trace extends AppStateUpdateHandler
   }
 
   /** @hide */
-  /** @hide */
   @VisibleForTesting
   static final Parcelable.Creator<Trace> CREATOR_DATAONLY =
       new Parcelable.Creator<Trace>() {
@@ -730,7 +709,6 @@ public class Trace extends AppStateUpdateHandler
         }
       };
 
-  /** @hide */
   /** @hide */
   @VisibleForTesting
   List<PerfSession> getSessions() {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/TraceMetricBuilder.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/TraceMetricBuilder.java
@@ -26,7 +26,6 @@ import java.util.Map;
  *
  * @hide
  */
-/** @hide */
 class TraceMetricBuilder {
   private final Trace mTrace;
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/resource/ResourceType.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/resource/ResourceType.java
@@ -21,7 +21,6 @@ import java.lang.annotation.RetentionPolicy;
 /** Annotates various resource types in Firebase Performance. */
 @StringDef({ResourceType.TRACE, ResourceType.NETWORK})
 @Retention(RetentionPolicy.RUNTIME)
-/** @hide */
 public @interface ResourceType {
   String TRACE = "Trace";
   String NETWORK = "Network";

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/validator/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/validator/package-info.java
@@ -13,6 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-/** @hide */
 package com.google.firebase.perf.metrics.validator;
-

--- a/firebase-perf/src/main/java/com/google/firebase/perf/network/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/network/package-info.java
@@ -13,6 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-/** @hide */
 package com.google.firebase.perf.network;
-

--- a/firebase-perf/src/main/java/com/google/firebase/perf/provider/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/provider/package-info.java
@@ -13,6 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-/** @hide */
 package com.google.firebase.perf.provider;
-

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/PerfSession.java
@@ -28,12 +28,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Details of a session including a unique Id and related information.
- *
- * @hide
- */
-/** @hide */
+/** Details of a session including a unique Id and related information. */
 public class PerfSession implements Parcelable {
 
   private String mSessionId;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionAwareObject.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionAwareObject.java
@@ -18,17 +18,13 @@ package com.google.firebase.perf.session;
  * Any object that cares about changes in the {@link com.google.firebase.perf.session.PerfSession}
  * that is active for the given app. This object is then registered with the {@link SessionManager}
  * which then supplies it with updates as needed.
- *
- * @hide
  */
-/** @hide */
 public interface SessionAwareObject {
 
   /**
    * Updates the SessionAwareObject with the new sessionId.
    *
    * @param session The new PerfSession.
-   * @hide
    */
   void updateSession(PerfSession session);
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/SessionManager.java
@@ -28,12 +28,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-/**
- * Session manager to generate sessionIDs and broadcast to the application.
- *
- * @hide
- */
-/** @hide */
+/** Session manager to generate sessionIDs and broadcast to the application. */
 @Keep // Needed because of b/117526359.
 public class SessionManager extends AppStateUpdateHandler {
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/CpuGaugeCollector.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/CpuGaugeCollector.java
@@ -40,10 +40,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>The class methods are not generally thread safe, but it is thread safe to read and write to
  * the ConcurrentLinkedQueue.
- *
- * @hide
  */
-/** @hide */
 public class CpuGaugeCollector {
 
   private static final AndroidLogger logger = AndroidLogger.getInstance();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
@@ -37,11 +37,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * This class is responsible for orchestrating different Gauges like CPU and Memory, collating that
  * information and logging it to the Transport.
- *
- * @hide
  */
-
-/** @hide */
 @Keep // Needed because of b/117526359.
 public class GaugeManager {
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/MemoryGaugeCollector.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/MemoryGaugeCollector.java
@@ -35,10 +35,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>The class methods are not generally thread safe, but it is thread safe to read and write to
  * the ConcurrentLinkedQueue.
- *
- * @hide
  */
-/** @hide */
 public class MemoryGaugeCollector {
 
   private static final AndroidLogger logger = AndroidLogger.getInstance();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/package-info.java
@@ -13,6 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-/** @hide */
 package com.google.firebase.perf.session.gauges;
-

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/package-info.java
@@ -13,6 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-/** @hide */
 package com.google.firebase.perf.session;
-

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -78,11 +78,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>TODO(b/172008005): Implement a Callback functionality for the caller/subscriber to know
  * whether the log was actually dispatched or not.
- *
- * @hide
  */
-
-/** @hide */
 public class TransportManager implements AppStateCallback {
 
   private static final AndroidLogger logger = AndroidLogger.getInstance();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/package-info.java
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 /** @hide */
-package com.google.firebase.perf.metrics.resource;
+package com.google.firebase.perf.transport;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/ImmutableBundle.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/ImmutableBundle.java
@@ -21,10 +21,7 @@ import com.google.firebase.perf.logging.AndroidLogger;
  * An immutable, thread safe wrapper around @{link android.os.Bundle} that only exposes get methods.
  * This assumes that the keys and values themselves are immutable and so it only performs a shallow
  * copy of the bundle.
- *
- * @hide
  */
-/** @hide */
 public final class ImmutableBundle {
 
   private static final AndroidLogger logger = AndroidLogger.getInstance();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/StorageUnit.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/StorageUnit.java
@@ -21,10 +21,7 @@ package com.google.firebase.perf.util;
  * <p>Similar to {@link java.util.concurrent.TimeUnit}, but for storage quantities.
  *
  * <p>Reference: {@link com.google.android.libraries.stitch.util.StorageUnit}
- *
- * @hide
  */
-/** @hide */
 public enum StorageUnit {
   TERABYTES(1024L * 1024L * 1024L * 1024L) {
     @Override

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Utils.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Utils.java
@@ -94,11 +94,7 @@ public class Utils {
     return ret;
   }
 
-  /**
-   * @return true if logcat is enabled via AndroidManifest meta data flag, false otherwise
-   * @hide
-   */
-  /** @hide */
+  /** @return true if logcat is enabled via AndroidManifest meta data flag, false otherwise */
   public static boolean isDebugLoggingEnabled(@NonNull Context context) {
     if (mIsDebugLoggingEnabled != null) {
       return mIsDebugLoggingEnabled;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/package-info.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/package-info.java
@@ -13,6 +13,5 @@
 // limitations under the License.
 
 /** @hide */
-/** @hide */
 package com.google.firebase.perf.util;
 


### PR DESCRIPTION
## Few Points:

* We should be using `@hide` javadoc annotation to hide certain packages/classes/methods (_which are declared public_) to be considered a part of public API.

* Double use of `@hide` javadoc annotation is not required. This was a requirement with GmsCore (go/gmscore-hide-annotation-lsc). Also that second annotation was `@Hide` Java annotation (_which is a GmsCore annotation_) and not `@hide` javadoc annotation (_which is a general javadoc annotation_) which seems like happened during code migration to GitHub.

* This annotation should only be used in public classes/methods.

* Adding this annotation to the **method** will hide that method.

* Adding this annotation to the **class level** will hide the entire class and its public methods.

* Adding this annotation to the **package** declaration in the`package-info.java` class makes the entire classes within that package to be hidden. Note that this does not work transitively for child packages and so each child package would also need there own `package-info.java` class.

* There's no way currently to not hide some of the classes/methods when the entire package is marked hidden. So in that case where a package contains some classes/methods which has to be public than we have to apply this annotation class/method wise. 

## What does `hiding` means?
 - No javadoc will be generated for that package/class/method
 - api.txt won't get updated for that package/class/method

## FAQs

 - Does this PR trigger any public api change?
   No, I have already validated everything by running the below command and no change was detected (_**caveat:** sometimes you have to touch the `api.txt` file to trigger the run_).

  ```
  firebase-android-sdk$./gradlew firebase-perf:generateApiTxtFile
  ```


WANT_LGTM = @vkryachko 