### PR TITLE
Fix fireperf RateLimiter replenishment behavior and unit alignment.

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/RateLimiter.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/RateLimiter.java
@@ -264,14 +264,14 @@ final class RateLimiter {
               0,
               (long)
                   (lastTimeTokenReplenished.getDurationMicros(now)
-                      * rate.getTokenPerSeconds()
+                      * rate.getTokensPerSeconds()
                       / MICROS_IN_A_SECOND));
       tokenCount = Math.min(tokenCount + newTokens, capacity);
       if (newTokens > 0) {
         lastTimeTokenReplenished =
             new Timer(
                 lastTimeTokenReplenished.getMicros()
-                    + (long) (newTokens * MICROS_IN_A_SECOND / rate.getTokenPerSeconds()));
+                    + (long) (newTokens * MICROS_IN_A_SECOND / rate.getTokensPerSeconds()));
       }
       if (tokenCount > 0) {
         tokenCount--;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/RateLimiter.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/RateLimiter.java
@@ -16,6 +16,7 @@ package com.google.firebase.perf.transport;
 
 import static com.google.firebase.perf.metrics.resource.ResourceType.NETWORK;
 import static com.google.firebase.perf.metrics.resource.ResourceType.TRACE;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
@@ -25,6 +26,7 @@ import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.metrics.resource.ResourceType;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
+import com.google.firebase.perf.util.Rate;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.util.Utils;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
@@ -34,7 +36,6 @@ import com.google.firebase.perf.v1.SessionVerbosity;
 import com.google.firebase.perf.v1.TraceMetric;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Implement the Token Bucket rate limiting algorithm. The token bucket initially holds "capacity"
@@ -60,10 +61,10 @@ final class RateLimiter {
    * Construct a token bucket rate limiter.
    *
    * @param appContext the application's context.
-   * @param rate number of token generated per minute.
+   * @param rate the Rate object representing the number of tokens generated per specified time unit
    * @param capacity token bucket capacity
    */
-  public RateLimiter(@NonNull Context appContext, final double rate, final long capacity) {
+  public RateLimiter(@NonNull Context appContext, final Rate rate, final long capacity) {
     this(rate, capacity, new Clock(), getSamplingBucketId(), ConfigResolver.getInstance());
     this.isLogcatEnabled = Utils.isDebugLoggingEnabled(appContext);
   }
@@ -75,7 +76,7 @@ final class RateLimiter {
   }
 
   RateLimiter(
-      final double rate,
+      final Rate rate,
       final long capacity,
       final Clock clock,
       float samplingBucketId,
@@ -211,29 +212,29 @@ final class RateLimiter {
   static class RateLimiterImpl {
 
     private static final AndroidLogger logger = AndroidLogger.getInstance();
-    private static final long MICROS_IN_A_SECOND = TimeUnit.SECONDS.toMicros(1);
+    private static final long MICROS_IN_A_SECOND = SECONDS.toMicros(1);
 
     private final Clock clock;
     private final boolean isLogcatEnabled;
 
     // Last time a token is consumed.
-    private Timer lastTimeTokenConsumed;
+    private Timer lastTimeTokenReplenished;
 
-    // Number of new tokens generated per second.
-    private double rate;
+    // The Rate object representing the number of tokens generated per specified time unit
+    private Rate rate;
     // Token bucket capacity, also the initial number of tokens in the bucket.
     private long capacity;
     // Number of tokens in the bucket.
     private long tokenCount;
 
-    private double foregroundRate;
-    private double backgroundRate;
+    private Rate foregroundRate;
+    private Rate backgroundRate;
 
     private long foregroundCapacity;
     private long backgroundCapacity;
 
     RateLimiterImpl(
-        final double rate,
+        final Rate rate,
         final long capacity,
         final Clock clock,
         ConfigResolver configResolver,
@@ -243,7 +244,7 @@ final class RateLimiter {
       this.capacity = capacity;
       this.rate = rate;
       tokenCount = capacity;
-      lastTimeTokenConsumed = this.clock.getTime();
+      lastTimeTokenReplenished = this.clock.getTime();
       setRateByReadingRemoteConfigValues(configResolver, type, isLogcatEnabled);
       this.isLogcatEnabled = isLogcatEnabled;
     }
@@ -260,11 +261,20 @@ final class RateLimiter {
       Timer now = clock.getTime();
       long newTokens =
           Math.max(
-              0, (long) (lastTimeTokenConsumed.getDurationMicros(now) * rate / MICROS_IN_A_SECOND));
+              0,
+              (long)
+                  (lastTimeTokenReplenished.getDurationMicros(now)
+                      * rate.getTokenPerSeconds()
+                      / MICROS_IN_A_SECOND));
       tokenCount = Math.min(tokenCount + newTokens, capacity);
+      if (newTokens > 0) {
+        lastTimeTokenReplenished =
+            new Timer(
+                lastTimeTokenReplenished.getMicros()
+                    + (long) (newTokens * MICROS_IN_A_SECOND / rate.getTokenPerSeconds()));
+      }
       if (tokenCount > 0) {
         tokenCount--;
-        lastTimeTokenConsumed = now;
         return true;
       }
       if (isLogcatEnabled) {
@@ -297,7 +307,7 @@ final class RateLimiter {
       long fLimitTime = getFlimitSec(configResolver, type);
       long fLimitEvents = getFlimitEvents(configResolver, type);
 
-      foregroundRate = ((double) fLimitEvents) / fLimitTime;
+      foregroundRate = new Rate(fLimitEvents, fLimitTime, SECONDS);
       foregroundCapacity = fLimitEvents;
       if (isLogcatEnabled) {
         logger.debug(
@@ -309,7 +319,7 @@ final class RateLimiter {
       long bLimitTime = getBlimitSec(configResolver, type);
       long bLimitEvents = getBlimitEvents(configResolver, type);
 
-      backgroundRate = ((double) bLimitEvents) / bLimitTime;
+      backgroundRate = new Rate(bLimitEvents, bLimitTime, SECONDS);
       backgroundCapacity = bLimitEvents;
       if (isLogcatEnabled) {
         logger.debug(
@@ -350,7 +360,7 @@ final class RateLimiter {
     }
 
     @VisibleForTesting
-    double getForegroundRate() {
+    Rate getForegroundRate() {
       return foregroundRate;
     }
 
@@ -360,7 +370,7 @@ final class RateLimiter {
     }
 
     @VisibleForTesting
-    double getBackgroundRate() {
+    Rate getBackgroundRate() {
       return backgroundRate;
     }
 
@@ -370,12 +380,12 @@ final class RateLimiter {
     }
 
     @VisibleForTesting
-    double getRate() {
+    Rate getRate() {
       return rate;
     }
 
     @VisibleForTesting
-    void setRate(double newRate) {
+    void setRate(Rate newRate) {
       rate = newRate;
     }
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -15,6 +15,7 @@
 package com.google.firebase.perf.transport;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 import android.content.Context;
 import android.content.pm.PackageInfo;
@@ -39,6 +40,7 @@ import com.google.firebase.perf.metrics.validator.PerfMetricValidator;
 import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.Constants.CounterNames;
+import com.google.firebase.perf.util.Rate;
 import com.google.firebase.perf.v1.AndroidApplicationInfo;
 import com.google.firebase.perf.v1.ApplicationInfo;
 import com.google.firebase.perf.v1.ApplicationProcessState;
@@ -202,7 +204,9 @@ public class TransportManager implements AppStateCallback {
   private void syncInit() {
     appContext = firebaseApp.getApplicationContext();
     configResolver = ConfigResolver.getInstance();
-    rateLimiter = new RateLimiter(appContext, Constants.RATE_PER_MINUTE, Constants.BURST_CAPACITY);
+    rateLimiter =
+        new RateLimiter(
+            appContext, new Rate(Constants.RATE_PER_MINUTE, 1, MINUTES), Constants.BURST_CAPACITY);
     appStateMonitor = AppStateMonitor.getInstance();
     flgTransport =
         new FlgTransport(flgTransportFactoryProvider, configResolver.getAndCacheLogSourceName());

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Rate.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Rate.java
@@ -21,10 +21,6 @@ import java.util.concurrent.TimeUnit;
 /** A Rate object representing the number of tokens per total specified time unit. */
 public class Rate {
 
-  private static final long NANO_IN_SECOND = SECONDS.toNanos(1);
-  private static final long MICRO_IN_SECOND = SECONDS.toMicros(1);
-  private static final long MILLI_IN_SECOND = SECONDS.toMillis(1);
-
   private long numTokensPerTotalTimeUnit;
   private long numTimeUnits;
   private TimeUnit timeUnit;
@@ -54,11 +50,11 @@ public class Rate {
   public double getTokensPerSeconds() {
     switch (timeUnit) {
       case NANOSECONDS:
-        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * NANO_IN_SECOND;
+        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * SECONDS.toNanos(1);
       case MICROSECONDS:
-        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * MICRO_IN_SECOND;
+        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * SECONDS.toMicros(1);
       case MILLISECONDS:
-        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * MILLI_IN_SECOND;
+        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * SECONDS.toMillis(1);
       default:
         return (double) numTokensPerTotalTimeUnit / timeUnit.toSeconds(numTimeUnits);
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Rate.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Rate.java
@@ -1,0 +1,64 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.perf.util;
+
+import java.util.concurrent.TimeUnit;
+
+/** A Rate object representing the number of tokens per total specified time unit. */
+public class Rate {
+
+  private static final long NANO_IN_SECOND = 1000 * 1000 * 1000;
+  private static final long MICRO_IN_SECOND = 1000 * 1000;
+  private static final long MILLI_IN_SECOND = 1000;
+
+  private long numTokensPerTotalTimeUnit;
+  private long numTimeUnits;
+  private TimeUnit timeUnit;
+
+  /**
+   * Constructs a Rate object.
+   *
+   * <p>For example, a rate of 3 tokens per minute can be represented by new Rate(3, 1, MINUTES) or
+   * new Rate(3, 60, SECONDS).
+   *
+   * @param numTokensPerTotalTimeUnit The number of tokens to be issued within the specified time
+   * @param numTimeUnits The number of specified time unit
+   * @param timeUnit The specified time unit
+   */
+  public Rate(long numTokensPerTotalTimeUnit, long numTimeUnits, TimeUnit timeUnit) {
+    assert numTimeUnits > 0;
+    this.numTokensPerTotalTimeUnit = numTokensPerTotalTimeUnit;
+    this.numTimeUnits = numTimeUnits;
+    this.timeUnit = timeUnit;
+  }
+
+  /**
+   * Converts the rate to tokens per second.
+   *
+   * @return rate in tokens per second
+   */
+  public double getTokenPerSeconds() {
+    switch (timeUnit) {
+      case NANOSECONDS:
+        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * NANO_IN_SECOND;
+      case MICROSECONDS:
+        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * MICRO_IN_SECOND;
+      case MILLISECONDS:
+        return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * MILLI_IN_SECOND;
+      default:
+        return (double) numTokensPerTotalTimeUnit / timeUnit.toSeconds(numTimeUnits);
+    }
+  }
+}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Rate.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Rate.java
@@ -14,14 +14,16 @@
 
 package com.google.firebase.perf.util;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.concurrent.TimeUnit;
 
 /** A Rate object representing the number of tokens per total specified time unit. */
 public class Rate {
 
-  private static final long NANO_IN_SECOND = 1000 * 1000 * 1000;
-  private static final long MICRO_IN_SECOND = 1000 * 1000;
-  private static final long MILLI_IN_SECOND = 1000;
+  private static final long NANO_IN_SECOND = SECONDS.toNanos(1);
+  private static final long MICRO_IN_SECOND = SECONDS.toMicros(1);
+  private static final long MILLI_IN_SECOND = SECONDS.toMillis(1);
 
   private long numTokensPerTotalTimeUnit;
   private long numTimeUnits;
@@ -49,7 +51,7 @@ public class Rate {
    *
    * @return rate in tokens per second
    */
-  public double getTokenPerSeconds() {
+  public double getTokensPerSeconds() {
     switch (timeUnit) {
       case NANOSECONDS:
         return ((double) numTokensPerTotalTimeUnit / numTimeUnits) * NANO_IN_SECOND;

--- a/firebase-perf/src/test/java/com/google/firebase/perf/transport/RateLimiterTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/transport/RateLimiterTest.java
@@ -515,10 +515,10 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             NETWORK,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate().getTokenPerSeconds()).isEqualTo(2.0);
-    assertThat(limiter.getForegroundRate().getTokenPerSeconds()).isEqualTo(700.0d / 60L);
+    assertThat(limiter.getRate().getTokensPerSeconds()).isEqualTo(2.0);
+    assertThat(limiter.getForegroundRate().getTokensPerSeconds()).isEqualTo(700.0d / 60L);
     assertThat(limiter.getForegroundCapacity()).isEqualTo(700L);
-    assertThat(limiter.getBackgroundRate().getTokenPerSeconds()).isEqualTo(60.0d / 60L);
+    assertThat(limiter.getBackgroundRate().getTokensPerSeconds()).isEqualTo(60.0d / 60L);
     assertThat(limiter.getBackgroundCapacity()).isEqualTo(60L);
   }
 
@@ -535,11 +535,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             NETWORK,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate().getTokenPerSeconds()).isEqualTo(2.0);
+    assertThat(limiter.getRate().getTokensPerSeconds()).isEqualTo(2.0);
 
-    assertThat(limiter.getForegroundRate().getTokenPerSeconds()).isEqualTo(700.0d / 600);
+    assertThat(limiter.getForegroundRate().getTokensPerSeconds()).isEqualTo(700.0d / 600);
     assertThat(limiter.getForegroundCapacity()).isEqualTo(700L);
-    assertThat(limiter.getBackgroundRate().getTokenPerSeconds()).isEqualTo(70.0d / 600);
+    assertThat(limiter.getBackgroundRate().getTokensPerSeconds()).isEqualTo(70.0d / 600);
     assertThat(limiter.getBackgroundCapacity()).isEqualTo(70L);
   }
 
@@ -560,10 +560,10 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             TRACE,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate().getTokenPerSeconds()).isEqualTo(2.0);
-    assertThat(limiter.getForegroundRate().getTokenPerSeconds()).isEqualTo(600.0d / 60L);
+    assertThat(limiter.getRate().getTokensPerSeconds()).isEqualTo(2.0);
+    assertThat(limiter.getForegroundRate().getTokensPerSeconds()).isEqualTo(600.0d / 60L);
     assertThat(limiter.getForegroundCapacity()).isEqualTo(600L);
-    assertThat(limiter.getBackgroundRate().getTokenPerSeconds()).isEqualTo(60.0d / 60L);
+    assertThat(limiter.getBackgroundRate().getTokensPerSeconds()).isEqualTo(60.0d / 60L);
     assertThat(limiter.getBackgroundCapacity()).isEqualTo(60L);
   }
 
@@ -580,11 +580,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             TRACE,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate().getTokenPerSeconds()).isEqualTo(2.0);
+    assertThat(limiter.getRate().getTokensPerSeconds()).isEqualTo(2.0);
 
-    assertThat(limiter.getForegroundRate().getTokenPerSeconds()).isEqualTo(300.0d / 600);
+    assertThat(limiter.getForegroundRate().getTokensPerSeconds()).isEqualTo(300.0d / 600);
     assertThat(limiter.getForegroundCapacity()).isEqualTo(300L);
-    assertThat(limiter.getBackgroundRate().getTokenPerSeconds()).isEqualTo(30.0d / 600);
+    assertThat(limiter.getBackgroundRate().getTokensPerSeconds()).isEqualTo(30.0d / 600);
     assertThat(limiter.getBackgroundCapacity()).isEqualTo(30L);
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/transport/RateLimiterTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/transport/RateLimiterTest.java
@@ -17,6 +17,9 @@ package com.google.firebase.perf.transport;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.perf.metrics.resource.ResourceType.NETWORK;
 import static com.google.firebase.perf.metrics.resource.ResourceType.TRACE;
+import static java.time.temporal.ChronoUnit.MICROS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -27,6 +30,7 @@ import com.google.firebase.perf.transport.RateLimiter.RateLimiterImpl;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.Constants.TraceNames;
+import com.google.firebase.perf.util.Rate;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.GaugeMetric;
 import com.google.firebase.perf.v1.NetworkRequestMetric;
@@ -34,10 +38,10 @@ import com.google.firebase.perf.v1.PerfMetric;
 import com.google.firebase.perf.v1.PerfSession;
 import com.google.firebase.perf.v1.SessionVerbosity;
 import com.google.firebase.perf.v1.TraceMetric;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,12 +54,13 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class RateLimiterTest extends FirebasePerformanceTestBase {
 
-  private static final long FIFTEEN_SECONDS = TimeUnit.SECONDS.toMicros(15);
-
   @Mock private Clock mClock;
   @Mock private ConfigResolver mockConfigResolver;
 
-  private long currentTime = 0;
+  private Instant currentTime = Instant.ofEpochSecond(0);
+  private static final Rate TWO_TOKENS_PER_MINUTE = new Rate(2, 1, MINUTES);
+  private static final Rate FOUR_TOKENS_PER_MINUTE = new Rate(4, 1, MINUTES);
+  private static final Rate TWO_TOKENS_PER_SECOND = new Rate(2, 1, SECONDS);
 
   @Before
   public void setUp() {
@@ -64,7 +69,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             new Answer<Timer>() {
               @Override
               public Timer answer(InvocationOnMock invocationOnMock) throws Throwable {
-                return new Timer(currentTime, currentTime * 1000);
+                return new Timer(MICROS.between(Instant.EPOCH, currentTime));
               }
             })
         .when(mClock)
@@ -84,39 +89,121 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
     RateLimiterImpl limiter =
-        new RateLimiterImpl(2.0d / 60, 2, mClock, mockConfigResolver, NETWORK, false);
+        new RateLimiterImpl(TWO_TOKENS_PER_MINUTE, 2, mClock, mockConfigResolver, NETWORK, false);
     PerfMetric metric = PerfMetric.getDefaultInstance();
     // clock is 15 seconds, token count is 1.
-    currentTime = 1 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
-    // clock is 30 seconds, count is 0.
-    currentTime = 2 * FIFTEEN_SECONDS;
+    // clock is 30 seconds, count is 1.
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 45 seconds, count is 0.
-    currentTime = 3 * FIFTEEN_SECONDS;
-    assertThat(limiter.check(metric)).isFalse();
-    ;
-    // clock is 60 seconds, count is 0
-    currentTime = 4 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 60 seconds, count is 1
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 75 seconds, count is 0,
-    currentTime = 5 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isFalse();
-    // clock is 90 seconds, count is 0
-    currentTime = 6 * FIFTEEN_SECONDS;
+    // clock is 90 seconds, count is 1
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 105 seconds, count is 0
-    currentTime = 7 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isFalse();
-    // clock is 120 seconds, count is 0,
-    currentTime = 8 * FIFTEEN_SECONDS;
+    // clock is 120 seconds, count is 1,
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 135 seconds, count is 0,
-    currentTime = 9 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isFalse();
-    // clock is 150 seconds, count is 0,
-    currentTime = 10 * FIFTEEN_SECONDS;
+    // clock is 150 seconds, count is 1,
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
+  }
+
+  /** An edge test case for Token Bucket algorithm. */
+  @Test
+  public void testRateLimitImplWithIrregularTimeIntervals() {
+
+    makeConfigResolverReturnDefaultValues();
+
+    // Make Config Resolver returns default value for resource sampling rate.
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
+
+    // allow 2 logs every minute. token bucket capacity is 2.
+    // clock is 0, token count is 2.
+    RateLimiterImpl limiter =
+        new RateLimiterImpl(TWO_TOKENS_PER_MINUTE, 2, mClock, mockConfigResolver, NETWORK, false);
+    PerfMetric metric = PerfMetric.getDefaultInstance();
+    // clock is 20 seconds, count before check is 2, 0 new tokens added, count after check is 1
+    currentTime = currentTime.plusSeconds(20);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 40 seconds, count before check is 1, 1 new tokens added, count after check is 1
+    currentTime = currentTime.plusSeconds(20);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 59 seconds, count before check is 1, 0 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(19);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 60 seconds, count before check is 0, 1 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(1);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 80 seconds, count before check is 0, 0 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(20);
+    assertThat(limiter.check(metric)).isFalse();
+    // clock is 130 seconds, count before check is 0, 2 new tokens added, count after check is 1
+    currentTime = currentTime.plusSeconds(50);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 131 seconds, count before check is 1, 0 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(1);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 132 seconds, count before check is 0, 0 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(1);
+    assertThat(limiter.check(metric)).isFalse();
+  }
+
+  @Test
+  public void testRateLimitImplWithLongTimeGapBetweenEvents_doesNotAccumulateTokensOrCauseBurst() {
+
+    makeConfigResolverReturnDefaultValues();
+
+    // Make Config Resolver returns default value for resource sampling rate.
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
+
+    // allow 2 logs every minute. token bucket capacity is 2.
+    // clock is 0, token count is 2.
+    RateLimiterImpl limiter =
+        new RateLimiterImpl(TWO_TOKENS_PER_MINUTE, 2, mClock, mockConfigResolver, NETWORK, false);
+    PerfMetric metric = PerfMetric.getDefaultInstance();
+
+    // clock is 20 seconds, count before check is 2, 0 new tokens added, count after check is 1
+    currentTime = currentTime.plusSeconds(20);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 40 seconds, count before check is 1, 1 new tokens added, count after check is 1
+    currentTime = currentTime.plusSeconds(20);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 59 seconds, count before check is 1, 0 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(19);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 60 seconds, count before check is 0, 1 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(1);
+    assertThat(limiter.check(metric)).isTrue();
+
+    // clock is 660 seconds, count before check is 0, 2 new tokens added, count after check is 1
+    currentTime = currentTime.plusSeconds(600);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 661 seconds, count before check is 1, 0 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(1);
+    assertThat(limiter.check(metric)).isTrue();
+    // clock is 662 seconds, count before check is 0, 0 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(1);
+    assertThat(limiter.check(metric)).isFalse();
+    // clock is 663 seconds, count before check is 0, 0 new tokens added, count after check is 0
+    currentTime = currentTime.plusSeconds(1);
+    assertThat(limiter.check(metric)).isFalse();
   }
 
   /**
@@ -136,7 +223,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.99f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
     PerfMetric metric = PerfMetric.getDefaultInstance();
     // if PerfMetric object has neither TraceMetric or NetworkRequestMetric field set, always return
     // false.
@@ -149,43 +237,43 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             .setNetworkRequestMetric(NetworkRequestMetric.getDefaultInstance())
             .build();
     // clock is 15 seconds, token count is 1.
-    currentTime = 1 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isTrue();
     assertThat(limiter.check(network)).isTrue();
     // clock is 30 seconds, count is 0.
-    currentTime = 2 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isTrue();
     assertThat(limiter.check(network)).isTrue();
     // clock is 45 seconds, count is 0.
-    currentTime = 3 * FIFTEEN_SECONDS;
-    assertThat(limiter.check(trace)).isFalse();
-    assertThat(limiter.check(network)).isFalse();
+    currentTime = currentTime.plusSeconds(15);
+    assertThat(limiter.check(trace)).isTrue();
+    assertThat(limiter.check(network)).isTrue();
     // clock is 60 seconds, count is 0
-    currentTime = 4 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isTrue();
     assertThat(limiter.check(network)).isTrue();
     // clock is 75 seconds, count is 0,
-    currentTime = 5 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isFalse();
     assertThat(limiter.check(network)).isFalse();
     // clock is 90 seconds, count is 0
-    currentTime = 6 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isTrue();
     assertThat(limiter.check(network)).isTrue();
     // clock is 105 seconds, count is 0
-    currentTime = 7 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isFalse();
     assertThat(limiter.check(network)).isFalse();
     // clock is 120 seconds, count is 0,
-    currentTime = 8 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isTrue();
     assertThat(limiter.check(network)).isTrue();
     // clock is 135 seconds, count is 0,
-    currentTime = 9 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isFalse();
     assertThat(limiter.check(network)).isFalse();
     // clock is 150 seconds, count is 0,
-    currentTime = 10 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(trace)).isTrue();
     assertThat(limiter.check(network)).isTrue();
   }
@@ -196,7 +284,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.02f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.49f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isTrue();
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isFalse();
@@ -208,7 +297,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.02f);
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.49f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isTrue();
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isFalse();
@@ -219,7 +309,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
     when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.00000001f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.000000005f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.000000005f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isTrue();
   }
@@ -229,7 +320,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
     when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.00000001f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.000000011f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.000000011f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isFalse();
   }
@@ -239,7 +331,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.00000001f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.000000005f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.000000005f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isTrue();
   }
@@ -249,7 +342,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.00000001f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.000000011f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.000000011f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isFalse();
   }
@@ -260,7 +354,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.49f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isTrue();
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isTrue();
@@ -272,7 +367,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.51f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.51f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isFalse();
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isFalse();
@@ -283,7 +379,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
     when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.51f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.51f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isFalse();
 
@@ -297,7 +394,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5f);
 
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.51f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.51f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isFalse();
 
@@ -316,17 +414,17 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
 
     RateLimiterImpl limiter =
         new RateLimiterImpl(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             mockConfigResolver,
             NETWORK,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate()).isEqualTo(2.0);
-    assertThat(limiter.getForegroundRate()).isEqualTo(700.0d / 60L);
+    assertThat(limiter.getRate().getTokenPerSeconds()).isEqualTo(2.0);
+    assertThat(limiter.getForegroundRate().getTokenPerSeconds()).isEqualTo(700.0d / 60L);
     assertThat(limiter.getForegroundCapacity()).isEqualTo(700L);
-    assertThat(limiter.getBackgroundRate()).isEqualTo(60.0d / 60L);
+    assertThat(limiter.getBackgroundRate().getTokenPerSeconds()).isEqualTo(60.0d / 60L);
     assertThat(limiter.getBackgroundCapacity()).isEqualTo(60L);
   }
 
@@ -336,18 +434,18 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
 
     RateLimiterImpl limiter =
         new RateLimiterImpl(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             mockConfigResolver,
             NETWORK,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate()).isEqualTo(2.0);
+    assertThat(limiter.getRate().getTokenPerSeconds()).isEqualTo(2.0);
 
-    assertThat(limiter.getForegroundRate()).isEqualTo(700.0d / 600);
+    assertThat(limiter.getForegroundRate().getTokenPerSeconds()).isEqualTo(700.0d / 600);
     assertThat(limiter.getForegroundCapacity()).isEqualTo(700L);
-    assertThat(limiter.getBackgroundRate()).isEqualTo(70.0d / 600);
+    assertThat(limiter.getBackgroundRate().getTokenPerSeconds()).isEqualTo(70.0d / 600);
     assertThat(limiter.getBackgroundCapacity()).isEqualTo(70L);
   }
 
@@ -361,17 +459,17 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
 
     RateLimiterImpl limiter =
         new RateLimiterImpl(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             mockConfigResolver,
             TRACE,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate()).isEqualTo(2.0);
-    assertThat(limiter.getForegroundRate()).isEqualTo(600.0d / 60L);
+    assertThat(limiter.getRate().getTokenPerSeconds()).isEqualTo(2.0);
+    assertThat(limiter.getForegroundRate().getTokenPerSeconds()).isEqualTo(600.0d / 60L);
     assertThat(limiter.getForegroundCapacity()).isEqualTo(600L);
-    assertThat(limiter.getBackgroundRate()).isEqualTo(60.0d / 60L);
+    assertThat(limiter.getBackgroundRate().getTokenPerSeconds()).isEqualTo(60.0d / 60L);
     assertThat(limiter.getBackgroundCapacity()).isEqualTo(60L);
   }
 
@@ -381,23 +479,23 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
 
     RateLimiterImpl limiter =
         new RateLimiterImpl(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             mockConfigResolver,
             TRACE,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate()).isEqualTo(2.0);
+    assertThat(limiter.getRate().getTokenPerSeconds()).isEqualTo(2.0);
 
-    assertThat(limiter.getForegroundRate()).isEqualTo(300.0d / 600);
+    assertThat(limiter.getForegroundRate().getTokenPerSeconds()).isEqualTo(300.0d / 600);
     assertThat(limiter.getForegroundCapacity()).isEqualTo(300L);
-    assertThat(limiter.getBackgroundRate()).isEqualTo(30.0d / 600);
+    assertThat(limiter.getBackgroundRate().getTokenPerSeconds()).isEqualTo(30.0d / 600);
     assertThat(limiter.getBackgroundCapacity()).isEqualTo(30L);
   }
 
   /**
-   * Initial rate is 2/minute, then increate to 4/minute. Compare to test case testRateLimit(), more
+   * Initial rate is 2/minute, then increase to 4/minute. Compare to test case testRateLimit(), more
    * logs are allowed.
    */
   @Test
@@ -407,39 +505,39 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
     RateLimiterImpl limiter =
-        new RateLimiterImpl(2.0d / 60, 2, mClock, mockConfigResolver, TRACE, false);
+        new RateLimiterImpl(TWO_TOKENS_PER_MINUTE, 2, mClock, mockConfigResolver, TRACE, false);
     PerfMetric metric = PerfMetric.getDefaultInstance();
     // clock is 15 seconds, token count is 1.
-    currentTime = 1 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 30 seconds, count is 0.
-    currentTime = 2 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 45 seconds, count is 0.
-    currentTime = 3 * FIFTEEN_SECONDS;
-    assertThat(limiter.check(metric)).isFalse();
+    currentTime = currentTime.plusSeconds(15);
+    assertThat(limiter.check(metric)).isTrue();
     // clock is 60 seconds, count is 0
-    currentTime = 4 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // change rate to 4/minute
-    limiter.setRate(4.0d / 60);
+    limiter.setRate(FOUR_TOKENS_PER_MINUTE);
     // clock is 75 seconds, count is 0,
-    currentTime = 5 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 90 seconds, count is 0
-    currentTime = 6 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 105 seconds, count is 0
-    currentTime = 7 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 120 seconds, count is 0,
-    currentTime = 8 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 135 seconds, count is 0,
-    currentTime = 9 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
     // clock is 150 seconds, count is 0,
-    currentTime = 10 * FIFTEEN_SECONDS;
+    currentTime = currentTime.plusSeconds(15);
     assertThat(limiter.check(metric)).isTrue();
   }
 
@@ -477,7 +575,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testBackgroundTraceWithCountersIsNotRateLimited() {
     makeConfigResolverReturnDefaultValues();
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.99f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
 
     PerfMetric metric =
         PerfMetric.newBuilder()
@@ -493,7 +592,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testBackgroundTraceWithoutCountersIsRateLimited() {
     makeConfigResolverReturnDefaultValues();
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.99f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
 
     PerfMetric metric =
         PerfMetric.newBuilder()
@@ -508,7 +608,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testForegroundTraceWithCountersIsNotRateLimited() {
     makeConfigResolverReturnDefaultValues();
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.99f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
 
     PerfMetric metric =
         PerfMetric.newBuilder()
@@ -524,7 +625,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testForegroundTraceWithoutCountersIsRateLimited() {
     makeConfigResolverReturnDefaultValues();
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.99f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
 
     PerfMetric metric =
         PerfMetric.newBuilder()
@@ -538,7 +640,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testGaugeMetricIsNotRateLimited() {
     makeConfigResolverReturnDefaultValues();
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.99f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
 
     PerfMetric metric =
         PerfMetric.newBuilder().setGaugeMetric(GaugeMetric.getDefaultInstance()).build();
@@ -549,7 +652,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testTraceMetricNoSpecialNameIsRateLimited() {
     makeConfigResolverReturnDefaultValues();
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.99f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
 
     PerfMetric metric =
         PerfMetric.newBuilder()
@@ -562,7 +666,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testNetworkRequestMetricIsRateLimited() {
     makeConfigResolverReturnDefaultValues();
-    RateLimiter limiter = new RateLimiter(2.0d / 60, 2, mClock, 0.99f, mockConfigResolver);
+    RateLimiter limiter =
+        new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
 
     PerfMetric metric =
         PerfMetric.newBuilder()
@@ -581,7 +686,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     // the sampling will be enabled causing all the metrics to be dropped
     RateLimiter limiter =
         new RateLimiter(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             /* samplingBucketId= */ 0.71f,
@@ -607,7 +712,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     // the sampling will be enabled causing all the metrics to be dropped
     RateLimiter limiter =
         new RateLimiter(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             /* samplingBucketId= */ 0.71f,
@@ -633,7 +738,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     // the sampling will be enabled causing all the metrics to be dropped
     RateLimiter limiter =
         new RateLimiter(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             /* samplingBucketId= */ 0.71f,
@@ -659,7 +764,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     // the sampling will be enabled causing all the metrics to be dropped
     RateLimiter limiter =
         new RateLimiter(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             /* samplingBucketId= */ 0.71f,
@@ -686,7 +791,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     // the sampling will be enabled causing all the metrics to be dropped
     RateLimiter limiter =
         new RateLimiter(
-            /* rate= */ 2,
+            /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
             mClock,
             /* samplingBucketId= */ 0.71f,

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/RateTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/RateTest.java
@@ -55,7 +55,8 @@ public class RateTest {
 
     assertThat(twoTokensPerMillisecond.getTokensPerSeconds()).isEqualTo(2.0 * 1000);
     assertThat(sevenTokensPerTenMillisecond.getTokensPerSeconds()).isEqualTo((7.0 / 10) * 1000);
-    assertThat(thirtyOneTokensPerTenMillisecond.getTokensPerSeconds()).isEqualTo((31.0 / 10) * 1000);
+    assertThat(thirtyOneTokensPerTenMillisecond.getTokensPerSeconds())
+        .isEqualTo((31.0 / 10) * 1000);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/RateTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/RateTest.java
@@ -26,61 +26,61 @@ import org.robolectric.RobolectricTestRunner;
 public class RateTest {
 
   @Test
-  public void ratePerMinute() throws InterruptedException {
+  public void ratePerMinute() throws Exception {
     Rate twoTokensPerMinute = new Rate(2, 1, TimeUnit.MINUTES);
     Rate twentyTokensPerTenMinutes = new Rate(5, 10, TimeUnit.MINUTES);
     Rate twoTokensPerTenMinutes = new Rate(2, 10, TimeUnit.MINUTES);
 
-    assertThat(twoTokensPerMinute.getTokenPerSeconds()).isEqualTo(2.0 / 60);
-    assertThat(twentyTokensPerTenMinutes.getTokenPerSeconds()).isEqualTo((5.0 / 10) / 60);
-    assertThat(twoTokensPerTenMinutes.getTokenPerSeconds()).isEqualTo((2.0 / 10) / 60);
+    assertThat(twoTokensPerMinute.getTokensPerSeconds()).isEqualTo(2.0 / 60);
+    assertThat(twentyTokensPerTenMinutes.getTokensPerSeconds()).isEqualTo((5.0 / 10) / 60);
+    assertThat(twoTokensPerTenMinutes.getTokensPerSeconds()).isEqualTo((2.0 / 10) / 60);
   }
 
   @Test
-  public void ratePerSecond() throws InterruptedException {
+  public void ratePerSecond() throws Exception {
     Rate twoTokensPerSecond = new Rate(2, 1, TimeUnit.SECONDS);
     Rate twoTokensPerThirtySeconds = new Rate(2, 30, TimeUnit.SECONDS);
     Rate seventyTokensPerThirtySeconds = new Rate(70, 30, TimeUnit.SECONDS);
 
-    assertThat(twoTokensPerSecond.getTokenPerSeconds()).isEqualTo(2.0);
-    assertThat(twoTokensPerThirtySeconds.getTokenPerSeconds()).isEqualTo(2.0 / 30);
-    assertThat(seventyTokensPerThirtySeconds.getTokenPerSeconds()).isEqualTo(70.0 / 30);
+    assertThat(twoTokensPerSecond.getTokensPerSeconds()).isEqualTo(2.0);
+    assertThat(twoTokensPerThirtySeconds.getTokensPerSeconds()).isEqualTo(2.0 / 30);
+    assertThat(seventyTokensPerThirtySeconds.getTokensPerSeconds()).isEqualTo(70.0 / 30);
   }
 
   @Test
-  public void ratePerMillisecond() throws InterruptedException {
+  public void ratePerMillisecond() throws Exception {
     Rate twoTokensPerMillisecond = new Rate(2, 1, TimeUnit.MILLISECONDS);
     Rate sevenTokensPerTenMillisecond = new Rate(7, 10, TimeUnit.MILLISECONDS);
     Rate thirtyOneTokensPerTenMillisecond = new Rate(31, 10, TimeUnit.MILLISECONDS);
 
-    assertThat(twoTokensPerMillisecond.getTokenPerSeconds()).isEqualTo(2.0 * 1000);
-    assertThat(sevenTokensPerTenMillisecond.getTokenPerSeconds()).isEqualTo((7.0 / 10) * 1000);
-    assertThat(thirtyOneTokensPerTenMillisecond.getTokenPerSeconds()).isEqualTo((31.0 / 10) * 1000);
+    assertThat(twoTokensPerMillisecond.getTokensPerSeconds()).isEqualTo(2.0 * 1000);
+    assertThat(sevenTokensPerTenMillisecond.getTokensPerSeconds()).isEqualTo((7.0 / 10) * 1000);
+    assertThat(thirtyOneTokensPerTenMillisecond.getTokensPerSeconds()).isEqualTo((31.0 / 10) * 1000);
   }
 
   @Test
-  public void ratePerMicrosecond() throws InterruptedException {
+  public void ratePerMicrosecond() throws Exception {
     Rate twoTokensPerMicrosecond = new Rate(2, 1, TimeUnit.MICROSECONDS);
     Rate sevenTokensPerTenMicroseconds = new Rate(7, 10, TimeUnit.MICROSECONDS);
     Rate thirtyOneTokensPerTenMicroseconds = new Rate(31, 10, TimeUnit.MICROSECONDS);
 
-    assertThat(twoTokensPerMicrosecond.getTokenPerSeconds()).isEqualTo(2.0 * 1000 * 1000);
-    assertThat(sevenTokensPerTenMicroseconds.getTokenPerSeconds())
+    assertThat(twoTokensPerMicrosecond.getTokensPerSeconds()).isEqualTo(2.0 * 1000 * 1000);
+    assertThat(sevenTokensPerTenMicroseconds.getTokensPerSeconds())
         .isEqualTo((7.0 / 10) * 1000 * 1000);
-    assertThat(thirtyOneTokensPerTenMicroseconds.getTokenPerSeconds())
+    assertThat(thirtyOneTokensPerTenMicroseconds.getTokensPerSeconds())
         .isEqualTo((31.0 / 10) * 1000 * 1000);
   }
 
   @Test
-  public void ratePerNanosecond() throws InterruptedException {
+  public void ratePerNanosecond() throws Exception {
     Rate twoTokensPerNanosecond = new Rate(2, 1, TimeUnit.NANOSECONDS);
     Rate sevenTokensPerTenNanoseconds = new Rate(7, 10, TimeUnit.NANOSECONDS);
     Rate thirtyOneTokensPerTenNanoseconds = new Rate(31, 10, TimeUnit.NANOSECONDS);
 
-    assertThat(twoTokensPerNanosecond.getTokenPerSeconds()).isEqualTo(2.0 * 1000 * 1000 * 1000);
-    assertThat(sevenTokensPerTenNanoseconds.getTokenPerSeconds())
+    assertThat(twoTokensPerNanosecond.getTokensPerSeconds()).isEqualTo(2.0 * 1000 * 1000 * 1000);
+    assertThat(sevenTokensPerTenNanoseconds.getTokensPerSeconds())
         .isEqualTo((7.0 / 10) * 1000 * 1000 * 1000);
-    assertThat(thirtyOneTokensPerTenNanoseconds.getTokenPerSeconds())
+    assertThat(thirtyOneTokensPerTenNanoseconds.getTokensPerSeconds())
         .isEqualTo((31.0 / 10) * 1000 * 1000 * 1000);
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/RateTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/RateTest.java
@@ -1,0 +1,86 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.perf.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Unit tests for {@link Rate}. */
+@RunWith(RobolectricTestRunner.class)
+public class RateTest {
+
+  @Test
+  public void ratePerMinute() throws InterruptedException {
+    Rate twoTokensPerMinute = new Rate(2, 1, TimeUnit.MINUTES);
+    Rate twentyTokensPerTenMinutes = new Rate(5, 10, TimeUnit.MINUTES);
+    Rate twoTokensPerTenMinutes = new Rate(2, 10, TimeUnit.MINUTES);
+
+    assertThat(twoTokensPerMinute.getTokenPerSeconds()).isEqualTo(2.0 / 60);
+    assertThat(twentyTokensPerTenMinutes.getTokenPerSeconds()).isEqualTo((5.0 / 10) / 60);
+    assertThat(twoTokensPerTenMinutes.getTokenPerSeconds()).isEqualTo((2.0 / 10) / 60);
+  }
+
+  @Test
+  public void ratePerSecond() throws InterruptedException {
+    Rate twoTokensPerSecond = new Rate(2, 1, TimeUnit.SECONDS);
+    Rate twoTokensPerThirtySeconds = new Rate(2, 30, TimeUnit.SECONDS);
+    Rate seventyTokensPerThirtySeconds = new Rate(70, 30, TimeUnit.SECONDS);
+
+    assertThat(twoTokensPerSecond.getTokenPerSeconds()).isEqualTo(2.0);
+    assertThat(twoTokensPerThirtySeconds.getTokenPerSeconds()).isEqualTo(2.0 / 30);
+    assertThat(seventyTokensPerThirtySeconds.getTokenPerSeconds()).isEqualTo(70.0 / 30);
+  }
+
+  @Test
+  public void ratePerMillisecond() throws InterruptedException {
+    Rate twoTokensPerMillisecond = new Rate(2, 1, TimeUnit.MILLISECONDS);
+    Rate sevenTokensPerTenMillisecond = new Rate(7, 10, TimeUnit.MILLISECONDS);
+    Rate thirtyOneTokensPerTenMillisecond = new Rate(31, 10, TimeUnit.MILLISECONDS);
+
+    assertThat(twoTokensPerMillisecond.getTokenPerSeconds()).isEqualTo(2.0 * 1000);
+    assertThat(sevenTokensPerTenMillisecond.getTokenPerSeconds()).isEqualTo((7.0 / 10) * 1000);
+    assertThat(thirtyOneTokensPerTenMillisecond.getTokenPerSeconds()).isEqualTo((31.0 / 10) * 1000);
+  }
+
+  @Test
+  public void ratePerMicrosecond() throws InterruptedException {
+    Rate twoTokensPerMicrosecond = new Rate(2, 1, TimeUnit.MICROSECONDS);
+    Rate sevenTokensPerTenMicroseconds = new Rate(7, 10, TimeUnit.MICROSECONDS);
+    Rate thirtyOneTokensPerTenMicroseconds = new Rate(31, 10, TimeUnit.MICROSECONDS);
+
+    assertThat(twoTokensPerMicrosecond.getTokenPerSeconds()).isEqualTo(2.0 * 1000 * 1000);
+    assertThat(sevenTokensPerTenMicroseconds.getTokenPerSeconds())
+        .isEqualTo((7.0 / 10) * 1000 * 1000);
+    assertThat(thirtyOneTokensPerTenMicroseconds.getTokenPerSeconds())
+        .isEqualTo((31.0 / 10) * 1000 * 1000);
+  }
+
+  @Test
+  public void ratePerNanosecond() throws InterruptedException {
+    Rate twoTokensPerNanosecond = new Rate(2, 1, TimeUnit.NANOSECONDS);
+    Rate sevenTokensPerTenNanoseconds = new Rate(7, 10, TimeUnit.NANOSECONDS);
+    Rate thirtyOneTokensPerTenNanoseconds = new Rate(31, 10, TimeUnit.NANOSECONDS);
+
+    assertThat(twoTokensPerNanosecond.getTokenPerSeconds()).isEqualTo(2.0 * 1000 * 1000 * 1000);
+    assertThat(sevenTokensPerTenNanoseconds.getTokenPerSeconds())
+        .isEqualTo((7.0 / 10) * 1000 * 1000 * 1000);
+    assertThat(thirtyOneTokensPerTenNanoseconds.getTokenPerSeconds())
+        .isEqualTo((31.0 / 10) * 1000 * 1000 * 1000);
+  }
+}


### PR DESCRIPTION
Fixed two bugs in the RateLimiter:
- Rate was represented by a long, which causes confusion around the units (per second vs per minute)
- the token replenishment behavior is wrong and keeps track of lastTimeTokenConsumed instead of lastTimeTokenReplenished, causing less tokens to be generated overtime