### PR TITLE
Implement GetAppCheckToken API

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/src/androidTest/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck-debug-testing/src/androidTest/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckTest.java
@@ -25,7 +25,6 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.AppCheckToken;
 import com.google.firebase.appcheck.AppCheckTokenResult;
 import com.google.firebase.appcheck.FirebaseAppCheck;
-import com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.ListResult;
 import java.util.concurrent.ExecutionException;

--- a/appcheck/firebase-appcheck-debug-testing/src/androidTest/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck-debug-testing/src/androidTest/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckTest.java
@@ -22,8 +22,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.appcheck.AppCheckToken;
 import com.google.firebase.appcheck.AppCheckTokenResult;
 import com.google.firebase.appcheck.FirebaseAppCheck;
+import com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.ListResult;
 import java.util.concurrent.ExecutionException;
@@ -52,7 +54,7 @@ public class FirebaseAppCheckTest {
   }
 
   @Test
-  public void exchangeDebugSecretForAppCheckToken() throws Exception {
+  public void exchangeDebugSecretForAppCheckToken_interopApi() throws Exception {
     debugAppCheckTestHelper.withDebugProvider(
         () -> {
           Task<AppCheckTokenResult> tokenResultTask = firebaseAppCheck.getToken(true);
@@ -60,6 +62,17 @@ public class FirebaseAppCheckTest {
           AppCheckTokenResult result = tokenResultTask.getResult();
           assertThat(result.getToken()).isNotEmpty();
           assertThat(result.getError()).isNull();
+        });
+  }
+
+  @Test
+  public void exchangeDebugSecretForAppCheckToken_publicApi() throws Exception {
+    debugAppCheckTestHelper.withDebugProvider(
+        () -> {
+          Task<AppCheckToken> tokenTask = firebaseAppCheck.getAppCheckToken(true);
+          Tasks.await(tokenTask);
+          AppCheckToken result = tokenTask.getResult();
+          assertThat(result.getToken()).isNotEmpty();
         });
   }
 

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/FirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/FirebaseAppCheck.java
@@ -16,6 +16,7 @@ package com.google.firebase.appcheck;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.interop.AppCheckTokenListener;
 import com.google.firebase.appcheck.interop.InternalAppCheckTokenProvider;
@@ -69,4 +70,30 @@ public abstract class FirebaseAppCheck implements InternalAppCheckTokenProvider 
 
   /** Sets the {@code isTokenAutoRefreshEnabled} flag. */
   public abstract void setTokenAutoRefreshEnabled(boolean isTokenAutoRefreshEnabled);
+
+  /**
+   * Requests a Firebase App Check token. This method should be used ONLY if you need to authorize
+   * requests to a non-Firebase backend. Requests to Firebase backends are authorized automatically
+   * if configured.
+   */
+  @NonNull
+  public abstract Task<AppCheckToken> getAppCheckToken(boolean forceRefresh);
+
+  /**
+   * Registers an {@link AppCheckListener} to changes in the token state. This method should be used
+   * ONLY if you need to authorize requests to a non-Firebase backend. Requests to Firebase backends
+   * are authorized automatically if configured.
+   */
+  public abstract void addAppCheckListener(@NonNull AppCheckListener listener);
+
+  /** Unregisters an {@link AppCheckListener} to changes in the token state. */
+  public abstract void removeAppCheckListener(@NonNull AppCheckListener listener);
+
+  public interface AppCheckListener {
+    /**
+     * This method gets invoked on the UI thread on changes to the token state. Does not trigger on
+     * token expiry.
+     */
+    void onAppCheckTokenChanged(@NonNull AppCheckToken token);
+  }
 }

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -161,23 +161,6 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
               new FirebaseException("No AppCheckProvider installed.")));
     }
     // TODO: Cache the in-flight task.
