### PR TITLE
FAD Add SignIn persistence to SDK 

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -31,6 +31,7 @@ import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.tasks.CancellationTokenSource;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appdistribution.internal.AppDistributionReleaseInternal;
 import com.google.firebase.installations.FirebaseInstallationsApi;
@@ -53,15 +54,19 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
       null;
   private CancellationTokenSource updateToLatestReleaseCancellationSource;
 
+  private SignInStorage signInStorage;
+
   /** Constructor for FirebaseAppDistribution */
   @VisibleForTesting
   FirebaseAppDistribution(
       @NonNull FirebaseApp firebaseApp,
       @NonNull TesterSignInClient testerSignInClient,
-      @NonNull CheckForUpdateClient checkForUpdateClient) {
+      @NonNull CheckForUpdateClient checkForUpdateClient,
+      @NonNull SignInStorage signInStorage) {
     this.firebaseApp = firebaseApp;
     this.testerSignInClient = testerSignInClient;
     this.checkForUpdateClient = checkForUpdateClient;
+    this.signInStorage = signInStorage;
   }
 
   /** Constructor for FirebaseAppDistribution */
@@ -72,7 +77,8 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
         firebaseApp,
         new TesterSignInClient(firebaseApp, firebaseInstallationsApi),
         new CheckForUpdateClient(
-            firebaseApp, new FirebaseAppDistributionTesterApiClient(), firebaseInstallationsApi));
+            firebaseApp, new FirebaseAppDistributionTesterApiClient(), firebaseInstallationsApi),
+        new SignInStorage(firebaseApp.getApplicationContext()));
   }
 
   /** @return a FirebaseAppDistribution instance */
@@ -113,32 +119,21 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
     updateToLatestReleaseTaskCompletionSource =
         new TaskCompletionSource<>(updateToLatestReleaseCancellationSource.getToken());
 
-    // todo: when persistence is implemented and user already signed in, skip signInTester
-    signInTester()
-        .addOnSuccessListener(
-            unused -> {
-              checkForUpdate()
-                  .addOnSuccessListener(
-                      latestRelease -> {
-                        if (latestRelease != null) {
-                          showUpdateAlertDialog(latestRelease);
-                        } else {
-                          updateToLatestReleaseTaskCompletionSource.setResult(null);
-                        }
-                      })
-                  .addOnFailureListener(
-                      e ->
-                          setUpdateToLatestReleaseErrorWithDefault(
-                              e,
-                              new FirebaseAppDistributionException(
-                                  Constants.ErrorMessages.NETWORK_ERROR, NETWORK_FAILURE)));
-            })
-        .addOnFailureListener(
-            e ->
-                setUpdateToLatestReleaseErrorWithDefault(
-                    e,
-                    new FirebaseAppDistributionException(
-                        Constants.ErrorMessages.AUTHENTICATION_ERROR, AUTHENTICATION_FAILURE)));
+    if (isTesterSignedIn()) {
+      checkForNewReleaseAndUpdateIfAvailable();
+    } else {
+      signInTester()
+          .addOnSuccessListener(
+              unused -> {
+                checkForNewReleaseAndUpdateIfAvailable();
+              })
+          .addOnFailureListener(
+              e ->
+                  setUpdateToLatestReleaseErrorWithDefault(
+                      e,
+                      new FirebaseAppDistributionException(
+                          Constants.ErrorMessages.AUTHENTICATION_ERROR, AUTHENTICATION_FAILURE)));
+    }
 
     return updateToLatestReleaseTaskCompletionSource.getTask();
   }
