### PR TITLE
Fix incremental builds for firebase-crashlytics-ndk

### DIFF
--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -76,7 +76,7 @@ android {
             }
 
             tasks.findAll {
-                it.name.startsWith("externalNativeBuild")
+                it.name.startsWith("externalNativeBuild") && !it.name.contains("Clean")
             }.each {
                 func.dependsOn it
             }


### PR DESCRIPTION
One task was incorrectly relying on `externalNativeBuildClean`,
which caused all native files to be rebuilt on every build,
regardless of if they were changed. That task dependency has
been removed, reducing incremental build times from 6m to ~13s.