### PR TITLE
Use manual foreground detection to trigger network reconnect

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Unreleased
+# Unreelased
+- [changed] Increases the aggressiveness of network retires when an app's
+  visibility status changes.
+
+# 23.0.1
 - [changed] The SDK now tries to immediately establish a connection to the
   backend when the app enters the foreground.
 

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreelased
+# Unreleased
 - [changed] Increases the aggressiveness of network retires when an app's
-  visibility status changes.
+  foreground status changes.
 
 # 23.0.1
 - [changed] The SDK now tries to immediately establish a connection to the

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/remote/RemoteStoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/remote/RemoteStoreTest.java
@@ -81,16 +81,16 @@ public class RemoteStoreTest {
     RemoteStore remoteStore =
         new RemoteStore(callback, localStore, datastore, testQueue, connectivityMonitor);
 
-    waitFor(testQueue.enqueue(() -> remoteStore.forceEnableNetwork()));
+    waitFor(testQueue.enqueue(remoteStore::forceEnableNetwork));
     drain(testQueue);
     networkChangeSemaphore.drainPermits();
 
     connectivityMonitor.goOffline();
     waitFor(networkChangeSemaphore);
     drain(testQueue);
-
-    waitFor(testQueue.enqueue(() -> remoteStore.forceEnableNetwork()));
     networkChangeSemaphore.drainPermits();
+
+    waitFor(testQueue.enqueue(remoteStore::forceEnableNetwork));
     connectivityMonitor.goOnline();
     waitFor(networkChangeSemaphore);
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidConnectivityMonitor.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidConnectivityMonitor.java
@@ -17,6 +17,8 @@ package com.google.firebase.firestore.remote;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -24,9 +26,11 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.os.Build;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.google.android.gms.common.api.internal.BackgroundDetector;
 import com.google.firebase.firestore.util.Consumer;
+import com.google.firebase.firestore.util.Logger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,8 +40,9 @@ import java.util.List;
  * <p>Implementation note: Most of the code here was shamelessly stolen from
  * https://github.com/grpc/grpc-java/blob/master/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
  */
-public final class AndroidConnectivityMonitor
-    implements ConnectivityMonitor, BackgroundDetector.BackgroundStateChangeListener {
+public final class AndroidConnectivityMonitor implements ConnectivityMonitor {
+
+  private static final String LOG_TAG = "AndroidConnectivityMonitor";
 
   private final Context context;
   @Nullable private final ConnectivityManager connectivityManager;
@@ -78,34 +83,56 @@ public final class AndroidConnectivityMonitor
       final DefaultNetworkCallback defaultNetworkCallback = new DefaultNetworkCallback();
       connectivityManager.registerDefaultNetworkCallback(defaultNetworkCallback);
       unregisterRunnable =
-          new Runnable() {
-            @Override
-            public void run() {
-              connectivityManager.unregisterNetworkCallback(defaultNetworkCallback);
-            }
-          };
+          () -> connectivityManager.unregisterNetworkCallback(defaultNetworkCallback);
     } else {
       NetworkReceiver networkReceiver = new NetworkReceiver();
       @SuppressWarnings("deprecation")
       IntentFilter networkIntentFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
       context.registerReceiver(networkReceiver, networkIntentFilter);
-      unregisterRunnable =
-          new Runnable() {
-            @Override
-            public void run() {
-              context.unregisterReceiver(networkReceiver);
-            }
-          };
+      unregisterRunnable = () -> context.unregisterReceiver(networkReceiver);
     }
   }
 
   private void configureBackgroundStateListener() {
-    BackgroundDetector.getInstance().addListener(this);
+    // Manually register an ActivityLifecycleCallback. Android's BackgroundDetector only notifies
+    // when it is certain that the app transitioned from background to foreground. Instead, we
+    // want to be notified whenever there is a slight chance that this transition happened.
+    ((Application) context.getApplicationContext())
+        .registerActivityLifecycleCallbacks(
+            new Application.ActivityLifecycleCallbacks() {
+              @Override
+              public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
+                raiseForegroundNotification();
+              }
+
+              @Override
+              public void onActivityStarted(@NonNull Activity activity) {
+                raiseForegroundNotification();
+              }
+
+              @Override
+              public void onActivityResumed(@NonNull Activity activity) {
+                raiseForegroundNotification();
+              }
+
+              @Override
+              public void onActivityPaused(@NonNull Activity activity) {}
+
+              @Override
+              public void onActivityStopped(@NonNull Activity activity) {}
+
+              @Override
+              public void onActivitySaveInstanceState(
+                  @NonNull Activity activity, @NonNull Bundle outState) {}
+
+              @Override
+              public void onActivityDestroyed(@NonNull Activity activity) {}
+            });
   }
 