@@ -156,17 +151,19 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
    */
   @NonNull
   public Task<AppDistributionRelease> checkForUpdate() {
-    return this.checkForUpdateClient
-        .checkForUpdate()
-        .continueWith(
-            task -> {
-              // Calling task.getResult() on a failed task will cause the Continuation to fail
-              // with the original exception. See:
-              // https://developers.google.com/android/reference/com/google/android/gms/tasks/Continuation
-              AppDistributionReleaseInternal latestRelease = task.getResult();
-              setCachedLatestRelease(latestRelease);
-              return convertToAppDistributionRelease(latestRelease);
-            });
+    if (isTesterSignedIn()) {
+      return getCheckForUpdateTask();
+    } else {
+      return signInTester()
+          .continueWithTask(
+              task -> {
+                if (task.isSuccessful()) {
+                  return getCheckForUpdateTask();
+                } else {
+                  return Tasks.forException(task.getException());
+                }
+              });
+    }
   }
 
   /**
@@ -180,44 +177,51 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
   @NonNull
   public UpdateTask updateApp() throws FirebaseAppDistributionException {
 
-    if (updateAppTaskCompletionSource != null
-        && !updateAppTaskCompletionSource.getTask().isComplete()) {
-      updateAppCancellationSource.cancel();
-    }
-
-    updateAppCancellationSource = new CancellationTokenSource();
-    updateAppTaskCompletionSource =
-        new TaskCompletionSource<>(updateAppCancellationSource.getToken());
-    Context context = firebaseApp.getApplicationContext();
-    this.updateTask = new UpdateTaskImpl(updateAppTaskCompletionSource.getTask());
-
-    if (cachedLatestRelease == null) {
-      setUpdateAppTaskCompletionError(
-          new FirebaseAppDistributionException(
-              context.getString(R.string.no_update_available),
-              FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE));
-    } else {
-      if (cachedLatestRelease.getBinaryType() == BinaryType.AAB) {
-        redirectToPlayForAabUpdate(cachedLatestRelease.getDownloadUrl());
-      } else {
-        // todo: create update class when implementing APK
-        throw new UnsupportedOperationException("Not yet implemented.");
+    if (isTesterSignedIn()) {
+      if (updateAppTaskCompletionSource != null
+          && !updateAppTaskCompletionSource.getTask().isComplete()) {
+        updateAppCancellationSource.cancel();
       }
+
+      updateAppCancellationSource = new CancellationTokenSource();
+      updateAppTaskCompletionSource =
+          new TaskCompletionSource<>(updateAppCancellationSource.getToken());
+      Context context = firebaseApp.getApplicationContext();
+      this.updateTask = new UpdateTaskImpl(updateAppTaskCompletionSource.getTask());
+
+      if (cachedLatestRelease == null) {
+        setUpdateAppTaskCompletionError(
+            new FirebaseAppDistributionException(
+                context.getString(R.string.no_update_available),
+                FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE));
+      } else {
+        if (cachedLatestRelease.getBinaryType() == BinaryType.AAB) {
+          redirectToPlayForAabUpdate(cachedLatestRelease.getDownloadUrl());
+        } else {
+          // todo: create update class when implementing APK
+          throw new UnsupportedOperationException("Not yet implemented.");
+        }
+      }
+      return this.updateTask;
     }
 
-    return this.updateTask;
+    // if user is not signedIn
+    return new UpdateTaskImpl(
+        Tasks.forException(
+            new FirebaseAppDistributionException(
+                Constants.ErrorMessages.NOT_FOUND_ERROR,
+                FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE)));
   }
 
   /** Returns true if the App Distribution tester is signed in */
   public boolean isTesterSignedIn() {
-    // todo: implement when signIn persistence is done
-    throw new UnsupportedOperationException("Not yet implemented.");
+    return this.signInStorage.getSignInStatus();
   }
 
   /** Signs out the App Distribution tester */
   public void signOutTester() {
-    // todo: implement when signIn persistence is done
-    throw new UnsupportedOperationException("Not yet implemented.");
+    this.cachedLatestRelease = null;
+    this.signInStorage.storeSignInStatus(false);
   }
 
   @Override
@@ -226,6 +230,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
     // if SignInResultActivity is created, sign-in was successful
     if (activity instanceof SignInResultActivity) {
       this.testerSignInClient.setSuccessfulSignInResult();
+      this.signInStorage.storeSignInStatus(true);
     }
   }
 
