### PR TITLE
Fix crash in messaging when no Firebase app is initialized

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/MessagingAnalytics.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/MessagingAnalytics.java
@@ -308,13 +308,17 @@ public class MessagingAnalytics {
     }
 
     // TODO(b/78465387) Use components dependency framework to get analyticsConnector obj
-    @SuppressWarnings("FirebaseUseExplicitDependencies")
-    AnalyticsConnector analytics = FirebaseApp.getInstance().get(AnalyticsConnector.class);
-    if (analytics != null) {
-      analytics.logEvent(ScionAnalytics.ORIGIN_FCM, event, scionPayload);
-    } else {
-      // Client did not include the measurement library
-      Log.w(TAG, "Unable to log event: analytics library is missing");
+    try {
+      @SuppressWarnings("FirebaseUseExplicitDependencies")
+      AnalyticsConnector analytics = FirebaseApp.getInstance().get(AnalyticsConnector.class);
+      if (analytics != null) {
+        analytics.logEvent(ScionAnalytics.ORIGIN_FCM, event, scionPayload);
+      } else {
+        // Client did not include the measurement library
+        Log.w(TAG, "Unable to log event: analytics library is missing");
+      }
+    } catch (IllegalStateException e) {
+      Log.w(TAG, "Unable to log event: Firebase app not initialized");
     }
   }
 


### PR DESCRIPTION
Our app has been seeing the following crashes since we updated to the latest Firebase Messaging SDK:
```
com.google.firebase.FirebaseApp.getInstance FirebaseApp.java:183
com.google.firebase.messaging.MessagingAnalytics.logToScion com.google.firebase:firebase-messaging@@21.1.0:27
com.google.firebase.messaging.MessagingAnalytics.logNotificationDismiss com.google.firebase:firebase-messaging@@21.1.0:1
com.google.firebase.iid.FirebaseInstanceIdReceiver.onNotificationDismissed com.google.firebase:firebase-messaging@@21.1.0:3
com.google.android.gms.cloudmessaging.CloudMessagingReceiver.zza com.google.android.gms:play-services-cloud-messaging@@16.0.0:29
com.google.android.gms.cloudmessaging.CloudMessagingReceiver.zza com.google.android.gms:play-services-cloud-messaging@@16.0.0:58
com.google.android.gms.cloudmessaging.zzd.run
java.util.concurrent.ThreadPoolExecutor.runWorker ThreadPoolExecutor.java:1167
java.util.concurrent.ThreadPoolExecutor$Worker.run ThreadPoolExecutor.java:641
com.google.android.gms.common.util.concurrent.zza.run
java.lang.Thread.run Thread.java:923
```

Our app initialized Firebase dynamically, after settings are downloaded from our servers. It appears that notifications are being dismissed when the app has not been started. Since there is a TODO in the code to remove the Firebase app dependency, I did a simple fix to surround the code with a try/catch.