### PR TITLE
Update getTotalBytes() docs

### DIFF
--- a/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FileDownloadTask.java
@@ -284,7 +284,7 @@ public class FileDownloadTask extends StorageTask<FileDownloadTask.TaskSnapshot>
       return mBytesDownloaded;
     }
 
-    /** @return the total bytes to upload.. */
+    /** @return the total bytes of the download or -1 if the size of the download is not known. */
     public long getTotalByteCount() {
       return FileDownloadTask.this.getTotalBytes();
     }

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StreamDownloadTask.java
@@ -480,7 +480,7 @@ public class StreamDownloadTask extends StorageTask<StreamDownloadTask.TaskSnaps
       return mBytesDownloaded;
     }
 
-    /** @return the total bytes of the download. */
+    /** @return the total bytes of the download or -1 if the size of the download is not known. */
     public long getTotalByteCount() {
       return StreamDownloadTask.this.getTotalBytes();
     }


### PR DESCRIPTION
The method can return -1 for chunked/gzipped downloads. I didn't go into detail since the exact causes for this behavior are not clear to me.