### PR TITLE
Inject backend registry into SQLiteEventStore

### DIFF
--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/SynchronizationComponent.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/SynchronizationComponent.java
@@ -15,6 +15,7 @@
 package com.google.android.datatransport.runtime;
 
 import android.content.Context;
+import com.google.android.datatransport.runtime.backends.BackendRegistryModule;
 import com.google.android.datatransport.runtime.scheduling.persistence.SQLiteEventStore;
 import com.google.android.datatransport.runtime.scheduling.persistence.TestEventStoreModule;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
@@ -23,7 +24,7 @@ import dagger.BindsInstance;
 import dagger.Component;
 import javax.inject.Singleton;
 
-@Component(modules = {TestEventStoreModule.class, TimeModule.class})
+@Component(modules = {TestEventStoreModule.class, TimeModule.class, BackendRegistryModule.class})
 @Singleton
 public abstract class SynchronizationComponent {
   private static SQLiteEventStore INSTANCE;

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SpyEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SpyEventStoreModule.java
@@ -17,6 +17,7 @@ package com.google.android.datatransport.runtime.scheduling.persistence;
 import static org.mockito.Mockito.spy;
 
 import android.content.Context;
+import com.google.android.datatransport.runtime.backends.BackendRegistry;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
 import com.google.android.datatransport.runtime.time.Clock;
 import com.google.android.datatransport.runtime.time.Monotonic;
@@ -42,8 +43,11 @@ public abstract class SpyEventStoreModule {
       @Monotonic Clock clock,
       EventStoreConfig config,
       SchemaManager schemaManager,
-      @Named("PACKAGE_NAME") Lazy<String> packageName) {
-    return spy(new SQLiteEventStore(wallClock, clock, config, schemaManager, packageName));
+      @Named("PACKAGE_NAME") Lazy<String> packageName,
+      BackendRegistry backendRegistry) {
+    return spy(
+        new SQLiteEventStore(
+            wallClock, clock, config, schemaManager, packageName, backendRegistry));
   }
 
   @Binds

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -28,6 +28,7 @@ import com.google.android.datatransport.Encoding;
 import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
+import com.google.android.datatransport.runtime.backends.BackendRegistry;
 import com.google.android.datatransport.runtime.firebase.transport.ClientMetrics;
 import com.google.android.datatransport.runtime.firebase.transport.GlobalMetrics;
 import com.google.android.datatransport.runtime.firebase.transport.LogEventDropped;
@@ -73,6 +74,7 @@ public class SQLiteEventStore
   private final Clock monotonicClock;
   private final EventStoreConfig config;
   private final Lazy<String> packageName;
+  private final BackendRegistry backendRegistry;
 
   @Inject
   SQLiteEventStore(
@@ -80,13 +82,15 @@ public class SQLiteEventStore
       @Monotonic Clock clock,
       EventStoreConfig config,
       SchemaManager schemaManager,
-      @Named("PACKAGE_NAME") Lazy<String> packageName) {
+      @Named("PACKAGE_NAME") Lazy<String> packageName,
+      BackendRegistry backendRegistry) {
 
     this.schemaManager = schemaManager;
     this.wallClock = wallClock;
     this.monotonicClock = clock;
     this.config = config;
     this.packageName = packageName;
+    this.backendRegistry = backendRegistry;
   }
 
   @VisibleForTesting

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
@@ -16,6 +16,7 @@ package com.google.android.datatransport.runtime.scheduling.persistence;
 import static com.google.android.datatransport.runtime.scheduling.persistence.SchemaManager.DB_NAME;
 import static com.google.android.datatransport.runtime.scheduling.persistence.SchemaManager.SCHEMA_VERSION;
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
@@ -25,6 +26,7 @@ import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
+import com.google.android.datatransport.runtime.backends.BackendRegistry;
 import com.google.android.datatransport.runtime.time.TestClock;
 import com.google.android.datatransport.runtime.time.UptimeClock;
 import com.google.android.datatransport.runtime.util.PriorityMapping;
@@ -66,6 +68,8 @@ public class SchemaManagerTest {
               new EncodedPayload(PROTOBUF_ENCODING, "World".getBytes(Charset.defaultCharset())))
           .build();
 
+  private BackendRegistry mockRegistry = mock(BackendRegistry.class);
+
   private static final long HOUR = 60 * 60 * 1000;
   private static final EventStoreConfig CONFIG =
       EventStoreConfig.DEFAULT.toBuilder().setLoadBatchSize(5).setEventCleanUpAge(HOUR).build();
@@ -79,7 +83,8 @@ public class SchemaManagerTest {
     SchemaManager schemaManager =
         new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, SCHEMA_VERSION);
     SQLiteEventStore store =
-        new SQLiteEventStore(clock, new UptimeClock(), CONFIG, schemaManager, packageName);
+        new SQLiteEventStore(
+            clock, new UptimeClock(), CONFIG, schemaManager, packageName, mockRegistry);
 
     PersistedEvent newEvent = store.persist(CONTEXT1, EVENT1);
     Iterable<PersistedEvent> events = store.loadBatch(CONTEXT1);
@@ -96,7 +101,8 @@ public class SchemaManagerTest {
         new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, oldVersion);
 
     SQLiteEventStore store =
-        new SQLiteEventStore(clock, new UptimeClock(), CONFIG, schemaManager, packageName);
+        new SQLiteEventStore(
+            clock, new UptimeClock(), CONFIG, schemaManager, packageName, mockRegistry);
 
     schemaManager.onUpgrade(schemaManager.getWritableDatabase(), oldVersion, newVersion);
     PersistedEvent newEvent1 = store.persist(CONTEXT1, EVENT1);
@@ -111,7 +117,8 @@ public class SchemaManagerTest {
     SchemaManager schemaManager =
         new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, oldVersion);
     SQLiteEventStore store =
-        new SQLiteEventStore(clock, new UptimeClock(), CONFIG, schemaManager, packageName);
+        new SQLiteEventStore(
+            clock, new UptimeClock(), CONFIG, schemaManager, packageName, mockRegistry);
     // We simulate operations as done by an older SQLLiteEventStore at V1
     // We cannot simulate older operations with a newer client
     PersistedEvent event1 = simulatedPersistOnV1Database(schemaManager, CONTEXT1, EVENT1);
@@ -129,7 +136,8 @@ public class SchemaManagerTest {
     SchemaManager schemaManager =
         new SchemaManager(ApplicationProvider.getApplicationContext(), DB_NAME, oldVersion);
     SQLiteEventStore store =
-        new SQLiteEventStore(clock, new UptimeClock(), CONFIG, schemaManager, packageName);
+        new SQLiteEventStore(
+            clock, new UptimeClock(), CONFIG, schemaManager, packageName, mockRegistry);
     // We simulate operations as done by an older SQLLiteEventStore at V1
     // We cannot simulate older operations with a newer client
     PersistedEvent event1 = simulatedPersistOnV1Database(schemaManager, CONTEXT1, EVENT1);


### PR DESCRIPTION
Inject `BaclendRegistry` into `SQLiteEventStore`
- `BaclendRegistry` will be used to get `TransportBackend` through `backendName` to determine its upload options.