### PR TITLE
Upgrade storage schema version to V5 and add log_event_dropped and time tables.

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -83,7 +83,22 @@ final class SchemaManager extends SQLiteOpenHelper {
 
   private static final String DROP_PAYLOADS_SQL = "DROP TABLE IF EXISTS event_payloads";
 
-  static int SCHEMA_VERSION = 4;
+  private static final String CREATE_LOG_EVENT_DROPPED_TABLE =
+      "CREATE TABLE log_event_dropped "
+          + "(log_source VARCHAR(45) NOT NULL,"
+          + "reason INTEGER NOT NULL,"
+          + "events_dropped_count BIGINT NOT NULL,"
+          + "PRIMARY KEY(log_source, reason))";
+
+  private static final String CREATE_LOG_EVENT_DROPPED_TIME_TABLE =
+      "CREATE TABLE log_event_dropped_time (start_ms BIGINT PRIMARY KEY)";
+
+  private static final String DROP_LOG_EVENT_DROPPED_SQL = "DROP TABLE IF EXISTS log_event_dropped";
+
+  private static final String DROP_LOG_EVENT_DROPPED_TIME_SQL =
+      "DROP TABLE IF EXISTS log_event_dropped_time";
+
+  static int SCHEMA_VERSION = 5;
 
   private static final SchemaManager.Migration MIGRATE_TO_V1 =
       (db) -> {
@@ -111,8 +126,14 @@ final class SchemaManager extends SQLiteOpenHelper {
         db.execSQL(CREATE_PAYLOADS_TABLE_V4);
       };
 
+  private static final SchemaManager.Migration MIGRATION_TO_V5 =
+      db -> {
+        db.execSQL(CREATE_LOG_EVENT_DROPPED_TABLE);
+        db.execSQL(CREATE_LOG_EVENT_DROPPED_TIME_TABLE);
+      };
+
   private static final List<Migration> INCREMENTAL_MIGRATIONS =
-      Arrays.asList(MIGRATE_TO_V1, MIGRATE_TO_V2, MIGRATE_TO_V3, MIGRATE_TO_V4);
+      Arrays.asList(MIGRATE_TO_V1, MIGRATE_TO_V2, MIGRATE_TO_V3, MIGRATE_TO_V4, MIGRATION_TO_V5);
 
   @Inject
   SchemaManager(
@@ -164,6 +185,8 @@ final class SchemaManager extends SQLiteOpenHelper {
     db.execSQL(DROP_EVENT_METADATA_SQL);
     db.execSQL(DROP_CONTEXTS_SQL);
     db.execSQL(DROP_PAYLOADS_SQL);
+    db.execSQL(DROP_LOG_EVENT_DROPPED_SQL);
+    db.execSQL(DROP_LOG_EVENT_DROPPED_TIME_SQL);
     // Indices are dropped automatically when the tables are dropped
 
     onCreate(db, newVersion);

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -90,13 +90,13 @@ final class SchemaManager extends SQLiteOpenHelper {
           + "events_dropped_count BIGINT NOT NULL,"
           + "PRIMARY KEY(log_source, reason))";
 
-  private static final String CREATE_LOG_EVENT_DROPPED_TIME_TABLE =
-      "CREATE TABLE log_event_dropped_time (start_ms BIGINT PRIMARY KEY)";
+  private static final String CREATE_GLOBAL_LOG_EVENT_STATE_TABLE =
+      "CREATE TABLE global_log_event_state (last_metrics_upload_ms BIGINT PRIMARY KEY)";
 
   private static final String DROP_LOG_EVENT_DROPPED_SQL = "DROP TABLE IF EXISTS log_event_dropped";
 
-  private static final String DROP_LOG_EVENT_DROPPED_TIME_SQL =
-      "DROP TABLE IF EXISTS log_event_dropped_time";
+  private static final String DROP_GLOBAL_LOG_EVENT_STATE_SQL =
+      "DROP TABLE IF EXISTS global_log_event_state";
 
   static int SCHEMA_VERSION = 5;
 
@@ -129,7 +129,7 @@ final class SchemaManager extends SQLiteOpenHelper {
   private static final SchemaManager.Migration MIGRATION_TO_V5 =
       db -> {
         db.execSQL(CREATE_LOG_EVENT_DROPPED_TABLE);
-        db.execSQL(CREATE_LOG_EVENT_DROPPED_TIME_TABLE);
+        db.execSQL(CREATE_GLOBAL_LOG_EVENT_STATE_TABLE);
       };
 
   private static final List<Migration> INCREMENTAL_MIGRATIONS =
@@ -186,7 +186,7 @@ final class SchemaManager extends SQLiteOpenHelper {
     db.execSQL(DROP_CONTEXTS_SQL);
     db.execSQL(DROP_PAYLOADS_SQL);
     db.execSQL(DROP_LOG_EVENT_DROPPED_SQL);
-    db.execSQL(DROP_LOG_EVENT_DROPPED_TIME_SQL);
+    db.execSQL(DROP_GLOBAL_LOG_EVENT_STATE_SQL);
     // Indices are dropped automatically when the tables are dropped
 
     onCreate(db, newVersion);

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerMigrationTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerMigrationTest.java
@@ -37,6 +37,7 @@ public class SchemaManagerMigrationTest {
     simulatorMap.put(2, new StateSimulations.V2());
     simulatorMap.put(3, new StateSimulations.V3());
     simulatorMap.put(4, new StateSimulations.V4());
+    simulatorMap.put(5, new StateSimulations.V5());
   }
 
   @ParameterizedRobolectricTestRunner.Parameters(name = "lowVersion = {0}, highVersion = {1}")

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/StateSimulations.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/StateSimulations.java
@@ -246,10 +246,10 @@ class StateSimulations {
       long recordId = db.insert("log_event_dropped", null, metrics);
       assertThat(recordId).isNotEqualTo(-1);
 
-      ContentValues timeValue = new ContentValues();
-      timeValue.put("start_ms", 1311);
-      long timeValueId = db.insert("log_event_dropped_time", null, timeValue);
-      assertThat(timeValueId).isNotEqualTo(-1);
+      ContentValues globalState = new ContentValues();
+      globalState.put("last_metrics_upload_ms", 1311);
+      long stateId = db.insert("global_log_event_state", null, globalState);
+      assertThat(stateId).isNotEqualTo(-1);
     }
   }
 }


### PR DESCRIPTION
Upgraded storage schema version to V5 from V4

**Changes in V5**  
 - Added `log_event_dropped` table
   - `log_event_dropped` table is used to persist the general metrics about dropped events
 - Added `global_log_event_state` tables
   - `global_log_event_state` contains a single global value "last_metrics_upload_ms", this value is only used to present the start time of collecting Client Analytics metrics. "last_metrics_upload_ms" will be reset to current_time if existing metrics were sent to the server successfully.
 
_Note: existing tests in `SchemaManagerMigrationTest` make sure storage scheme can downgrade and upgrade successfully._