### PR TITLE
Re-enable App Check integration tests

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
+++ b/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
@@ -32,8 +32,7 @@ android {
         minSdkVersion project.minSdkVersion
         versionName version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        // TODO: Uncomment the line below once we configure the debug secret environment variable in the public repo.
-        // testInstrumentationRunnerArgument "firebaseAppCheckDebugSecret", System.getenv("FIREBASE_APP_CHECK_DEBUG_SECRET") ?: ''
+        testInstrumentationRunnerArgument "firebaseAppCheckDebugSecret", System.getenv("FIREBASE_APP_CHECK_DEBUG_SECRET") ?: ''
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/appcheck/firebase-appcheck-debug-testing/src/androidTest/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck-debug-testing/src/androidTest/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
-@Ignore("TODO: Re-enable after setting up debug secret environment variable in public repo.")
 public class FirebaseAppCheckTest {
   private final DebugAppCheckTestHelper debugAppCheckTestHelper =
       DebugAppCheckTestHelper.fromInstrumentationArgs();


### PR DESCRIPTION
Re-enable App Check integration tests.

App Check integration tests were disabled in #2601, since the debug secret environment variable was not configured for the public repo.