### PR TITLE
Adding AppDistributionReleaseInternal and AAB release identification

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -385,7 +385,8 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
       long currentInstalledVersionCode =
           getInstalledAppVersionCode(firebaseApp.getApplicationContext());
 
-      if (isNewerBuildVersion(retrievedLatestRelease) && !isInstalledRelease(retrievedLatestRelease)) {
+      if (isNewerBuildVersion(retrievedLatestRelease)
+          && !isInstalledRelease(retrievedLatestRelease)) {
         return convertToAppDistributionRelease(retrievedLatestRelease);
       } else {
         // Return null if retrieved latest release is older or currently installed

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -42,6 +42,8 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.appdistribution.internal.AppDistributionReleaseInternal;
+import com.google.firebase.appdistribution.internal.ReleaseIdentificationUtils;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
 import java.net.ProtocolException;
@@ -66,7 +68,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
 
   private TaskCompletionSource<AppDistributionRelease> checkForUpdateTaskCompletionSource = null;
   private CancellationTokenSource checkForUpdateCancellationSource;
-  private Executor checkForUpdateExecutor;
+  private final Executor checkForUpdateExecutor;
 
   /** Constructor for FirebaseAppDistribution */
   public FirebaseAppDistribution(
@@ -95,7 +97,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
   @NonNull
   public static FirebaseAppDistribution getInstance(@NonNull FirebaseApp app) {
     Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
-    return (FirebaseAppDistribution) app.get(FirebaseAppDistribution.class);
+    return app.get(FirebaseAppDistribution.class);
   }
 
   /**
@@ -169,7 +171,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
     Task<InstallationTokenResult> installationAuthTokenTask =
         firebaseInstallationsApi.getToken(false);
 
-    Tasks.whenAllComplete(installationIdTask, installationAuthTokenTask)
+    Tasks.whenAllSuccess(installationIdTask, installationAuthTokenTask)
         .addOnSuccessListener(
             tasks -> {
               String fid = installationIdTask.getResult();
@@ -177,22 +179,18 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
                   installationAuthTokenTask.getResult();
               checkForUpdateExecutor.execute(
                   () -> {
-                    AppDistributionRelease latestRelease =
-                        getLatestReleaseFromClient(
-                            fid,
-                            firebaseApp.getOptions().getApplicationId(),
-                            firebaseApp.getOptions().getApiKey(),
-                            installationTokenResult.getToken());
-
-                    updateOnUiThread(
-                        new Runnable() {
-                          @Override
-                          public void run() {
-                            if (!checkForUpdateTaskCompletionSource.getTask().isComplete()) {
-                              checkForUpdateTaskCompletionSource.setResult(latestRelease);
-                            }
-                          }
-                        });
+                    try {
+                      AppDistributionRelease latestRelease =
+                          getLatestReleaseFromClient(
+                              fid,
+                              firebaseApp.getOptions().getApplicationId(),
+                              firebaseApp.getOptions().getApiKey(),
+                              installationTokenResult.getToken());
+                      updateOnUiThread(
+                          () -> checkForUpdateTaskCompletionSource.setResult(latestRelease));
+                    } catch (FirebaseAppDistributionException ex) {
+                      updateOnUiThread(() -> setCheckForUpdateTaskCompletionError(ex));
+                    }
                   });
             })
         .addOnFailureListener(
@@ -378,31 +376,39 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
   }
 
   AppDistributionRelease getLatestReleaseFromClient(
-      String fid, String appId, String apiKey, String authToken) {
-    AppDistributionRelease latestRelease = null;
+      String fid, String appId, String apiKey, String authToken)
+      throws FirebaseAppDistributionException {
     try {
-      AppDistributionRelease retrievedLatestRelease =
+      AppDistributionReleaseInternal retrievedLatestRelease =
           firebaseAppDistributionTesterApiClient.fetchLatestRelease(fid, appId, apiKey, authToken);
 
       long currentInstalledVersionCode =
           getInstalledAppVersionCode(firebaseApp.getApplicationContext());
 
-      // todo: change to comparing codehash
-      if (Long.parseLong(retrievedLatestRelease.getBuildVersion()) > currentInstalledVersionCode) {
-        // only return a release if device can upgrade to the new release without
-        // uninstalling
-        latestRelease = retrievedLatestRelease;
+      if (isNewerBuildVersion(retrievedLatestRelease) && !isInstalledRelease(retrievedLatestRelease)) {
+        return convertToAppDistributionRelease(retrievedLatestRelease);
+      } else {
+        // Return null if retrieved latest release is older or currently installed
+        return null;
       }
     } catch (FirebaseAppDistributionException | ProtocolException | NumberFormatException e) {
       if (e instanceof FirebaseAppDistributionException) {
-        setCheckForUpdateTaskCompletionError((FirebaseAppDistributionException) e);
+        throw (FirebaseAppDistributionException) e;
       } else {
-        setCheckForUpdateTaskCompletionError(
-            new FirebaseAppDistributionException(
-                e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE));
+        throw new FirebaseAppDistributionException(
+            e.getMessage(), FirebaseAppDistributionException.Status.NETWORK_FAILURE);
       }
     }
-    return latestRelease;
+  }
+
+  private AppDistributionRelease convertToAppDistributionRelease(
+      AppDistributionReleaseInternal internalRelease) {
+    return AppDistributionRelease.builder()
+        .setBuildVersion(internalRelease.getBuildVersion())
+        .setDisplayVersion(internalRelease.getDisplayVersion())
+        .setReleaseNotes(internalRelease.getReleaseNotes())
+        .setBinaryType(internalRelease.getBinaryType())
+        .build();
   }
 
   private void updateOnUiThread(Runnable runnable) {
@@ -432,5 +438,27 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
     if (signInTaskCompletionSource != null && !signInTaskCompletionSource.getTask().isComplete()) {
       signInTaskCompletionSource.setException(e);
     }
+  }
+
+  private boolean isNewerBuildVersion(AppDistributionReleaseInternal latestRelease) {
+    return Long.parseLong(latestRelease.getBuildVersion())
+        >= getInstalledAppVersionCode(firebaseApp.getApplicationContext());
+  }
+
+  private boolean isInstalledRelease(AppDistributionReleaseInternal latestRelease) {
+    if (latestRelease.getBinaryType().equals(BinaryType.APK)) {
+      // TODO(rachelprince): APK codehash verification
+      return false;
+    }
+
+    if (latestRelease.getIasArtifactId() == null) {
+      return false;
+    }
+    // AAB BinaryType
+    return latestRelease
+        .getIasArtifactId()
+        .equals(
+            ReleaseIdentificationUtils.extractInternalAppSharingArtifactId(
+                firebaseApp.getApplicationContext()));
   }
 }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -187,7 +187,11 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
                               firebaseApp.getOptions().getApiKey(),
                               installationTokenResult.getToken());
                       updateOnUiThread(
-                          () -> checkForUpdateTaskCompletionSource.setResult(latestRelease));
+                          () -> {
+                            if (checkForUpdateTaskCompletionSource != null
+                                    && !checkForUpdateTaskCompletionSource.getTask().isComplete())
+                            checkForUpdateTaskCompletionSource.setResult(latestRelease);
+                          });
                     } catch (FirebaseAppDistributionException ex) {
                       updateOnUiThread(() -> setCheckForUpdateTaskCompletionError(ex));
                     }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -189,8 +189,8 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
                       updateOnUiThread(
                           () -> {
                             if (checkForUpdateTaskCompletionSource != null
-                                    && !checkForUpdateTaskCompletionSource.getTask().isComplete())
-                            checkForUpdateTaskCompletionSource.setResult(latestRelease);
+                                && !checkForUpdateTaskCompletionSource.getTask().isComplete())
+                              checkForUpdateTaskCompletionSource.setResult(latestRelease);
                           });
                     } catch (FirebaseAppDistributionException ex) {
                       updateOnUiThread(() -> setCheckForUpdateTaskCompletionError(ex));

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/AppDistributionReleaseInternal.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/AppDistributionReleaseInternal.java
@@ -55,9 +55,9 @@ public abstract class AppDistributionReleaseInternal {
   @Nullable
   public abstract String getCodeHash();
 
-  /** IAS artifact id.
-   * This value is inserted into the manifest of APK's installed via
-   * Used to map a release to an APK installed via an app bundle
+  /**
+   * IAS artifact id. This value is inserted into the manifest of APK's installed via Used to map a
+   * release to an APK installed via an app bundle
    */
   @Nullable
   public abstract String getIasArtifactId();

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/AppDistributionReleaseInternal.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/AppDistributionReleaseInternal.java
@@ -51,12 +51,18 @@ public abstract class AppDistributionReleaseInternal {
   @NonNull
   public abstract BinaryType getBinaryType();
 
+  /** Hash of binary of an Android app */
   @Nullable
   public abstract String getCodeHash();
 
+  /** IAS artifact id.
+   * This value is inserted into the manifest of APK's installed via
+   * Used to map a release to an APK installed via an app bundle
+   */
   @Nullable
   public abstract String getIasArtifactId();
 
+  /** Short-lived download URL */
   @Nullable
   public abstract String getDownloadUrl();
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/AppDistributionReleaseInternal.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/AppDistributionReleaseInternal.java
@@ -1,0 +1,91 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.internal;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+import com.google.firebase.appdistribution.BinaryType;
+
+/**
+ * This class represents the AppDistributionRelease object returned by the App Distribution backend
+ *
+ * <p>It is an immutable value class implemented by AutoValue.
+ *
+ * @see <a
+ *     href="https://github.com/google/auto/tree/master/value">https://github.com/google/auto/tree/master/value</a>
+ */
+@AutoValue
+public abstract class AppDistributionReleaseInternal {
+
+  @NonNull
+  public static Builder builder() {
+    return new AutoValue_AppDistributionReleaseInternal.Builder();
+  }
+
+  /** The short bundle version of this build (example 1.0.0) */
+  @NonNull
+  public abstract String getDisplayVersion();
+
+  /** The bundle version of this build (example: 123) */
+  @NonNull
+  public abstract String getBuildVersion();
+
+  /** The release notes for this build */
+  @Nullable
+  public abstract String getReleaseNotes();
+
+  /** The binary type for this build */
+  @NonNull
+  public abstract BinaryType getBinaryType();
+
+  @Nullable
+  public abstract String getCodeHash();
+
+  @Nullable
+  public abstract String getIasArtifactId();
+
+  @Nullable
+  public abstract String getDownloadUrl();
+
+  /** Builder for {@link AppDistributionReleaseInternal}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    @NonNull
+    public abstract Builder setDisplayVersion(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setBuildVersion(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setReleaseNotes(@Nullable String value);
+
+    @NonNull
+    public abstract Builder setBinaryType(@NonNull BinaryType value);
+
+    @NonNull
+    public abstract Builder setCodeHash(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setIasArtifactId(@NonNull String value);
+
+    @NonNull
+    public abstract Builder setDownloadUrl(@NonNull String value);
+
+    @NonNull
+    public abstract AppDistributionReleaseInternal build();
+  }
+}

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/ReleaseIdentificationUtils.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/ReleaseIdentificationUtils.java
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.internal;
+
+import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+public final class ReleaseIdentificationUtils {
+  private static final String TAG = "ReleaseIdentification";
+
+  @Nullable
+  public static String extractInternalAppSharingArtifactId(Context appContext) {
+    try {
+      PackageInfo packageInfo =
+          appContext
+              .getPackageManager()
+              .getPackageInfo(appContext.getPackageName(), PackageManager.GET_META_DATA);
+      if (packageInfo.applicationInfo.metaData == null) {
+        return null;
+      }
+      return packageInfo.applicationInfo.metaData.getString("com.android.vending.internal.apk.id");
+    } catch (PackageManager.NameNotFoundException e) {
+      Log.w(TAG, "Could not extract internal app sharing artifact ID");
+      return null;
+    }
+  }
+}

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/ReleaseIdentificationUtils.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/ReleaseIdentificationUtils.java
@@ -18,7 +18,6 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/ReleaseIdentificationUtils.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/internal/ReleaseIdentificationUtils.java
@@ -19,13 +19,14 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public final class ReleaseIdentificationUtils {
   private static final String TAG = "ReleaseIdentification";
 
   @Nullable
-  public static String extractInternalAppSharingArtifactId(Context appContext) {
+  public static String extractInternalAppSharingArtifactId(@NonNull Context appContext) {
     try {
       PackageInfo packageInfo =
           appContext

--- a/firebase-app-distribution/src/test/assets/testAabReleaseResponse.json
+++ b/firebase-app-distribution/src/test/assets/testAabReleaseResponse.json
@@ -1,0 +1,15 @@
+{"releases":
+  [{
+    "name": "devices/fffffffffffceccaffffffff/testerApps/1:123456789:android:123456789/releases/123456789",
+    "releaseTime":"2021-07-07T17:10:03Z",
+    "buildVersion":"3",
+    "displayVersion":"3.0",
+    "releaseNotes":"This is a test release.",
+    "downloadUrl":"http://test-url-aab",
+    "latest": true,
+    "fileSize": "3725041",
+    "expirationTime": "2021-12-04T17:10:03Z",
+    "iasArtifactId": "ias-artifact-id-1",
+    "binaryType": "AAB"
+  }]
+}

--- a/firebase-app-distribution/src/test/assets/testApkReleaseResponse.json
+++ b/firebase-app-distribution/src/test/assets/testApkReleaseResponse.json
@@ -5,9 +5,9 @@
     "buildVersion":"3",
     "displayVersion":"3.0",
     "releaseNotes":"This is a test release.",
-    "downloadUrl":"https://firebaseapptesters.googleapis.com/v1alpha/devices/fffffffffffceccaffffffff/testerApps/1:123456789:android:123456789/releases/123456789",
+    "downloadUrl":"http://test-url-apk",
     "latest": true,
-    "codeHash": "aabbccddeeffgghhjjkkllmmnnooppqqrrssttuu",
+    "codeHash": "code-hash-apk-1",
     "fileSize": "3725041",
     "expirationTime": "2021-12-04T17:10:03Z",
     "binaryType": "APK"

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,16 +29,22 @@ import static org.robolectric.Shadows.shadowOf;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.core.content.pm.ApplicationInfoBuilder;
+import androidx.test.core.content.pm.PackageInfoBuilder;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.appdistribution.internal.AppDistributionReleaseInternal;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
+import java.net.ProtocolException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,28 +62,31 @@ public class FirebaseAppDistributionTest {
   private static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
   private static final String TEST_PROJECT_ID = "777777777777";
   private static final String TEST_FID_1 = "cccccccccccccccccccccc";
-  private static final String TEST_FID_2 = "dddddddddddddddddddddd";
   private static final String TEST_AUTH_TOKEN = "fad.auth.token";
-  private static final String TEST_URL =
+  private static final String TEST_IAS_ARTIFACT_ID = "ias-artifact-id";
+  private static final String IAS_ARTIFACT_ID_KEY = "com.android.vending.internal.apk.id";
+  private static final long INSTALLED_VERSION_CODE = 2;
+
+  public static final String TEST_URL =
       String.format(
           "https://appdistribution.firebase.google.com/pub/testerapps/%s/installations/%s/buildalerts"
               + "?appName=com.google.firebase.appdistribution.test"
               + "&packageName=com.google.firebase.appdistribution.test",
           TEST_APP_ID_1, TEST_FID_1);
-  private static AppDistributionRelease TEST_RELEASE_1 =
-      AppDistributionRelease.builder()
-          .setBinaryType(BinaryType.APK)
+  private static final AppDistributionReleaseInternal TEST_RELEASE_NEWER =
+      AppDistributionReleaseInternal.builder()
           .setBuildVersion("3")
           .setDisplayVersion("3.0")
           .setReleaseNotes("Newer version.")
+          .setBinaryType(BinaryType.APK)
           .build();
 
-  AppDistributionRelease TEST_RELEASE_2 =
-      AppDistributionRelease.builder()
+  private static final AppDistributionReleaseInternal TEST_RELEASE_CURRENT =
+      AppDistributionReleaseInternal.builder()
           .setBinaryType(BinaryType.APK)
-          .setBuildVersion("0")
-          .setDisplayVersion("0.0")
-          .setReleaseNotes("Older version.")
+          .setBuildVersion(Long.toString(INSTALLED_VERSION_CODE))
+          .setDisplayVersion("2.0")
+          .setReleaseNotes("Current version.")
           .build();
 
   private FirebaseApp firebaseApp;
@@ -84,6 +94,7 @@ public class FirebaseAppDistributionTest {
   private TestActivity activity;
   private ShadowActivity shadowActivity;
   private ShadowPackageManager shadowPackageManager;
+  private ApplicationInfo applicationInfo;
 
   @Mock private FirebaseInstallationsApi mockFirebaseInstallations;
   @Mock private FirebaseAppDistributionTesterApiClient mockFirebaseAppDistributionTesterApiClient;
@@ -115,19 +126,31 @@ public class FirebaseAppDistributionTest {
 
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
     when(mockFirebaseInstallations.getToken(false))
-        .thenReturn(Tasks.forResult(mockInstallationTokenResult));
+            .thenReturn(Tasks.forResult(mockInstallationTokenResult));
+
     when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
 
     when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(
             TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
-        .thenReturn(TEST_RELEASE_1);
-
-    when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(
-            TEST_FID_2, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
-        .thenReturn(TEST_RELEASE_2);
+        .thenReturn(TEST_RELEASE_CURRENT);
 
     shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
+
+    applicationInfo =
+        ApplicationInfoBuilder.newBuilder()
+            .setPackageName(ApplicationProvider.getApplicationContext().getPackageName())
+            .build();
+    applicationInfo.metaData = new Bundle();
+    applicationInfo.metaData.putString(IAS_ARTIFACT_ID_KEY, TEST_IAS_ARTIFACT_ID);
+    PackageInfo packageInfo =
+            PackageInfoBuilder.newBuilder()
+                    .setPackageName(ApplicationProvider.getApplicationContext().getPackageName())
+                    .setApplicationInfo(applicationInfo)
+                    .build();
+    packageInfo.setLongVersionCode(INSTALLED_VERSION_CODE);
+    shadowPackageManager.installPackage(packageInfo);
+
     activity = Robolectric.buildActivity(TestActivity.class).create().get();
     shadowActivity = shadowOf(activity);
   }
@@ -233,21 +256,86 @@ public class FirebaseAppDistributionTest {
   }
 
   @Test
-  public void getLatestReleaseFromClient_whenNotOnLatestBuild_returnsRelease() {
+  public void getLatestReleaseFromClient_whenLatestReleaseIsNewerBuildThanInstalled_returnsRelease()
+      throws FirebaseAppDistributionException, ProtocolException {
+    when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
+        .thenReturn(TEST_RELEASE_NEWER);
+
     AppDistributionRelease release =
         firebaseAppDistribution.getLatestReleaseFromClient(
             TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
 
     assertNotNull(release);
-    assertEquals(TEST_RELEASE_1.getBuildVersion(), release.getBuildVersion());
+    assertEquals(TEST_RELEASE_NEWER.getBuildVersion(), release.getBuildVersion());
   }
 
   @Test
-  public void getLatestReleaseFromClient_whenOnLatestBuild_returnsNull() {
+  public void getLatestReleaseFromClient_whenLatestReleaseIsOlderBuildThanInstalled_returnsNull()
+          throws FirebaseAppDistributionException, ProtocolException {
+    AppDistributionReleaseInternal olderTestRelease =
+            AppDistributionReleaseInternal.builder()
+                    .setBinaryType(BinaryType.APK)
+                    .setBuildVersion("1")
+                    .setDisplayVersion("1.0")
+                    .setReleaseNotes("Older version.")
+                    .build();
+    when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
+            .thenReturn(olderTestRelease);
+
     AppDistributionRelease release =
-        firebaseAppDistribution.getLatestReleaseFromClient(
-            TEST_FID_2, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+            firebaseAppDistribution.getLatestReleaseFromClient(
+                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
 
     assertNull(release);
+  }
+
+  @Test
+  public void handleLatestReleaseFromClient_whenNewAabIsAvailable_returnsRelease()
+      throws Exception {
+    firebaseAppDistribution.onActivityResumed(activity);
+    when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(any(), any(), any(), any()))
+        .thenReturn(
+            AppDistributionReleaseInternal.builder()
+                .setBuildVersion(TEST_RELEASE_CURRENT.getBuildVersion())
+                .setDisplayVersion(TEST_RELEASE_CURRENT.getDisplayVersion())
+                .setCodeHash("codehash")
+                .setDownloadUrl("http://fake-download-url")
+                .setIasArtifactId("test-ias-artifact-id-2")
+                .setBinaryType(BinaryType.AAB)
+                .build());
+
+    AppDistributionRelease result =
+        firebaseAppDistribution.getLatestReleaseFromClient(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    assertEquals(
+        AppDistributionRelease.builder()
+                .setBuildVersion(TEST_RELEASE_CURRENT.getBuildVersion())
+                .setDisplayVersion(TEST_RELEASE_CURRENT.getDisplayVersion())
+            .setBinaryType(BinaryType.AAB)
+            .build(),
+        result);
+  }
+
+  @Test
+  public void handleLatestReleaseFromClient_whenLatestReleaseIsSameAsInstalledAab_returnsNull()
+      throws FirebaseAppDistributionException, ProtocolException {
+    firebaseAppDistribution.onActivityResumed(activity);
+    when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(any(), any(), any(), any()))
+        .thenReturn(
+            AppDistributionReleaseInternal.builder()
+                .setBuildVersion(TEST_RELEASE_CURRENT.getBuildVersion())
+                .setDisplayVersion(TEST_RELEASE_CURRENT.getDisplayVersion())
+                .setCodeHash("codehash")
+                .setDownloadUrl("http://fake-download-url")
+                .setIasArtifactId(TEST_IAS_ARTIFACT_ID)
+                .setBinaryType(BinaryType.AAB)
+                .build());
+
+    AppDistributionRelease result =
+        firebaseAppDistribution.getLatestReleaseFromClient(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    assertNull(result);
   }
 }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -109,21 +109,22 @@ public class FirebaseAppDistributionTest {
 
     FirebaseApp.clearInstancesForTest();
 
-    FirebaseApp firebaseApp = FirebaseApp.initializeApp(
+    FirebaseApp firebaseApp =
+        FirebaseApp.initializeApp(
             ApplicationProvider.getApplicationContext(),
             new FirebaseOptions.Builder()
-                    .setApplicationId(TEST_APP_ID_1)
-                    .setProjectId(TEST_PROJECT_ID)
-                    .setApiKey(TEST_API_KEY)
-                    .build());
+                .setApplicationId(TEST_APP_ID_1)
+                .setProjectId(TEST_PROJECT_ID)
+                .setApiKey(TEST_API_KEY)
+                .build());
 
     firebaseAppDistribution =
         new FirebaseAppDistribution(
-                firebaseApp, mockFirebaseInstallations, mockFirebaseAppDistributionTesterApiClient);
+            firebaseApp, mockFirebaseInstallations, mockFirebaseAppDistributionTesterApiClient);
 
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
     when(mockFirebaseInstallations.getToken(false))
-            .thenReturn(Tasks.forResult(mockInstallationTokenResult));
+        .thenReturn(Tasks.forResult(mockInstallationTokenResult));
 
     when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
 
@@ -134,16 +135,17 @@ public class FirebaseAppDistributionTest {
     shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
 
-    ApplicationInfo applicationInfo = ApplicationInfoBuilder.newBuilder()
+    ApplicationInfo applicationInfo =
+        ApplicationInfoBuilder.newBuilder()
             .setPackageName(ApplicationProvider.getApplicationContext().getPackageName())
             .build();
     applicationInfo.metaData = new Bundle();
     applicationInfo.metaData.putString(IAS_ARTIFACT_ID_KEY, TEST_IAS_ARTIFACT_ID);
     PackageInfo packageInfo =
-            PackageInfoBuilder.newBuilder()
-                    .setPackageName(ApplicationProvider.getApplicationContext().getPackageName())
-                    .setApplicationInfo(applicationInfo)
-                    .build();
+        PackageInfoBuilder.newBuilder()
+            .setPackageName(ApplicationProvider.getApplicationContext().getPackageName())
+            .setApplicationInfo(applicationInfo)
+            .build();
     packageInfo.setLongVersionCode(INSTALLED_VERSION_CODE);
     shadowPackageManager.installPackage(packageInfo);
 
@@ -268,21 +270,21 @@ public class FirebaseAppDistributionTest {
 
   @Test
   public void getLatestReleaseFromClient_whenLatestReleaseIsOlderBuildThanInstalled_returnsNull()
-          throws FirebaseAppDistributionException, ProtocolException {
+      throws FirebaseAppDistributionException, ProtocolException {
     AppDistributionReleaseInternal olderTestRelease =
-            AppDistributionReleaseInternal.builder()
-                    .setBinaryType(BinaryType.APK)
-                    .setBuildVersion("1")
-                    .setDisplayVersion("1.0")
-                    .setReleaseNotes("Older version.")
-                    .build();
+        AppDistributionReleaseInternal.builder()
+            .setBinaryType(BinaryType.APK)
+            .setBuildVersion("1")
+            .setDisplayVersion("1.0")
+            .setReleaseNotes("Older version.")
+            .build();
     when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(
             TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
-            .thenReturn(olderTestRelease);
+        .thenReturn(olderTestRelease);
 
     AppDistributionRelease release =
-            firebaseAppDistribution.getLatestReleaseFromClient(
-                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+        firebaseAppDistribution.getLatestReleaseFromClient(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
 
     assertNull(release);
   }
@@ -307,8 +309,8 @@ public class FirebaseAppDistributionTest {
             TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
     assertEquals(
         AppDistributionRelease.builder()
-                .setBuildVersion(TEST_RELEASE_CURRENT.getBuildVersion())
-                .setDisplayVersion(TEST_RELEASE_CURRENT.getDisplayVersion())
+            .setBuildVersion(TEST_RELEASE_CURRENT.getBuildVersion())
+            .setDisplayVersion(TEST_RELEASE_CURRENT.getDisplayVersion())
             .setBinaryType(BinaryType.AAB)
             .build(),
         result);

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -89,12 +89,10 @@ public class FirebaseAppDistributionTest {
           .setReleaseNotes("Current version.")
           .build();
 
-  private FirebaseApp firebaseApp;
   private FirebaseAppDistribution firebaseAppDistribution;
   private TestActivity activity;
   private ShadowActivity shadowActivity;
   private ShadowPackageManager shadowPackageManager;
-  private ApplicationInfo applicationInfo;
 
   @Mock private FirebaseInstallationsApi mockFirebaseInstallations;
   @Mock private FirebaseAppDistributionTesterApiClient mockFirebaseAppDistributionTesterApiClient;
@@ -111,18 +109,17 @@ public class FirebaseAppDistributionTest {
 
     FirebaseApp.clearInstancesForTest();
 
-    firebaseApp =
-        FirebaseApp.initializeApp(
+    FirebaseApp firebaseApp = FirebaseApp.initializeApp(
             ApplicationProvider.getApplicationContext(),
             new FirebaseOptions.Builder()
-                .setApplicationId(TEST_APP_ID_1)
-                .setProjectId(TEST_PROJECT_ID)
-                .setApiKey(TEST_API_KEY)
-                .build());
+                    .setApplicationId(TEST_APP_ID_1)
+                    .setProjectId(TEST_PROJECT_ID)
+                    .setApiKey(TEST_API_KEY)
+                    .build());
 
     firebaseAppDistribution =
         new FirebaseAppDistribution(
-            firebaseApp, mockFirebaseInstallations, mockFirebaseAppDistributionTesterApiClient);
+                firebaseApp, mockFirebaseInstallations, mockFirebaseAppDistributionTesterApiClient);
 
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
     when(mockFirebaseInstallations.getToken(false))
@@ -137,8 +134,7 @@ public class FirebaseAppDistributionTest {
     shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
 
-    applicationInfo =
-        ApplicationInfoBuilder.newBuilder()
+    ApplicationInfo applicationInfo = ApplicationInfoBuilder.newBuilder()
             .setPackageName(ApplicationProvider.getApplicationContext().getPackageName())
             .build();
     applicationInfo.metaData = new Bundle();
@@ -240,14 +236,14 @@ public class FirebaseAppDistributionTest {
   }
 
   @Test
-  public void checkForUpdate_whenCalled_getsFidAndAuthToken() throws Exception {
-    Task<AppDistributionRelease> task = firebaseAppDistribution.checkForUpdate();
+  public void checkForUpdate_whenCalled_getsFidAndAuthToken() {
+    firebaseAppDistribution.checkForUpdate();
     verify(mockFirebaseInstallations, times(1)).getId();
     verify(mockFirebaseInstallations, times(1)).getToken(false);
   }
 
   @Test
-  public void checkForUpdateTask_whenCalledMultipleTimes_cancelsPreviousTask() throws Exception {
+  public void checkForUpdateTask_whenCalledMultipleTimes_cancelsPreviousTask() {
     Task<AppDistributionRelease> checkForUpdateTask1 = firebaseAppDistribution.checkForUpdate();
     Task<AppDistributionRelease> checkForUpdateTask2 = firebaseAppDistribution.checkForUpdate();
 

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.google.firebase.appdistribution.internal.AppDistributionReleaseInternal;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,18 +62,37 @@ public class FirebaseAppDistributionTesterApiClientTest {
   }
 
   @Test
-  public void fetchLatestRelease_whenResponseSuccessful_returnsRelease() throws Exception {
-    JSONObject releaseJson = getTestJSON("testReleaseResponse.json");
+  public void fetchLatestRelease_whenResponseSuccessfulForApk_returnsRelease() throws Exception {
+    JSONObject releaseJson = getTestJSON("testApkReleaseResponse.json");
     InputStream response =
         new ByteArrayInputStream(releaseJson.toString().getBytes(StandardCharsets.UTF_8));
     when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
-    AppDistributionRelease release =
+    AppDistributionReleaseInternal release =
         firebaseAppDistributionTesterApiClient.fetchLatestRelease(
             TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
     assertEquals(release.getBinaryType(), BinaryType.APK);
     assertEquals(release.getBuildVersion(), "3");
     assertEquals(release.getDisplayVersion(), "3.0");
     assertEquals(release.getReleaseNotes(), "This is a test release.");
+    assertEquals(release.getDownloadUrl(), "http://test-url-apk");
+    assertEquals(release.getCodeHash(), "code-hash-apk-1");
+  }
+
+  @Test
+  public void fetchLatestRelease_whenResponseSuccessfulForAab_returnsRelease() throws Exception {
+    JSONObject releaseJson = getTestJSON("testAabReleaseResponse.json");
+    InputStream response =
+        new ByteArrayInputStream(releaseJson.toString().getBytes(StandardCharsets.UTF_8));
+    when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
+    AppDistributionReleaseInternal release =
+        firebaseAppDistributionTesterApiClient.fetchLatestRelease(
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    assertEquals(release.getBinaryType(), BinaryType.AAB);
+    assertEquals(release.getBuildVersion(), "3");
+    assertEquals(release.getDisplayVersion(), "3.0");
+    assertEquals(release.getReleaseNotes(), "This is a test release.");
+    assertEquals(release.getDownloadUrl(), "http://test-url-aab");
+    assertEquals(release.getIasArtifactId(), "ias-artifact-id-1");
   }
 
   @Test


### PR DESCRIPTION
* Added release identification for AABs
* Added new AppDistributionReleaseInternal class that represents the response from the server
* refactored some tests