### PR TITLE
FDL getDynamicLink(Intent) method to accept null intent.

### DIFF
--- a/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/FirebaseDynamicLinks.java
+++ b/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/FirebaseDynamicLinks.java
@@ -18,6 +18,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -99,7 +100,7 @@ public abstract class FirebaseDynamicLinks {
    * <p>If a dynamic link, the call will also send FirebaseAnalytics dynamic link event.
    */
   @NonNull
-  public abstract Task<PendingDynamicLinkData> getDynamicLink(@NonNull Intent intent);
+  public abstract Task<PendingDynamicLinkData> getDynamicLink(@Nullable Intent intent);
 
   /**
    * Determine if the app has a pending dynamic link and provide access to the dynamic link

--- a/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/internal/FirebaseDynamicLinksImpl.java
+++ b/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/internal/FirebaseDynamicLinksImpl.java
@@ -92,15 +92,20 @@ public class FirebaseDynamicLinksImpl extends FirebaseDynamicLinks {
   }
 
   @Override
-  public Task<PendingDynamicLinkData> getDynamicLink(@NonNull final Intent intent) {
+  public Task<PendingDynamicLinkData> getDynamicLink(@Nullable final Intent intent) {
+    String dynamicLinkDataString = intent != null ? intent.getDataString() : null;
     Task<PendingDynamicLinkData> result =
-        googleApi.doWrite(new GetDynamicLinkImpl(analytics, intent.getDataString()));
-    PendingDynamicLinkData pendingDynamicLinkData = getPendingDynamicLinkData(intent);
-    if (pendingDynamicLinkData != null) {
-      // DynamicLinkData included in the Intent, return it immediately and allow the Task to run in
-      // the background to do logging and mark the FDL as returned.
-      result = Tasks.forResult(pendingDynamicLinkData);
+        googleApi.doWrite(new GetDynamicLinkImpl(analytics, dynamicLinkDataString));
+
+    if (intent != null) {
+      PendingDynamicLinkData pendingDynamicLinkData = getPendingDynamicLinkData(intent);
+      if (pendingDynamicLinkData != null) {
+        // DynamicLinkData included in the Intent, return it immediately and allow the Task to run
+        // in the background to do logging and mark the FDL as returned.
+        result = Tasks.forResult(pendingDynamicLinkData);
+      }
     }
+
     return result;
   }
 

--- a/firebase-dynamic-links/src/test/java/com/google/firebase/dynamiclinks/internal/FirebaseDynamicLinksImplTest.java
+++ b/firebase-dynamic-links/src/test/java/com/google/firebase/dynamiclinks/internal/FirebaseDynamicLinksImplTest.java
@@ -154,6 +154,13 @@ public class FirebaseDynamicLinksImplTest {
   }
 
   @Test
+  public void testGetDynamicLink_NullIntent() {
+    api.getDynamicLink((Intent) null);
+    verify(mockGoogleApi)
+        .doWrite(ArgumentMatchers.<TaskApiCall<DynamicLinksClient, PendingDynamicLinkData>>any());
+  }
+
+  @Test
   public void testGetDynamicLink_IntentWithDynamicLinkData() {
     Bundle extensions = new Bundle();
     extensions.putString(PARAMETER, VALUE);


### PR DESCRIPTION
Changing the @NonNull to @Nullable for `Intent` argument in getDynamicLink(intent) method.

The intent parameter should be the intent that launched the application, or can be null if the intent does not include the dynamic link. A non-null intent is necessary only when the app is launched directly using the dynamic link, such as when using App Links.

Changes:
- Changed the annotation from  @NonNull to @Nullable.
- Modified getDynamicLink(Intent) method to handle null intents.
- Added test with null intent.

Related issue: https://github.com/firebase/firebase-android-sdk/issues/2336