@@ -319,6 +324,38 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
     } else {
       setUpdateToLatestReleaseTaskCompletionError(defaultFirebaseException);
     }
+  }
+
+  private Task<AppDistributionRelease> getCheckForUpdateTask() {
+    return this.checkForUpdateClient
+        .checkForUpdate()
+        .continueWith(
+            task -> {
+              // Calling task.getResult() on a failed task will cause the Continuation to fail
+              // with the original exception. See:
+              // https://developers.google.com/android/reference/com/google/android/gms/tasks/Continuation
+              AppDistributionReleaseInternal latestRelease = task.getResult();
+              setCachedLatestRelease(latestRelease);
+              return convertToAppDistributionRelease(latestRelease);
+            });
+  }
+
+  private void checkForNewReleaseAndUpdateIfAvailable() {
+    checkForUpdate()
+        .addOnSuccessListener(
+            latestRelease -> {
+              if (latestRelease != null) {
+                showUpdateAlertDialog(latestRelease);
+              } else {
+                updateToLatestReleaseTaskCompletionSource.setResult(null);
+              }
+            })
+        .addOnFailureListener(
+            e ->
+                setUpdateToLatestReleaseErrorWithDefault(
+                    e,
+                    new FirebaseAppDistributionException(
+                        Constants.ErrorMessages.NETWORK_ERROR, NETWORK_FAILURE)));
   }
 
   private void redirectToPlayForAabUpdate(String downloadUrl)

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -189,27 +189,27 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
           Tasks.forException(
               new FirebaseAppDistributionException(
                   Constants.ErrorMessages.NOT_FOUND_ERROR, UPDATE_NOT_AVAILABLE)));
-    } else {
-      if (updateAppTaskCompletionSource != null
-          && !updateAppTaskCompletionSource.getTask().isComplete()) {
-        updateAppCancellationSource.cancel();
-      }
-
-      updateAppCancellationSource = new CancellationTokenSource();
-      updateAppTaskCompletionSource =
-          new TaskCompletionSource<>(updateAppCancellationSource.getToken());
-      Context context = firebaseApp.getApplicationContext();
-      this.updateTask = new UpdateTaskImpl(updateAppTaskCompletionSource.getTask());
-
-      if (cachedLatestRelease.getBinaryType() == BinaryType.AAB) {
-        redirectToPlayForAabUpdate(cachedLatestRelease.getDownloadUrl());
-      } else {
-        // todo: create update class when implementing APK
-        throw new UnsupportedOperationException("Not yet implemented.");
-      }
-
-      return this.updateTask;
     }
+
+    if (updateAppTaskCompletionSource != null
+        && !updateAppTaskCompletionSource.getTask().isComplete()) {
+      updateAppCancellationSource.cancel();
+    }
+
+    updateAppCancellationSource = new CancellationTokenSource();
+    updateAppTaskCompletionSource =
+        new TaskCompletionSource<>(updateAppCancellationSource.getToken());
+    Context context = firebaseApp.getApplicationContext();
+    this.updateTask = new UpdateTaskImpl(updateAppTaskCompletionSource.getTask());
+
+    if (cachedLatestRelease.getBinaryType() == BinaryType.AAB) {
+      redirectToPlayForAabUpdate(cachedLatestRelease.getDownloadUrl());
+    } else {
+      // todo: create update class when implementing APK
+      throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    return this.updateTask;
   }
 
   /** Returns true if the App Distribution tester is signed in */

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -201,19 +201,13 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
       Context context = firebaseApp.getApplicationContext();
       this.updateTask = new UpdateTaskImpl(updateAppTaskCompletionSource.getTask());
 
