### PR TITLE
Disable desugaring.

### DIFF
--- a/alternative-root-project.gradle
+++ b/alternative-root-project.gradle
@@ -37,7 +37,6 @@ buildscript {
         classpath 'org.jsoup:jsoup:1.11.2'
         classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.8'
         classpath 'com.google.gms:google-services:4.3.0'
-        classpath 'me.tatarka:gradle-retrolambda:3.7.1'
         classpath 'digital.wup:android-maven-publish:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:7.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ buildscript {
         classpath 'org.jsoup:jsoup:1.13.1'
         classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.9'
         classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'me.tatarka:gradle-retrolambda:3.7.1'
         classpath 'digital.wup:android-maven-publish:3.6.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.2.1'
@@ -106,10 +105,7 @@ configure(subprojects) {
 
 
 /**
- * Configure "Preguarding" and Desugaring for the subprojects.
- *
- * <p>Desugaring is enabled with the 'me.tatarka:gradle-retrolambda' plugin as the built-in Android
- * desugaring is not supported for libraries.
+ * Configure "Preguarding" for the subprojects.
  *
  * <p> The way it works is every library subproject that has the android plugin applied and:
  *
@@ -127,9 +123,6 @@ configure(subprojects) {
         if (sub.plugins.findPlugin('com.android.library') == null) {
             return
         }
-
-        // Apply the retrolambda plugin
-        sub.apply plugin: 'me.tatarka.retrolambda'
 
         boolean skipPreguard = sub.getProperties().getOrDefault('firebaseSkipPreguard', 'true').toBoolean()
         def defaultPreguard = rootProject.getProperties().getOrDefault('firebaseDefaultPreguardFile', 'default-preguard.txt')

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -50,6 +50,11 @@ android {
     }
   }
 
+  compileOptions {
+    sourceCompatibility 1.8
+    targetCompatibility 1.8
+  }
+
   if (project.hasProperty("testBuildType")) {
     testBuildType project.getProperty("testBuildType")
   }


### PR DESCRIPTION
Going forward Firebase SDKs will ship Java 8 bytecode.

Safe to merge now, since this is happening in the next release.