### PR TITLE
androidx support: Update Picasso

### DIFF
--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
 
-    implementation "com.squareup.picasso:picasso:2.71828"
+    implementation "com.squareup.picasso:picasso:2.8"
     implementation "com.squareup.okhttp:okhttp:2.7.5"
 
     vendor ('com.google.dagger:dagger:2.27') {


### PR DESCRIPTION
## What
* Update picasso to latest version

## Why
* Current version of picasso depends on `com.android.support:support-annotations:27.1.0` and `com.android.support:exifinterface:27.1.0`. This is blocking removing jetifier