### PR TITLE
Add environment flag to control indexing

### DIFF
--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -96,6 +96,12 @@ android.libraryVariants.all { variant ->
         variant.buildConfigField("boolean", "USE_EMULATOR_FOR_TESTS", "true")
     }
 
+    Boolean enableIndexing = System.env.FIRESTOR_ENABLE_INDEXING ?: false
+    if (enableIndexing) {
+        variant.buildConfigField("boolean", "ENABLE_INDEXING", "true")
+    } else {
+        variant.buildConfigField("boolean", "ENABLE_INDEXING", "false")
+    }
 }
 
 configurations.all {

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -96,8 +96,14 @@ android.libraryVariants.all { variant ->
         variant.buildConfigField("boolean", "USE_EMULATOR_FOR_TESTS", "true")
     }
 
-    Boolean enableIndexing = System.env.FIRESTOR_ENABLE_INDEXING ?: false
-    if (enableIndexing) {
+    def localProps = new Properties()
+
+    try {
+    file("local.properties").withInputStream { localProps.load(it) }
+    } catch (FileNotFoundException e) {
+    }
+
+    if (localProps['firestoreEnableIndexing']) {
         variant.buildConfigField("boolean", "ENABLE_INDEXING", "true")
     } else {
         variant.buildConfigField("boolean", "ENABLE_INDEXING", "false")

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/Persistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/Persistence.java
@@ -14,9 +14,9 @@
 
 package com.google.firebase.firestore.local;
 
+import com.google.firebase.firestore.BuildConfig;
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.util.Supplier;
-import com.google.firebase.firestore.BuildConfig;
 
 /**
  * Persistence is the lowest-level shared interface to persistent storage in Firestore.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/Persistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/Persistence.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore.local;
 
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.util.Supplier;
+import com.google.firebase.firestore.BuildConfig;
 
 /**
  * Persistence is the lowest-level shared interface to persistent storage in Firestore.
@@ -51,7 +52,7 @@ public abstract class Persistence {
 
   /** Temporary setting for enabling indexing-specific code paths while in development. */
   // TODO: Remove this.
-  public static boolean INDEXING_SUPPORT_ENABLED = false;
+  public static boolean INDEXING_SUPPORT_ENABLED = BuildConfig.ENABLE_INDEXING;
 
   // Local subclasses only, please.
   Persistence() {}


### PR DESCRIPTION
 We are starting with development for Firestore's long awaited indexing support. This PR adds a environment variable that controls whether indexing is enabled in the final build. It is meant to replace the hard-coded flag as we do not want to accidentally change it to true and check it in to master.