### PR TITLE
Add IndexConfiguration

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/IndexingTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/IndexingTest.java
@@ -1,0 +1,106 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore;
+
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testFirestore;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.firestore.testutil.Assert;
+import com.google.firebase.firestore.testutil.IntegrationTestUtil;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class IndexingTest {
+
+  @After
+  public void tearDown() {
+    IntegrationTestUtil.tearDown();
+  }
+
+  @Test
+  public void testCanConfigureIndices() throws ExecutionException, InterruptedException {
+    FirebaseFirestore db = testFirestore();
+    Task<Void> indexTask =
+        db.configureIndices(
+            "{\n"
+                + "  \"indexes\": [\n"
+                + "    {\n"
+                + "      \"collectionGroup\": \"restaurants\",\n"
+                + "      \"queryScope\": \"COLLECTION\",\n"
+                + "      \"fields\": [\n"
+                + "        {\n"
+                + "          \"fieldPath\": \"price\",\n"
+                + "          \"order\": \"ASCENDING\"\n"
+                + "        },\n"
+                + "        {\n"
+                + "          \"fieldPath\": \"avgRating\",\n"
+                + "          \"order\": \"DESCENDING\"\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"collectionGroup\": \"restaurants\",\n"
+                + "      \"queryScope\": \"COLLECTION\",\n"
+                + "      \"fields\": [\n"
+                + "        {\n"
+                + "          \"fieldPath\": \"price\",\n"
+                + "          \"order\": \"ASCENDING\"\n"
+                + "        }"
+                + "      ]\n"
+                + "    }\n"
+                + "  ],\n"
+                + "  \"fieldOverrides\": []\n"
+                + "}");
+    Tasks.await(indexTask);
+  }
+
+  @Test
+  public void testBadJsonDoesNotCrashClient() {
+    FirebaseFirestore db = testFirestore();
+
+    Assert.assertThrows(IllegalArgumentException.class, () -> db.configureIndices("{,"));
+  }
+
+  @Test
+  public void testBadIndexDoesNotCrashClient() {
+    FirebaseFirestore db = testFirestore();
+    Assert.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            db.configureIndices(
+                "{\n"
+                    + "  \"indexes\": [\n"
+                    + "    {\n"
+                    + "      \"collectionGroup\": \"restaurants\",\n"
+                    + "      \"queryScope\": \"COLLECTION\",\n"
+                    + "      \"fields\": [\n"
+                    + "        {\n"
+                    + "          \"fieldPath\": \"price\",\n"
+                    + "          \"order\": \"INVALID\"\n"
+                    + "        ,\n"
+                    + "      ]\n"
+                    + "    }\n"
+                    + "  ],\n"
+                    + "  \"fieldOverrides\": []\n"
+                    + "}"));
+  }
+
+  // TODO(indexing): Add tests that validate that indices are active
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
@@ -38,6 +39,8 @@ import com.google.firebase.firestore.core.DatabaseInfo;
 import com.google.firebase.firestore.core.FirestoreClient;
 import com.google.firebase.firestore.local.SQLitePersistence;
 import com.google.firebase.firestore.model.DatabaseId;
+import com.google.firebase.firestore.model.FieldIndex;
+import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.remote.FirestoreChannel;
 import com.google.firebase.firestore.remote.GrpcMetadataProvider;
