### PR TITLE
Fix personalization test and add check for optionalProvider.

### DIFF
--- a/firebase-config/firebase-config.gradle
+++ b/firebase-config/firebase-config.gradle
@@ -64,6 +64,7 @@ dependencies {
 
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'com.google.truth:truth:0.44'
+    testImplementation 'androidx.test.ext:truth:1.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "org.skyscreamer:jsonassert:1.5.0"


### PR DESCRIPTION
The personalization test was using the default namespace, and because another instance of config already existed in that namespace, the test instance was not being created. This caused the personalization test to try to use real objects instead of the mocks, including the direct executor. This PR fixes this and uses a provider to fake the interaction when Analytics is present and when it's not.