### PR TITLE
Fixing FIAM Java doc issues

### DIFF
--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ForegroundNotifier.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ForegroundNotifier.java
@@ -63,7 +63,7 @@ public class ForegroundNotifier implements Application.ActivityLifecycleCallback
   private Runnable check;
   private final BehaviorSubject<String> foregroundSubject = BehaviorSubject.create();
 
-  /** @returns a {@link ConnectableFlowable} representing a stream of foreground events */
+  /** @return a {@link ConnectableFlowable} representing a stream of foreground events */
   public ConnectableFlowable<String> foregroundFlowable() {
     return foregroundSubject.toFlowable(BackpressureStrategy.BUFFER).publish();
   }

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/InAppMessage.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/InAppMessage.java
@@ -141,21 +141,21 @@ public abstract class InAppMessage {
     return backgroundHexColor;
   }
 
-  /** @deprecated Use {@link #getCampaignMetadata()#getCampaignId()} instead. */
+  /** @deprecated Use {@link #getCampaignMetadata()} instead. */
   @Nullable
   @Deprecated
   public String getCampaignId() {
     return campaignMetadata.getCampaignId();
   }
 
-  /** @deprecated Use {@link #getCampaignMetadata()#getCampaignName()} instead. */
+  /** @deprecated Use {@link #getCampaignMetadata()} instead. */
   @Nullable
   @Deprecated
   public String getCampaignName() {
     return campaignMetadata.getCampaignName();
   }
 
-  /** @deprecated Use {@link #getCampaignMetadata()#getIsTestMessage()} instead. */
+  /** @deprecated Use {@link #getCampaignMetadata()} instead. */
   @Nullable
   @Deprecated
   public Boolean getIsTestMessage() {


### PR DESCRIPTION
Fixing following java doc issues: 

/home/prow/go/src/github.com/FirebasePrivate/firebase-android-release/oss/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ForegroundNotifier.java:66: lint 103: Unknown tag: @returns
DroidDoc took 3 sec. to write docs to /home/prow/go/src/github.com/FirebasePrivate/firebase-android-release/oss/firebase-inappmessaging/build/docs/javadoc
/home/prow/go/src/github.com/FirebasePrivate/firebase-android-release/oss/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/InAppMessage.java:144: warning 101: Unresolved link/see tag "#getCampaignMetadata()#getCampaignId()" in com.google.firebase.inappmessaging.model.InAppMessage
/home/prow/go/src/github.com/FirebasePrivate/firebase-android-release/oss/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/InAppMessage.java:151: warning 101: Unresolved link/see tag "#getCampaignMetadata()#getCampaignName()" in com.google.firebase.inappmessaging.model.InAppMessage
/home/prow/go/src/github.com/FirebasePrivate/firebase-android-release/oss/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/InAppMessage.java:158: warning 101: Unresolved link/see tag "#getCampaignMetadata()#getIsTestMessage()" in com.google.firebase.inappmessaging.model.InAppMessage