### PR TITLE
FAD implement checkForUpdate MVP and TesterApiClient 

### DIFF
--- a/firebase-app-distribution/firebase-app-distribution.gradle
+++ b/firebase-app-distribution/firebase-app-distribution.gradle
@@ -51,6 +51,8 @@ dependencies {
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation "org.mockito:mockito-android:2.25.0"
+    androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
     testImplementation 'androidx.test:core:1.2.0'
 
     implementation 'com.google.android.gms:play-services-tasks:17.0.0'

--- a/firebase-app-distribution/firebase-app-distribution.gradle
+++ b/firebase-app-distribution/firebase-app-distribution.gradle
@@ -45,8 +45,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation project(path: ':firebase-installations')
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:2.25.0'

--- a/firebase-app-distribution/firebase-app-distribution.gradle
+++ b/firebase-app-distribution/firebase-app-distribution.gradle
@@ -51,8 +51,6 @@ dependencies {
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation "org.mockito:mockito-android:2.25.0"
-    androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
-    testImplementation 'androidx.arch.core:core-testing:2.1.0'
     testImplementation 'androidx.test:core:1.2.0'
 
     implementation 'com.google.android.gms:play-services-tasks:17.0.0'

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -157,10 +157,12 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
                         new OnSuccessListener<InstallationTokenResult>() {
                           @Override
                           public void onSuccess(InstallationTokenResult installationTokenResult) {
+
                             String authToken = installationTokenResult.getToken();
                             String appId = firebaseApp.getOptions().getApplicationId();
                             String apiKey = firebaseApp.getOptions().getApiKey();
 
+                            //make into method parameters
                             FirebaseAppDistributionTesterApiClient client =
                                 new FirebaseAppDistributionTesterApiClient(fid, appId, apiKey);
 
@@ -194,6 +196,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
               Context context = firebaseApp.getApplicationContext();
               long currentInstalledVersionCode = getInstalledAppVersionCode(context);
 
+              //move logic outside,
               checkForUpdateHandler.post(
                   new Runnable() {
                     @Override

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -249,7 +249,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
     // throw error if app reentered during signin
     if (currentlySigningIn) {
       currentlySigningIn = false;
-      setSignInTaskCompletionError(new FirebaseAppDistributionException(AUTHENTICATION_FAILURE));
+      setSignInTaskCompletionError(new FirebaseAppDistributionException(AUTHENTICATION_CANCELED));
     }
     this.currentActivity = activity;
   }
@@ -386,9 +386,13 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
         latestRelease = retrievedLatestRelease;
       }
     } catch (FirebaseAppDistributionException | ProtocolException e) {
-      setCheckForUpdateTaskCompletionError(
-          new FirebaseAppDistributionException(
-              e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE));
+      if (e.getClass().equals(FirebaseAppDistributionException.class)) {
+        setCheckForUpdateTaskCompletionError((FirebaseAppDistributionException) e);
+      } else {
+        setCheckForUpdateTaskCompletionError(
+                new FirebaseAppDistributionException(
+                        e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE));
+      }
     }
     return latestRelease;
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -382,8 +382,8 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
       AppDistributionRelease retrievedLatestRelease =
           firebaseAppDistributionTesterApiClient.fetchLatestRelease(fid, appId, apiKey, authToken);
 
-      Context context = firebaseApp.getApplicationContext();
-      long currentInstalledVersionCode = getInstalledAppVersionCode(context);
+      long currentInstalledVersionCode =
+          getInstalledAppVersionCode(firebaseApp.getApplicationContext());
 
       // todo: change to comparing codehash
       if (Long.parseLong(retrievedLatestRelease.getBuildVersion()) > currentInstalledVersionCode) {
@@ -391,7 +391,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
         // uninstalling
         latestRelease = retrievedLatestRelease;
       }
-    } catch (FirebaseAppDistributionException | ProtocolException e) {
+    } catch (FirebaseAppDistributionException | ProtocolException | NumberFormatException e) {
       if (e instanceof FirebaseAppDistributionException) {
         setCheckForUpdateTaskCompletionError((FirebaseAppDistributionException) e);
       } else {

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -390,8 +390,8 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
         setCheckForUpdateTaskCompletionError((FirebaseAppDistributionException) e);
       } else {
         setCheckForUpdateTaskCompletionError(
-                new FirebaseAppDistributionException(
-                        e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE));
+            new FirebaseAppDistributionException(
+                e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE));
       }
     }
     return latestRelease;

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -169,9 +169,9 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
     Tasks.whenAllComplete(installationIdTask, installationAuthTokenTask)
         .addOnSuccessListener(
             tasks -> {
-              String fid = (String) tasks.get(0).getResult();
+              String fid = installationIdTask.getResult();
               InstallationTokenResult installationTokenResult =
-                  (InstallationTokenResult) tasks.get(1).getResult();
+                  installationAuthTokenTask.getResult();
               checkForUpdateExecutor.execute(
                   () -> {
                     AppDistributionRelease latestRelease =

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -188,7 +188,9 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
                         new Runnable() {
                           @Override
                           public void run() {
-                            checkForUpdateTaskCompletionSource.setResult(latestRelease);
+                            if (!checkForUpdateTaskCompletionSource.getTask().isComplete()) {
+                              checkForUpdateTaskCompletionSource.setResult(latestRelease);
+                            }
                           }
                         });
                   });

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -386,7 +386,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
         latestRelease = retrievedLatestRelease;
       }
     } catch (FirebaseAppDistributionException | ProtocolException e) {
-      if (e.getClass().equals(FirebaseAppDistributionException.class)) {
+      if (e instanceof FirebaseAppDistributionException) {
         setCheckForUpdateTaskCompletionError((FirebaseAppDistributionException) e);
       } else {
         setCheckForUpdateTaskCompletionError(

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
@@ -69,6 +69,12 @@ public class FirebaseAppDistributionException extends FirebaseException {
     this.release = null;
   }
 
+  public FirebaseAppDistributionException(@NonNull String message, @NonNull Status status) {
+    super(message);
+    this.status = status;
+    this.release = null;
+  }
+
   public FirebaseAppDistributionException(
       @NonNull String message, @NonNull Status status, @Nullable AppDistributionRelease release) {
     super(message);

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
@@ -58,13 +58,13 @@ public class FirebaseAppDistributionException extends FirebaseException {
   @NonNull private final Status status;
   @Nullable private final AppDistributionRelease release;
 
-  FirebaseAppDistributionException(
+  public FirebaseAppDistributionException(
       @NonNull Status status, @Nullable AppDistributionRelease release) {
     this.status = status;
     this.release = release;
   }
 
-  FirebaseAppDistributionException(@NonNull Status status) {
+  public FirebaseAppDistributionException(@NonNull Status status) {
     this.status = status;
     this.release = null;
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionRegistrar.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionRegistrar.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.appdistribution;
 
-import android.util.Log;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import com.google.firebase.FirebaseApp;
@@ -35,7 +34,6 @@ import java.util.List;
 public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
   @Override
   public @NonNull List<Component<?>> getComponents() {
-    Log.v("registrar", "before");
     return Arrays.asList(
         Component.builder(FirebaseAppDistribution.class)
             .add(Dependency.required(FirebaseApp.class))
@@ -43,7 +41,9 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
             .factory(
                 c ->
                     new FirebaseAppDistribution(
-                        c.get(FirebaseApp.class), c.get(FirebaseInstallationsApi.class)))
+                        c.get(FirebaseApp.class),
+                        c.get(FirebaseInstallationsApi.class),
+                        new FirebaseAppDistributionTesterApiClient()))
             .build(),
         LibraryVersionComponent.create("fire-app-distribution", BuildConfig.VERSION_NAME));
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionRegistrar.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionRegistrar.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.appdistribution;
 
+import android.util.Log;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import com.google.firebase.FirebaseApp;
@@ -34,6 +35,7 @@ import java.util.List;
 public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
   @Override
   public @NonNull List<Component<?>> getComponents() {
+    Log.v("registrar", "before");
     return Arrays.asList(
         Component.builder(FirebaseAppDistribution.class)
             .add(Dependency.required(FirebaseApp.class))

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionRegistrar.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionRegistrar.java
@@ -43,6 +43,7 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
                     new FirebaseAppDistribution(
                         c.get(FirebaseApp.class),
                         c.get(FirebaseInstallationsApi.class),
+                        // todo: check if this is best way to inject client
                         new FirebaseAppDistributionTesterApiClient()))
             .build(),
         LibraryVersionComponent.create("fire-app-distribution", BuildConfig.VERSION_NAME));

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -1,18 +1,14 @@
 package com.google.firebase.appdistribution;
 
-import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
-import java.util.stream.Collectors;
 import javax.net.ssl.HttpsURLConnection;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -22,8 +18,6 @@ public class FirebaseAppDistributionTesterApiClient {
   private final String fid;
   private final String appId;
   private final String apiKey;
-  private final String authToken;
-  private final long versionCode;
 
   private final String TAG = "FADTesterApiClient";
 
@@ -36,52 +30,44 @@ public class FirebaseAppDistributionTesterApiClient {
   private static final String DISPLAY_VERSION_JSON_KEY = "displayVersion";
   private static final String RELEASE_NOTES_JSON_KEY = "releaseNotes";
   private static final String BINARY_TYPE_JSON_KEY = "binaryType";
+  public static final int DEFAULT_BUFFER_SIZE = 8192;
 
   FirebaseAppDistributionTesterApiClient(
-      @NonNull String fid,
-      @NonNull String appId,
-      @NonNull String apiKey,
-      @NonNull String authToken,
-      long versionCode) {
+      @NonNull String fid, @NonNull String appId, @NonNull String apiKey) {
     this.fid = fid;
     this.appId = appId;
     this.apiKey = apiKey;
-    this.authToken = authToken;
-    this.versionCode = versionCode;
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
-  public AppDistributionRelease fetchLatestRelease()
+  public AppDistributionRelease fetchLatestRelease(@NonNull String authToken)
       throws FirebaseAppDistributionException, ProtocolException {
 
     AppDistributionRelease latestRelease = null;
     HttpsURLConnection conn = openHttpsUrlConnection();
     conn.setRequestMethod(REQUEST_METHOD);
     conn.setRequestProperty(API_KEY_HEADER, this.apiKey);
-    conn.setRequestProperty(INSTALLATION_AUTH_HEADER, this.authToken);
+    conn.setRequestProperty(INSTALLATION_AUTH_HEADER, authToken);
 
     try {
       Log.v(TAG, String.valueOf(conn.getResponseCode()));
       JSONObject latestReleaseJson = readFetchReleaseInputStream(conn.getInputStream());
       Log.v("Json release", latestReleaseJson.toString());
+
       long latestBuildVersion = Long.parseLong(latestReleaseJson.getString(BUILD_VERSION_JSON_KEY));
-      if (this.versionCode < latestBuildVersion) {
-        // new release available
-        final String displayVersion = latestReleaseJson.getString(DISPLAY_VERSION_JSON_KEY);
-        final String buildVersion = latestReleaseJson.getString(BUILD_VERSION_JSON_KEY);
-        String releaseNotes;
-        try {
-          releaseNotes = latestReleaseJson.getString(RELEASE_NOTES_JSON_KEY);
-        } catch (JSONException e) {
-          releaseNotes = "";
-        }
-        final BinaryType binaryType =
-            latestReleaseJson.getString(BINARY_TYPE_JSON_KEY).equals("APK")
-                ? BinaryType.APK
-                : BinaryType.AAB;
-        latestRelease =
-            new AppDistributionRelease(displayVersion, buildVersion, releaseNotes, binaryType);
+      final String displayVersion = latestReleaseJson.getString(DISPLAY_VERSION_JSON_KEY);
+      final String buildVersion = latestReleaseJson.getString(BUILD_VERSION_JSON_KEY);
+      String releaseNotes;
+      try {
+        releaseNotes = latestReleaseJson.getString(RELEASE_NOTES_JSON_KEY);
+      } catch (JSONException e) {
+        releaseNotes = "";
       }
+      final BinaryType binaryType =
+          latestReleaseJson.getString(BINARY_TYPE_JSON_KEY).equals("APK")
+              ? BinaryType.APK
+              : BinaryType.AAB;
+      latestRelease =
+          new AppDistributionRelease(displayVersion, buildVersion, releaseNotes, binaryType);
 
     } catch (IOException | JSONException e) {
       throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
@@ -92,13 +78,11 @@ public class FirebaseAppDistributionTesterApiClient {
     return latestRelease;
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.N)
   private JSONObject readFetchReleaseInputStream(InputStream in)
-      throws FirebaseAppDistributionException {
+      throws FirebaseAppDistributionException, IOException {
     JSONObject latestRelease = null;
     InputStream jsonIn = new BufferedInputStream(in);
-    String result =
-        new BufferedReader(new InputStreamReader(jsonIn)).lines().collect(Collectors.joining("\n"));
+    String result = convertInputStreamToString(jsonIn);
     try {
       JSONObject json = new JSONObject(result);
       Log.v("all releases", json.getJSONArray("releases").toString());
@@ -106,7 +90,6 @@ public class FirebaseAppDistributionTesterApiClient {
     } catch (JSONException e) {
       throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
     }
-
     return latestRelease;
   }
 
@@ -128,5 +111,15 @@ public class FirebaseAppDistributionTesterApiClient {
     } catch (MalformedURLException e) {
       throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
     }
+  }
+
+  private static String convertInputStreamToString(InputStream is) throws IOException {
+    ByteArrayOutputStream result = new ByteArrayOutputStream();
+    byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+    int length;
+    while ((length = is.read(buffer)) != -1) {
+      result.write(buffer, 0, length);
+    }
+    return result.toString();
   }
 }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -1,0 +1,95 @@
+package com.google.firebase.appdistribution;
+
+import android.os.Build;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.util.stream.Collectors;
+
+import javax.net.ssl.HttpsURLConnection;
+
+public class FirebaseAppDistributionTesterApiClient {
+
+    private final String fid;
+    private final String appId;
+    private final String apiKey;
+    private final String authToken;
+
+    private final String TAG = "FADTesterApiClient";
+
+    private static final String RELEASE_ENDPOINT_URL_FORMAT = "https://firebaseapptesters.googleapis.com/v1alpha/devices/-/testerApps/%s/installations/%s/releases";
+    private static final String REQUEST_METHOD = "GET";
+    private static final String API_KEY_HEADER = "x-goog-api-key";
+    private static final String INSTALLATION_AUTH_HEADER = "X-Goog-Firebase-Installations-Auth";
+    //endpoint template @"https://firebaseapptesters.googleapis.com/v1alpha/devices/"
+    //    @"-/testerApps/%@/installations/%@/releases";
+
+
+
+    FirebaseAppDistributionTesterApiClient(@NonNull String fid, @NonNull String appId,
+                                           @NonNull String apiKey, @NonNull String authToken) {
+        this.fid = fid;
+        this.appId = appId;
+        this.apiKey = apiKey;
+        this.authToken = authToken;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public AppDistributionRelease fetchLatestRelease() throws FirebaseAppDistributionException, ProtocolException {
+
+        HttpsURLConnection conn = openHttpsUrlConnection();
+        try {
+            InputStream in = new BufferedInputStream(conn.getInputStream());
+            int code = conn.getResponseCode();
+            Log.v(TAG, String.valueOf(code));
+            String result = new BufferedReader(new InputStreamReader(in))
+                    .lines().collect(Collectors.joining("\n"));
+            Log.v(TAG, result);
+        } catch (IOException e) {
+            e.printStackTrace();
+            Log.v(TAG, "ioexception");
+        } finally {
+            conn.disconnect();
+        }
+        return null;
+    }
+
+
+    private HttpsURLConnection openHttpsUrlConnection() throws FirebaseAppDistributionException, ProtocolException {
+        HttpsURLConnection httpsURLConnection;
+        URL url = getReleasesEndpointUrl();
+        try {
+            httpsURLConnection = (HttpsURLConnection) url.openConnection();
+        } catch (IOException ignored) {
+            throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
+        }
+        httpsURLConnection.setRequestMethod(REQUEST_METHOD);
+        httpsURLConnection.setRequestProperty(API_KEY_HEADER, this.apiKey);
+        httpsURLConnection.setRequestProperty(INSTALLATION_AUTH_HEADER, this.authToken);
+
+
+
+        return httpsURLConnection;
+    }
+
+    private URL getReleasesEndpointUrl() throws FirebaseAppDistributionException {
+        try {
+            return new URL( String.format(RELEASE_ENDPOINT_URL_FORMAT, this.appId, this.fid));
+        } catch (MalformedURLException e) {
+            throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
+        }
+    }
+
+
+}

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -66,8 +66,14 @@ public class FirebaseAppDistributionTesterApiClient {
           latestReleaseJson.getString(BINARY_TYPE_JSON_KEY).equals("APK")
               ? BinaryType.APK
               : BinaryType.AAB;
+
       latestRelease =
-          new AppDistributionRelease(displayVersion, buildVersion, releaseNotes, binaryType);
+          AppDistributionRelease.builder()
+              .setDisplayVersion(displayVersion)
+              .setBuildVersion(buildVersion)
+              .setReleaseNotes(releaseNotes)
+              .setBinaryType(binaryType)
+              .build();
 
     } catch (IOException | JSONException e) {
       throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -2,94 +2,131 @@ package com.google.firebase.appdistribution;
 
 import android.os.Build;
 import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 import java.util.stream.Collectors;
-
 import javax.net.ssl.HttpsURLConnection;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class FirebaseAppDistributionTesterApiClient {
 
-    private final String fid;
-    private final String appId;
-    private final String apiKey;
-    private final String authToken;
+  private final String fid;
+  private final String appId;
+  private final String apiKey;
+  private final String authToken;
+  private final long versionCode;
 
-    private final String TAG = "FADTesterApiClient";
+  private final String TAG = "FADTesterApiClient";
 
-    private static final String RELEASE_ENDPOINT_URL_FORMAT = "https://firebaseapptesters.googleapis.com/v1alpha/devices/-/testerApps/%s/installations/%s/releases";
-    private static final String REQUEST_METHOD = "GET";
-    private static final String API_KEY_HEADER = "x-goog-api-key";
-    private static final String INSTALLATION_AUTH_HEADER = "X-Goog-Firebase-Installations-Auth";
-    //endpoint template @"https://firebaseapptesters.googleapis.com/v1alpha/devices/"
-    //    @"-/testerApps/%@/installations/%@/releases";
+  private static final String RELEASE_ENDPOINT_URL_FORMAT =
+      "https://firebaseapptesters.googleapis.com/v1alpha/devices/-/testerApps/%s/installations/%s/releases";
+  private static final String REQUEST_METHOD = "GET";
+  private static final String API_KEY_HEADER = "x-goog-api-key";
+  private static final String INSTALLATION_AUTH_HEADER = "X-Goog-Firebase-Installations-Auth";
+  private static final String BUILD_VERSION_JSON_KEY = "buildVersion";
+  private static final String DISPLAY_VERSION_JSON_KEY = "displayVersion";
+  private static final String RELEASE_NOTES_JSON_KEY = "releaseNotes";
+  private static final String BINARY_TYPE_JSON_KEY = "binaryType";
 
+  FirebaseAppDistributionTesterApiClient(
+      @NonNull String fid,
+      @NonNull String appId,
+      @NonNull String apiKey,
+      @NonNull String authToken,
+      long versionCode) {
+    this.fid = fid;
+    this.appId = appId;
+    this.apiKey = apiKey;
+    this.authToken = authToken;
+    this.versionCode = versionCode;
+  }
 
+  @RequiresApi(api = Build.VERSION_CODES.N)
+  public AppDistributionRelease fetchLatestRelease()
+      throws FirebaseAppDistributionException, ProtocolException {
 
-    FirebaseAppDistributionTesterApiClient(@NonNull String fid, @NonNull String appId,
-                                           @NonNull String apiKey, @NonNull String authToken) {
-        this.fid = fid;
-        this.appId = appId;
-        this.apiKey = apiKey;
-        this.authToken = authToken;
-    }
+    AppDistributionRelease latestRelease = null;
+    HttpsURLConnection conn = openHttpsUrlConnection();
+    conn.setRequestMethod(REQUEST_METHOD);
+    conn.setRequestProperty(API_KEY_HEADER, this.apiKey);
+    conn.setRequestProperty(INSTALLATION_AUTH_HEADER, this.authToken);
 
-    @RequiresApi(api = Build.VERSION_CODES.N)
-    public AppDistributionRelease fetchLatestRelease() throws FirebaseAppDistributionException, ProtocolException {
-
-        HttpsURLConnection conn = openHttpsUrlConnection();
+    try {
+      Log.v(TAG, String.valueOf(conn.getResponseCode()));
+      JSONObject latestReleaseJson = readFetchReleaseInputStream(conn.getInputStream());
+      Log.v("Json release", latestReleaseJson.toString());
+      long latestBuildVersion = Long.parseLong(latestReleaseJson.getString(BUILD_VERSION_JSON_KEY));
+      if (this.versionCode < latestBuildVersion) {
+        // new release available
+        final String displayVersion = latestReleaseJson.getString(DISPLAY_VERSION_JSON_KEY);
+        final String buildVersion = latestReleaseJson.getString(BUILD_VERSION_JSON_KEY);
+        String releaseNotes;
         try {
-            InputStream in = new BufferedInputStream(conn.getInputStream());
-            int code = conn.getResponseCode();
-            Log.v(TAG, String.valueOf(code));
-            String result = new BufferedReader(new InputStreamReader(in))
-                    .lines().collect(Collectors.joining("\n"));
-            Log.v(TAG, result);
-        } catch (IOException e) {
-            e.printStackTrace();
-            Log.v(TAG, "ioexception");
-        } finally {
-            conn.disconnect();
+          releaseNotes = latestReleaseJson.getString(RELEASE_NOTES_JSON_KEY);
+        } catch (JSONException e) {
+          releaseNotes = "";
         }
-        return null;
+        final BinaryType binaryType =
+            latestReleaseJson.getString(BINARY_TYPE_JSON_KEY).equals("APK")
+                ? BinaryType.APK
+                : BinaryType.AAB;
+        latestRelease =
+            new AppDistributionRelease(displayVersion, buildVersion, releaseNotes, binaryType);
+      }
+
+    } catch (IOException | JSONException e) {
+      throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
+    } finally {
+      conn.disconnect();
     }
 
+    return latestRelease;
+  }
 
-    private HttpsURLConnection openHttpsUrlConnection() throws FirebaseAppDistributionException, ProtocolException {
-        HttpsURLConnection httpsURLConnection;
-        URL url = getReleasesEndpointUrl();
-        try {
-            httpsURLConnection = (HttpsURLConnection) url.openConnection();
-        } catch (IOException ignored) {
-            throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
-        }
-        httpsURLConnection.setRequestMethod(REQUEST_METHOD);
-        httpsURLConnection.setRequestProperty(API_KEY_HEADER, this.apiKey);
-        httpsURLConnection.setRequestProperty(INSTALLATION_AUTH_HEADER, this.authToken);
-
-
-
-        return httpsURLConnection;
+  @RequiresApi(api = Build.VERSION_CODES.N)
+  private JSONObject readFetchReleaseInputStream(InputStream in)
+      throws FirebaseAppDistributionException {
+    JSONObject latestRelease = null;
+    InputStream jsonIn = new BufferedInputStream(in);
+    String result =
+        new BufferedReader(new InputStreamReader(jsonIn)).lines().collect(Collectors.joining("\n"));
+    try {
+      JSONObject json = new JSONObject(result);
+      Log.v("all releases", json.getJSONArray("releases").toString());
+      latestRelease = json.getJSONArray("releases").getJSONObject(0);
+    } catch (JSONException e) {
+      throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
     }
 
-    private URL getReleasesEndpointUrl() throws FirebaseAppDistributionException {
-        try {
-            return new URL( String.format(RELEASE_ENDPOINT_URL_FORMAT, this.appId, this.fid));
-        } catch (MalformedURLException e) {
-            throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
-        }
+    return latestRelease;
+  }
+
+  private HttpsURLConnection openHttpsUrlConnection()
+      throws FirebaseAppDistributionException, ProtocolException {
+    HttpsURLConnection httpsURLConnection;
+    URL url = getReleasesEndpointUrl();
+    try {
+      httpsURLConnection = (HttpsURLConnection) url.openConnection();
+    } catch (IOException ignored) {
+      throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
     }
+    return httpsURLConnection;
+  }
 
-
+  private URL getReleasesEndpointUrl() throws FirebaseAppDistributionException {
+    try {
+      return new URL(String.format(RELEASE_ENDPOINT_URL_FORMAT, this.appId, this.fid));
+    } catch (MalformedURLException e) {
+      throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
+    }
+  }
 }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -52,7 +52,6 @@ public class FirebaseAppDistributionTesterApiClient {
 
     try {
       JSONObject latestReleaseJson = readFetchReleaseInputStream(conn.getInputStream());
-      long latestBuildVersion = Long.parseLong(latestReleaseJson.getString(BUILD_VERSION_JSON_KEY));
       final String displayVersion = latestReleaseJson.getString(DISPLAY_VERSION_JSON_KEY);
       final String buildVersion = latestReleaseJson.getString(BUILD_VERSION_JSON_KEY);
       String releaseNotes;

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.appdistribution;
 
 import android.util.Log;
@@ -15,10 +29,6 @@ import org.json.JSONObject;
 
 public class FirebaseAppDistributionTesterApiClient {
 
-  private final String fid;
-  private final String appId;
-  private final String apiKey;
-
   private final String TAG = "FADTesterApiClient";
 
   private static final String RELEASE_ENDPOINT_URL_FORMAT =
@@ -32,20 +42,14 @@ public class FirebaseAppDistributionTesterApiClient {
   private static final String BINARY_TYPE_JSON_KEY = "binaryType";
   public static final int DEFAULT_BUFFER_SIZE = 8192;
 
-  FirebaseAppDistributionTesterApiClient(
-      @NonNull String fid, @NonNull String appId, @NonNull String apiKey) {
-    this.fid = fid;
-    this.appId = appId;
-    this.apiKey = apiKey;
-  }
-
-  public AppDistributionRelease fetchLatestRelease(@NonNull String authToken)
+  public AppDistributionRelease fetchLatestRelease(
+      @NonNull String fid, @NonNull String appId, @NonNull String apiKey, @NonNull String authToken)
       throws FirebaseAppDistributionException, ProtocolException {
 
     AppDistributionRelease latestRelease = null;
-    HttpsURLConnection conn = openHttpsUrlConnection();
+    HttpsURLConnection conn = openHttpsUrlConnection(appId, fid);
     conn.setRequestMethod(REQUEST_METHOD);
-    conn.setRequestProperty(API_KEY_HEADER, this.apiKey);
+    conn.setRequestProperty(API_KEY_HEADER, apiKey);
     conn.setRequestProperty(INSTALLATION_AUTH_HEADER, authToken);
 
     try {
@@ -99,10 +103,10 @@ public class FirebaseAppDistributionTesterApiClient {
     return latestRelease;
   }
 
-  private HttpsURLConnection openHttpsUrlConnection()
+  private HttpsURLConnection openHttpsUrlConnection(String appId, String fid)
       throws FirebaseAppDistributionException, ProtocolException {
     HttpsURLConnection httpsURLConnection;
-    URL url = getReleasesEndpointUrl();
+    URL url = getReleasesEndpointUrl(appId, fid);
     try {
       httpsURLConnection = (HttpsURLConnection) url.openConnection();
     } catch (IOException ignored) {
@@ -111,9 +115,10 @@ public class FirebaseAppDistributionTesterApiClient {
     return httpsURLConnection;
   }
 
-  private URL getReleasesEndpointUrl() throws FirebaseAppDistributionException {
+  private URL getReleasesEndpointUrl(String appId, String fid)
+      throws FirebaseAppDistributionException {
     try {
-      return new URL(String.format(RELEASE_ENDPOINT_URL_FORMAT, this.appId, this.fid));
+      return new URL(String.format(RELEASE_ENDPOINT_URL_FORMAT, appId, fid));
     } catch (MalformedURLException e) {
       throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
     }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -30,7 +30,7 @@ public class FirebaseAppDistributionTesterApiClient {
 
   private static final String TAG = "FADTesterApiClient";
   private static final String RELEASE_ENDPOINT_URL_FORMAT =
-      "https://firebaseapptesters.googleapis.com/v1alpha/devices123/-/testerApps/%s/installations/%s/releases";
+      "https://firebaseapptesters.googleapis.com/v1alpha/devices/-/testerApps/%s/installations/%s/releases";
   private static final String REQUEST_METHOD = "GET";
   private static final String API_KEY_HEADER = "x-goog-api-key";
   private static final String INSTALLATION_AUTH_HEADER = "X-Goog-Firebase-Installations-Auth";

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.appdistribution;
 
-import android.util.Log;
 import androidx.annotation.NonNull;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
@@ -29,8 +28,7 @@ import org.json.JSONObject;
 
 public class FirebaseAppDistributionTesterApiClient {
 
-  private final String TAG = "FADTesterApiClient";
-
+  private static final String TAG = "FADTesterApiClient";
   private static final String RELEASE_ENDPOINT_URL_FORMAT =
       "https://firebaseapptesters.googleapis.com/v1alpha/devices/-/testerApps/%s/installations/%s/releases";
   private static final String REQUEST_METHOD = "GET";
@@ -53,10 +51,7 @@ public class FirebaseAppDistributionTesterApiClient {
     conn.setRequestProperty(INSTALLATION_AUTH_HEADER, authToken);
 
     try {
-      Log.v(TAG, String.valueOf(conn.getResponseCode()));
       JSONObject latestReleaseJson = readFetchReleaseInputStream(conn.getInputStream());
-      Log.v("Json release", latestReleaseJson.toString());
-
       long latestBuildVersion = Long.parseLong(latestReleaseJson.getString(BUILD_VERSION_JSON_KEY));
       final String displayVersion = latestReleaseJson.getString(DISPLAY_VERSION_JSON_KEY);
       final String buildVersion = latestReleaseJson.getString(BUILD_VERSION_JSON_KEY);
@@ -80,7 +75,8 @@ public class FirebaseAppDistributionTesterApiClient {
               .build();
 
     } catch (IOException | JSONException e) {
-      throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
+      throw new FirebaseAppDistributionException(
+          FirebaseAppDistributionException.Status.NETWORK_FAILURE);
     } finally {
       conn.disconnect();
     }
@@ -95,7 +91,6 @@ public class FirebaseAppDistributionTesterApiClient {
     String result = convertInputStreamToString(jsonIn);
     try {
       JSONObject json = new JSONObject(result);
-      Log.v("all releases", json.getJSONArray("releases").toString());
       latestRelease = json.getJSONArray("releases").getJSONObject(0);
     } catch (JSONException e) {
       throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
@@ -110,7 +105,8 @@ public class FirebaseAppDistributionTesterApiClient {
     try {
       httpsURLConnection = (HttpsURLConnection) url.openConnection();
     } catch (IOException ignored) {
-      throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
+      throw new FirebaseAppDistributionException(
+          FirebaseAppDistributionException.Status.NETWORK_FAILURE);
     }
     return httpsURLConnection;
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -40,7 +40,7 @@ public class FirebaseAppDistributionTesterApiClient {
   private static final String BINARY_TYPE_JSON_KEY = "binaryType";
   public static final int DEFAULT_BUFFER_SIZE = 8192;
 
-  public AppDistributionRelease fetchLatestRelease(
+  public @NonNull AppDistributionRelease fetchLatestRelease(
       @NonNull String fid, @NonNull String appId, @NonNull String apiKey, @NonNull String authToken)
       throws FirebaseAppDistributionException, ProtocolException {
 
@@ -93,20 +93,21 @@ public class FirebaseAppDistributionTesterApiClient {
       JSONObject json = new JSONObject(result);
       latestRelease = json.getJSONArray("releases").getJSONObject(0);
     } catch (JSONException e) {
-      throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
+      throw new FirebaseAppDistributionException(
+          e.getMessage(), FirebaseAppDistributionException.Status.UNKNOWN);
     }
     return latestRelease;
   }
 
-  private HttpsURLConnection openHttpsUrlConnection(String appId, String fid)
+  HttpsURLConnection openHttpsUrlConnection(String appId, String fid)
       throws FirebaseAppDistributionException, ProtocolException {
     HttpsURLConnection httpsURLConnection;
     URL url = getReleasesEndpointUrl(appId, fid);
     try {
       httpsURLConnection = (HttpsURLConnection) url.openConnection();
-    } catch (IOException ignored) {
+    } catch (IOException e) {
       throw new FirebaseAppDistributionException(
-          FirebaseAppDistributionException.Status.NETWORK_FAILURE);
+          e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE);
     }
     return httpsURLConnection;
   }
@@ -116,7 +117,8 @@ public class FirebaseAppDistributionTesterApiClient {
     try {
       return new URL(String.format(RELEASE_ENDPOINT_URL_FORMAT, appId, fid));
     } catch (MalformedURLException e) {
-      throw new FirebaseAppDistributionException(FirebaseAppDistributionException.Status.UNKNOWN);
+      throw new FirebaseAppDistributionException(
+          e.getMessage(), FirebaseAppDistributionException.Status.UNKNOWN);
     }
   }
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -77,7 +77,7 @@ public class FirebaseAppDistributionTesterApiClient {
     } catch (IOException | JSONException e) {
       // todo: change error status based on response code
       throw new FirebaseAppDistributionException(
-          e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE);
+          FirebaseAppDistributionException.Status.NETWORK_FAILURE);
     } finally {
       conn.disconnect();
     }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClient.java
@@ -30,7 +30,7 @@ public class FirebaseAppDistributionTesterApiClient {
 
   private static final String TAG = "FADTesterApiClient";
   private static final String RELEASE_ENDPOINT_URL_FORMAT =
-      "https://firebaseapptesters.googleapis.com/v1alpha/devices/-/testerApps/%s/installations/%s/releases";
+      "https://firebaseapptesters.googleapis.com/v1alpha/devices123/-/testerApps/%s/installations/%s/releases";
   private static final String REQUEST_METHOD = "GET";
   private static final String API_KEY_HEADER = "x-goog-api-key";
   private static final String INSTALLATION_AUTH_HEADER = "X-Goog-Firebase-Installations-Auth";
@@ -75,8 +75,9 @@ public class FirebaseAppDistributionTesterApiClient {
               .build();
 
     } catch (IOException | JSONException e) {
+      // todo: change error status based on response code
       throw new FirebaseAppDistributionException(
-          FirebaseAppDistributionException.Status.NETWORK_FAILURE);
+          e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE);
     } finally {
       conn.disconnect();
     }

--- a/firebase-app-distribution/src/test/assets/testReleaseResponse.json
+++ b/firebase-app-distribution/src/test/assets/testReleaseResponse.json
@@ -1,0 +1,15 @@
+{"releases":
+  [{
+    "name": "devices/fffffffffffceccaffffffff/testerApps/1:123456789:android:123456789/releases/123456789",
+    "releaseTime":"2021-07-07T17:10:03Z",
+    "buildVersion":"3",
+    "displayVersion":"3.0",
+    "releaseNotes":"This is a test release.",
+    "downloadUrl":"https://firebaseapptesters.googleapis.com/v1alpha/devices/fffffffffffceccaffffffff/testerApps/1:123456789:android:123456789/releases/123456789",
+    "latest": true,
+    "codeHash": "aabbccddeeffgghhjjkkllmmnnooppqqrrssttuu",
+    "fileSize": "3725041",
+    "expirationTime": "2021-12-04T17:10:03Z",
+    "binaryType": "APK"
+  }]
+}

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -51,18 +51,33 @@ import org.robolectric.shadows.ShadowPackageManager;
 
 @RunWith(RobolectricTestRunner.class)
 public class FirebaseAppDistributionTest {
-  public static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
-  public static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
-  public static final String TEST_PROJECT_ID = "777777777777";
-  public static final String TEST_FID_1 = "cccccccccccccccccccccc";
-  public static final String TEST_FID_2 = "dddddddddddddddddddddd";
-  public static final String TEST_AUTH_TOKEN = "fad.auth.token";
-  public static final String TEST_URL =
+  private static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
+  private static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
+  private static final String TEST_PROJECT_ID = "777777777777";
+  private static final String TEST_FID_1 = "cccccccccccccccccccccc";
+  private static final String TEST_FID_2 = "dddddddddddddddddddddd";
+  private static final String TEST_AUTH_TOKEN = "fad.auth.token";
+  private static final String TEST_URL =
       String.format(
           "https://appdistribution.firebase.google.com/pub/testerapps/%s/installations/%s/buildalerts"
               + "?appName=com.google.firebase.appdistribution.test"
               + "&packageName=com.google.firebase.appdistribution.test",
           TEST_APP_ID_1, TEST_FID_1);
+  private static AppDistributionRelease TEST_RELEASE_1 =
+          AppDistributionRelease.builder()
+                  .setBinaryType(BinaryType.APK)
+                  .setBuildVersion("3")
+                  .setDisplayVersion("3.0")
+                  .setReleaseNotes("Newer version.")
+                  .build();
+
+  AppDistributionRelease TEST_RELEASE_2 =
+          AppDistributionRelease.builder()
+                  .setBinaryType(BinaryType.APK)
+                  .setBuildVersion("0")
+                  .setDisplayVersion("0.0")
+                  .setReleaseNotes("Older version.")
+                  .build();
 
   private FirebaseApp firebaseApp;
   private FirebaseAppDistribution firebaseAppDistribution;
@@ -103,29 +118,14 @@ public class FirebaseAppDistributionTest {
         .thenReturn(Tasks.forResult(mockInstallationTokenResult));
     when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
 
-    AppDistributionRelease testRelease1 =
-        AppDistributionRelease.builder()
-            .setBinaryType(BinaryType.APK)
-            .setBuildVersion("3")
-            .setDisplayVersion("3.0")
-            .setReleaseNotes("Newer version.")
-            .build();
-
-    AppDistributionRelease testRelease2 =
-        AppDistributionRelease.builder()
-            .setBinaryType(BinaryType.APK)
-            .setBuildVersion("0")
-            .setDisplayVersion("0.0")
-            .setReleaseNotes("Older version.")
-            .build();
 
     when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(
             TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
-        .thenReturn(testRelease1);
+        .thenReturn(TEST_RELEASE_1);
 
     when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(
             TEST_FID_2, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
-        .thenReturn(testRelease2);
+        .thenReturn(TEST_RELEASE_2);
 
     shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
@@ -240,7 +240,7 @@ public class FirebaseAppDistributionTest {
             TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
 
     assertNotNull(release);
-    assertEquals("3", release.getBuildVersion());
+    assertEquals(TEST_RELEASE_1.getBuildVersion(), release.getBuildVersion());
   }
 
   @Test

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -61,7 +61,7 @@ public class FirebaseAppDistributionTest {
   public static final String TEST_AUTH_TOKEN = "fad.auth.token";
   public static final String TEST_URL =
       String.format(
-          "https://appdistribution.firebase.google.com/pub/apps/%s/installations/%s/buildalerts"
+          "https://appdistribution.firebase.google.com/pub/testerapps/%s/installations/%s/buildalerts"
               + "?appName=com.google.firebase.appdistribution.test"
               + "&packageName=com.google.firebase.appdistribution.test",
           TEST_APP_ID_1, TEST_FID_1);

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -64,20 +64,20 @@ public class FirebaseAppDistributionTest {
               + "&packageName=com.google.firebase.appdistribution.test",
           TEST_APP_ID_1, TEST_FID_1);
   private static AppDistributionRelease TEST_RELEASE_1 =
-          AppDistributionRelease.builder()
-                  .setBinaryType(BinaryType.APK)
-                  .setBuildVersion("3")
-                  .setDisplayVersion("3.0")
-                  .setReleaseNotes("Newer version.")
-                  .build();
+      AppDistributionRelease.builder()
+          .setBinaryType(BinaryType.APK)
+          .setBuildVersion("3")
+          .setDisplayVersion("3.0")
+          .setReleaseNotes("Newer version.")
+          .build();
 
   AppDistributionRelease TEST_RELEASE_2 =
-          AppDistributionRelease.builder()
-                  .setBinaryType(BinaryType.APK)
-                  .setBuildVersion("0")
-                  .setDisplayVersion("0.0")
-                  .setReleaseNotes("Older version.")
-                  .build();
+      AppDistributionRelease.builder()
+          .setBinaryType(BinaryType.APK)
+          .setBuildVersion("0")
+          .setDisplayVersion("0.0")
+          .setReleaseNotes("Older version.")
+          .build();
 
   private FirebaseApp firebaseApp;
   private FirebaseAppDistribution firebaseAppDistribution;
@@ -117,7 +117,6 @@ public class FirebaseAppDistributionTest {
     when(mockFirebaseInstallations.getToken(true))
         .thenReturn(Tasks.forResult(mockInstallationTokenResult));
     when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
-
 
     when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(
             TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -66,6 +66,7 @@ public class FirebaseAppDistributionTest {
   private ShadowPackageManager shadowPackageManager;
 
   @Mock private FirebaseInstallationsApi mockFirebaseInstallations;
+  @Mock private FirebaseAppDistributionTesterApiClient mockFirebaseAppDistributionTesterApiClient;
   @Mock private Bundle mockBundle;
   @Mock SignInResultActivity mockSignInResultActivity;
 
@@ -87,7 +88,9 @@ public class FirebaseAppDistributionTest {
                 .setApiKey(TEST_API_KEY)
                 .build());
 
-    firebaseAppDistribution = new FirebaseAppDistribution(firebaseApp, mockFirebaseInstallations);
+    firebaseAppDistribution =
+        new FirebaseAppDistribution(
+            firebaseApp, mockFirebaseInstallations, mockFirebaseAppDistributionTesterApiClient);
 
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
 

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -114,7 +114,7 @@ public class FirebaseAppDistributionTest {
             firebaseApp, mockFirebaseInstallations, mockFirebaseAppDistributionTesterApiClient);
 
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
-    when(mockFirebaseInstallations.getToken(true))
+    when(mockFirebaseInstallations.getToken(false))
         .thenReturn(Tasks.forResult(mockInstallationTokenResult));
     when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
 
@@ -220,7 +220,7 @@ public class FirebaseAppDistributionTest {
   public void checkForUpdate_whenCalled_getsFidAndAuthToken() throws Exception {
     Task<AppDistributionRelease> task = firebaseAppDistribution.checkForUpdate();
     verify(mockFirebaseInstallations, times(1)).getId();
-    verify(mockFirebaseInstallations, times(1)).getToken(true);
+    verify(mockFirebaseInstallations, times(1)).getToken(false);
   }
 
   @Test

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -14,14 +14,18 @@
 
 package com.google.firebase.appdistribution;
 
+import static androidx.test.InstrumentationRegistry.getContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import javax.net.ssl.HttpsURLConnection;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +44,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
   public static final String INVALID_RESPONSE = "InvalidResponse";
   public static final String SUCCESSFUL_RESPONSE =
       "{\"releases\": [{\"name\":\"devices/3d6942794f7cecca44e0ff4f/testerApps/1:378474073654:android:f886de0625fd488dc21297/releases/2g0n7rk01mjdo\",\"releaseTime\":\"2021-07-07T17:10:03Z\",\"buildVersion\":\"3\",\"displayVersion\":\"3.0\",\"releaseNotes\":\"This is a test release.\",\"downloadUrl\":\"https://firebaseapptesters.googleapis.com/v1alpha/devices/3d6942794f7cecca44e0ff4f/testerApps/1:378474073654:android:f886de0625fd488dc21297/releases/2g0n7rk01mjdo:download?tester_client=ios_sdk&token=AFb1MRwAAAAAYO3Cpy79kVVQDN4P1P-ija4QSO3MKnkfrYvx1XYkcbQ_1mCZ6mUjto5d4NG77CnEL0lFLqLGuSTi9DbTzAa-tKCukMP2yuvif8Rm9wtCO9k8KekV7mHNNNlWs9WczBc1quZjJ8pwHCGE-XAlXxR5hN7ZxNFXns0igQlRZoryjmADZdnvfHlJ3-dC616_g93vRsAHmjBVMz-gO1Wv1iuYhw9Des0Eh0VOmzqLgYZxaRdcdJOzpPijHzQAYiyMS3VkOhrdAQKsWZ48NwYHJMbI_o0G9WLElH1wlL63Vs9DAeBwZNRCqtFpAkcpzO9UuTipP-UsFRmanf7IH6QceOda4dM8vzM&key=AIzaSyCT43_YT7B59u5KtzIlbJrwANinug62pHo\",\"latest\":true,\"codeHash\":\"aa8002876b1e9b90b81df4ca3bb80529be670f35\",\"fileSize\":\"3725041\",\"expirationTime\":\"2021-12-04T17:10:03Z\",\"binaryType\":\"APK\"}]}";
+  private static final int DEFAULT_BUFFER_SIZE = 8192;
 
   private FirebaseAppDistributionTesterApiClient firebaseAppDistributionTesterApiClient;
   @Mock private HttpsURLConnection mockHttpsURLConnection;
@@ -47,8 +52,12 @@ public class FirebaseAppDistributionTesterApiClientTest {
   @Before
   public void setup() throws Exception {
     MockitoAnnotations.initMocks(this);
+
+    // using spy allows using doReturn to specify output
+    // of a method while leaving other methods unmocked
     firebaseAppDistributionTesterApiClient =
         Mockito.spy(new FirebaseAppDistributionTesterApiClient());
+
     Mockito.doReturn(mockHttpsURLConnection)
         .when(firebaseAppDistributionTesterApiClient)
         .openHttpsUrlConnection(TEST_APP_ID_1, TEST_FID_1);
@@ -56,8 +65,9 @@ public class FirebaseAppDistributionTesterApiClientTest {
 
   @Test
   public void fetchLatestRelease_whenResponseSuccessful_returnsRelease() throws Exception {
+    JSONObject releaseJson = getTestJSON("testReleaseResponse.json");
     InputStream response =
-        new ByteArrayInputStream(SUCCESSFUL_RESPONSE.getBytes(StandardCharsets.UTF_8));
+        new ByteArrayInputStream(releaseJson.toString().getBytes(StandardCharsets.UTF_8));
     when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
     AppDistributionRelease release =
         firebaseAppDistributionTesterApiClient.fetchLatestRelease(
@@ -70,6 +80,20 @@ public class FirebaseAppDistributionTesterApiClientTest {
 
   @Test
   public void fetchLatestRelease_whenResponseFails_throwsError() throws Exception {
+    when(mockHttpsURLConnection.getInputStream()).thenThrow(new IOException());
+    AppDistributionRelease release = null;
+    try {
+      release =
+          firebaseAppDistributionTesterApiClient.fetchLatestRelease(
+              TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    } catch (Exception e) {
+      assertEquals(e.getClass(), FirebaseAppDistributionException.class);
+    }
+    assertNull(release);
+  }
+
+  @Test
+  public void fetchLatestRelease_whenInvalidJson_throwsError() throws Exception {
     InputStream response =
         new ByteArrayInputStream(INVALID_RESPONSE.getBytes(StandardCharsets.UTF_8));
     when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
@@ -82,5 +106,17 @@ public class FirebaseAppDistributionTesterApiClientTest {
       assertEquals(e.getClass(), FirebaseAppDistributionException.class);
     }
     assertNull(release);
+  }
+
+  private JSONObject getTestJSON(String fileName) throws IOException, JSONException {
+    final InputStream jsonInputStream = getContext().getResources().getAssets().open(fileName);
+    final String testJsonString = streamToString(jsonInputStream);
+    final JSONObject testJson = new JSONObject(testJsonString);
+    return testJson;
+  }
+
+  private static String streamToString(InputStream is) {
+    final java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
+    return s.hasNext() ? s.next() : "";
   }
 }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -1,0 +1,72 @@
+package com.google.firebase.appdistribution;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import javax.net.ssl.HttpsURLConnection;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class FirebaseAppDistributionTesterApiClientTest {
+
+  public static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
+  public static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
+  public static final String TEST_AUTH_TOKEN = "fad.auth.token";
+  public static final String TEST_FID_1 = "cccccccccccccccccccccc";
+  public static final String INVALID_RESPONSE = "InvalidResponse";
+  public static final String SUCCESSFUL_RESPONSE =
+      "{\"releases\": [{\"name\":\"devices/3d6942794f7cecca44e0ff4f/testerApps/1:378474073654:android:f886de0625fd488dc21297/releases/2g0n7rk01mjdo\",\"releaseTime\":\"2021-07-07T17:10:03Z\",\"buildVersion\":\"3\",\"displayVersion\":\"3.0\",\"releaseNotes\":\"This is a test release.\",\"downloadUrl\":\"https://firebaseapptesters.googleapis.com/v1alpha/devices/3d6942794f7cecca44e0ff4f/testerApps/1:378474073654:android:f886de0625fd488dc21297/releases/2g0n7rk01mjdo:download?tester_client=ios_sdk&token=AFb1MRwAAAAAYO3Cpy79kVVQDN4P1P-ija4QSO3MKnkfrYvx1XYkcbQ_1mCZ6mUjto5d4NG77CnEL0lFLqLGuSTi9DbTzAa-tKCukMP2yuvif8Rm9wtCO9k8KekV7mHNNNlWs9WczBc1quZjJ8pwHCGE-XAlXxR5hN7ZxNFXns0igQlRZoryjmADZdnvfHlJ3-dC616_g93vRsAHmjBVMz-gO1Wv1iuYhw9Des0Eh0VOmzqLgYZxaRdcdJOzpPijHzQAYiyMS3VkOhrdAQKsWZ48NwYHJMbI_o0G9WLElH1wlL63Vs9DAeBwZNRCqtFpAkcpzO9UuTipP-UsFRmanf7IH6QceOda4dM8vzM&key=AIzaSyCT43_YT7B59u5KtzIlbJrwANinug62pHo\",\"latest\":true,\"codeHash\":\"aa8002876b1e9b90b81df4ca3bb80529be670f35\",\"fileSize\":\"3725041\",\"expirationTime\":\"2021-12-04T17:10:03Z\",\"binaryType\":\"APK\"}]}";
+
+  private FirebaseAppDistributionTesterApiClient firebaseAppDistributionTesterApiClient;
+  @Mock private HttpsURLConnection mockHttpsURLConnection;
+
+  @Before
+  public void setup() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    firebaseAppDistributionTesterApiClient =
+        Mockito.spy(new FirebaseAppDistributionTesterApiClient());
+    Mockito.doReturn(mockHttpsURLConnection)
+        .when(firebaseAppDistributionTesterApiClient)
+        .openHttpsUrlConnection(TEST_APP_ID_1, TEST_FID_1);
+  }
+
+  @Test
+  public void fetchLatestRelease_whenResponseSuccessful_returnsRelease() throws Exception {
+    InputStream response =
+        new ByteArrayInputStream(SUCCESSFUL_RESPONSE.getBytes(StandardCharsets.UTF_8));
+    when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
+    AppDistributionRelease release =
+        firebaseAppDistributionTesterApiClient.fetchLatestRelease(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    assertEquals(release.getBinaryType(), BinaryType.APK);
+    assertEquals(release.getBuildVersion(), "3");
+    assertEquals(release.getDisplayVersion(), "3.0");
+    assertEquals(release.getReleaseNotes(), "This is a test release.");
+  }
+
+  @Test
+  public void fetchLatestRelease_whenResponseFails_throwsError() throws Exception {
+    InputStream response =
+        new ByteArrayInputStream(INVALID_RESPONSE.getBytes(StandardCharsets.UTF_8));
+    when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
+    AppDistributionRelease release = null;
+    try {
+      release =
+          firebaseAppDistributionTesterApiClient.fetchLatestRelease(
+              TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    } catch (Exception e) {
+      assertEquals(e.getClass(), FirebaseAppDistributionException.class);
+    }
+    assertNull(release);
+  }
+}

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.appdistribution;
 
 import static org.junit.Assert.assertEquals;

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -42,9 +42,6 @@ public class FirebaseAppDistributionTesterApiClientTest {
   public static final String TEST_AUTH_TOKEN = "fad.auth.token";
   public static final String TEST_FID_1 = "cccccccccccccccccccccc";
   public static final String INVALID_RESPONSE = "InvalidResponse";
-  public static final String SUCCESSFUL_RESPONSE =
-      "{\"releases\": [{\"name\":\"devices/3d6942794f7cecca44e0ff4f/testerApps/1:378474073654:android:f886de0625fd488dc21297/releases/2g0n7rk01mjdo\",\"releaseTime\":\"2021-07-07T17:10:03Z\",\"buildVersion\":\"3\",\"displayVersion\":\"3.0\",\"releaseNotes\":\"This is a test release.\",\"downloadUrl\":\"https://firebaseapptesters.googleapis.com/v1alpha/devices/3d6942794f7cecca44e0ff4f/testerApps/1:378474073654:android:f886de0625fd488dc21297/releases/2g0n7rk01mjdo:download?tester_client=ios_sdk&token=AFb1MRwAAAAAYO3Cpy79kVVQDN4P1P-ija4QSO3MKnkfrYvx1XYkcbQ_1mCZ6mUjto5d4NG77CnEL0lFLqLGuSTi9DbTzAa-tKCukMP2yuvif8Rm9wtCO9k8KekV7mHNNNlWs9WczBc1quZjJ8pwHCGE-XAlXxR5hN7ZxNFXns0igQlRZoryjmADZdnvfHlJ3-dC616_g93vRsAHmjBVMz-gO1Wv1iuYhw9Des0Eh0VOmzqLgYZxaRdcdJOzpPijHzQAYiyMS3VkOhrdAQKsWZ48NwYHJMbI_o0G9WLElH1wlL63Vs9DAeBwZNRCqtFpAkcpzO9UuTipP-UsFRmanf7IH6QceOda4dM8vzM&key=AIzaSyCT43_YT7B59u5KtzIlbJrwANinug62pHo\",\"latest\":true,\"codeHash\":\"aa8002876b1e9b90b81df4ca3bb80529be670f35\",\"fileSize\":\"3725041\",\"expirationTime\":\"2021-12-04T17:10:03Z\",\"binaryType\":\"APK\"}]}";
-  private static final int DEFAULT_BUFFER_SIZE = 8192;
 
   private FirebaseAppDistributionTesterApiClient firebaseAppDistributionTesterApiClient;
   @Mock private HttpsURLConnection mockHttpsURLConnection;

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.appdistribution;
 
 import static androidx.test.InstrumentationRegistry.getContext;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -79,8 +78,11 @@ public class FirebaseAppDistributionTesterApiClientTest {
   @Test
   public void fetchLatestRelease_whenResponseFails_throwsError() throws Exception {
     when(mockHttpsURLConnection.getInputStream()).thenThrow(new IOException());
-    assertThrows(FirebaseAppDistributionException.class, () -> firebaseAppDistributionTesterApiClient.fetchLatestRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
+    assertThrows(
+        FirebaseAppDistributionException.class,
+        () ->
+            firebaseAppDistributionTesterApiClient.fetchLatestRelease(
+                TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
   }
 
   @Test
@@ -88,8 +90,11 @@ public class FirebaseAppDistributionTesterApiClientTest {
     InputStream response =
         new ByteArrayInputStream(INVALID_RESPONSE.getBytes(StandardCharsets.UTF_8));
     when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
-    assertThrows(FirebaseAppDistributionException.class, () -> firebaseAppDistributionTesterApiClient.fetchLatestRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
+    assertThrows(
+        FirebaseAppDistributionException.class,
+        () ->
+            firebaseAppDistributionTesterApiClient.fetchLatestRelease(
+                TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
   }
 
   private JSONObject getTestJSON(String fileName) throws IOException, JSONException {

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -84,7 +84,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
           firebaseAppDistributionTesterApiClient.fetchLatestRelease(
               TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
     } catch (Exception e) {
-      assertEquals(e.getClass(), FirebaseAppDistributionException.class);
+      assertEquals(FirebaseAppDistributionException.class, e.getClass());
     }
     assertNull(release);
   }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -17,6 +17,7 @@ package com.google.firebase.appdistribution;
 import static androidx.test.InstrumentationRegistry.getContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -37,11 +38,11 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class FirebaseAppDistributionTesterApiClientTest {
 
-  public static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
-  public static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
-  public static final String TEST_AUTH_TOKEN = "fad.auth.token";
-  public static final String TEST_FID_1 = "cccccccccccccccccccccc";
-  public static final String INVALID_RESPONSE = "InvalidResponse";
+  private static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
+  private static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
+  private static final String TEST_AUTH_TOKEN = "fad.auth.token";
+  private static final String TEST_FID_1 = "cccccccccccccccccccccc";
+  private static final String INVALID_RESPONSE = "InvalidResponse";
 
   private FirebaseAppDistributionTesterApiClient firebaseAppDistributionTesterApiClient;
   @Mock private HttpsURLConnection mockHttpsURLConnection;
@@ -78,15 +79,8 @@ public class FirebaseAppDistributionTesterApiClientTest {
   @Test
   public void fetchLatestRelease_whenResponseFails_throwsError() throws Exception {
     when(mockHttpsURLConnection.getInputStream()).thenThrow(new IOException());
-    AppDistributionRelease release = null;
-    try {
-      release =
-          firebaseAppDistributionTesterApiClient.fetchLatestRelease(
-              TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
-    } catch (Exception e) {
-      assertEquals(FirebaseAppDistributionException.class, e.getClass());
-    }
-    assertNull(release);
+    assertThrows(FirebaseAppDistributionException.class, () -> firebaseAppDistributionTesterApiClient.fetchLatestRelease(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
   }
 
   @Test
@@ -94,15 +88,8 @@ public class FirebaseAppDistributionTesterApiClientTest {
     InputStream response =
         new ByteArrayInputStream(INVALID_RESPONSE.getBytes(StandardCharsets.UTF_8));
     when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
-    AppDistributionRelease release = null;
-    try {
-      release =
-          firebaseAppDistributionTesterApiClient.fetchLatestRelease(
-              TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
-    } catch (Exception e) {
-      assertEquals(e.getClass(), FirebaseAppDistributionException.class);
-    }
-    assertNull(release);
+    assertThrows(FirebaseAppDistributionException.class, () -> firebaseAppDistributionTesterApiClient.fetchLatestRelease(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
   }
 
   private JSONObject getTestJSON(String fileName) throws IOException, JSONException {


### PR DESCRIPTION
- Implement checkForUpdate MVP (currently compares build versions, will be changed for code hashes)
- Added FirebaseAppDistributionTesterApiClient to handle calls to ListTesterAppInstallationReleasesAction endpoint 
- Add unit tests for checkForUpdate and Client  
