### PR TITLE
Add a tools:remove rule to the discovery service definition.

### DIFF
--- a/firebase-common/src/main/AndroidManifest.xml
+++ b/firebase-common/src/main/AndroidManifest.xml
@@ -30,11 +30,6 @@
             android:name="com.google.firebase.components.ComponentDiscoveryService"
             android:directBootAware="true"
             android:exported="false"
-            tools:targetApi="n">
-            <!--This registrar is not defined in the dynamic-module-support sdk itself to allow non-firebase
-                clients to use it as well, by defining this registrar in their own core/common library.-->
-            <meta-data android:name="com.google.firebase.components:com.google.firebase.dynamicloading.DynamicLoadingRegistrar"
-              android:value="com.google.firebase.components.ComponentRegistrar" />
-        </service>
+            tools:targetApi="n" />
     </application>
 </manifest>

--- a/firebase-components/firebase-dynamic-module-support/src/main/AndroidManifest.xml
+++ b/firebase-components/firebase-dynamic-module-support/src/main/AndroidManifest.xml
@@ -18,4 +18,16 @@
     package="com.google.firebase.dynamicloading">
     <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
     <!--<uses-sdk android:minSdkVersion="14"/>-->
+
+  <application>
+    <service
+      android:name="com.google.firebase.components.ComponentDiscoveryService"
+      android:exported="false"
+      tools:remove="android:splitName">
+      <!-- The above splitName removal is necessary to avoid manifest merge conflicts
+           when more than one dynamic-feature module depends on Firebase libraries. -->
+        <meta-data android:name="com.google.firebase.components:com.google.firebase.dynamicloading.DynamicLoadingRegistrar"
+          android:value="com.google.firebase.components.ComponentRegistrar" />
+    </service>
+  </application>
 </manifest>


### PR DESCRIPTION
The removal is needed to satisfy the manifest merger when it merges
manifests across dynamic feature modules into the base app.

Since each Firebase SDK has a discovery service definition in its
manifest, placing them into a dynamic feature adds
`android:splitName="featureName"` to the discovery service. Subsequent
merge into the main app manifest causes a conflict since the splitName
is different in each feature.

Note that this change is also moving the dynamic module support
registrar definition to `firebase-dynamic-module-support` since having
an `android:remove` in `firebase-common` produces a warning when the app
does not use dynamic feature modules. To avoid this warning, the
manifest entry will now live in the dynamic module support sdk, since
it's only expected to be used if the host app uses dynamic features.

http://b/184263558