### PR TITLE
Check For Update Refactor and tests

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
@@ -14,8 +14,6 @@
 
 package com.google.firebase.appdistribution;
 
-import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.AUTHENTICATION_FAILURE;
-
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
@@ -40,12 +40,10 @@ class CheckForUpdateClient {
   private static final int UPDATE_THREAD_POOL_SIZE = 4;
 
   private final FirebaseApp firebaseApp;
-  private FirebaseAppDistributionTesterApiClient firebaseAppDistributionTesterApiClient;
+  private final FirebaseAppDistributionTesterApiClient firebaseAppDistributionTesterApiClient;
   private final FirebaseInstallationsApi firebaseInstallationsApi;
 
-  private TaskCompletionSource<AppDistributionReleaseInternal> checkForUpdateTaskCompletionSource =
-      null;
-  private CancellationTokenSource checkForUpdateCancellationSource;
+  Task<AppDistributionReleaseInternal> cachedCheckForUpdate = null;
   private final Executor checkForUpdateExecutor;
 
   CheckForUpdateClient(
@@ -59,31 +57,36 @@ class CheckForUpdateClient {
     this.checkForUpdateExecutor = Executors.newFixedThreadPool(UPDATE_THREAD_POOL_SIZE);
   }
 
+  CheckForUpdateClient(
+          @NonNull FirebaseApp firebaseApp,
+          @NonNull FirebaseAppDistributionTesterApiClient firebaseAppDistributionTesterApiClient,
+          @NonNull FirebaseInstallationsApi firebaseInstallationsApi,
+          @NonNull Executor executor) {
+    this.firebaseApp = firebaseApp;
+    this.firebaseAppDistributionTesterApiClient = firebaseAppDistributionTesterApiClient;
+    this.firebaseInstallationsApi = firebaseInstallationsApi;
+    // TODO: verify if this is best way to use executorservice here
+    this.checkForUpdateExecutor = executor;
+  }
+
   @NonNull
-  public Task<AppDistributionReleaseInternal> checkForUpdate() {
+  public synchronized Task<AppDistributionReleaseInternal> checkForUpdate() {
 
-    if (checkForUpdateTaskCompletionSource != null
-        && !checkForUpdateTaskCompletionSource.getTask().isComplete()) {
-      checkForUpdateCancellationSource.cancel();
+    if(cachedCheckForUpdate != null && !cachedCheckForUpdate.isComplete()) {
+      return cachedCheckForUpdate;
     }
-
-    checkForUpdateCancellationSource = new CancellationTokenSource();
-    checkForUpdateTaskCompletionSource =
-        new TaskCompletionSource<>(checkForUpdateCancellationSource.getToken());
 
     Task<String> installationIdTask = firebaseInstallationsApi.getId();
     // forceRefresh is false to get locally cached token if available
     Task<InstallationTokenResult> installationAuthTokenTask =
         firebaseInstallationsApi.getToken(false);
 
-    Tasks.whenAllSuccess(installationIdTask, installationAuthTokenTask)
-        .addOnSuccessListener(
-            tasks -> {
+    this.cachedCheckForUpdate = Tasks.whenAllSuccess(installationIdTask, installationAuthTokenTask)
+        .onSuccessTask(
+            checkForUpdateExecutor, tasks -> {
               String fid = installationIdTask.getResult();
               InstallationTokenResult installationTokenResult =
                   installationAuthTokenTask.getResult();
-              checkForUpdateExecutor.execute(
-                  () -> {
                     try {
                       AppDistributionReleaseInternal latestRelease =
                           getLatestReleaseFromClient(
@@ -91,24 +94,16 @@ class CheckForUpdateClient {
                               firebaseApp.getOptions().getApplicationId(),
                               firebaseApp.getOptions().getApiKey(),
                               installationTokenResult.getToken());
-                      updateOnUiThread(
-                          () -> {
-                            if (checkForUpdateTaskCompletionSource != null
-                                && !checkForUpdateTaskCompletionSource.getTask().isComplete())
-                              checkForUpdateTaskCompletionSource.setResult(latestRelease);
-                          });
+                      return Tasks.forResult(latestRelease);
                     } catch (FirebaseAppDistributionException ex) {
-                      updateOnUiThread(() -> setCheckForUpdateTaskCompletionError(ex));
+                      return Tasks.forException(ex);
                     }
-                  });
             })
         .addOnFailureListener(
-            e ->
-                setCheckForUpdateTaskCompletionError(
-                    new FirebaseAppDistributionException(
-                        Constants.ErrorMessages.AUTHENTICATION_ERROR, AUTHENTICATION_FAILURE, e)));
+            e -> Tasks.forException(new FirebaseAppDistributionException(
+                    Constants.ErrorMessages.AUTHENTICATION_ERROR, AUTHENTICATION_FAILURE, e)));
 
-    return checkForUpdateTaskCompletionSource.getTask();
+    return cachedCheckForUpdate;
   }
 
   @VisibleForTesting
@@ -134,18 +129,7 @@ class CheckForUpdateClient {
     }
   }
 
-  private void updateOnUiThread(Runnable runnable) {
-    HandlerCompat.createAsync(Looper.getMainLooper()).post(runnable);
-  }
-
-  private void setCheckForUpdateTaskCompletionError(FirebaseAppDistributionException e) {
-    if (checkForUpdateTaskCompletionSource != null
-        && !checkForUpdateTaskCompletionSource.getTask().isComplete()) {
-      this.checkForUpdateTaskCompletionSource.setException(e);
-    }
-  }
-
-  private boolean isNewerBuildVersion(AppDistributionReleaseInternal latestRelease) {
+  private boolean isNewerBuildVersion(AppDistributionReleaseInternal latestRelease) throws FirebaseAppDistributionException {
     return Long.parseLong(latestRelease.getBuildVersion())
         >= getInstalledAppVersionCode(firebaseApp.getApplicationContext());
   }
@@ -167,16 +151,15 @@ class CheckForUpdateClient {
                 firebaseApp.getApplicationContext()));
   }
 
-  private long getInstalledAppVersionCode(Context context) {
-    PackageInfo pInfo = null;
+  private long getInstalledAppVersionCode(Context context) throws FirebaseAppDistributionException {
+    PackageInfo pInfo;
     try {
       pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
     } catch (PackageManager.NameNotFoundException e) {
-      checkForUpdateTaskCompletionSource.setException(
-          new FirebaseAppDistributionException(
+      throw new FirebaseAppDistributionException(
               Constants.ErrorMessages.UNKNOWN_ERROR,
               FirebaseAppDistributionException.Status.UNKNOWN,
-              e));
+              e);
     }
     return PackageInfoCompat.getLongVersionCode(pInfo);
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
@@ -95,7 +95,10 @@ class CheckForUpdateClient {
                     return Tasks.forException(ex);
                   }
                 })
-            .addOnFailureListener(Tasks::forException);
+            .continueWithTask(checkForUpdateExecutor,
+                task -> TaskUtils.handleTaskFailure(task,
+                        Constants.ErrorMessages.NETWORK_ERROR,
+                        FirebaseAppDistributionException.Status.NETWORK_FAILURE));
 
     return cachedCheckForUpdate;
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
@@ -97,13 +97,7 @@ class CheckForUpdateClient {
                     return Tasks.forException(ex);
                   }
                 })
-            .addOnFailureListener(
-                e ->
-                    Tasks.forException(
-                        new FirebaseAppDistributionException(
-                            Constants.ErrorMessages.AUTHENTICATION_ERROR,
-                            AUTHENTICATION_FAILURE,
-                            e)));
+            .addOnFailureListener(Tasks::forException);
 
     return cachedCheckForUpdate;
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForUpdateClient.java
@@ -95,8 +95,11 @@ class CheckForUpdateClient {
                     return Tasks.forException(ex);
                   }
                 })
