### PR TITLE
Record log event dropped due to cache full

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -114,6 +114,8 @@ public class SQLiteEventStore
               // TODO(vkryachko): come up with a more sophisticated algorithm for limiting disk
               // space.
               if (isStorageAtLimit()) {
+                recordLogEventDropped(
+                    1, LogEventDropped.Reason.CACHE_FULL, event.getTransportName());
                 return -1L;
               }
 


### PR DESCRIPTION
Before persisting the events to database, it firstly check if the storage limit has been reached
- if so, it will drop the events and make a call to `ClientHealthMetricsStore` to `recordLogEventDropped` for the reason of `CACHE_FULL`.