-      if (cachedLatestRelease == null) {
-        setUpdateAppTaskCompletionError(
-            new FirebaseAppDistributionException(
-                context.getString(R.string.no_update_available),
-                FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE));
+      if (cachedLatestRelease.getBinaryType() == BinaryType.AAB) {
+        redirectToPlayForAabUpdate(cachedLatestRelease.getDownloadUrl());
       } else {
-        if (cachedLatestRelease.getBinaryType() == BinaryType.AAB) {
-          redirectToPlayForAabUpdate(cachedLatestRelease.getDownloadUrl());
-        } else {
-          // todo: create update class when implementing APK
-          throw new UnsupportedOperationException("Not yet implemented.");
-        }
+        // todo: create update class when implementing APK
+        throw new UnsupportedOperationException("Not yet implemented.");
       }
+
       return this.updateTask;
     }
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/SignInStorage.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/SignInStorage.java
@@ -21,7 +21,7 @@ import android.content.SharedPreferences;
 public class SignInStorage {
 
   private static final String SIGNIN_PREFERENCES_NAME = "FirebaseAppDistributionSignInStorage";
-  private static final String SIGNIN_TAG = "firebase_app_distro_signin";
+  private static final String SIGNIN_TAG = "firebase_app_distribution_signin";
 
   private final SharedPreferences signInSharedPreferences;
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/SignInStorage.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/SignInStorage.java
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/** Class that handles storage for App Distribution SignIn persistence. */
+public class SignInStorage {
+
+  private static final String SIGNIN_PREFERENCES_NAME = "FirebaseAppDistributionSignInStorage";
+  private static final String SIGNIN_TAG = "firebase_app_distro_signin";
+
+  private final SharedPreferences signInSharedPreferences;
+
+  SignInStorage(Context applicationContext) {
+    this.signInSharedPreferences =
+        applicationContext.getSharedPreferences(SIGNIN_PREFERENCES_NAME, Context.MODE_PRIVATE);
+  }
+
+  void storeSignInStatus(boolean testerSignedIn) {
+    this.signInSharedPreferences.edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
+  }
+
+  boolean getSignInStatus() {
+    return signInSharedPreferences.getBoolean(SIGNIN_TAG, false);
+  }
+}

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/SignInStorage.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/SignInStorage.java
@@ -30,7 +30,7 @@ public class SignInStorage {
         applicationContext.getSharedPreferences(SIGNIN_PREFERENCES_NAME, Context.MODE_PRIVATE);
   }
 
-  void storeSignInStatus(boolean testerSignedIn) {
+  void setSignInStatus(boolean testerSignedIn) {
     this.signInSharedPreferences.edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
   }
 

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -51,7 +51,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
@@ -117,7 +116,7 @@ public class FirebaseAppDistributionTest {
                 .build());
 
     // this is spy instead of mock to be able to test isTesterSingedIn functionality
-//    signInStorage = spy(new SignInStorage(firebaseApp.getApplicationContext()));
+    //    signInStorage = spy(new SignInStorage(firebaseApp.getApplicationContext()));
 
     firebaseAppDistribution =
         spy(

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -115,9 +115,6 @@ public class FirebaseAppDistributionTest {
                 .setApiKey(TEST_API_KEY)
                 .build());
 
-    // this is spy instead of mock to be able to test isTesterSingedIn functionality
-    //    signInStorage = spy(new SignInStorage(firebaseApp.getApplicationContext()));
-
     firebaseAppDistribution =
         spy(
             new FirebaseAppDistribution(
@@ -265,6 +262,8 @@ public class FirebaseAppDistributionTest {
   @Test
   public void updateToLatestRelease_whenNewAabReleaseAvailable_showsUpdateDialog()
       throws Exception {
+    // mockSignInStorage returns false then true to simulate logging in during first signIn check in
+    // updateToLatestRelease
     when(mockSignInStorage.getSignInStatus()).thenReturn(false).thenReturn(true);
     when(mockCheckForUpdateClient.checkForUpdate())
         .thenReturn(Tasks.forResult(TEST_RELEASE_NEWER_AAB_INTERNAL));


### PR DESCRIPTION
- Add sign in persistence through SignInStorage class using SharedPreferences 
- Implement isTesterSignedIn and signOutTester
- Fix tests affected by persistence 
- Add signIn checks in updateToLatestRelease, updateApp, and checkForUpdate 
- Add unit tests