### PR TITLE
 Disable fetching of Firebase Installation Id when data collection is disabled

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/ProviderProxyNativeComponentTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/ProviderProxyNativeComponentTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import androidx.test.runner.AndroidJUnit4;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CLSUUIDTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CLSUUIDTest.java
@@ -30,7 +30,12 @@ public class CLSUUIDTest extends CrashlyticsTestCase {
     super.setUp();
     FirebaseInstallationsApi installationsApiMock = mock(FirebaseInstallationsApi.class);
     when(installationsApiMock.getId()).thenReturn(Tasks.forResult("instanceId"));
-    idManager = new IdManager(getContext(), getContext().getPackageName(), installationsApiMock);
+    idManager =
+        new IdManager(
+            getContext(),
+            getContext().getPackageName(),
+            installationsApiMock,
+            DataCollectionArbiterTest.createMockDataCollectionArbiter(true));
     uuid = new CLSUUID(idManager);
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CLSUUIDTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CLSUUIDTest.java
@@ -35,7 +35,7 @@ public class CLSUUIDTest extends CrashlyticsTestCase {
             getContext(),
             getContext().getPackageName(),
             installationsApiMock,
-            DataCollectionArbiterTest.createMockDataCollectionArbiter(true));
+            DataCollectionArbiterTest.MOCK_ARBITER_ENABLED);
     uuid = new CLSUUID(idManager);
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -67,7 +67,7 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
             testContext,
             testContext.getPackageName(),
             installationsApiMock,
-            DataCollectionArbiterTest.createMockDataCollectionArbiter(true));
+            DataCollectionArbiterTest.MOCK_ARBITER_ENABLED);
 
     // For each test case, create a new, random subdirectory to guarantee a clean slate for file
     // manipulation.

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -62,7 +62,12 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
 
     FirebaseInstallationsApi installationsApiMock = mock(FirebaseInstallationsApi.class);
     when(installationsApiMock.getId()).thenReturn(Tasks.forResult("instanceId"));
-    idManager = new IdManager(testContext, testContext.getPackageName(), installationsApiMock);
+    idManager =
+        new IdManager(
+            testContext,
+            testContext.getPackageName(),
+            installationsApiMock,
+            DataCollectionArbiterTest.createMockDataCollectionArbiter(true));
 
     // For each test case, create a new, random subdirectory to guarantee a clean slate for file
     // manipulation.

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -97,7 +97,12 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
 
       FirebaseInstallationsApi installationsApiMock = mock(FirebaseInstallationsApi.class);
       when(installationsApiMock.getId()).thenReturn(Tasks.forResult("instanceId"));
-      idManager = new IdManager(context, context.getPackageName(), installationsApiMock);
+      idManager =
+          new IdManager(
+              context,
+              context.getPackageName(),
+              installationsApiMock,
+              DataCollectionArbiterTest.createMockDataCollectionArbiter(true));
 
       nativeComponent = new ProviderProxyNativeComponent(() -> null);
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -102,7 +102,7 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
               context,
               context.getPackageName(),
               installationsApiMock,
