### PR TITLE
Disable jetifier.

### DIFF
--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -32,6 +32,13 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    lintOptions {
+        // com.squareup.picasso:picasso:2.71828 depends on com.android.support:exifinterface so we
+        // disable this lint error since we have no control over that dependency and enabling
+        // jetification in our SDK build will still require developers to use jetification in their
+        // apps.
+        disable "GradleCompatible"
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,10 +13,6 @@
 # limitations under the License.
 org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=8g
 
-android.enableJetifier=true
-android.useAndroidX=true
-android.jetifier.blacklist=errorprone,firebase-encoders-processor
-
 org.gradle.parallel=true
 org.gradle.caching=true
 


### PR DESCRIPTION
Jetifier is no longer needed and is causing failures for the encoders
proto plugin.