### PR TITLE
Standardize spelling of canceled

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/Constants.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/Constants.java
@@ -25,14 +25,13 @@ class Constants {
 
     public static final String AUTHORIZATION_ERROR = "Failed to authorize the tester";
 
-    public static final String AUTHENTICATION_CANCELLED =
-        "Tester cancelled the authentication flow";
+    public static final String AUTHENTICATION_CANCELED = "Tester canceled the authentication flow";
 
     public static final String NOT_FOUND_ERROR = "Tester or release not found";
 
     public static final String TIMEOUT_ERROR = "Failed to fetch releases due to timeout";
 
-    public static final String UPDATE_CANCELLED = "Update cancelled";
+    public static final String UPDATE_CANCELED = "Update canceled";
 
     public static final String UNKNOWN_ERROR = "Unknown Error";
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -378,7 +378,7 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
           dialogInterface.dismiss();
           setUpdateToLatestReleaseTaskCompletionError(
               new FirebaseAppDistributionException(
-                  Constants.ErrorMessages.UPDATE_CANCELLED,
+                  Constants.ErrorMessages.UPDATE_CANCELED,
                   FirebaseAppDistributionException.Status.INSTALLATION_CANCELED));
         });
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/TesterSignInClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/TesterSignInClient.java
@@ -33,6 +33,7 @@ import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.appdistribution.Constants.ErrorMessages;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import java.util.List;
 
@@ -75,7 +76,7 @@ class TesterSignInClient {
   void setCanceledAuthenticationError() {
     setSignInTaskCompletionError(
         new FirebaseAppDistributionException(
-            Constants.ErrorMessages.AUTHENTICATION_CANCELLED, AUTHENTICATION_CANCELED));
+            Constants.ErrorMessages.AUTHENTICATION_CANCELED, AUTHENTICATION_CANCELED));
   }
 
   void setSuccessfulSignInResult() {
@@ -117,7 +118,7 @@ class TesterSignInClient {
           public void onClick(DialogInterface dialogInterface, int i) {
             setSignInTaskCompletionError(
                 new FirebaseAppDistributionException(
-                    "Tester cancelled authentication flow", AUTHENTICATION_CANCELED));
+                    ErrorMessages.AUTHENTICATION_CANCELED, AUTHENTICATION_CANCELED));
             dialogInterface.dismiss();
           }
         });

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateStatus.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateStatus.java
@@ -31,7 +31,7 @@ public enum UpdateStatus {
   /** Update installed */
   INSTALLED,
 
-  /** Installation cancelled */
+  /** Installation canceled */
   INSTALL_CANCELED,
 
   /** Installation failed */

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -280,12 +280,12 @@ public class FirebaseAppDistributionTest {
   }
 
   @Test
-  public void updateToLatestRelease_whenSignInCancelled_checkForUpdateNotCalled() {
+  public void updateToLatestRelease_whenSignInCanceled_checkForUpdateNotCalled() {
     when(mockTesterSignInClient.signInTester(any()))
         .thenReturn(
             Tasks.forException(
                 new FirebaseAppDistributionException(
-                    ErrorMessages.AUTHENTICATION_CANCELLED, AUTHENTICATION_CANCELED)));
+                    ErrorMessages.AUTHENTICATION_CANCELED, AUTHENTICATION_CANCELED)));
 
     firebaseAppDistribution.onActivityResumed(activity);
     Task<AppDistributionRelease> task = firebaseAppDistribution.updateToLatestRelease();
@@ -298,7 +298,7 @@ public class FirebaseAppDistributionTest {
     verify(mockCheckForUpdateClient, never()).checkForUpdate();
     assertTrue(task.getException() instanceof FirebaseAppDistributionException);
     FirebaseAppDistributionException e = (FirebaseAppDistributionException) task.getException();
-    assertEquals("Tester cancelled the authentication flow", e.getMessage());
+    assertEquals("Tester canceled the authentication flow", e.getMessage());
     assertEquals(AUTHENTICATION_CANCELED, e.getErrorCode());
   }
 


### PR DESCRIPTION
Standardizing how we spell canceled in our SDK codebase