### PR TITLE
Removing FIAM Display SDK dependency on Analytics.

### DIFF
--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -70,10 +70,6 @@ dependencies {
     implementation project(':firebase-components')
     implementation project(':firebase-inappmessaging')
 
-    implementation('com.google.firebase:firebase-measurement-connector:18.0.0') {
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-    }
-
     implementation 'com.google.android.gms:play-services-tasks:17.1.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayRegistrar.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayRegistrar.java
@@ -17,7 +17,6 @@ package com.google.firebase.inappmessaging.display;
 import android.app.Application;
 import androidx.annotation.Keep;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.analytics.connector.AnalyticsConnector;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentContainer;
 import com.google.firebase.components.ComponentRegistrar;
@@ -46,7 +45,6 @@ public class FirebaseInAppMessagingDisplayRegistrar implements ComponentRegistra
     return Arrays.asList(
         Component.builder(FirebaseInAppMessagingDisplay.class)
             .add(Dependency.required(FirebaseApp.class))
-            .add(Dependency.required(AnalyticsConnector.class))
             .add(Dependency.required(FirebaseInAppMessaging.class))
             .factory(this::buildFirebaseInAppMessagingUI)
             .eagerInDefaultApp()

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayRegistrar.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayRegistrar.java
@@ -54,7 +54,7 @@ public class FirebaseInAppMessagingDisplayRegistrar implements ComponentRegistra
 
   private FirebaseInAppMessagingDisplay buildFirebaseInAppMessagingUI(
       ComponentContainer container) {
-    FirebaseApp firebaseApp = FirebaseApp.getInstance();
+    FirebaseApp firebaseApp = container.get(FirebaseApp.class);
     FirebaseInAppMessaging headless = container.get(FirebaseInAppMessaging.class);
     Application firebaseApplication = (Application) firebaseApp.getApplicationContext();
 


### PR DESCRIPTION
Removing FIAM Display SDK dependency on Analytics since its not used by FIAM Display SDK

Changes:

- Removed analytics dependency from FirebaseInAppMessagingDisplayRegistrar
- Removed analytics dependency from FirebaseInAppMessagingDisplay - Gradle