-  @Override
-  public void onBackgroundStateChanged(boolean background) {
-    if (!background && isConnected()) {
+  public void raiseForegroundNotification() {
+    Logger.debug(LOG_TAG, "App has entered the foreground.");
+    if (isConnected()) {
       raiseCallbacks(/* connected= */ true);
     }
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidConnectivityMonitor.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidConnectivityMonitor.java
@@ -100,6 +100,8 @@ public final class AndroidConnectivityMonitor implements ConnectivityMonitor {
     ((Application) context.getApplicationContext())
         .registerActivityLifecycleCallbacks(
             new Application.ActivityLifecycleCallbacks() {
+              @Nullable Activity lastActivity = null;
+
               @Override
               public void onActivityCreated(
                   @NonNull Activity activity, Bundle savedInstanceState) {}
@@ -109,11 +111,19 @@ public final class AndroidConnectivityMonitor implements ConnectivityMonitor {
 
               @Override
               public void onActivityResumed(@NonNull Activity activity) {
-                raiseForegroundNotification();
+                // Only raise the foreground notification if the same activity when to the
+                // background before. This prevents notifications when an app switches between
+                // activities.
+                if (activity == lastActivity) {
+                  raiseForegroundNotification();
+                }
+                lastActivity = null;
               }
 
               @Override
-              public void onActivityPaused(@NonNull Activity activity) {}
+              public void onActivityPaused(@NonNull Activity activity) {
+                lastActivity = activity;
+              }
 
               @Override
               public void onActivityStopped(@NonNull Activity activity) {}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidConnectivityMonitor.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AndroidConnectivityMonitor.java
@@ -101,14 +101,11 @@ public final class AndroidConnectivityMonitor implements ConnectivityMonitor {
         .registerActivityLifecycleCallbacks(
             new Application.ActivityLifecycleCallbacks() {
               @Override
-              public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
-                raiseForegroundNotification();
-              }
+              public void onActivityCreated(
+                  @NonNull Activity activity, Bundle savedInstanceState) {}
 
               @Override
-              public void onActivityStarted(@NonNull Activity activity) {
-                raiseForegroundNotification();
-              }
+              public void onActivityStarted(@NonNull Activity activity) {}
 
               @Override
               public void onActivityResumed(@NonNull Activity activity) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/OnlineStateTracker.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/OnlineStateTracker.java
@@ -88,6 +88,11 @@ class OnlineStateTracker {
     shouldWarnClientIsOffline = true;
   }
 
+  /** Returns the current online state. */
+  OnlineState getState() {
+    return state;
+  }
+
   /**
    * Called by RemoteStore when a watch stream is started (including on each backoff attempt).
    *

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
@@ -216,7 +216,7 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
 
                 // If the network has been explicitly disabled, make sure we don't accidentally
                 // re-enable it.
-                if (canUseNetwork()) {
+                if (!onlineStateTracker.getState().equals(OnlineState.ONLINE) && canUseNetwork()) {
                   // Tear down and re-create our network streams. This will ensure the backoffs are
                   // reset.
                   Logger.debug(LOG_TAG, "Restarting streams for network reachability change.");

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/RemoteStore.java
@@ -214,14 +214,29 @@ public final class RemoteStore implements WatchChangeAggregator.TargetMetadataPr
                 // Porting Note: Unlike iOS, `restartNetwork()` is called even when the network
                 // becomes unreachable as we don't have any other way to tear down our streams.
 
+                // We only invoke restartNetwork() when the network status differs from our online
+                // state. This prevents frequent reconnects as the callback is invoked whenever
+                // the app reaches the foreground.
+                if (networkStatus.equals(NetworkStatus.REACHABLE)
+                    && onlineStateTracker.getState().equals(OnlineState.ONLINE)) {
+                  return;
+                }
+
+                if (networkStatus.equals(NetworkStatus.UNREACHABLE)
+                    && onlineStateTracker.getState().equals(OnlineState.OFFLINE)) {
+                  return;
+                }
+
                 // If the network has been explicitly disabled, make sure we don't accidentally
                 // re-enable it.
-                if (!onlineStateTracker.getState().equals(OnlineState.ONLINE) && canUseNetwork()) {
-                  // Tear down and re-create our network streams. This will ensure the backoffs are
-                  // reset.
-                  Logger.debug(LOG_TAG, "Restarting streams for network reachability change.");
-                  restartNetwork();
+                if (!canUseNetwork()) {
+                  return;
                 }
+
+                // Tear down and re-create our network streams. This will ensure the backoffs are
+                // reset.
+                Logger.debug(LOG_TAG, "Restarting streams for network reachability change.");
+                restartNetwork();
               });
         });
   }


### PR DESCRIPTION
This is a follow up to https://github.com/firebase/firebase-android-sdk/pull/2693, which used Android's built-in BackgroundDetector to fast-forward network reconnects when an app entered the foreground. Unfortunately, the BackgroundDetector is pretty conservative and only fires if it knows for certain that the app was in the background and now is in the foreground. This leads to some suppressed notifications. This PR just hooks directly into the notification API and always raises the foreground notification.

Logs:

```
2021-06-25 13:30:40.601 4251-4665/com.google.firebase.example.fireeats I/Firestore: (23.0.2) [OnlineStateTracker]: Could not reach Cloud Firestore backend. Connection failed 1 times. Most recent error: Status{code=UNAVAILABLE, description=Unable to resolve host foo, cause=java.lang.RuntimeException: java.net.UnknownHostException: Unable to resolve host "foo": No address associated with hostname
...
    This typically indicates that your device does not have a healthy Internet connection at the moment. The client will operate in offline mode until it is able to successfully connect to the backend.
2021-06-25 13:30:40.605 4251-4665/com.google.firebase.example.fireeats I/Firestore: (23.0.2) [ExponentialBackoff]: Backing off for 8220 ms (base delay: 7593 ms, delay with jitter: 8372 ms, last attempt: 152 ms ago)
...
2021-06-25 13:30:46.836 4251-4251/com.google.firebase.example.fireeats I/Firestore: (23.0.2) [AndroidConnectivityMonitor]: App has entered the foreground.
2021-06-25 13:30:46.843 4251-4665/com.google.firebase.example.fireeats I/Firestore: (23.0.2) [RemoteStore]: Restarting streams for network reachability change.
2021-06-25 13:30:46.845 4251-4665/com.google.firebase.example.fireeats I/Firestore: (23.0.2) [WatchStream]: (f298b8) Performing stream teardown
2021-06-25 13:30:46.866 4251-4665/com.google.firebase.example.fireeats I/Firestore: (23.0.2) [WatchStream]: (f298b8) Stream is open
```

Fixes https://github.com/firebase/firebase-android-sdk/issues/2637