### PR TITLE
Upgrade kotlin dsl plugin

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 plugins {
-    id "org.gradle.kotlin.kotlin-dsl" version "1.2.6"
+    id "org.gradle.kotlin.kotlin-dsl" version "1.2.9"
     id "org.jlleitschuh.gradle.ktlint" version "9.2.1"
     id 'com.github.sherter.google-java-format' version '0.9'
 }


### PR DESCRIPTION
Gradle 5.6.4 expects the plugin to be version 1.2.9.