### PR TITLE
Configure google-services.json for macrobenchmark tests.

### DIFF
--- a/ci/fireci/fireciplugins/macrobenchmark.py
+++ b/ci/fireci/fireciplugins/macrobenchmark.py
@@ -40,10 +40,11 @@ def macrobenchmark():
 async def _launch_macrobenchmark_test():
   _logger.info('Starting macrobenchmark test...')
 
-  artifact_versions, config, _ = await asyncio.gather(
+  artifact_versions, config, _, _ = await asyncio.gather(
     _parse_artifact_versions(),
     _parse_config_yaml(),
-    _create_gradle_wrapper()
+    _create_gradle_wrapper(),
+    _copy_google_services(),
   )
 
   with chdir('macrobenchmark'):
@@ -89,6 +90,14 @@ async def _create_gradle_wrapper():
     'macrobenchmark'
   )
   await proc.wait()
+
+
+async def _copy_google_services():
+  if 'FIREBASE_CI' in os.environ:
+    src = os.environ['FIREBASE_GOOGLE_SERVICES_PATH']
+    dst = 'macrobenchmark/template/app/google-services.json'
+    _logger.info(f'Running on CI. Copying "{src}" to "{dst}"...')
+    shutil.copyfile(src, dst)
 
 
 class MacrobenchmarkTest:

--- a/ci/fireci/fireciplugins/macrobenchmark.py
+++ b/ci/fireci/fireciplugins/macrobenchmark.py
@@ -85,7 +85,7 @@ async def _create_gradle_wrapper():
     './gradlew',
     'wrapper',
     '--gradle-version',
-    '7.0',
+    '6.9',
     '--project-dir',
     'macrobenchmark'
   )

--- a/macrobenchmark/config.yaml
+++ b/macrobenchmark/config.yaml
@@ -44,7 +44,7 @@ firebase-inappmessaging-display:
   name: inappmessaging
   application-id: com.google.firebase.benchmark.inappmessaging
   dependencies:
-    - com.google.firebase:firebase-inappmessaging-ktx
+    - com.google.firebase:firebase-analytics-ktx
     - com.google.firebase:firebase-inappmessaging-display-ktx
 
 firebase-messaging:

--- a/macrobenchmark/config.yaml
+++ b/macrobenchmark/config.yaml
@@ -44,7 +44,8 @@ firebase-inappmessaging-display:
   name: inappmessaging
   application-id: com.google.firebase.benchmark.inappmessaging
   dependencies:
-    - com.google.firebase:firebase-analytics-ktx
+    - com.google.firebase:firebase-analytics-ktx@18.0.3
+    - com.google.firebase:firebase-inappmessaging-ktx
     - com.google.firebase:firebase-inappmessaging-display-ktx
 
 firebase-messaging:


### PR DESCRIPTION
Downgrade gradle wrapper version from 7.0 to 6.9 to speed up test apps assembly.

- [macrobenchmark run](https://android-ci.firebaseopensource.com/view/gcs/android-ci/pr-logs/pull/firebase_firebase-android-sdk/2650/macrobenchmark/1390903202219560964) with gradle 7.0 (total: 42m 23s)
  - assembleAllForSmokeTests (10m 51s)
  - assemble assembleAndroidTest (for all test apps, 5m 21s ~ 9m 46s)
- [macrobenchmark run](https://android-ci.firebaseopensource.com/view/gcs/android-ci/pr-logs/pull/firebase_firebase-android-sdk/2650/macrobenchmark/1391796275434754055) with gradle 6.9 (total: 36m50s)
  - assembleAllForSmokeTests (8m 40s)
  - assemble assembleAndroidTest (for all test apps, 4m 15s ~ 7m 13s)