### PR TITLE
Add global db storage limit

### DIFF
--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
@@ -667,6 +667,18 @@ public class SQLiteEventStoreTest {
   }
 
   @Test
+  public void recordLogEventDropped_whenDbSizeOnDiskIsAtGlobalLimit_shouldNotRecordAnything() {
+    SQLiteEventStore storeUnderTest =
+        newStoreWithConfig(
+            clock, CONFIG.toBuilder().setMaxGlobalStorageSizeInBytes(0).build(), packageName);
+
+    storeUnderTest.recordLogEventDropped(1, REASON_MAX_RETRIES_REACHED, LOG_SOURCE_1);
+
+    ClientMetrics clientMetrics = storeUnderTest.loadClientMetrics();
+    assertThat(clientMetrics.getLogSourceMetricsList().size()).isEqualTo(0);
+  }
+
+  @Test
   public void loadClientMetrics_shouldIncludeCorrectLogSourceMetrics() {
     store.resetClientMetrics();
     store.recordLogEventDropped(

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/TestEventStoreModule.java
@@ -24,6 +24,7 @@ import javax.inject.Named;
 @Module
 public abstract class TestEventStoreModule {
   private static final long MAX_DB_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+  private static final long MAX_DB_GLOBAL_STORAGE_SIZE_IN_BYTES = 12 * 1024 * 1024;
   private static final int LOAD_BATCH_SIZE = 200;
   private static final int LOCK_TIME_OUT_MS = 0;
 
@@ -31,6 +32,7 @@ public abstract class TestEventStoreModule {
   static EventStoreConfig storeConfig() {
     return EventStoreConfig.builder()
         .setMaxStorageSizeInBytes(MAX_DB_STORAGE_SIZE_IN_BYTES)
+        .setMaxGlobalStorageSizeInBytes(MAX_DB_GLOBAL_STORAGE_SIZE_IN_BYTES)
         .setLoadBatchSize(LOAD_BATCH_SIZE)
         .setCriticalSectionEnterTimeoutMs(LOCK_TIME_OUT_MS)
         .setEventCleanUpAge(60 * 1000)

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreConfig.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreConfig.java
@@ -19,6 +19,7 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 abstract class EventStoreConfig {
   private static final long MAX_DB_STORAGE_SIZE_IN_BYTES = 10 * 1024 * 1024;
+  private static final long MAX_DB_GLOBAL_STORAGE_SIZE_IN_BYTES = 12 * 1024 * 1024;
   private static final int LOAD_BATCH_SIZE = 200;
   private static final int LOCK_TIME_OUT_MS = 10000;
   private static final long DURATION_ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -27,6 +28,7 @@ abstract class EventStoreConfig {
   static final EventStoreConfig DEFAULT =
       EventStoreConfig.builder()
           .setMaxStorageSizeInBytes(MAX_DB_STORAGE_SIZE_IN_BYTES)
+          .setMaxGlobalStorageSizeInBytes(MAX_DB_GLOBAL_STORAGE_SIZE_IN_BYTES)
           .setLoadBatchSize(LOAD_BATCH_SIZE)
           .setCriticalSectionEnterTimeoutMs(LOCK_TIME_OUT_MS)
           .setEventCleanUpAge(DURATION_ONE_WEEK_MS)
@@ -34,6 +36,8 @@ abstract class EventStoreConfig {
           .build();
 
   abstract long getMaxStorageSizeInBytes();
+
+  abstract long getMaxGlobalStorageSizeInBytes();
 
   abstract int getLoadBatchSize();
 
@@ -50,6 +54,7 @@ abstract class EventStoreConfig {
   Builder toBuilder() {
     return builder()
         .setMaxStorageSizeInBytes(getMaxStorageSizeInBytes())
+        .setMaxGlobalStorageSizeInBytes(getMaxGlobalStorageSizeInBytes())
         .setLoadBatchSize(getLoadBatchSize())
         .setCriticalSectionEnterTimeoutMs(getCriticalSectionEnterTimeoutMs())
         .setEventCleanUpAge(getEventCleanUpAge())
@@ -59,6 +64,8 @@ abstract class EventStoreConfig {
   @AutoValue.Builder
   abstract static class Builder {
     abstract Builder setMaxStorageSizeInBytes(long value);
+
+    abstract Builder setMaxGlobalStorageSizeInBytes(long value);
 
     abstract Builder setLoadBatchSize(int value);
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -587,6 +587,9 @@ public class SQLiteEventStore
       long eventsDroppedCount, LogEventDropped.Reason reason, String logSource) {
     inTransaction(
         db -> {
+          if (isStorageAtGlobalLimit()) {
+            return null;
+          }
           String selectSql =
               "SELECT 1 FROM log_event_dropped" + " WHERE log_source = ? AND reason = ?";
           String[] selectionArgs = new String[] {logSource, Integer.toString(reason.getNumber())};
@@ -786,6 +789,12 @@ public class SQLiteEventStore
     long byteSize = getPageCount() * getPageSize();
 
     return byteSize >= config.getMaxStorageSizeInBytes();
+  }
+
+  private boolean isStorageAtGlobalLimit() {
+    long byteSize = getPageCount() * getPageSize();
+
+    return byteSize >= config.getMaxGlobalStorageSizeInBytes();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Add `MAX_DB_GLOBAL_STORAGE_SIZE_IN_BYTES` to store the data which needs to be beyond the current limit, such as recording cache full records in `ClientHealthMetrics` 
