### PR TITLE
Restore state when appcheck is used without auth.

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 20.0.1
+- [fixed] Fixed an issue where connections would hang when using appcheck
+  without Auth.
+
 # 19.7.0
 - [added] Added `Query.startAfter()` and `Query.endBefore()` filter for paginating
   RTDB queries.

--- a/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
@@ -1148,7 +1148,7 @@ public class PersistentConnectionImpl implements Connection.Delegate, Persistent
         };
 
     Map<String, Object> request = new HashMap<>();
-    hardAssert(appCheckToken != null, "Auth token must be set to authenticate!");
+    hardAssert(appCheckToken != null, "App check token must be set!");
     request.put(REQUEST_APPCHECK_TOKEN, appCheckToken);
     sendSensitive(REQUEST_ACTION_APPCHECK, /*isSensitive=*/ true, request, onComplete);
   }
@@ -1173,17 +1173,15 @@ public class PersistentConnectionImpl implements Connection.Delegate, Persistent
         "Wanted to restore tokens, but was in wrong state: %s",
         this.connectionState);
 
-    if (authToken == null && appCheckToken == null) {
-      if (logger.logsDebug()) logger.debug("Not restoring auth because tokens are null.");
-      this.connectionState = ConnectionState.Connected;
-      restoreState();
-      return;
-    }
-
     if (authToken != null) {
       if (logger.logsDebug()) logger.debug("Restoring auth.");
       this.connectionState = ConnectionState.Authenticating;
       sendAuthAndRestoreState();
+    } else {
+      if (logger.logsDebug()) logger.debug("Not restoring auth because auth token is null.");
+      this.connectionState = ConnectionState.Connected;
+      // Send our appcheck token (if we have one), then restore state.
+      sendAppCheckTokenHelper(true);
     }
   }
 


### PR DESCRIPTION
In the case where `authToken == null` and `appCheckToken != null`, this would never call `restoreState`. This fixes that case by calling `sendAppCheckTokenHelper` (that function also handles the case where `appCheckToken == null`.