### PR TITLE
Change Uploader's `logAndUpdateState` to upload all pending events

### DIFF
--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/UploaderIntegrationTest.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/UploaderIntegrationTest.java
@@ -16,6 +16,7 @@ package com.google.android.datatransport.runtime;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -108,14 +109,12 @@ public class UploaderIntegrationTest {
     transport.send(stringEvent);
     verify(mockBackend, times(2))
         .send(eq(BackendRequest.create(Collections.singletonList(expectedEvent))));
-    verify(spyScheduler, times(1)).schedule(any(), eq(2));
+    verify(spyScheduler, times(1)).schedule(any(), eq(2), anyBoolean());
     Iterable<PersistedEvent> eventList = store.loadBatch(transportContext);
     assertThat(eventList).isNotEmpty();
     for (PersistedEvent persistedEvent : eventList) {
       assertThat(persistedEvent.getEvent()).isEqualTo(expectedEvent);
     }
-
-    assertThat(store.getNextCallTime(transportContext)).isEqualTo(0);
   }
 
   @Test
@@ -183,7 +182,6 @@ public class UploaderIntegrationTest {
         .send(eq(BackendRequest.create(Collections.singletonList(expectedEvent))));
     verify(spyScheduler, times(0)).schedule(any(), eq(2));
     assertThat(store.loadBatch(transportContext)).isEmpty();
-    assertThat(store.getNextCallTime(transportContext)).isEqualTo(0);
   }
 
   @Test

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -127,11 +127,12 @@ public class Uploader {
                     .build());
       }
       if (response.getStatus() == BackendResponse.Status.TRANSIENT_ERROR) {
+        long finalMaxNextRequestWaitMillis1 = maxNextRequestWaitMillis;
         guard.runCriticalSection(
             () -> {
               eventStore.recordFailure(persistedEvents);
               eventStore.recordNextCallTime(
-                  transportContext, clock.getTime() + maxNextRequestWaitMillis);
+                  transportContext, clock.getTime() + finalMaxNextRequestWaitMillis1);
               return null;
             });
         workScheduler.schedule(transportContext, attemptNumber + 1, true);
@@ -148,9 +149,10 @@ public class Uploader {
         }
       }
     }
+    long finalMaxNextRequestWaitMillis = maxNextRequestWaitMillis;
     guard.runCriticalSection(() -> {
         eventStore.recordNextCallTime(
-            transportContext, clock.getTime() + maxNextRequestWaitMillis);
+            transportContext, clock.getTime() + finalMaxNextRequestWaitMillis);
         return null;
     });
   }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -150,10 +150,11 @@ public class Uploader {
       }
     }
     long finalMaxNextRequestWaitMillis = maxNextRequestWaitMillis;
-    guard.runCriticalSection(() -> {
-        eventStore.recordNextCallTime(
-            transportContext, clock.getTime() + finalMaxNextRequestWaitMillis);
-        return null;
-    });
+    guard.runCriticalSection(
+        () -> {
+          eventStore.recordNextCallTime(
+              transportContext, clock.getTime() + finalMaxNextRequestWaitMillis);
+          return null;
+        });
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -97,50 +97,61 @@ public class Uploader {
 
   void logAndUpdateState(TransportContext transportContext, int attemptNumber) {
     TransportBackend backend = backendRegistry.get(transportContext.getBackendName());
+    long maxNextRequestWaitMillis = 0;
 
-    Iterable<PersistedEvent> persistedEvents =
-        guard.runCriticalSection(() -> eventStore.loadBatch(transportContext));
+    while (guard.runCriticalSection(() -> eventStore.hasPendingEventsFor(transportContext))) {
+      Iterable<PersistedEvent> persistedEvents =
+          guard.runCriticalSection(() -> eventStore.loadBatch(transportContext));
 
-    // Do not make a call to the backend if the list is empty.
-    if (!persistedEvents.iterator().hasNext()) {
-      return;
-    }
-
-    BackendResponse response;
-    if (backend == null) {
-      Logging.d(
-          LOG_TAG, "Unknown backend for %s, deleting event batch for it...", transportContext);
-      response = BackendResponse.fatalError();
-    } else {
-      List<EventInternal> eventInternals = new ArrayList<>();
-
-      for (PersistedEvent persistedEvent : persistedEvents) {
-        eventInternals.add(persistedEvent.getEvent());
+      // Do not make a call to the backend if the list is empty.
+      if (!persistedEvents.iterator().hasNext()) {
+        return;
       }
-      response =
-          backend.send(
-              BackendRequest.builder()
-                  .setEvents(eventInternals)
-                  .setExtras(transportContext.getExtras())
-                  .build());
-    }
 
-    guard.runCriticalSection(
-        () -> {
-          if (response.getStatus() == BackendResponse.Status.TRANSIENT_ERROR) {
-            eventStore.recordFailure(persistedEvents);
-            workScheduler.schedule(transportContext, attemptNumber + 1);
-          } else {
-            eventStore.recordSuccess(persistedEvents);
-            if (response.getStatus() == BackendResponse.Status.OK) {
+      BackendResponse response;
+      if (backend == null) {
+        Logging.d(
+            LOG_TAG, "Unknown backend for %s, deleting event batch for it...", transportContext);
+        response = BackendResponse.fatalError();
+      } else {
+        List<EventInternal> eventInternals = new ArrayList<>();
+
+        for (PersistedEvent persistedEvent : persistedEvents) {
+          eventInternals.add(persistedEvent.getEvent());
+        }
+        response =
+            backend.send(
+                BackendRequest.builder()
+                    .setEvents(eventInternals)
+                    .setExtras(transportContext.getExtras())
+                    .build());
+      }
+      if (response.getStatus() == BackendResponse.Status.TRANSIENT_ERROR) {
+        guard.runCriticalSection(
+            () -> {
+              eventStore.recordFailure(persistedEvents);
               eventStore.recordNextCallTime(
-                  transportContext, clock.getTime() + response.getNextRequestWaitMillis());
-            }
-            if (eventStore.hasPendingEventsFor(transportContext)) {
-              workScheduler.schedule(transportContext, 1, true);
-            }
-          }
-          return null;
-        });
+                  transportContext, clock.getTime() + maxNextRequestWaitMillis);
+              return null;
+            });
+        workScheduler.schedule(transportContext, attemptNumber + 1, true);
+        return;
+      } else {
+        guard.runCriticalSection(
+            () -> {
+              eventStore.recordSuccess(persistedEvents);
+              return null;
+            });
+        if (response.getStatus() == BackendResponse.Status.OK) {
+          maxNextRequestWaitMillis =
+              Math.max(maxNextRequestWaitMillis, response.getNextRequestWaitMillis());
+        }
+      }
+    }
+    guard.runCriticalSection(() -> {
+        eventStore.recordNextCallTime(
+            transportContext, clock.getTime() + maxNextRequestWaitMillis);
+        return null;
+    });
   }
 }


### PR DESCRIPTION
Instead of uploading one batch, the Uploader will now upload all pending events - this will get around a throughput issue that the uploader can experience.