### PR TITLE
Inject ClientHealthMetricsStore into Uploader

### DIFF
--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SpyEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SpyEventStoreModule.java
@@ -52,6 +52,9 @@ public abstract class SpyEventStoreModule {
   @Binds
   abstract SynchronizationGuard synchronizationGuard(SQLiteEventStore store);
 
+  @Binds
+  abstract ClientHealthMetricsStore clientHealthMetricsStore(SQLiteEventStore store);
+
   @Provides
   @Named("SCHEMA_VERSION")
   static int schemaVersion() {

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
@@ -44,6 +44,9 @@ public abstract class TestEventStoreModule {
   @Binds
   abstract SynchronizationGuard synchronizationGuard(SQLiteEventStore store);
 
+  @Binds
+  abstract ClientHealthMetricsStore clientHealthMetricsStore(SQLiteEventStore store);
+
   @Provides
   @Named("SCHEMA_VERSION")
   static int schemaVersion() {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -24,6 +24,7 @@ import com.google.android.datatransport.runtime.backends.BackendRequest;
 import com.google.android.datatransport.runtime.backends.BackendResponse;
 import com.google.android.datatransport.runtime.backends.TransportBackend;
 import com.google.android.datatransport.runtime.logging.Logging;
+import com.google.android.datatransport.runtime.scheduling.persistence.ClientHealthMetricsStore;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
 import com.google.android.datatransport.runtime.scheduling.persistence.PersistedEvent;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationException;
@@ -47,6 +48,7 @@ public class Uploader {
   private final Executor executor;
   private final SynchronizationGuard guard;
   private final Clock clock;
+  private final ClientHealthMetricsStore clientHealthMetricsStore;
 
   @Inject
   public Uploader(
@@ -56,7 +58,8 @@ public class Uploader {
       WorkScheduler workScheduler,
       Executor executor,
       SynchronizationGuard guard,
-      @WallTime Clock clock) {
+      @WallTime Clock clock,
+      ClientHealthMetricsStore clientHealthMetricsStore) {
     this.context = context;
     this.backendRegistry = backendRegistry;
     this.eventStore = eventStore;
@@ -64,6 +67,7 @@ public class Uploader {
     this.executor = executor;
     this.guard = guard;
     this.clock = clock;
+    this.clientHealthMetricsStore = clientHealthMetricsStore;
   }
 
   boolean isNetworkAvailable() {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreModule.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreModule.java
@@ -35,6 +35,9 @@ public abstract class EventStoreModule {
   @Binds
   abstract SynchronizationGuard synchronizationGuard(SQLiteEventStore store);
 
+  @Binds
+  abstract ClientHealthMetricsStore clientHealthMetricsStore(SQLiteEventStore store);
+
   @Provides
   @Named("SCHEMA_VERSION")
   static int schemaVersion() {

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
@@ -121,7 +121,7 @@ public class TransportRuntimeTest {
             fixedClock(EVENT_MILLIS),
             fixedClock(UPTIME_MILLIS),
             new ImmediateScheduler(Runnable::run, mockRegistry),
-            new Uploader(null, null, null, null, null, null, () -> 2),
+            new Uploader(null, null, null, null, null, null, () -> 2, null),
             mockInitializer);
 
     verify(mockInitializer, times(1)).ensureContextsScheduled();
@@ -172,7 +172,7 @@ public class TransportRuntimeTest {
             fixedClock(EVENT_MILLIS),
             fixedClock(UPTIME_MILLIS),
             new ImmediateScheduler(Runnable::run, mockRegistry),
-            new Uploader(null, null, null, null, null, null, () -> 2),
+            new Uploader(null, null, null, null, null, null, () -> 2, null),
             mockInitializer);
 
     verify(mockInitializer, times(1)).ensureContextsScheduled();
@@ -202,7 +202,7 @@ public class TransportRuntimeTest {
             fixedClock(UPTIME_MILLIS),
             new DefaultScheduler(
                 Runnable::run, mockRegistry, mockWorkScheduler, mockEventStore, guard),
-            new Uploader(null, null, null, null, null, null, () -> 2),
+            new Uploader(null, null, null, null, null, null, () -> 2, null),
             mockInitializer);
 
     verify(mockInitializer, times(1)).ensureContextsScheduled();
@@ -250,7 +250,7 @@ public class TransportRuntimeTest {
             fixedClock(UPTIME_MILLIS),
             new DefaultScheduler(
                 Runnable::run, mockRegistry, mockWorkScheduler, mockEventStore, guard),
-            new Uploader(null, null, null, null, null, null, () -> 2),
+            new Uploader(null, null, null, null, null, null, () -> 2, null),
             mockInitializer);
 
     verify(mockInitializer, times(1)).ensureContextsScheduled();
@@ -276,7 +276,7 @@ public class TransportRuntimeTest {
             fixedClock(EVENT_MILLIS),
             fixedClock(UPTIME_MILLIS),
             new ImmediateScheduler(Runnable::run, mockRegistry),
-            new Uploader(null, null, null, null, null, null, () -> 2),
+            new Uploader(null, null, null, null, null, null, () -> 2, null),
             mockInitializer);
 
     TransportFactory transportFactory = runtime.newFactory(new TestDestination());
@@ -298,7 +298,7 @@ public class TransportRuntimeTest {
             fixedClock(EVENT_MILLIS),
             fixedClock(UPTIME_MILLIS),
             new ImmediateScheduler(Runnable::run, mockRegistry),
-            new Uploader(null, null, null, null, null, null, () -> 2),
+            new Uploader(null, null, null, null, null, null, () -> 2, null),
             mockInitializer);
 
     TransportFactory transportFactory = runtime.newFactory(new YamlEncodedDestination());

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
@@ -31,6 +31,7 @@ import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.backends.BackendRegistry;
 import com.google.android.datatransport.runtime.backends.BackendResponse;
 import com.google.android.datatransport.runtime.backends.TransportBackend;
+import com.google.android.datatransport.runtime.scheduling.persistence.ClientHealthMetricsStore;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
 import com.google.android.datatransport.runtime.scheduling.persistence.InMemoryEventStore;
 import com.google.android.datatransport.runtime.scheduling.persistence.PersistedEvent;
@@ -72,6 +73,8 @@ public class UploaderTest {
   private TransportBackend mockBackend = mock(TransportBackend.class);
   private WorkScheduler mockScheduler = mock(WorkScheduler.class);
   private Runnable mockRunnable = mock(Runnable.class);
+  private ClientHealthMetricsStore mockClientHealthMetricsStore =
+      mock(ClientHealthMetricsStore.class);
   private Uploader uploader =
       spy(
           new Uploader(
@@ -81,7 +84,8 @@ public class UploaderTest {
               mockScheduler,
               Runnable::run,
               guard,
-              () -> 2));
+              () -> 2,
+              mockClientHealthMetricsStore));
 
   @Before
   public void setUp() {


### PR DESCRIPTION
It will be used to record log event dropped when network response is `INVLIAD_PAYLOAD` and `FATAK_ERROR`