### PR TITLE
Standardize transaction retries to attempts

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -639,14 +639,15 @@ public class TransactionTest {
     DocumentReference doc1 = firestore.collection("counters").document();
     AtomicInteger count = new AtomicInteger(0);
     waitFor(doc1.set(map("count", 15)));
-    Task<Void> transactionTask = firestore.runTransaction(
-        transaction -> {
-          // Get the first doc.
-          transaction.get(doc1);
-          // Do a write outside of the transaction to cause the transaction to fail.
-          waitFor(doc1.set(map("count", 1234 + count.incrementAndGet())));
-          return null;
-        });
+    Task<Void> transactionTask =
+        firestore.runTransaction(
+            transaction -> {
+              // Get the first doc.
+              transaction.get(doc1);
+              // Do a write outside of the transaction to cause the transaction to fail.
+              waitFor(doc1.set(map("count", 1234 + count.incrementAndGet())));
+              return null;
+            });
 
     Exception e = waitForException(transactionTask);
     assertEquals(Code.FAILED_PRECONDITION, ((FirebaseFirestoreException) e).getCode());

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -29,6 +29,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.FirebaseFirestoreException.Code;
+import com.google.firebase.firestore.core.TransactionRunner;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import com.google.firebase.firestore.util.AsyncQueue.TimerId;
 import java.util.ArrayList;
@@ -630,6 +631,26 @@ public class TransactionTest {
     Exception e = waitForException(transactionTask);
     assertEquals(Code.INVALID_ARGUMENT, ((FirebaseFirestoreException) e).getCode());
     assertEquals(1, count.get());
+  }
+
+  @Test
+  public void testMakesDefaultMaxAttempts() {
+    FirebaseFirestore firestore = testFirestore();
+    DocumentReference doc1 = firestore.collection("counters").document();
+    AtomicInteger count = new AtomicInteger(0);
+    waitFor(doc1.set(map("count", 15)));
+    Task<Void> transactionTask = firestore.runTransaction(
+        transaction -> {
+          // Get the first doc.
+          transaction.get(doc1);
+          // Do a write outside of the transaction to cause the transaction to fail.
+          waitFor(doc1.set(map("count", 1234 + count.incrementAndGet())));
+          return null;
+        });
+
+    Exception e = waitForException(transactionTask);
+    assertEquals(Code.FAILED_PRECONDITION, ((FirebaseFirestoreException) e).getCode());
+    assertEquals(TransactionRunner.DEFAULT_MAX_ATTEMPTS_COUNT, count.get());
   }
 
   @Test

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TransactionRunner.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/TransactionRunner.java
@@ -27,11 +27,11 @@ import com.google.firebase.firestore.util.Function;
 
 /** TransactionRunner encapsulates the logic needed to run and retry transactions with backoff. */
 public class TransactionRunner<TResult> {
-  private static final int RETRY_COUNT = 5;
+  public static final int DEFAULT_MAX_ATTEMPTS_COUNT = 5;
   private AsyncQueue asyncQueue;
   private RemoteStore remoteStore;
   private Function<Transaction, Task<TResult>> updateFunction;
-  private int retriesLeft;
+  private int attemptsRemaining;
 
   private ExponentialBackoff backoff;
   private TaskCompletionSource<TResult> taskSource = new TaskCompletionSource<>();
@@ -44,7 +44,7 @@ public class TransactionRunner<TResult> {
     this.asyncQueue = asyncQueue;
     this.remoteStore = remoteStore;
     this.updateFunction = updateFunction;
-    this.retriesLeft = RETRY_COUNT;
+    this.attemptsRemaining = DEFAULT_MAX_ATTEMPTS_COUNT;
 
     backoff = new ExponentialBackoff(asyncQueue, TimerId.RETRY_TRANSACTION);
   }
@@ -56,6 +56,7 @@ public class TransactionRunner<TResult> {
   }
 
   private void runWithBackoff() {
+    attemptsRemaining -= 1;
     backoff.backoffAndRun(
         () -> {
           final Transaction transaction = remoteStore.createTransaction();
@@ -84,8 +85,7 @@ public class TransactionRunner<TResult> {
   }
 
   private void handleTransactionError(Task task) {
-    if (retriesLeft > 0 && isRetryableTransactionError(task.getException())) {
-      retriesLeft -= 1;
+    if (attemptsRemaining > 0 && isRetryableTransactionError(task.getException())) {
       runWithBackoff();
     } else {
       taskSource.setException(task.getException());


### PR DESCRIPTION
This PR standardizes transaction retry language to use "attempts" rather than "retries" as part of b/147440261