### PR TITLE
Implement ClientAnalyticsStore

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -29,6 +29,12 @@ import com.google.android.datatransport.Encoding;
 import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
+import com.google.android.datatransport.runtime.firebase.transport.ClientMetrics;
+import com.google.android.datatransport.runtime.firebase.transport.GlobalMetrics;
+import com.google.android.datatransport.runtime.firebase.transport.LogEventDropped;
+import com.google.android.datatransport.runtime.firebase.transport.LogSourceMetrics;
+import com.google.android.datatransport.runtime.firebase.transport.StorageMetrics;
+import com.google.android.datatransport.runtime.firebase.transport.TimeWindow;
 import com.google.android.datatransport.runtime.logging.Logging;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationException;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
@@ -51,7 +57,7 @@ import javax.inject.Singleton;
 /** {@link EventStore} implementation backed by a SQLite database. */
 @Singleton
 @WorkerThread
-public class SQLiteEventStore implements EventStore, SynchronizationGuard {
+public class SQLiteEventStore implements EventStore, SynchronizationGuard, ClientAnalyticsStore {
 
   private static final String LOG_TAG = "SQLiteEventStore";
 
@@ -528,6 +534,142 @@ public class SQLiteEventStore implements EventStore, SynchronizationGuard {
         SystemClock.sleep(LOCK_RETRY_BACK_OFF_MILLIS);
       }
     } while (true);
+  }
+
+  /**
+   * Record log event dropped.
+   *
+   * @param eventsDroppedCount number of events dropped
+   * @param reason reason why events are dropped
+   * @param logSource log source of the dropped events
+   */
+  @Override
+  public void recordLogEventDropped(
+      long eventsDroppedCount, LogEventDropped.Reason reason, String logSource) {
+    if (!isLogEventDroppedExist(reason, logSource)) {
+      ContentValues metrics = new ContentValues();
+      metrics.put("log_source", logSource);
+      metrics.put("reason", reason.getNumber());
+      metrics.put("events_dropped_count", eventsDroppedCount);
+      inTransaction(
+          db -> {
+            db.insert("log_event_dropped", null, metrics);
+            return null;
+          });
+    } else {
+      String query =
+          "UPDATE log_event_dropped SET events_dropped_count = events_dropped_count + "
+              + eventsDroppedCount
+              + " WHERE log_source = ? AND reason = ?";
+      inTransaction(
+          db -> {
+            db.execSQL(query, new String[] {logSource, Integer.toString(reason.getNumber())});
+            return null;
+          });
+    }
+  }
+
+  private boolean isLogEventDroppedExist(LogEventDropped.Reason reason, String logSource) {
+    String query = "SELECT 1 FROM log_event_dropped" + " WHERE log_source = ? AND reason = ?";
+    String[] selectionArgs = new String[] {logSource, Integer.toString(reason.getNumber())};
+    return inTransaction(
+        db -> tryWithCursor(db.rawQuery(query, selectionArgs), cursor -> cursor.getCount() > 0));
+  }
+
+  /**
+   * Load full-populated ClientMetrics.
+   *
+   * @return the returned ClientMetrics is fully populated with persisted and non-persisted fields.
+   */
+  @Override
+  public ClientMetrics loadClientMetrics() {
+    long currentTime = wallClock.getTime();
+    ClientMetrics.Builder clientMetricsBuilder = ClientMetrics.newBuilder();
+    Map<String, List<LogEventDropped>> metricsMap = new HashMap<>();
+    String query = "SELECT log_source, reason, events_dropped_count FROM log_event_dropped";
+
+    return inTransaction(
+        db ->
+            tryWithCursor(
+                db.rawQuery(query, new String[] {}),
+                cursor -> {
+                  while (cursor.moveToNext()) {
+                    String logSource = cursor.getString(0);
+                    LogEventDropped.Reason reason =
+                        LogEventDropped.Reason.values()[cursor.getInt(1)];
+                    long eventsDroppedCount = cursor.getLong(2);
+                    if (!metricsMap.containsKey(logSource)) {
+                      metricsMap.put(logSource, new ArrayList<>());
+                    }
+                    metricsMap
+                        .get(logSource)
+                        .add(
+                            LogEventDropped.newBuilder()
+                                .setReason(reason)
+                                .setEventsDroppedCount(eventsDroppedCount)
+                                .build());
+                  }
+                  populateLogSourcesMetrics(clientMetricsBuilder, metricsMap);
+                  setTimeWindow(clientMetricsBuilder, currentTime);
+                  setNonePersistedClientAnalyticsFields(clientMetricsBuilder);
+                  return clientMetricsBuilder.build();
+                }));
+  }
+
+  private void populateLogSourcesMetrics(
+      ClientMetrics.Builder clientMetricsBuilder, Map<String, List<LogEventDropped>> metricsMap) {
+    for (Map.Entry<String, List<LogEventDropped>> entry : metricsMap.entrySet()) {
+      clientMetricsBuilder.addLogSourceMetrics(
+          LogSourceMetrics.newBuilder()
+              .setLogSource(entry.getKey())
+              .setLogEventDroppedList(entry.getValue())
+              .build());
+    }
+  }
+
+  private void setTimeWindow(ClientMetrics.Builder clientMetricsBuilder, long currentTime) {
+    inTransaction(
+        db ->
+            tryWithCursor(
+                db.rawQuery(
+                    "SELECT last_metrics_upload_ms FROM global_log_event_state", new String[] {}),
+                cursor -> {
+                  while (cursor.moveToNext()) {
+                    long start_ms = cursor.getLong(0);
+                    clientMetricsBuilder.setWindow(
+                        TimeWindow.newBuilder().setStartMs(start_ms).setEndMs(currentTime).build());
+                  }
+                  return null;
+                }));
+  }
+
+  private void setNonePersistedClientAnalyticsFields(ClientMetrics.Builder clientMetricsBuilder) {
+    clientMetricsBuilder.setAppNamespace(context.getPackageName());
+
+    clientMetricsBuilder.setGlobalMetrics(
+        GlobalMetrics.newBuilder()
+            .setStorageMetrics(
+                StorageMetrics.newBuilder()
+                    .setCurrentCacheSizeBytes(getByteSize())
+                    .setMaxCacheSizeBytes(EventStoreConfig.DEFAULT.getMaxStorageSizeInBytes())
+                    .build())
+            .build());
+  }
+
+  /**
+   * This Method delete every rows in log_event_dropped table, and update last_metrics_upload_ms in
+   * global_log_event_state table to current time.
+   */
+  @Override
+  public void resetClientMetrics() {
+    inTransaction(
+        db -> {
+          db.compileStatement("DELETE FROM log_event_dropped").execute();
+          db.compileStatement(
+                  "UPDATE global_log_event_state SET last_metrics_upload_ms=" + wallClock.getTime())
+              .execute();
+          return null;
+        });
   }
 
   interface Producer<T> {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -93,6 +93,9 @@ final class SchemaManager extends SQLiteOpenHelper {
   private static final String CREATE_GLOBAL_LOG_EVENT_STATE_TABLE =
       "CREATE TABLE global_log_event_state (last_metrics_upload_ms BIGINT PRIMARY KEY)";
 
+  private static final String CREATE_INITIAL_GLOBAL_LOG_EVENT_STATE_VALUE_SQL =
+      "INSERT INTO global_log_event_state VALUES (" + System.currentTimeMillis() + ")";
+
   private static final String DROP_LOG_EVENT_DROPPED_SQL = "DROP TABLE IF EXISTS log_event_dropped";
 
   private static final String DROP_GLOBAL_LOG_EVENT_STATE_SQL =
@@ -130,6 +133,7 @@ final class SchemaManager extends SQLiteOpenHelper {
       db -> {
         db.execSQL(CREATE_LOG_EVENT_DROPPED_TABLE);
         db.execSQL(CREATE_GLOBAL_LOG_EVENT_STATE_TABLE);
+        db.execSQL(CREATE_INITIAL_GLOBAL_LOG_EVENT_STATE_VALUE_SQL);
       };
 
   private static final List<Migration> INCREMENTAL_MIGRATIONS =


### PR DESCRIPTION
This PR implemented the following three methods:
-`recordLogEventDropped`
  - this method will be called to record the number of events dropped for what reason and its original destination
  - It firstly check if there is an existing row for that `log_source` and `reason`. If so, it will increment the count of events_dropped_count; if not, it will create a new row with given attributes.

-`loadClientMetrics`
  - this method will return an full-populated `ClientMetrics`
  - In order to be fully populated:
    1. it populates persisted fields, including `log_source`, `reason`, and `eventsDroppedCount`. 
    2. it populates with start time(got from `global_log_event_state`) and end time(current time)
    3. it populates none-Persisted fields, including AppNamespace, current cache size, and max cache size.

-`resetClientMetrics`
 - It delete every rows in `log_event_dropped table`, and update `last_metrics_upload_ms` in `global_log_event_state` table to current time.
 - This method will be called after client analytics metrics was successfully sent to the server.
