### PR TITLE
Extend TransportBackend to have a default method

### DIFF
--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
@@ -36,6 +36,7 @@ import com.google.android.datatransport.cct.internal.NetworkConnectionInfo;
 import com.google.android.datatransport.cct.internal.QosTier;
 import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.backends.BackendRequest;
 import com.google.android.datatransport.runtime.backends.BackendResponse;
 import com.google.android.datatransport.runtime.backends.TransportBackend;
@@ -394,6 +395,11 @@ final class CctTransportBackend implements TransportBackend {
       Logging.e(LOG_TAG, "Could not make request to the backend", e);
       return BackendResponse.transientError();
     }
+  }
+
+  @Override
+  public boolean shouldUploadClientHealthMetrics(TransportContext transportContext) {
+    return transportContext.getExtras() != null;
   }
 
   @VisibleForTesting

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
@@ -40,6 +40,7 @@ import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.backends.BackendRequest;
 import com.google.android.datatransport.runtime.backends.BackendResponse;
 import com.google.android.datatransport.runtime.backends.TransportBackend;
+import com.google.android.datatransport.runtime.backends.UploadOptions;
 import com.google.android.datatransport.runtime.logging.Logging;
 import com.google.android.datatransport.runtime.time.Clock;
 import com.google.firebase.encoders.DataEncoder;
@@ -398,8 +399,10 @@ final class CctTransportBackend implements TransportBackend {
   }
 
   @Override
