### PR TITLE
Add a null check on AnalyticsConnector provider

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -238,7 +238,7 @@ public class RemoteConfigComponent {
       String namespace, ConfigCacheClient fetchedCacheClient, ConfigMetadataClient metadataClient) {
     return new ConfigFetchHandler(
         firebaseInstallations,
-        isPrimaryApp(firebaseApp) ? analyticsConnector : null,
+        isPrimaryApp(firebaseApp) ? analyticsConnector : () -> null,
         executorService,
         DEFAULT_CLOCK,
         DEFAULT_RANDOM,

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -498,9 +498,7 @@ public class ConfigFetchHandler {
   @WorkerThread
   private Map<String, String> getUserProperties() {
     Map<String, String> userPropertiesMap = new HashMap<>();
-    AnalyticsConnector connector = this.analyticsConnector != null
-                ? this.analyticsConnector.get() : null;
-    
+    AnalyticsConnector connector = this.analyticsConnector.get();
     if (connector == null) {
       return userPropertiesMap;
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -498,7 +498,9 @@ public class ConfigFetchHandler {
   @WorkerThread
   private Map<String, String> getUserProperties() {
     Map<String, String> userPropertiesMap = new HashMap<>();
-    AnalyticsConnector connector = this.analyticsConnector.get();
+    AnalyticsConnector connector = this.analyticsConnector != null
+                ? this.analyticsConnector.get() : null;
+    
     if (connector == null) {
       return userPropertiesMap;
     }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -127,7 +127,7 @@ public class RemoteConfigComponentTest {
         getNewFrcComponent()
             .getFetchHandler(DEFAULT_NAMESPACE, mockFetchedCache, mockMetadataClient);
 
-    assertThat(fetchHandler.getAnalyticsConnector()).isNull();
+    assertThat(fetchHandler.getAnalyticsConnector().get()).isNull();
   }
 
   @Test


### PR DESCRIPTION
Creating the ConfigFetchHandler for a non-default firebase application marks the provider as null which caused a NullPointerException

```
java.lang.NullPointerException: Attempt to invoke interface method 'java.lang.Object com.google.firebase.inject.Provider.get()' on a null object reference
at com.google.firebase.remoteconfig.internal.ConfigFetchHandler.getUserProperties(ConfigFetchHandler.java:501)
at com.google.firebase.remoteconfig.internal.ConfigFetchHandler.fetchFromBackend(ConfigFetchHandler.java:311)
at com.google.firebase.remoteconfig.internal.ConfigFetchHandler.fetchFromBackendAndCacheResponse(ConfigFetchHandler.java:278)
at com.google.firebase.remoteconfig.internal.ConfigFetchHandler.lambda$fetchIfCacheExpiredAndNotThrottled$1$ConfigFetchHandler(ConfigFetchHandler.java:215)
at com.google.firebase.remoteconfig.internal.ConfigFetchHandler$$ExternalSyntheticLambda1.then(Unknown Source:8)
at com.google.android.gms.tasks.zzf.run(com.google.android.gms:play-services-tasks@@17.2.0:2)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
at java.lang.Thread.run(Thread.java:919)