-    return fetchTokenResultFromProvider();
-  }
-
-  @NonNull
-  @Override
-  public Task<AppCheckToken> getAppCheckToken(boolean forceRefresh) {
-    if (!forceRefresh && hasValidToken()) {
-      return Tasks.forResult(cachedToken);
-    }
-    if (appCheckProvider == null) {
-      return Tasks.forException(new FirebaseException("No AppCheckProvider installed."));
-    }
-    return fetchTokenFromProvider();
-  }
-
-  /** Fetches an {@link AppCheckTokenResult} via the installed {@link AppCheckProvider}. */
-  Task<AppCheckTokenResult> fetchTokenResultFromProvider() {
     return fetchTokenFromProvider()
         .continueWithTask(
             new Continuation<AppCheckToken, Task<AppCheckTokenResult>>() {
@@ -195,6 +178,18 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
                             task.getException().getMessage(), task.getException())));
               }
             });
+  }
+
+  @NonNull
+  @Override
+  public Task<AppCheckToken> getAppCheckToken(boolean forceRefresh) {
+    if (!forceRefresh && hasValidToken()) {
+      return Tasks.forResult(cachedToken);
+    }
+    if (appCheckProvider == null) {
+      return Tasks.forException(new FirebaseException("No AppCheckProvider installed."));
+    }
+    return fetchTokenFromProvider();
   }
 
   /** Fetches an {@link AppCheckToken} via the installed {@link AppCheckProvider}. */

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -184,12 +184,8 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
               @Override
               public Task<AppCheckTokenResult> then(@NonNull Task<AppCheckToken> task) {
                 if (task.isSuccessful()) {
-                  AppCheckTokenResult tokenResult =
-                      DefaultAppCheckTokenResult.constructFromAppCheckToken(task.getResult());
-                  for (AppCheckTokenListener listener : appCheckTokenListenerList) {
-                    listener.onAppCheckTokenChanged(tokenResult);
-                  }
-                  return Tasks.forResult(tokenResult);
+                  return Tasks.forResult(
+                      DefaultAppCheckTokenResult.constructFromAppCheckToken(task.getResult()));
                 }
                 // If the token exchange failed, return a dummy token for integrators to attach in
                 // their headers.
@@ -214,6 +210,11 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
                   updateStoredToken(token);
                   for (AppCheckListener listener : appCheckListenerList) {
                     listener.onAppCheckTokenChanged(token);
+                  }
+                  AppCheckTokenResult tokenResult =
+                      DefaultAppCheckTokenResult.constructFromAppCheckToken(token);
+                  for (AppCheckTokenListener listener : appCheckTokenListenerList) {
+                    listener.onAppCheckTokenChanged(tokenResult);
                   }
                 }
                 return task;

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultTokenRefresher.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultTokenRefresher.java
@@ -20,10 +20,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
-import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.appcheck.AppCheckTokenResult;
-import com.google.firebase.appcheck.internal.util.Logger;
+import com.google.firebase.appcheck.AppCheckToken;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -94,20 +93,12 @@ public class DefaultTokenRefresher {
   }
 
   private void onRefresh() {
-    Task<AppCheckTokenResult> task = firebaseAppCheck.fetchTokenFromProvider();
-    task.addOnCompleteListener(
-        new OnCompleteListener<AppCheckTokenResult>() {
+    Task<AppCheckToken> task = firebaseAppCheck.fetchTokenFromProvider();
+    task.addOnFailureListener(
+        new OnFailureListener() {
           @Override
-          public void onComplete(@NonNull Task<AppCheckTokenResult> task) {
-            if (task.isSuccessful()) {
-              AppCheckTokenResult tokenResult = task.getResult();
-              if (tokenResult.getError() != null) {
-                scheduleRefreshAfterFailure();
-              }
-            } else {
-              // Task was not successful; this should not happen.
-              Logger.getLogger().e("Unexpected failure while fetching token.");
-            }
+          public void onFailure(@NonNull Exception e) {
+            scheduleRefreshAfterFailure();
           }
         });
   }

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultTokenRefresher.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultTokenRefresher.java
@@ -21,8 +21,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.OnFailureListener;
-import com.google.android.gms.tasks.Task;
-import com.google.firebase.appcheck.AppCheckToken;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -93,14 +91,15 @@ public class DefaultTokenRefresher {
   }
 
   private void onRefresh() {
-    Task<AppCheckToken> task = firebaseAppCheck.fetchTokenFromProvider();
-    task.addOnFailureListener(
-        new OnFailureListener() {
-          @Override
-          public void onFailure(@NonNull Exception e) {
-            scheduleRefreshAfterFailure();
-          }
-        });
+    firebaseAppCheck
+        .fetchTokenFromProvider()
+        .addOnFailureListener(
+            new OnFailureListener() {
+              @Override
+              public void onFailure(@NonNull Exception e) {
+                scheduleRefreshAfterFailure();
+              }
+            });
   }
 
   /** Cancels the in-flight scheduled refresh. */

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultTokenRefresherTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultTokenRefresherTest.java
@@ -24,8 +24,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.android.gms.tasks.Tasks;
-import com.google.firebase.FirebaseException;
-import com.google.firebase.appcheck.AppCheckTokenResult;
+import com.google.firebase.appcheck.AppCheckToken;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,7 +46,7 @@ public class DefaultTokenRefresherTest {
 
   @Mock DefaultFirebaseAppCheck mockFirebaseAppCheck;
   @Mock ScheduledExecutorService mockScheduledExecutorService;
-  @Mock AppCheckTokenResult mockAppCheckTokenResult;
+  @Mock AppCheckToken mockAppCheckToken;
 
   private DefaultTokenRefresher defaultTokenRefresher;
 
@@ -56,7 +55,7 @@ public class DefaultTokenRefresherTest {
     MockitoAnnotations.initMocks(this);
 
     when(mockFirebaseAppCheck.fetchTokenFromProvider())
-        .thenReturn(Tasks.forResult(mockAppCheckTokenResult));
+        .thenReturn(Tasks.forResult(mockAppCheckToken));
 
     defaultTokenRefresher =
         new DefaultTokenRefresher(mockFirebaseAppCheck, mockScheduledExecutorService);
@@ -77,7 +76,8 @@ public class DefaultTokenRefresherTest {
 
   @Test
   public void scheduleRefresh_taskFails_schedulesRefreshAfterFailure() {
-    when(mockAppCheckTokenResult.getError()).thenReturn(new FirebaseException(ERROR));
+    when(mockFirebaseAppCheck.fetchTokenFromProvider())
+        .thenReturn(Tasks.forException(new Exception()));
     defaultTokenRefresher.scheduleRefresh(TIME_TO_REFRESH_MILLIS);
 
     ArgumentCaptor<Runnable> onRefreshCaptor = ArgumentCaptor.forClass(Runnable.class);
@@ -94,7 +94,8 @@ public class DefaultTokenRefresherTest {
 
   @Test
   public void scheduleRefreshAfterFailure_exponentialBackoff() {
-    when(mockAppCheckTokenResult.getError()).thenReturn(new FirebaseException(ERROR));
+    when(mockFirebaseAppCheck.fetchTokenFromProvider())
+        .thenReturn(Tasks.forException(new Exception()));
     defaultTokenRefresher.scheduleRefresh(TIME_TO_REFRESH_MILLIS);
 
     ArgumentCaptor<Runnable> onRefreshCaptor = ArgumentCaptor.forClass(Runnable.class);
@@ -131,7 +132,8 @@ public class DefaultTokenRefresherTest {
 
   @Test
   public void scheduleRefresh_resetsDelay() {
-    when(mockAppCheckTokenResult.getError()).thenReturn(new FirebaseException(ERROR));
+    when(mockFirebaseAppCheck.fetchTokenFromProvider())
+        .thenReturn(Tasks.forException(new Exception()));
     defaultTokenRefresher.scheduleRefresh(TIME_TO_REFRESH_MILLIS);
 
     ArgumentCaptor<Runnable> onRefreshCaptor = ArgumentCaptor.forClass(Runnable.class);

--- a/appcheck/firebase-appcheck/test-app/src/main/java/com/googletest/firebase/appcheck/MainActivity.java
+++ b/appcheck/firebase-appcheck/test-app/src/main/java/com/googletest/firebase/appcheck/MainActivity.java
@@ -28,6 +28,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.AppCheckToken;
 import com.google.firebase.appcheck.FirebaseAppCheck;
+import com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener;
 import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory;
 import com.google.firebase.appcheck.safetynet.SafetyNetAppCheckProviderFactory;
 import com.google.firebase.storage.FirebaseStorage;
@@ -40,6 +41,7 @@ public class MainActivity extends AppCompatActivity {
 
   private FirebaseAppCheck firebaseAppCheck;
   private FirebaseStorage firebaseStorage;
+  private AppCheckListener appCheckListener;
   private Button installSafetyNetButton;
   private Button installDebugButton;
   private Button getAppCheckTokenButton;
@@ -54,10 +56,27 @@ public class MainActivity extends AppCompatActivity {
     initViews();
   }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+
+    firebaseAppCheck.removeAppCheckListener(appCheckListener);
+  }
+
   private void initFirebase() {
     FirebaseApp.initializeApp(this);
     firebaseAppCheck = FirebaseAppCheck.getInstance();
     firebaseStorage = FirebaseStorage.getInstance();
+
+    appCheckListener =
+        new AppCheckListener() {
+          @Override
+          public void onAppCheckTokenChanged(@NonNull AppCheckToken token) {
+            Log.d(TAG, "onAppCheckTokenChanged");
+          }
+        };
+
+    firebaseAppCheck.addAppCheckListener(appCheckListener);
   }
 
   private void initViews() {

--- a/appcheck/firebase-appcheck/test-app/src/main/java/com/googletest/firebase/appcheck/MainActivity.java
+++ b/appcheck/firebase-appcheck/test-app/src/main/java/com/googletest/firebase/appcheck/MainActivity.java
@@ -26,7 +26,7 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.appcheck.AppCheckTokenResult;
+import com.google.firebase.appcheck.AppCheckToken;
 import com.google.firebase.appcheck.FirebaseAppCheck;
 import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory;
 import com.google.firebase.appcheck.safetynet.SafetyNetAppCheckProviderFactory;
@@ -96,30 +96,21 @@ public class MainActivity extends AppCompatActivity {
         new OnClickListener() {
           @Override
           public void onClick(View v) {
-            Task<AppCheckTokenResult> task = firebaseAppCheck.getToken(/* forceRefresh= */ false);
+            Task<AppCheckToken> task = firebaseAppCheck.getAppCheckToken(/* forceRefresh= */ true);
             task.addOnSuccessListener(
-                new OnSuccessListener<AppCheckTokenResult>() {
+                new OnSuccessListener<AppCheckToken>() {
                   @Override
-                  public void onSuccess(AppCheckTokenResult appCheckTokenResult) {
-                    if (appCheckTokenResult.getError() == null) {
-                      Log.d(TAG, "Successfully retrieved AppCheck token.");
-                      showToast("Successfully retrieved AppCheck token.");
-                    } else {
-                      Log.d(
-                          TAG,
-                          "AppCheck token exchange failed with error: "
-                              + appCheckTokenResult.getError().getMessage());
-                      showToast("AppCheck token exchange failed.");
-                    }
+                  public void onSuccess(AppCheckToken appCheckToken) {
+                    Log.d(TAG, "Successfully retrieved AppCheck token.");
+                    showToast("Successfully retrieved AppCheck token.");
                   }
                 });
             task.addOnFailureListener(
                 new OnFailureListener() {
                   @Override
                   public void onFailure(@NonNull Exception e) {
-                    // This should not happen; the task should always return with a success.
-                    Log.e(TAG, "Unexpected failure in getToken: " + e.toString());
-                    showToast("Unexpected failure in getToken.");
+                    Log.d(TAG, "AppCheck token exchange failed with error: " + e.getMessage());
+                    showToast("AppCheck token exchange failed.");
                   }
                 });
           }


### PR DESCRIPTION
Implement API for 3P developers to request a Firebase App Check token as well as observe changes to the token. This will enable developers to protect their own (non-Firebase) backends with the FAC token.