-  public boolean shouldUploadClientHealthMetrics(TransportContext transportContext) {
-    return transportContext.getExtras() != null;
+  public UploadOptions getUploadOptions(TransportContext transportContext) {
+    return UploadOptions.builder()
+        .setShouldUploadClientHealthMetrics(transportContext.getExtras() != null)
+        .build();
   }
 
   @VisibleForTesting

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
@@ -40,6 +40,7 @@ import com.google.android.datatransport.cct.internal.ClientInfo;
 import com.google.android.datatransport.cct.internal.NetworkConnectionInfo;
 import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.backends.BackendRequest;
 import com.google.android.datatransport.runtime.backends.BackendResponse;
 import com.google.android.datatransport.runtime.time.TestClock;
@@ -708,6 +709,25 @@ public class CctTransportBackendTest {
             .withRequestBody(matchingJsonPath("$[?(@.logRequest[1].logEvent.size() == 1)]")));
 
     assertEquals(BackendResponse.ok(3), response);
+  }
+
+  @Test
+  public void shouldUploadClientHealthMetrics_returnTrueIfSendToFlg() {
+    assertThat(
+            BACKEND.shouldUploadClientHealthMetrics(
+                TransportContext.builder()
+                    .setBackendName("cct")
+                    .setExtras(CCTDestination.LEGACY_INSTANCE.getExtras())
+                    .build()))
+        .isTrue();
+  }
+
+  @Test
+  public void shouldUploadClientHealthMetrics_returnFalseIfSendToCct() {
+    assertThat(
+            BACKEND.shouldUploadClientHealthMetrics(
+                TransportContext.builder().setBackendName("cct").setExtras(null).build()))
+        .isFalse();
   }
 
   // When there is no active network, the ConnectivityManager returns null when

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
@@ -714,19 +714,23 @@ public class CctTransportBackendTest {
   @Test
   public void shouldUploadClientHealthMetrics_returnTrueIfSendToFlg() {
     assertThat(
-            BACKEND.shouldUploadClientHealthMetrics(
-                TransportContext.builder()
-                    .setBackendName("cct")
-                    .setExtras(CCTDestination.LEGACY_INSTANCE.getExtras())
-                    .build()))
+            BACKEND
+                .getUploadOptions(
+                    TransportContext.builder()
+                        .setBackendName("cct")
+                        .setExtras(CCTDestination.LEGACY_INSTANCE.getExtras())
+                        .build())
+                .shouldUploadClientHealthMetrics())
         .isTrue();
   }
 
   @Test
   public void shouldUploadClientHealthMetrics_returnFalseIfSendToCct() {
     assertThat(
-            BACKEND.shouldUploadClientHealthMetrics(
-                TransportContext.builder().setBackendName("cct").setExtras(null).build()))
+            BACKEND
+                .getUploadOptions(
+                    TransportContext.builder().setBackendName("cct").setExtras(null).build())
+                .shouldUploadClientHealthMetrics())
         .isFalse();
   }
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
@@ -24,8 +24,7 @@ public interface TransportBackend {
 
   /**
    * This method indicate whether data sent through {@link TransportBackend} with
-   * {@link TransportContext} should be recorded as client health metrics and uploaded
-   * to Flg server.
+   * {@link TransportContext} should be recorded as client health metrics and upload to Flg server.
    *
    * By default, it returns false, and events will not be recorded and uploaded to Flg server.
    */

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
@@ -23,10 +23,9 @@ public interface TransportBackend {
   BackendResponse send(BackendRequest backendRequest);
 
   /**
-   * This method indicate whether data sent through {@link TransportBackend} with {@link
-   * TransportContext} should be recorded as client health metrics and upload to Flg server.
+   * This method indicate whether data sent through {@link TransportBackend} should be uploaded.
    *
-   * <p>By default, it returns false, and events will not be recorded and uploaded to Flg server.
+   * <p>By default, it will not be upload to anywhere.
    */
   default UploadOptions getUploadOptions(TransportContext transportContext) {
     return UploadOptions.none();

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
@@ -23,10 +23,10 @@ public interface TransportBackend {
   BackendResponse send(BackendRequest backendRequest);
 
   /**
-   * This method indicate whether data sent through {@link TransportBackend} with
-   * {@link TransportContext} should be recorded as client health metrics and upload to Flg server.
+   * This method indicate whether data sent through {@link TransportBackend} with {@link
+   * TransportContext} should be recorded as client health metrics and upload to Flg server.
    *
-   * By default, it returns false, and events will not be recorded and uploaded to Flg server.
+   * <p>By default, it returns false, and events will not be recorded and uploaded to Flg server.
    */
   default boolean shouldUploadClientHealthMetrics(TransportContext transportContext) {
     return false;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
@@ -15,9 +15,14 @@
 package com.google.android.datatransport.runtime.backends;
 
 import com.google.android.datatransport.runtime.EventInternal;
+import com.google.android.datatransport.runtime.TransportContext;
 
 public interface TransportBackend {
   EventInternal decorate(EventInternal event);
 
   BackendResponse send(BackendRequest backendRequest);
+
+  default boolean shouldUploadClientHealthMetrics(TransportContext transportContext) {
+    return false;
+  }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
@@ -28,7 +28,7 @@ public interface TransportBackend {
    *
    * <p>By default, it returns false, and events will not be recorded and uploaded to Flg server.
    */
-  default boolean shouldUploadClientHealthMetrics(TransportContext transportContext) {
-    return false;
+  default UploadOptions getUploadOptions(TransportContext transportContext) {
+    return UploadOptions.none();
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/TransportBackend.java
@@ -22,6 +22,13 @@ public interface TransportBackend {
 
   BackendResponse send(BackendRequest backendRequest);
 
+  /**
+   * This method indicate whether data sent through {@link TransportBackend} with
+   * {@link TransportContext} should be recorded as client health metrics and uploaded
+   * to Flg server.
+   *
+   * By default, it returns false, and events will not be recorded and uploaded to Flg server.
+   */
   default boolean shouldUploadClientHealthMetrics(TransportContext transportContext) {
     return false;
   }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/UploadOptions.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/UploadOptions.java
@@ -1,0 +1,33 @@
+package com.google.android.datatransport.runtime.backends;
+
+import com.google.auto.value.AutoValue;
+
+/**
+ * Encapsulates all upload options to indicate whether data sent through {@link TransportBackend}
+ * should be uploaded.
+ */
+@AutoValue
+public abstract class UploadOptions {
+
+  /**
+   * It indicates whether data sent through {@link TransportBackend} should be recorded as client
+   * health metrics and upload to Flg server.
+   */
+  public abstract boolean shouldUploadClientHealthMetrics();
+
+  public static UploadOptions none() {
+    return UploadOptions.builder().setShouldUploadClientHealthMetrics(false).build();
+  }
+
+  public static UploadOptions.Builder builder() {
+    return new AutoValue_UploadOptions.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract UploadOptions.Builder setShouldUploadClientHealthMetrics(
+        boolean shouldUploadClientHealthMetrics);
+
+    public abstract UploadOptions build();
+  }
+}

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/UploadOptions.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/backends/UploadOptions.java
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.android.datatransport.runtime.backends;
 
 import com.google.auto.value.AutoValue;


### PR DESCRIPTION
Extend `TransportBackend` interface to have a default method `shouldUploadClientHealthMetrics`

`shouldUploadClientHealthMetrics`  indicate whether data sent through `TransportBackend` with
`TransportContext` should be recorded as client health metrics and upload to Flg server.