### PR TITLE
Fix flaky tests in FirebasePerformanceTest.java

### DIFF
--- a/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/FirebasePerformanceTest.java
@@ -545,11 +545,12 @@ public class FirebasePerformanceTest {
       Boolean sharedPreferencesEnabledDisabledKey,
       Provider<RemoteConfigComponent> firebaseRemoteConfigProvider,
       Provider<TransportFactory> transportFactoryProvider) {
+    DeviceCacheManager deviceCacheManager = new DeviceCacheManager(fakeDirectExecutorService);
+    deviceCacheManager.setContext(ApplicationProvider.getApplicationContext());
     if (sharedPreferencesEnabledDisabledKey != null) {
-      DeviceCacheManager deviceCacheManager = new DeviceCacheManager(fakeDirectExecutorService);
-      deviceCacheManager.setContext(ApplicationProvider.getApplicationContext());
       deviceCacheManager.setValue(Constants.ENABLE_DISABLE, sharedPreferencesEnabledDisabledKey);
     }
+    spyConfigResolver.setDeviceCacheManager(deviceCacheManager);
 
     Bundle bundle = new Bundle();
     if (metadataFireperfEnabledKey != null) {


### PR DESCRIPTION
This PR will unblock #2788.
`check-changed` should be passing based on the test result from #2813, which is based on #2788.

Context:
The failure examples could be found [here](https://storage.googleapis.com/android-ci/pr-logs/pull/firebase_firebase-android-sdk/2788/check-changed/1412872199047483392/artifacts/firebase-perf_build_test-results/testReleaseUnitTest/TEST-com.google.firebase.perf.FirebasePerformanceTest.xml)