-              DataCollectionArbiterTest.createMockDataCollectionArbiter(true));
+              DataCollectionArbiterTest.MOCK_ARBITER_ENABLED);
 
       nativeComponent = new ProviderProxyNativeComponent(() -> null);
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -395,7 +395,11 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
       final CrashlyticsCore crashlyticsCore =
           new CrashlyticsCore(
               app,
-              new IdManager(context, "unused", installationsApiMock),
+              new IdManager(
+                  context,
+                  "unused",
+                  installationsApiMock,
+                  DataCollectionArbiterTest.createMockDataCollectionArbiter(true)),
               nativeComponent,
               arbiter,
               breadcrumbSource,

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -399,7 +399,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
                   context,
                   "unused",
                   installationsApiMock,
-                  DataCollectionArbiterTest.createMockDataCollectionArbiter(true)),
+                  DataCollectionArbiterTest.MOCK_ARBITER_ENABLED),
               nativeComponent,
               arbiter,
               breadcrumbSource,

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
@@ -64,7 +64,11 @@ public class CrashlyticsReportDataCaptureTest {
         .thenAnswer(i -> i.getArguments()[0]);
     final Context context = getContext();
     final IdManager idManager =
-        new IdManager(context, context.getPackageName(), installationsApiMock);
+        new IdManager(
+            context,
+            context.getPackageName(),
+            installationsApiMock,
+            DataCollectionArbiterTest.createMockDataCollectionArbiter(true));
     final AppData appData =
         AppData.create(context, idManager, "googleAppId", "buildId", unityVersionProvider);
     dataCapture =

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
@@ -68,7 +68,7 @@ public class CrashlyticsReportDataCaptureTest {
             context,
             context.getPackageName(),
             installationsApiMock,
-            DataCollectionArbiterTest.createMockDataCollectionArbiter(true));
+            DataCollectionArbiterTest.MOCK_ARBITER_ENABLED);
     final AppData appData =
         AppData.create(context, idManager, "googleAppId", "buildId", unityVersionProvider);
     dataCapture =

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiterTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiterTest.java
@@ -27,6 +27,12 @@ public class DataCollectionArbiterTest extends CrashlyticsTestCase {
 
   final String PREFS_NAME = CommonUtils.SHARED_PREFS_NAME;
 
+  public static DataCollectionArbiter createMockDataCollectionArbiter(boolean collectionEnabled) {
+    DataCollectionArbiter dca = mock(DataCollectionArbiter.class);
+    when(dca.isAutomaticDataCollectionEnabled()).thenReturn(collectionEnabled);
+    return dca;
+  }
+
   public void testSetCrashlyticsDataCollectionEnabled() throws Exception {
     Context mockContext = mock(Context.class);
     FirebaseApp app = mock(FirebaseApp.class);

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiterTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiterTest.java
@@ -25,12 +25,15 @@ import java.lang.reflect.Method;
 
 public class DataCollectionArbiterTest extends CrashlyticsTestCase {
 
-  final String PREFS_NAME = CommonUtils.SHARED_PREFS_NAME;
+  static final DataCollectionArbiter MOCK_ARBITER_ENABLED;
+  static final DataCollectionArbiter MOCK_ARBITER_DISABLED;
 
-  public static DataCollectionArbiter createMockDataCollectionArbiter(boolean collectionEnabled) {
-    DataCollectionArbiter dca = mock(DataCollectionArbiter.class);
-    when(dca.isAutomaticDataCollectionEnabled()).thenReturn(collectionEnabled);
-    return dca;
+  static {
+    MOCK_ARBITER_ENABLED = mock(DataCollectionArbiter.class);
+    when(MOCK_ARBITER_ENABLED.isAutomaticDataCollectionEnabled()).thenReturn(true);
+
+    MOCK_ARBITER_DISABLED = mock(DataCollectionArbiter.class);
+    when(MOCK_ARBITER_DISABLED.isAutomaticDataCollectionEnabled()).thenReturn(false);
   }
 
   public void testSetCrashlyticsDataCollectionEnabled() throws Exception {

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/IdManagerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/IdManagerTest.java
@@ -150,11 +150,11 @@ public class IdManagerTest extends CrashlyticsTestCase {
   }
 
   public void testInstanceIdDoesntChange_dataCollectionEnabled() {
-    validateInstanceIdDoesntChange(/*dataCollectionEnabled*/ true);
+    validateInstanceIdDoesntChange(/*dataCollectionEnabled=*/ true);
   }
 
   public void testInstanceIdDoesntChange_dataCollectionDisabled() {
-    validateInstanceIdDoesntChange(/*dataCollectionEnabled*/ false);
+    validateInstanceIdDoesntChange(/*dataCollectionEnabled=*/ false);
   }
 
   public void testInstanceIdRotatesWithDataCollectionFlag() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -57,22 +57,25 @@ public class FirebaseCrashlytics {
   static final String LEGACY_CRASH_ANALYTICS_ORIGIN = "crash";
   static final int APP_EXCEPTION_CALLBACK_TIMEOUT_MS = 500;
 
-  static final String CRASHLYTICS_API_ENDPOINT = "com.crashlytics.ApiEndpoint";
-
   static @Nullable FirebaseCrashlytics init(
       @NonNull FirebaseApp app,
       @NonNull FirebaseInstallationsApi firebaseInstallationsApi,
       @NonNull Provider<CrashlyticsNativeComponent> nativeComponent,
       @NonNull Deferred<AnalyticsConnector> analyticsConnector) {
-    Logger.getLogger().i("Initializing Firebase Crashlytics " + CrashlyticsCore.getVersion());
+
     Context context = app.getApplicationContext();
-    // Set up the IdManager.
     final String appIdentifier = context.getPackageName();
-    final IdManager idManager = new IdManager(context, appIdentifier, firebaseInstallationsApi);
+    Logger.getLogger()
+        .i(
+            "Initializing Firebase Crashlytics "
+                + CrashlyticsCore.getVersion()
+                + " for "
+                + appIdentifier);
 
     final DataCollectionArbiter arbiter = new DataCollectionArbiter(app);
-
-    ProviderProxyNativeComponent proxyNativeComponent =
+    final IdManager idManager =
+        new IdManager(context, appIdentifier, firebaseInstallationsApi, arbiter);
+    final ProviderProxyNativeComponent proxyNativeComponent =
         new ProviderProxyNativeComponent(nativeComponent);
 
     // Integration with Firebase Analytics

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
@@ -118,8 +118,9 @@ public class IdManager implements InstallIdProvider {
       Logger.getLogger().v("Fetched Firebase Installation ID: " + trueFid);
 
       if (trueFid == null) {
-        // This shouldn't happen often; the safest thing to do is to create a synthetic ID instead
-        trueFid = createSyntheticFid();
+        // This shouldn't happen often. We will assume the cached FID is valid, if it exists.
+        // Otherwise, the safest thing to do is to create a synthetic ID instead
+        trueFid = (cachedFid == null ? createSyntheticFid() : cachedFid);
       }
 
       if (trueFid.equals(cachedFid)) {
@@ -148,11 +149,11 @@ public class IdManager implements InstallIdProvider {
     return crashlyticsInstallId;
   }
 
-  private String createSyntheticFid() {
+  static String createSyntheticFid() {
     return SYNTHETIC_FID_PREFIX + UUID.randomUUID().toString();
   }
 
-  private boolean isSyntheticFid(String fid) {
+  static boolean isSyntheticFid(String fid) {
     return (fid != null && fid.startsWith(SYNTHETIC_FID_PREFIX));
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.installations.FirebaseInstallationsApi;
@@ -37,6 +38,8 @@ public class IdManager implements InstallIdProvider {
   /** Regex for stripping all non-alphnumeric characters from ALL the identifier fields. */
   private static final Pattern ID_PATTERN = Pattern.compile("[^\\p{Alnum}]");
 
+  private static final String SYNTHETIC_FID_PREFIX = "SYN_";
+
   private static final String FORWARD_SLASH_REGEX = Pattern.quote("/");
 
   private final InstallerPackageNameProvider installerPackageNameProvider;
@@ -45,6 +48,9 @@ public class IdManager implements InstallIdProvider {
 
   // The FirebaseInstallationsApi encapsulates a Firebase-wide install id
   private final FirebaseInstallationsApi firebaseInstallationsApi;
+
+  private final DataCollectionArbiter dataCollectionArbiter;
+
   // Crashlytics maintains a Crashlytics-specific install id, used in the crash processing backend
   private String crashlyticsInstallId;
 
@@ -56,7 +62,10 @@ public class IdManager implements InstallIdProvider {
    *     null
    */
   public IdManager(
-      Context appContext, String appIdentifier, FirebaseInstallationsApi firebaseInstallationsApi) {
+      Context appContext,
+      String appIdentifier,
+      FirebaseInstallationsApi firebaseInstallationsApi,
+      DataCollectionArbiter dataCollectionArbiter) {
     if (appContext == null) {
       throw new IllegalArgumentException("appContext must not be null");
     }
@@ -66,6 +75,7 @@ public class IdManager implements InstallIdProvider {
     this.appContext = appContext;
     this.appIdentifier = appIdentifier;
     this.firebaseInstallationsApi = firebaseInstallationsApi;
+    this.dataCollectionArbiter = dataCollectionArbiter;
 
     installerPackageNameProvider = new InstallerPackageNameProvider();
   }
@@ -82,7 +92,8 @@ public class IdManager implements InstallIdProvider {
    * Return a UUID that is unique to this application installation, generating it if necessary.
    *
    * <p>The UUID is used to generate crash counts for a specific user, as well as for business
-   * metrics. It can be reset by resetting the Firebase Instance Id (FID).
+   * metrics. It can be reset by resetting the Firebase Instance Id (FID) or toggling Crashlytics
+   * data collection.
    *
    * <p>The first time this method is called, the returned value is read from Shared Preferences and
    * then cached in memory for the duration of the app execution. If the FID has been reset after
@@ -92,88 +103,83 @@ public class IdManager implements InstallIdProvider {
   @NonNull
   public synchronized String getCrashlyticsInstallId() {
     if (crashlyticsInstallId != null) {
-      // Once found, the id is cached locally for the duration of execution; see javadoc comment for
-      // this method.
       return crashlyticsInstallId;
     }
+
     Logger.getLogger().v("Determining Crashlytics installation ID...");
     final SharedPreferences prefs = CommonUtils.getSharedPrefs(appContext);
+    final String cachedFid = prefs.getString(PREFKEY_FIREBASE_IID, null);
+    Logger.getLogger().v("Cached Firebase Installation ID: " + cachedFid);
 
-    // Crashlytics rotates the Crashlytics-specific IID if the Firebase IID ("FID") is reset.
-    // This way, Crashlytics privacy controls are consistent with the rest of Firebase.
+    // We only look at the FID if Crashlytics data collection is enabled, since querying it can
+    // result in a network call that registers the FID with Firebase.
+    if (dataCollectionArbiter.isAutomaticDataCollectionEnabled()) {
+      String trueFid = fetchTrueFid();
+      Logger.getLogger().v("Fetched Firebase Installation ID: " + trueFid);
+
+      if (trueFid == null) {
+        // This shouldn't happen often; the safest thing to do is to create a synthetic ID instead
+        trueFid = createSyntheticFid();
+      }
+
+      if (trueFid.equals(cachedFid)) {
+        // the current FID is the same as the cached FID, so we keep the cached Crashlytics ID
+        crashlyticsInstallId = readCachedCrashlyticsInstallId(prefs);
+      } else {
+        // the current FID has changed, so we generate a new Crashlytics ID
+        crashlyticsInstallId = createAndCacheCrashlyticsInstallId(trueFid, prefs);
+      }
+    } else { // data collection is NOT enabled; we can't use the FID
+      if (isSyntheticFid(cachedFid)) {
+        // We already have a cached synthetic FID, so we don't need to change the Crashlytics ID
+        crashlyticsInstallId = readCachedCrashlyticsInstallId(prefs);
+      } else {
+        // we don't have a synthetic FID, so we need to replace the cached FID with a synthetic
+        // one and create a new Crashlytics install id.
+        crashlyticsInstallId = createAndCacheCrashlyticsInstallId(createSyntheticFid(), prefs);
+      }
+    }
+    if (crashlyticsInstallId == null) {
+      // Should not happen but we don't want to throw any exceptions
+      Logger.getLogger().w("Unable to determine Crashlytics Install Id, creating a new one.");
+      crashlyticsInstallId = createAndCacheCrashlyticsInstallId(createSyntheticFid(), prefs);
+    }
+    Logger.getLogger().v("Crashlytics installation ID: " + crashlyticsInstallId);
+    return crashlyticsInstallId;
+  }
+
+  private String createSyntheticFid() {
+    return SYNTHETIC_FID_PREFIX + UUID.randomUUID().toString();
+  }
+
+  private boolean isSyntheticFid(String fid) {
+    return (fid != null && fid.startsWith(SYNTHETIC_FID_PREFIX));
+  }
+
+  private String readCachedCrashlyticsInstallId(SharedPreferences prefs) {
+    return prefs.getString(PREFKEY_INSTALLATION_UUID, null);
+  }
+
+  /** Makes a blocking call to query FID. If the call fails, logs a warning and returns null. */
+  @Nullable
+  private String fetchTrueFid() {
     Task<String> currentFidTask = firebaseInstallationsApi.getId();
     String currentFid = null;
-    final String cachedFid = prefs.getString(PREFKEY_FIREBASE_IID, null);
 
     try {
       currentFid = Utils.awaitEvenIfOnMainThread(currentFidTask);
     } catch (Exception e) {
       Logger.getLogger().w("Failed to retrieve Firebase Installations ID.", e);
-
-      // this avoids rotating the identifier in the case that there was an exception which is likely
-      // to succeed in a future invocation
-      if (cachedFid != null) {
-        currentFid = cachedFid;
-      }
     }
-
-    if (cachedFid == null) {
-      Logger.getLogger().v("No cached Firebase Installations ID found.");
-      // This must be either 1) a new installation or 2) an upgrade from the legacy
-      // Crashlytics SDK.
-      // If it is a legacy upgrade, we'll migrate the legacy ID to the new pref store.
-      final SharedPreferences legacyPrefs = CommonUtils.getLegacySharedPrefs(appContext);
-      final String legacyId = legacyPrefs.getString(PREFKEY_LEGACY_INSTALLATION_UUID, null);
-
-      if (legacyId == null) {
-        Logger.getLogger().v("No legacy Crashlytics installation ID found, creating new ID.");
-        // if there's no legacy ID, this must be a new Crashlytics install.
-        crashlyticsInstallId = createAndStoreIid(currentFid, prefs);
-      } else { // must be a legacy upgrade
-        Logger.getLogger().v("A legacy Crashlytics installation ID was found. Upgrading.");
-        crashlyticsInstallId = legacyId;
-        migrateLegacyId(legacyId, currentFid, prefs, legacyPrefs);
-      }
-    } else {
-      // we have a cached FID, so check if it has been changed since previous launch
-      if (cachedFid.equals(currentFid)) {
-        crashlyticsInstallId = prefs.getString(PREFKEY_INSTALLATION_UUID, null);
-
-        Logger.getLogger().v("Firebase Installations ID is unchanged from previous startup.");
-        // Since we've cached an FID previously, the IID should always exist at this point.
-        // But check just in case:
-        if (crashlyticsInstallId == null) {
-          Logger.getLogger().v("Crashlytics installation ID was null, creating new ID.");
-          crashlyticsInstallId = createAndStoreIid(currentFid, prefs);
-        }
-      } else {
-        // the FID has changed, so we need to update our IID and cache the new FID value.
-        crashlyticsInstallId = createAndStoreIid(currentFid, prefs);
-      }
-    }
-
-    Logger.getLogger().v("Crashlytics installation ID is " + crashlyticsInstallId);
-    return crashlyticsInstallId;
+    return currentFid;
   }
 
-  private synchronized void migrateLegacyId(
-      String legacyId, String fidToCache, SharedPreferences prefs, SharedPreferences legacyPrefs) {
-    Logger.getLogger().v("Migrating legacy Crashlytics installation ID: " + legacyId);
-    prefs
-        .edit()
-        .putString(PREFKEY_INSTALLATION_UUID, legacyId)
-        .putString(PREFKEY_FIREBASE_IID, fidToCache)
-        .apply();
-    legacyPrefs
-        .edit()
-        .remove(PREFKEY_LEGACY_INSTALLATION_UUID)
-        .remove(PREFKEY_ADVERTISING_ID) // cleanup any previously-cached AdId from old SDK versions.
-        .apply();
-  }
-
-  private synchronized String createAndStoreIid(String fidToCache, SharedPreferences prefs) {
+  @NonNull
+  private synchronized String createAndCacheCrashlyticsInstallId(
+      String fidToCache, SharedPreferences prefs) {
     final String iid = formatId(UUID.randomUUID().toString());
-    Logger.getLogger().v("Created new Crashlytics installation ID: " + iid);
+    Logger.getLogger()
+        .v("Created new Crashlytics installation ID: " + iid + " for FID: " + fidToCache);
     prefs
         .edit()
         .putString(PREFKEY_INSTALLATION_UUID, iid)


### PR DESCRIPTION
Querying for the Firebase Installation Id makes a network call and potentially registers
new information to Firebase servers, so we should not access it from Crashlytics when
the data collection flag is disabled. Instead, we cache a synthetic FID to use as long
as collection is disabled. This can result in over-counting unique users who have experienced
a crash, but it better aligns with the privacy goals of the data collection flag.
    
See internal doc go/crashlytics-fid for more details.