### PR TITLE
Record LogEvent dropped due to max retries reached

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -222,12 +222,28 @@ public class SQLiteEventStore
     if (!events.iterator().hasNext()) {
       return;
     }
-    String query =
+    String incrementAttemptNumQuery =
         "UPDATE events SET num_attempts = num_attempts + 1 WHERE _id in " + toIdList(events);
+    String countMaxAttemptsEventsQuery =
+        "SELECT COUNT(*), transport_name FROM events "
+            + "WHERE num_attempts >= "
+            + MAX_RETRIES
+            + " GROUP BY transport_name";
 
     inTransaction(
         db -> {
-          db.compileStatement(query).execute();
+          db.compileStatement(incrementAttemptNumQuery).execute();
+          tryWithCursor(
+              db.rawQuery(countMaxAttemptsEventsQuery, null),
+              cursor -> {
+                while (cursor.moveToNext()) {
+                  int count = cursor.getInt(0);
+                  String transportName = cursor.getString(1);
+                  recordLogEventDropped(
+                      count, LogEventDropped.Reason.MAX_RETRIES_REACHED, transportName);
+                }
+                return null;
+              });
           db.compileStatement("DELETE FROM events WHERE num_attempts >= " + MAX_RETRIES).execute();
           return null;
         });


### PR DESCRIPTION
When `Uploader` tries to upload events to the server, but get response as `TRANSIENT_ERROR`, it will reschedule the upload task until max tries are reached (call `recordFailure` to increment `num_attempts` or delete the events if `num_attempts` reached `MAX_RETRIES`).
In that case, we will call `ClientHealthMetricsStore` to `recordLogEventDropped` for the reason of `MAX_RETRIES_REACHED`  before drop the events.