### PR TITLE
Include ClientMetrics into BachedLogRequest

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -47,7 +47,7 @@ import javax.inject.Inject;
 public class Uploader {
 
   private static final String LOG_TAG = "Uploader";
-  private static final String CLIENT_HEALTH_METRICS_LOG_SOURCE = "1710";
+  private static final String CLIENT_HEALTH_METRICS_LOG_SOURCE = "GDT_CLIENT_METRICS";
 
   private final Context context;
   private final BackendRegistry backendRegistry;

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -17,12 +17,15 @@ package com.google.android.datatransport.runtime.scheduling.jobscheduling;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import com.google.android.datatransport.Encoding;
+import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.backends.BackendRegistry;
 import com.google.android.datatransport.runtime.backends.BackendRequest;
 import com.google.android.datatransport.runtime.backends.BackendResponse;
 import com.google.android.datatransport.runtime.backends.TransportBackend;
+import com.google.android.datatransport.runtime.firebase.transport.ClientMetrics;
 import com.google.android.datatransport.runtime.firebase.transport.LogEventDropped;
 import com.google.android.datatransport.runtime.logging.Logging;
 import com.google.android.datatransport.runtime.scheduling.persistence.ClientHealthMetricsStore;
@@ -31,6 +34,7 @@ import com.google.android.datatransport.runtime.scheduling.persistence.Persisted
 import com.google.android.datatransport.runtime.synchronization.SynchronizationException;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
 import com.google.android.datatransport.runtime.time.Clock;
+import com.google.android.datatransport.runtime.time.Monotonic;
 import com.google.android.datatransport.runtime.time.WallTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,6 +47,7 @@ import javax.inject.Inject;
 public class Uploader {
 
   private static final String LOG_TAG = "Uploader";
+  private static final String CLIENT_HEALTH_METRICS_LOG_SOURCE = "1710";
 
   private final Context context;
   private final BackendRegistry backendRegistry;
@@ -51,6 +56,7 @@ public class Uploader {
   private final Executor executor;
   private final SynchronizationGuard guard;
   private final Clock clock;
+  private final Clock uptimeClock;
   private final ClientHealthMetricsStore clientHealthMetricsStore;
 
   @Inject
@@ -62,6 +68,7 @@ public class Uploader {
       Executor executor,
       SynchronizationGuard guard,
       @WallTime Clock clock,
+      @Monotonic Clock uptimeClock,
       ClientHealthMetricsStore clientHealthMetricsStore) {
     this.context = context;
     this.backendRegistry = backendRegistry;
@@ -70,6 +77,7 @@ public class Uploader {
     this.executor = executor;
     this.guard = guard;
     this.clock = clock;
+    this.uptimeClock = uptimeClock;
     this.clientHealthMetricsStore = clientHealthMetricsStore;
   }
 
@@ -126,6 +134,22 @@ public class Uploader {
         for (PersistedEvent persistedEvent : persistedEvents) {
           eventInternals.add(persistedEvent.getEvent());
         }
+
+        if (transportContext.shouldUploadClientHealthMetrics()) {
+          ClientMetrics clientMetrics =
+              guard.runCriticalSection(clientHealthMetricsStore::loadClientMetrics);
+          EventInternal eventInternal =
+              EventInternal.builder()
+                  .setEventMillis(clock.getTime())
+                  .setUptimeMillis(uptimeClock.getTime())
+                  .setTransportName(CLIENT_HEALTH_METRICS_LOG_SOURCE)
+                  .setEncodedPayload(
+                      new EncodedPayload(Encoding.of("proto"), clientMetrics.toByteArray()))
+                  .build();
+          EventInternal decoratedEvent = backend.decorate(eventInternal);
+          eventInternals.add(decoratedEvent);
+        }
+
         response =
             backend.send(
                 BackendRequest.builder()

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/TransportRuntimeTest.java
@@ -121,7 +121,7 @@ public class TransportRuntimeTest {
             fixedClock(EVENT_MILLIS),
             fixedClock(UPTIME_MILLIS),
             new ImmediateScheduler(Runnable::run, mockRegistry),
-            new Uploader(null, null, null, null, null, null, () -> 2, null),
+            new Uploader(null, null, null, null, null, null, () -> 2, null, null),
             mockInitializer);
 
     verify(mockInitializer, times(1)).ensureContextsScheduled();
@@ -172,7 +172,7 @@ public class TransportRuntimeTest {
             fixedClock(EVENT_MILLIS),
             fixedClock(UPTIME_MILLIS),
             new ImmediateScheduler(Runnable::run, mockRegistry),
-            new Uploader(null, null, null, null, null, null, () -> 2, null),
+            new Uploader(null, null, null, null, null, null, () -> 2, null, null),
             mockInitializer);
 
     verify(mockInitializer, times(1)).ensureContextsScheduled();
@@ -202,7 +202,7 @@ public class TransportRuntimeTest {
             fixedClock(UPTIME_MILLIS),
             new DefaultScheduler(
                 Runnable::run, mockRegistry, mockWorkScheduler, mockEventStore, guard),
-            new Uploader(null, null, null, null, null, null, () -> 2, null),
+            new Uploader(null, null, null, null, null, null, () -> 2, null, null),
             mockInitializer);
 
     verify(mockInitializer, times(1)).ensureContextsScheduled();
@@ -250,7 +250,7 @@ public class TransportRuntimeTest {
             fixedClock(UPTIME_MILLIS),
             new DefaultScheduler(
                 Runnable::run, mockRegistry, mockWorkScheduler, mockEventStore, guard),
-            new Uploader(null, null, null, null, null, null, () -> 2, null),
+            new Uploader(null, null, null, null, null, null, () -> 2, null, null),
             mockInitializer);
 
     verify(mockInitializer, times(1)).ensureContextsScheduled();
@@ -276,7 +276,7 @@ public class TransportRuntimeTest {
             fixedClock(EVENT_MILLIS),
             fixedClock(UPTIME_MILLIS),
             new ImmediateScheduler(Runnable::run, mockRegistry),
-            new Uploader(null, null, null, null, null, null, () -> 2, null),
+            new Uploader(null, null, null, null, null, null, () -> 2, null, null),
             mockInitializer);
 
     TransportFactory transportFactory = runtime.newFactory(new TestDestination());
@@ -298,7 +298,7 @@ public class TransportRuntimeTest {
             fixedClock(EVENT_MILLIS),
             fixedClock(UPTIME_MILLIS),
             new ImmediateScheduler(Runnable::run, mockRegistry),
-            new Uploader(null, null, null, null, null, null, () -> 2, null),
+            new Uploader(null, null, null, null, null, null, () -> 2, null, null),
             mockInitializer);
 
     TransportFactory transportFactory = runtime.newFactory(new YamlEncodedDestination());

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
@@ -60,7 +60,7 @@ public class UploaderTest {
       };
   private static final String BACKEND_NAME = "backend1";
   private static final String ANOTHER_BACKEND_NAME = "backend1";
-  private static final String CLIENT_HEALTH_METRICS_LOG_SOURCE = "1710";
+  private static final String CLIENT_HEALTH_METRICS_LOG_SOURCE = "GDT_CLIENT_METRICS";
   private static final TransportContext TRANSPORT_CONTEXT =
       TransportContext.builder().setBackendName(BACKEND_NAME).build();
   private static final TransportContext ANOTHER_TRANSPORT_CONTEXT =


### PR DESCRIPTION
Added an additional `EventInteral` to `BackEndRequest` to send `ClientMetrics`