-            .continueWithTask(checkForUpdateExecutor,
-                task -> TaskUtils.handleTaskFailure(task,
+            .continueWithTask(
+                checkForUpdateExecutor,
+                task ->
+                    TaskUtils.handleTaskFailure(
+                        task,
                         Constants.ErrorMessages.NETWORK_ERROR,
                         FirebaseAppDistributionException.Status.NETWORK_FAILURE));
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/TaskUtils.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/TaskUtils.java
@@ -18,15 +18,19 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 
 class TaskUtils {
-    static <TResult> Task<TResult> handleTaskFailure(Task<TResult> task, String defaultErrorMessage, FirebaseAppDistributionException.Status defaultErrorStatus) {
-        if (task.isComplete() && !task.isSuccessful()) {
-            Exception e = task.getException();
-            if (e instanceof FirebaseAppDistributionException) {
-                return task;
-            }
-
-            return Tasks.forException(new FirebaseAppDistributionException(defaultErrorMessage, defaultErrorStatus, e));
-        }
+  static <TResult> Task<TResult> handleTaskFailure(
+      Task<TResult> task,
+      String defaultErrorMessage,
+      FirebaseAppDistributionException.Status defaultErrorStatus) {
+    if (task.isComplete() && !task.isSuccessful()) {
+      Exception e = task.getException();
+      if (e instanceof FirebaseAppDistributionException) {
         return task;
+      }
+
+      return Tasks.forException(
+          new FirebaseAppDistributionException(defaultErrorMessage, defaultErrorStatus, e));
     }
+    return task;
+  }
 }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/TaskUtils.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/TaskUtils.java
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+
+class TaskUtils {
+    static <TResult> Task<TResult> handleTaskFailure(Task<TResult> task, String defaultErrorMessage, FirebaseAppDistributionException.Status defaultErrorStatus) {
+        if (task.isComplete() && !task.isSuccessful()) {
+            Exception e = task.getException();
+            if (e instanceof FirebaseAppDistributionException) {
+                return task;
+            }
+
+            return Tasks.forException(new FirebaseAppDistributionException(defaultErrorMessage, defaultErrorStatus, e));
+        }
+        return task;
+    }
+}

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/CheckForUpdateClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/CheckForUpdateClientTest.java
@@ -183,7 +183,8 @@ public class CheckForUpdateClientTest {
         assertThrows(FirebaseAppDistributionException.class, onCompleteListener::await);
 
     assertEquals(Constants.ErrorMessages.NETWORK_ERROR, actualException.getMessage());
-    assertEquals(FirebaseAppDistributionException.Status.NETWORK_FAILURE, actualException.getErrorCode());
+    assertEquals(
+        FirebaseAppDistributionException.Status.NETWORK_FAILURE, actualException.getErrorCode());
     assertEquals(expectedException, actualException.getCause());
   }
 
@@ -191,19 +192,21 @@ public class CheckForUpdateClientTest {
   public void checkForUpdate_appDistroFailure() throws Exception {
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
     when(mockFirebaseInstallations.getToken(false))
-            .thenReturn(Tasks.forResult(mockInstallationTokenResult));
+        .thenReturn(Tasks.forResult(mockInstallationTokenResult));
 
-    FirebaseAppDistributionException expectedException = new FirebaseAppDistributionException("test", FirebaseAppDistributionException.Status.UNKNOWN);
+    FirebaseAppDistributionException expectedException =
+        new FirebaseAppDistributionException(
+            "test", FirebaseAppDistributionException.Status.UNKNOWN);
     when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(any(), any(), any(), any()))
-            .thenThrow(expectedException);
+        .thenThrow(expectedException);
 
     TestOnCompleteListener<AppDistributionReleaseInternal> onCompleteListener =
-            new TestOnCompleteListener<>();
+        new TestOnCompleteListener<>();
     Task<AppDistributionReleaseInternal> task = checkForUpdateClient.checkForUpdate();
     task.addOnCompleteListener(testExecutor, onCompleteListener);
 
     FirebaseAppDistributionException actualException =
-            assertThrows(FirebaseAppDistributionException.class, onCompleteListener::await);
+        assertThrows(FirebaseAppDistributionException.class, onCompleteListener::await);
 
     assertEquals(expectedException, actualException);
   }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/CheckForUpdateClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/CheckForUpdateClientTest.java
@@ -82,8 +82,6 @@ public class CheckForUpdateClientTest {
 
   Executor testExecutor = Executors.newSingleThreadExecutor();
 
-  //  @Rule public InstantTaskExecutorRule executorRule = new InstantTaskExecutorRule();
-
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/CheckForUpdateClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/CheckForUpdateClientTest.java
@@ -15,10 +15,8 @@
 package com.google.firebase.appdistribution;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,8 +26,6 @@ import static org.robolectric.Shadows.shadowOf;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.os.Bundle;
-import android.os.Looper;
-
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.core.content.pm.ApplicationInfoBuilder;
 import androidx.test.core.content.pm.PackageInfoBuilder;
@@ -40,19 +36,15 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.appdistribution.internal.AppDistributionReleaseInternal;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowPackageManager;
-
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 @RunWith(RobolectricTestRunner.class)
 public class CheckForUpdateClientTest {
@@ -90,8 +82,7 @@ public class CheckForUpdateClientTest {
 
   Executor testExecutor = Executors.newSingleThreadExecutor();
 
-//  @Rule public InstantTaskExecutorRule executorRule = new InstantTaskExecutorRule();
-
+  //  @Rule public InstantTaskExecutorRule executorRule = new InstantTaskExecutorRule();
 
   @Before
   public void setup() {
@@ -133,19 +124,22 @@ public class CheckForUpdateClientTest {
 
     checkForUpdateClient =
         new CheckForUpdateClient(
-            firebaseApp, mockFirebaseAppDistributionTesterApiClient, mockFirebaseInstallations, testExecutor);
+            firebaseApp,
+            mockFirebaseAppDistributionTesterApiClient,
+            mockFirebaseInstallations,
+            testExecutor);
   }
 
   @Test
   public void checkForUpdate_succeeds() throws Exception {
     when(mockFirebaseAppDistributionTesterApiClient.fetchLatestRelease(any(), any(), any(), any()))
-            .thenReturn(TEST_RELEASE_CURRENT);
+        .thenReturn(TEST_RELEASE_CURRENT);
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
     when(mockFirebaseInstallations.getToken(false))
-            .thenReturn(Tasks.forResult(mockInstallationTokenResult));
+        .thenReturn(Tasks.forResult(mockInstallationTokenResult));
 
     TestOnCompleteListener<AppDistributionReleaseInternal> onCompleteListener =
-            new TestOnCompleteListener<>();
+        new TestOnCompleteListener<>();
     Task<AppDistributionReleaseInternal> task = checkForUpdateClient.checkForUpdate();
     task.addOnCompleteListener(testExecutor, onCompleteListener);
 

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/TestOnCompleteListener.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/TestOnCompleteListener.java
@@ -28,42 +28,42 @@ import java.util.concurrent.TimeUnit;
  * allowing the main thread to be woken up when the Tasks complete.
  */
 public class TestOnCompleteListener<TResult> implements OnCompleteListener<TResult> {
-    private static final long TIMEOUT_MS = 5000;
-    private final CountDownLatch latch = new CountDownLatch(1);
-    private volatile TResult result;
-    private volatile Exception exception;
-    private volatile boolean successful;
+  private static final long TIMEOUT_MS = 5000;
+  private final CountDownLatch latch = new CountDownLatch(1);
+  private volatile TResult result;
+  private volatile Exception exception;
+  private volatile boolean successful;
 
-    @Override
-    public void onComplete(@NonNull Task<TResult> task) {
-        successful = task.isSuccessful();
-        if (successful) {
-            result = task.getResult();
-        } else {
-            exception = task.getException();
-        }
-        latch.countDown();
+  @Override
+  public void onComplete(@NonNull Task<TResult> task) {
+    successful = task.isSuccessful();
+    if (successful) {
+      result = task.getResult();
+    } else {
+      exception = task.getException();
     }
+    latch.countDown();
+  }
 
-    /** Blocks until the {@link #onComplete} is called. */
-    public TResult await() throws InterruptedException, ExecutionException, FirebaseAppDistributionException {
-        if (!latch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-            throw new InterruptedException("timed out waiting for result");
-        }
-        if (successful) {
-            return result;
-        } else {
-            if (exception instanceof InterruptedException) {
-                throw (InterruptedException) exception;
-            }
-            if (exception instanceof FirebaseAppDistributionException) {
-                throw (FirebaseAppDistributionException) exception;
-            }
-            if (exception instanceof IOException) {
-                throw new ExecutionException(exception);
-            }
-            throw new IllegalStateException("got an unexpected exception type", exception);
-        }
+  /** Blocks until the {@link #onComplete} is called. */
+  public TResult await()
+      throws InterruptedException, ExecutionException, FirebaseAppDistributionException {
+    if (!latch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+      throw new InterruptedException("timed out waiting for result");
     }
+    if (successful) {
+      return result;
+    } else {
+      if (exception instanceof InterruptedException) {
+        throw (InterruptedException) exception;
+      }
+      if (exception instanceof FirebaseAppDistributionException) {
+        throw (FirebaseAppDistributionException) exception;
+      }
+      if (exception instanceof IOException) {
+        throw new ExecutionException(exception);
+      }
+      throw new IllegalStateException("got an unexpected exception type", exception);
+    }
+  }
 }
-

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/TestOnCompleteListener.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/TestOnCompleteListener.java
@@ -1,0 +1,69 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import androidx.annotation.NonNull;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Helper listener that works around a limitation of the Tasks API where await() cannot be called on
+ * the main thread. This listener works around it by running itself on a different thread, thus
+ * allowing the main thread to be woken up when the Tasks complete.
+ */
+public class TestOnCompleteListener<TResult> implements OnCompleteListener<TResult> {
+    private static final long TIMEOUT_MS = 5000;
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private volatile TResult result;
+    private volatile Exception exception;
+    private volatile boolean successful;
+
+    @Override
+    public void onComplete(@NonNull Task<TResult> task) {
+        successful = task.isSuccessful();
+        if (successful) {
+            result = task.getResult();
+        } else {
+            exception = task.getException();
+        }
+        latch.countDown();
+    }
+
+    /** Blocks until the {@link #onComplete} is called. */
+    public TResult await() throws InterruptedException, ExecutionException, FirebaseAppDistributionException {
+        if (!latch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            throw new InterruptedException("timed out waiting for result");
+        }
+        if (successful) {
+            return result;
+        } else {
+            if (exception instanceof InterruptedException) {
+                throw (InterruptedException) exception;
+            }
+            if (exception instanceof FirebaseAppDistributionException) {
+                throw (FirebaseAppDistributionException) exception;
+            }
+            if (exception instanceof IOException) {
+                throw new ExecutionException(exception);
+            }
+            throw new IllegalStateException("got an unexpected exception type", exception);
+        }
+    }
+}
+


### PR DESCRIPTION
* Refactoring checkForUpdate client to use onSuccessTask instead of task completion source to prevent race conditions
* Adding unit tests to validated task response

PAIR: @rachaprince 