### PR TITLE
Log a warning if the RTDB connection is forcefully killed.

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
@@ -560,8 +560,9 @@ public class PersistentConnectionImpl implements Connection.Delegate, Persistent
   @Override
   public void onKill(String reason) {
     logger.warn(
-      "Firebase Database connection was forcefully killed by the server. Will not attempt reconnect. Reason: "
-      + reason);
+        "Firebase Database connection was forcefully killed by the server. Will not attempt"
+            + " reconnect. Reason: "
+            + reason);
 
     interrupt(SERVER_KILL_INTERRUPT_REASON);
   }

--- a/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
@@ -559,10 +559,10 @@ public class PersistentConnectionImpl implements Connection.Delegate, Persistent
 
   @Override
   public void onKill(String reason) {
-    if (logger.logsDebug())
-      logger.debug(
-          "Firebase Database connection was forcefully killed by the server. Will not attempt reconnect. Reason: "
-              + reason);
+    logger.warn(
+      "Firebase Database connection was forcefully killed by the server. Will not attempt reconnect. Reason: "
+      + reason);
+
     interrupt(SERVER_KILL_INTERRUPT_REASON);
   }
 


### PR DESCRIPTION
We should also make sure pending requests are completed with an error, but I'll save that for another PR.