### PR TITLE
Keep smoke tests up to date.

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -85,9 +85,9 @@ dependencies {
   implementation "androidx.test:runner:1.2.0"
   implementation "com.google.truth:truth:0.44"
   implementation "junit:junit:4.12"
+  implementation "androidx.test:core:1.3.0"
 
   // Common utilities (instrumentation side)
-  androidTestImplementation "androidx.test:core:1.2.0"
   androidTestImplementation "androidx.test:runner:1.2.0"
   androidTestImplementation "junit:junit:4.12"
 }

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -77,7 +77,6 @@ dependencies {
   implementation "com.google.firebase:firebase-inappmessaging"
   // TODO(yifany): Restore after messaging in github is up to date
   // implementation "com.google.firebase:firebase-messaging"
-  implementation "com.google.firebase:firebase-ml-vision"
   implementation "com.google.firebase:firebase-perf"
   implementation "com.google.firebase:firebase-storage"
 
@@ -91,12 +90,6 @@ dependencies {
   androidTestImplementation "androidx.test:core:1.2.0"
   androidTestImplementation "androidx.test:runner:1.2.0"
   androidTestImplementation "junit:junit:4.12"
-
-  // TODO(yifany): Remove the temporary fix after b/164175567
-  // https://firebase.google.com/support/release-notes/android#mlkit-self-serve-fixes
-  implementation "com.google.android.gms:play-services-vision:20.1.1"
-  implementation "com.google.android.gms:play-services-vision-common:19.1.1"
-  implementation "com.google.android.gms:play-services-vision-image-label:18.0.5"
 }
 
 clean.doLast {

--- a/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
@@ -19,8 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.firebase.appindexing.FirebaseAppIndex;
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging;
 // import com.google.firebase.messaging.FirebaseMessaging;
-// import com.google.firebase.perf.FirebasePerformance;
-import com.google.firebase.ml.vision.FirebaseVision;
+import com.google.firebase.perf.FirebasePerformance;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -44,13 +43,8 @@ public final class BuildOnlyTest {
 //    assertThat(FirebaseMessaging.getInstance()).isNotNull();
 //  }
 
-//  @Test
-//  public void performance_IsNotNull() {
-//    assertThat(FirebasePerformance.getInstance()).isNotNull();
-//  }
-
   @Test
-  public void vision_IsNotNull() {
-    assertThat(FirebaseVision.getInstance()).isNotNull();
+  public void performance_IsNotNull() {
+    assertThat(FirebasePerformance.getInstance()).isNotNull();
   }
 }

--- a/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
@@ -24,13 +24,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+
 /** Contains initialization test cases for build-only libraries. */
 @RunWith(JUnit4.class)
 public final class BuildOnlyTest {
 
   @Test
   public void appindexing_IsNotNull() {
-    assertThat(FirebaseAppIndex.getInstance()).isNotNull();
+    assertThat(FirebaseAppIndex.getInstance(getApplicationContext())).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
* Remove tests for `firebase-ml-vision`, as it is removed from the bom in the [most recent release](https://firebase.google.com/support/release-notes/android#2021-05-11)
* Restore tests for `firebase-perf`. The issue for which the test had to be disabled temporarily was fixed  in the [release](https://firebase.google.com/support/release-notes/android#performance_v19-0-11)
* Change tests for `firebase-appindexing` to call a new api as the older one is removed in the [most recent release](https://firebase.google.com/support/release-notes/android#app-indexing_v20-0-0)