@@ -51,7 +54,12 @@ import com.google.firebase.inject.Deferred;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executor;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Represents a Cloud Firestore database and is the entry point for all Cloud Firestore operations.
@@ -262,6 +270,69 @@ public class FirebaseFirestore {
   @NonNull
   public FirebaseApp getApp() {
     return firebaseApp;
+  }
+
+  /**
+   * Configures Indexing for local query execution. Any previous index configuration is overridden.
+   * The Task resolves once the index configuration has been persisted.
+   *
+   * <p>The index entries themselves are created asynchronously. You can continue to use queries
+   * that require indexing even if the indices are not yet available. Query execution will
+   * automatically start using the index once the index entries have been written.
+   *
+   * <p>The method accepts the JSON format exported by the Firebase CLI (`firebase
+   * firestore:indexes`). If the JSON format is invalid, this method rejects the returned task.
+   *
+   * @param json The JSON format exported by the Firebase CLI.
+   * @return A task that resolves once all indices are successfully configured.
+   */
+  @VisibleForTesting
+  Task<Void> configureIndices(String json) {
+    ensureClientConfigured();
+
+    // Preconditions.checkState(BuildConfig.ENABLE_INDEXING, "Indexing support is not yet
+    // available.");
+
+    List<FieldIndex> parsedIndices = new ArrayList<>();
+
+    // See https://firebase.google.com/docs/reference/firestore/indexes/#json_format for the
+    // format of the index definition. Unlike the backend, the SDK does not distinguish between
+    // collection ID and collection group indices and hence the queryScope field is ignored.
+
+    try {
+      JSONObject jsonObject = new JSONObject(json);
+
+      if (jsonObject.has("indexes")) {
+        JSONArray indices = jsonObject.getJSONArray("indexes");
+        for (int i = 0; i < indices.length(); ++i) {
+          JSONObject definition = indices.getJSONObject(i);
+          FieldIndex fieldIndex = new FieldIndex(definition.getString("collectionGroup"));
+
+          JSONArray fields = definition.optJSONArray("fields");
+          for (int f = 0; fields != null && f < fields.length(); ++f) {
+            JSONObject field = fields.getJSONObject(f);
+            FieldPath fieldPath = FieldPath.fromServerFormat(field.getString("fieldPath"));
+            if ("CONTAINS".equals(field.optString("arrayConfig"))) {
+              fieldIndex = fieldIndex.withComponent(fieldPath, FieldIndex.Segment.Kind.CONTAINS);
+            } else if ("ASCENDING".equals(field.optString("order"))) {
+              fieldIndex = fieldIndex.withComponent(fieldPath, FieldIndex.Segment.Kind.ASCENDING);
+            } else if ("DESCENDING".equals(field.optString("order"))) {
+              fieldIndex = fieldIndex.withComponent(fieldPath, FieldIndex.Segment.Kind.DESCENDING);
+            } else {
+              throw new IllegalArgumentException(
+                  String.format(
+                      "Index definition not valid (for field \"%s\" of collection \"%s\")",
+                      fieldPath, fieldIndex.getCollectionId()));
+            }
+            parsedIndices.add(fieldIndex);
+          }
+        }
+      }
+    } catch (JSONException e) {
+      throw new IllegalArgumentException("Failed to parse index configuration", e);
+    }
+
+    return client.configureIndices(parsedIndices);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -38,6 +38,7 @@ import com.google.firebase.firestore.local.Persistence;
 import com.google.firebase.firestore.local.QueryResult;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
+import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.remote.Datastore;
 import com.google.firebase.firestore.remote.GrpcMetadataProvider;
@@ -299,6 +300,11 @@ public final class FirestoreClient {
           }
         });
     return completionSource.getTask();
+  }
+
+  public Task<Void> configureIndices(List<FieldIndex> fieldIndices) {
+    verifyNotTerminated();
+    return asyncQueue.enqueue(() -> localStore.configureIndices(fieldIndices));
   }
 
   public void removeSnapshotsInSyncListener(EventListener<Void> listener) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.local;
 
+import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
 import java.util.List;
 
@@ -39,4 +40,12 @@ public interface IndexManager {
    * being either a document location or the empty path for a root-level collection).
    */
   List<ResourcePath> getCollectionParents(String collectionId);
