### PR TITLE
Fix inaccurate activity screen metrics.

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -289,7 +289,8 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   public void onActivityPaused(Activity activity) {}
 
   /**
-   * Send screen trace.
+   * Send screen trace. If hardware acceleration is not enabled, all frame metrics will be zero and
+   * the trace will not be sent.
    *
    * @param activity activity object.
    */

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -149,6 +149,10 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   public synchronized void onActivityStarted(Activity activity) {
     if (isScreenTraceSupported(activity) && configResolver.isPerformanceMonitoringEnabled()) {
       // Starts recording frame metrics for this activity.
+      /**
+       * TODO: Only add activities that are hardware acceleration enabled so that calling {@link
+       * FrameMetricsAggregator#remove(Activity)} will not throw exceptions.
+       */
       frameMetricsAggregator.add(activity);
       // Start the Trace
       Trace screenTrace = new Trace(getScreenTraceName(activity), transportManager, clock, this);
@@ -307,7 +311,13 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     int totalFrames = 0;
     int slowFrames = 0;
     int frozenFrames = 0;
-    // Stops recording metrics for this Activity and returns the currently-collected metrics
+    /**
+     * Resets the metrics data and returns the currently-collected metrics. Note that {@link
+     * FrameMetricsAggregator#reset()} will not stop recording for the activity. The reason of using
+     * {@link FrameMetricsAggregator#reset()} is that {@link
+     * FrameMetricsAggregator#remove(Activity)} will throw exceptions for hardware acceleration
+     * disabled activities.
+     */
     SparseIntArray[] arr = frameMetricsAggregator.reset();
     if (arr != null) {
       SparseIntArray frameTimes = arr[FrameMetricsAggregator.TOTAL_INDEX];

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -20,7 +20,6 @@ import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.Context;
 import android.os.Bundle;
 import android.util.SparseIntArray;
-import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.core.app.FrameMetricsAggregator;
 import com.google.android.gms.common.util.VisibleForTesting;
@@ -308,7 +307,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     int slowFrames = 0;
     int frozenFrames = 0;
     // Stops recording metrics for this Activity and returns the currently-collected metrics
-    SparseIntArray[] arr = frameMetricsAggregator.remove(activity);
+    SparseIntArray[] arr = frameMetricsAggregator.reset();
     if (arr != null) {
       SparseIntArray frameTimes = arr[FrameMetricsAggregator.TOTAL_INDEX];
       if (frameTimes != null) {
@@ -391,21 +390,13 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   }
 
   /**
-   * Only send screen trace if FrameMetricsAggregator exists and the activity is hardware
-   * accelerated.
+   * Only send screen trace if FrameMetricsAggregator exists.
    *
    * @param activity The Activity for which we're monitoring the screen rendering performance.
    * @return true if supported, false if not.
    */
   private boolean isScreenTraceSupported(Activity activity) {
-    return hasFrameMetricsAggregator
-        // This check is needed because we can't observe frame rates for a non hardware accelerated
-        // view.
-        // See b/133827763.
-        && activity.getWindow() != null
-        && ((activity.getWindow().getAttributes().flags
-                & WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED)
-            != 0);
+    return hasFrameMetricsAggregator;
   }
 
   /**

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
@@ -373,13 +373,12 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void screenTrace_noHardwareAccelerated_traceNotCreated() {
+  public void screenTrace_noHardwareAccelerated_noExceptionThrown() {
     AppStateMonitor monitor = new AppStateMonitor(transportManager, clock);
     Activity activityWithNonHardwareAcceleratedView =
         createFakeActivity(/* isHardwareAccelerated =*/ false);
 
     monitor.onActivityStarted(activityWithNonHardwareAcceleratedView);
-    assertThat(monitor.getActivity2ScreenTrace()).isEmpty();
 
     // Confirm that this doesn't throw an exception.
     monitor.onActivityStopped(activityWithNonHardwareAcceleratedView);


### PR DESCRIPTION
This PR is to fix:
1. https://github.com/firebase/firebase-android-sdk/issues/2672 
2. Screen trace data not tracked for Android API levels 23 and below (b/191954905).

Summary of changes:
1. Replaced `frameMetricsAggregator.remove(activity)` with `frameMetricsAggregator.reset()` because `remove` does not clean the frame metrics, causes frame metrics for each activity is added on top of the data for all previous pages.
2. Removed [checks](https://github.com/firebase/firebase-android-sdk/blob/master/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java#L405-L407) for hardware accelerated. The reason for adding this check is due to the crash by calling `frameMetricsAggregator.remove(activity)` (see b/133827763). However, this check will return false even if hardware acceleration is turned on by default. Now, if an activity is not hardware accelerated, the metrics will just be 0.  