### PR TITLE
Functions to perform GET request when body data is empty

### DIFF
--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
@@ -299,7 +299,12 @@ public class FirebaseFunctions {
     MediaType contentType = MediaType.parse("application/json");
     RequestBody requestBody = RequestBody.create(contentType, bodyJSON.toString());
 
-    Request.Builder request = new Request.Builder().url(url).post(requestBody);
+    Request.Builder request = new Request.Builder().url(url);
+    if (data != null) {
+      request = request.post(requestBody);
+    } else {
+      request = request.get();
+    }
     if (context.getAuthToken() != null) {
       request = request.header("Authorization", "Bearer " + context.getAuthToken());
     }


### PR DESCRIPTION
Instead of always using a POST request, which is not always what devs want since express.js lets us build robust apis, functions will now perform a GET request when there is no body data.

Fixes and closes #2685 