### PR TITLE
Clean up old sessions in the NDK

### DIFF
--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashFilesManager.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashFilesManager.java
@@ -22,5 +22,7 @@ interface CrashFilesManager {
 
   File getSessionFileDirectory(String sessionId);
 
-  void deleteSessionFilesDirectory(String sessionId);
+  void deleteSessionFileDirectory(String sessionId);
+
+  void cleanOldSessionFileDirectories();
 }

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashpadController.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashpadController.java
@@ -29,7 +29,9 @@ import java.nio.charset.Charset;
 
 class CrashpadController implements NativeComponentController {
 
+  @SuppressWarnings("CharsetObjectCanBeUsed") // StandardCharsets requires API level 19.
   private static final Charset UTF_8 = Charset.forName("UTF-8");
+
   private static final String SESSION_METADATA_FILE = "session.json";
   private static final String APP_METADATA_FILE = "app.json";
   private static final String DEVICE_METADATA_FILE = "device.json";
@@ -48,6 +50,7 @@ class CrashpadController implements NativeComponentController {
   @Override
   public boolean initialize(String sessionId) {
     boolean initSuccess = false;
+    filesManager.cleanOldSessionFileDirectories();
     final File crashReportDirectory = filesManager.getSessionFileDirectory(sessionId);
     try {
       if (crashReportDirectory != null) {
@@ -71,7 +74,8 @@ class CrashpadController implements NativeComponentController {
 
   @Override
   public boolean finalizeSession(String sessionId) {
-    filesManager.deleteSessionFilesDirectory(sessionId);
+    filesManager.deleteSessionFileDirectory(sessionId);
+    filesManager.cleanOldSessionFileDirectories();
     return true;
   }
 

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/NdkCrashFilesManager.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/NdkCrashFilesManager.java
@@ -17,8 +17,13 @@ package com.google.firebase.crashlytics.ndk;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
 
 class NdkCrashFilesManager implements CrashFilesManager {
+  private static final Comparator<? super File> LATEST_SESSION_FIRST =
+      (f1, f2) -> f2.getName().compareTo(f1.getName());
+  private static final int MAX_SESSIONS = 8;
 
   private final File rootPath;
 
@@ -38,8 +43,19 @@ class NdkCrashFilesManager implements CrashFilesManager {
   }
 
   @Override
-  public void deleteSessionFilesDirectory(String sessionId) {
+  public void deleteSessionFileDirectory(String sessionId) {
     recursiveDelete(new File(rootPath, sessionId));
+  }
+
+  @Override
+  public void cleanOldSessionFileDirectories() {
+    File[] sessionFileDirectories = rootPath.listFiles(File::isDirectory);
+    if (sessionFileDirectories != null && sessionFileDirectories.length > MAX_SESSIONS) {
+      Arrays.sort(sessionFileDirectories, LATEST_SESSION_FIRST);
+      for (int i = MAX_SESSIONS; i < sessionFileDirectories.length; i++) {
+        recursiveDelete(sessionFileDirectories[i]);
+      }
+    }
   }
 
   @Nullable


### PR DESCRIPTION
Clean up old sessions in the NDK before initializing and after finalizing a session.

Tested manually with a test app.