+
+  /**
+   * Adds a field path index.
+   *
+   * <p>Values for this index are persisted asynchronously. The index will only be used for query
+   * execution once values are persisted.
+   */
+  void addFieldIndex(FieldIndex index);
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryIndexManager.java
@@ -15,6 +15,7 @@ package com.google.firebase.firestore.local;
 
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,6 +36,11 @@ class MemoryIndexManager implements IndexManager {
   @Override
   public List<ResourcePath> getCollectionParents(String collectionId) {
     return collectionParentsIndex.getEntries(collectionId);
+  }
+
+  @Override
+  public void addFieldIndex(FieldIndex index) {
+    // Field indices are not supported with memory persistence.
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLitePersistence.java
@@ -120,7 +120,7 @@ public final class SQLitePersistence extends Persistence {
     this.opener = openHelper;
     this.serializer = serializer;
     this.targetCache = new SQLiteTargetCache(this, this.serializer);
-    this.indexManager = new SQLiteIndexManager(this);
+    this.indexManager = new SQLiteIndexManager(this, this.serializer);
     this.bundleCache = new SQLiteBundleCache(this, this.serializer);
     this.remoteDocumentCache = new SQLiteRemoteDocumentCache(this, this.serializer);
     this.referenceDelegate = new SQLiteLruReferenceDelegate(this, params);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
@@ -1,0 +1,125 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.model;
+
+import androidx.annotation.NonNull;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * An index definition for field indices in Firestore.
+ *
+ * <p>Every index is associated with a collection. The definition contains a list of fields and the
+ * indexes sorting order (which can be {@link Segment.Kind#ASCENDING}, {@link
+ * Segment.Kind#DESCENDING} or {@link Segment.Kind#CONTAINS} for ArrayContains/ArrayContainsAn
+ * queries.
+ *
+ * <p>Unlike the backend, the SDK does not differentiate between collection or collection
+ * group-scoped indices. Every index can be used for both single collection and collection group
+ * queries.
+ */
+public class FieldIndex implements Iterable<FieldIndex.Segment> {
+
+  /** An index component consisting of field path and index type. */
+  public static class Segment {
+    /** The type of the index, e.g. for which sorting order it can be used. */
+    public enum Kind {
+      /** Ascending index. Can be used for <, <=, ==, >=, > and IN with ascending ordering. */
+      ASCENDING,
+      /** Descending index. Can be used for <, <=, ==, >=, > and IN with descending ordering. */
+      DESCENDING,
+      /** Contains index. Can be used for ArrayContains and ArrayContainsAny */
+      CONTAINS
+    }
+
+    private final FieldPath fieldPath;
+    private final Kind kind;
+
+    public Segment(FieldPath fieldPath, Kind kind) {
+      this.fieldPath = fieldPath;
+      this.kind = kind;
+    }
+
+    /** The field path of the component. */
+    public FieldPath getFieldPath() {
+      return fieldPath;
+    }
+
+    /** The indexes sorting order. */
+    public Kind getKind() {
+      return kind;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Segment segment = (Segment) o;
+      if (!fieldPath.equals(segment.fieldPath)) return false;
+      return kind == segment.kind;
+    }
+  }
+
+  private final String collectionId;
+  private final List<Segment> segments;
+
+  public FieldIndex(String collectionId) {
+    this.collectionId = collectionId;
+    this.segments = new ArrayList<>();
+  }
+
+  FieldIndex(String collectionId, List<Segment> segments) {
+    this.collectionId = collectionId;
+    this.segments = segments;
+  }
+
+  /** The collection ID this index applies to. */
+  public String getCollectionId() {
+    return collectionId;
+  }
+
+  @NonNull
+  @Override
+  public Iterator<Segment> iterator() {
+    return segments.iterator();
+  }
+
+  /** Returns a new field index with additional index segment. */
+  public FieldIndex withComponent(FieldPath fieldPath, Segment.Kind kind) {
+    List<Segment> newSegments = new ArrayList<>(segments);
+    newSegments.add(new Segment(fieldPath, kind));
+    return new FieldIndex(collectionId, newSegments);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    FieldIndex fieldIndex = (FieldIndex) o;
+
+    if (!segments.equals(fieldIndex.segments)) return false;
+    return collectionId.equals(fieldIndex.collectionId);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = collectionId.hashCode();
+    result = 31 * result + segments.hashCode();
+    return result;
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Preconditions.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Preconditions.java
@@ -161,4 +161,17 @@ public class Preconditions {
       throw new IllegalStateException();
     }
   }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @throws IllegalStateException if {@code expression} is false
+   */
+  public static void checkState(boolean expression, String message) {
+    if (!expression) {
+      throw new IllegalStateException(message);
+    }
+  }
 }

--- a/firebase-firestore/src/proto/google/firestore/admin/index.proto
+++ b/firebase-firestore/src/proto/google/firestore/admin/index.proto
@@ -1,0 +1,158 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.firestore.admin.v1;
+
+import "google/api/resource.proto";
+import "google/api/annotations.proto";
+
+option csharp_namespace = "Google.Cloud.Firestore.Admin.V1";
+option go_package = "google.golang.org/genproto/googleapis/firestore/admin/v1;admin";
+option java_multiple_files = true;
+option java_outer_classname = "IndexProto";
+option java_package = "com.google.firestore.admin.v1";
+option objc_class_prefix = "GCFS";
+option php_namespace = "Google\\Cloud\\Firestore\\Admin\\V1";
+option ruby_package = "Google::Cloud::Firestore::Admin::V1";
+
+// Cloud Firestore indexes enable simple and complex queries against
+// documents in a database.
+message Index {
+  option (google.api.resource) = {
+    type: "firestore.googleapis.com/Index"
+    pattern: "projects/{project}/databases/{database}/collectionGroups/{collection}/indexes/{index}"
+  };
+
+  // A field in an index.
+  // The field_path describes which field is indexed, the value_mode describes
+  // how the field value is indexed.
+  message IndexField {
+    // The supported orderings.
+    enum Order {
+      // The ordering is unspecified. Not a valid option.
+      ORDER_UNSPECIFIED = 0;
+
+      // The field is ordered by ascending field value.
+      ASCENDING = 1;
+
+      // The field is ordered by descending field value.
+      DESCENDING = 2;
+    }
+
+    // The supported array value configurations.
+    enum ArrayConfig {
+      // The index does not support additional array queries.
+      ARRAY_CONFIG_UNSPECIFIED = 0;
+
+      // The index supports array containment queries.
+      CONTAINS = 1;
+    }
+
+    // Can be __name__.
+    // For single field indexes, this must match the name of the field or may
+    // be omitted.
+    string field_path = 1;
+
+    // How the field value is indexed.
+    oneof value_mode {
+      // Indicates that this field supports ordering by the specified order or
+      // comparing using =, <, <=, >, >=.
+      Order order = 2;
+
+      // Indicates that this field supports operations on `array_value`s.
+      ArrayConfig array_config = 3;
+    }
+  }
+
+  // Query Scope defines the scope at which a query is run. This is specified on
+  // a StructuredQuery's `from` field.
+  enum QueryScope {
+    // The query scope is unspecified. Not a valid option.
+    QUERY_SCOPE_UNSPECIFIED = 0;
+
+    // Indexes with a collection query scope specified allow queries
+    // against a collection that is the child of a specific document, specified
+    // at query time, and that has the collection id specified by the index.
+    COLLECTION = 1;
+
+    // Indexes with a collection group query scope specified allow queries
+    // against all collections that has the collection id specified by the
+    // index.
+    COLLECTION_GROUP = 2;
+  }
+
+  // The state of an index. During index creation, an index will be in the
+  // `CREATING` state. If the index is created successfully, it will transition
+  // to the `READY` state. If the index creation encounters a problem, the index
+  // will transition to the `NEEDS_REPAIR` state.
+  enum State {
+    // The state is unspecified.
+    STATE_UNSPECIFIED = 0;
+
+    // The index is being created.
+    // There is an active long-running operation for the index.
+    // The index is updated when writing a document.
+    // Some index data may exist.
+    CREATING = 1;
+
+    // The index is ready to be used.
+    // The index is updated when writing a document.
+    // The index is fully populated from all stored documents it applies to.
+    READY = 2;
+
+    // The index was being created, but something went wrong.
+    // There is no active long-running operation for the index,
+    // and the most recently finished long-running operation failed.
+    // The index is not updated when writing a document.
+    // Some index data may exist.
+    // Use the google.longrunning.Operations API to determine why the operation
+    // that last attempted to create this index failed, then re-create the
+    // index.
+    NEEDS_REPAIR = 3;
+  }
+
+  // Output only. A server defined name for this index.
+  // The form of this name for composite indexes will be:
+  // `projects/{project_id}/databases/{database_id}/collectionGroups/{collection_id}/indexes/{composite_index_id}`
+  // For single field indexes, this field will be empty.
+  string name = 1;
+
+  // Indexes with a collection query scope specified allow queries
+  // against a collection that is the child of a specific document, specified at
+  // query time, and that has the same collection id.
+  //
+  // Indexes with a collection group query scope specified allow queries against
+  // all collections descended from a specific document, specified at query
+  // time, and that have the same collection id as this index.
+  QueryScope query_scope = 2;
+
+  // The fields supported by this index.
+  //
+  // For composite indexes, this is always 2 or more fields.
+  // The last field entry is always for the field path `__name__`. If, on
+  // creation, `__name__` was not specified as the last field, it will be added
+  // automatically with the same direction as that of the last field defined. If
+  // the final field in a composite index is not directional, the `__name__`
+  // will be ordered ASCENDING (unless explicitly specified).
+  //
+  // For single field indexes, this will always be exactly one entry with a
+  // field path equal to the field path of the associated field.
+  repeated IndexField fields = 3;
+
+  // Output only. The serving state of the index.
+  State state = 4;
+}


### PR DESCRIPTION
This PR adds an API to configure indices and the plumbing that is needed to store the indices in SQLLite. The API itself is marked for internal use only and will only be used during development. The final API to enable indices might look very different (it has not yet gone through review).

The PR also adds some very basic tests. Since it is not yet possible to determine whether an index has been enabled, the tests are somewhat limited in scope.