### PR TITLE
Add Index Encoding code from backend

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/DirectionalIndexByteEncoder.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/DirectionalIndexByteEncoder.java
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.index;
+
+import com.google.protobuf.ByteString;
+
+/** An index value encoder. */
+public abstract class DirectionalIndexByteEncoder {
+  // Note: This code is copied from the backend. Code that is not used by Firestore was removed.
+
+  public abstract void writeBytes(ByteString val);
+
+  public abstract void writeString(String val);
+
+  public abstract void writeLong(long val);
+
+  public abstract void writeDouble(double val);
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/FirestoreIndexValueWriter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/FirestoreIndexValueWriter.java
@@ -1,0 +1,169 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.index;
+
+import com.google.firebase.firestore.model.ResourcePath;
+import com.google.firestore.v1.ArrayValue;
+import com.google.firestore.v1.MapValue;
+import com.google.firestore.v1.Value;
+import com.google.protobuf.Timestamp;
+import com.google.type.LatLng;
+import java.util.Map;
+
+/**
+ * Firestore index value writer.
+ *
+ * <p>See the <a
+ * href="https://g3doc.corp.google.com/cloud/datastore/g3doc/architecture/spanner/storage_format.md">storage
+ * format design</a> for details.
+ */
+public class FirestoreIndexValueWriter {
+  // Note: This code is copied from the backend. Code that is not used by Firestore was removed.
+
+  public static final int INDEX_TYPE_NULL = 5;
+  public static final int INDEX_TYPE_BOOLEAN = 10;
+  public static final int INDEX_TYPE_NAN = 13;
+  public static final int INDEX_TYPE_NUMBER = 15;
+  public static final int INDEX_TYPE_TIMESTAMP = 10;
+  public static final int INDEX_TYPE_STRING = 25;
+  public static final int INDEX_TYPE_BLOB = 30;
+  public static final int INDEX_TYPE_REFERENCE = 37;
+  public static final int INDEX_TYPE_GEOPOINT = 45;
+  public static final int INDEX_TYPE_ARRAY = 50;
+  public static final int INDEX_TYPE_MAP = 55;
+  public static final int INDEX_TYPE_REFERENCE_SEGMENT = 60;
+
+  public static final FirestoreIndexValueWriter INSTANCE = new FirestoreIndexValueWriter();
+
+  private FirestoreIndexValueWriter() {}
+
+  // The write methods below short-circuit writing terminators for values containing a (terminating)
+  // truncated value.
+  //
+  // As an example, consider the resulting encoding for:
+  //
+  // ["bar", [2, "foo"]] -> (STRING, "bar", TERM, ARRAY, NUMBER, 2, STRING, "foo", TERM, TERM, TERM)
+  // ["bar", [2, truncated("foo")]] -> (STRING, "bar", TERM, ARRAY, NUMBER, 2, STRING, "foo", TRUNC)
+  // ["bar", truncated(["foo"])] -> (STRING, "bar", TERM, ARRAY. STRING, "foo", TERM, TRUNC)
+
+  /** Writes an index value. */
+  public void writeIndexValue(Value value, DirectionalIndexByteEncoder encoder) {
+    writeIndexValueAux(value, encoder);
+  }
+
+  private void writeIndexValueAux(Value indexValue, DirectionalIndexByteEncoder encoder) {
+    switch (indexValue.getValueTypeCase()) {
+      case NULL_VALUE:
+        writeValueTypeLabel(encoder, INDEX_TYPE_NULL);
+        break;
+      case BOOLEAN_VALUE:
+        writeValueTypeLabel(encoder, INDEX_TYPE_BOOLEAN);
+        encoder.writeLong(indexValue.getBooleanValue() ? 1 : 0);
+        break;
+      case DOUBLE_VALUE:
+        double number = indexValue.getDoubleValue();
+        if (Double.isNaN(number)) {
+          writeValueTypeLabel(encoder, INDEX_TYPE_NAN);
+          break;
+        }
+        writeValueTypeLabel(encoder, INDEX_TYPE_NUMBER);
+        encoder.writeDouble(number);
+        break;
+      case INTEGER_VALUE:
+        writeValueTypeLabel(encoder, INDEX_TYPE_NUMBER);
+        // Double and long sort the same
+        encoder.writeDouble(indexValue.getIntegerValue());
+        break;
+      case TIMESTAMP_VALUE:
+        Timestamp timestamp = indexValue.getTimestampValue();
+        writeValueTypeLabel(encoder, INDEX_TYPE_TIMESTAMP);
+        encoder.writeLong(timestamp.getSeconds());
+        encoder.writeLong(timestamp.getNanos());
+        break;
+      case STRING_VALUE:
+        writeIndexString(indexValue.getStringValue(), encoder);
+
+        break;
+      case BYTES_VALUE:
+        writeValueTypeLabel(encoder, INDEX_TYPE_BLOB);
+        encoder.writeBytes(indexValue.getBytesValue());
+        break;
+      case REFERENCE_VALUE:
+        writeIndexEntityRef(indexValue.getReferenceValue(), encoder);
+
+        break;
+      case GEO_POINT_VALUE:
+        LatLng geoPoint = indexValue.getGeoPointValue();
+        writeValueTypeLabel(encoder, INDEX_TYPE_GEOPOINT);
+        encoder.writeDouble(geoPoint.getLatitude());
+        encoder.writeDouble(geoPoint.getLongitude());
+        break;
+      case MAP_VALUE:
+        writeIndexMap(indexValue.getMapValue(), encoder);
+        break;
+      case ARRAY_VALUE:
+        writeIndexArray(indexValue.getArrayValue(), encoder);
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "unknown index value type " + indexValue.getValueTypeCase());
+    }
+  }
+
+  private void writeIndexString(String stringIndexValue, DirectionalIndexByteEncoder encoder) {
+    writeValueTypeLabel(encoder, INDEX_TYPE_STRING);
+    writeUnlabeledIndexString(stringIndexValue, encoder);
+  }
+
+  private void writeUnlabeledIndexString(
+      String stringIndexValue, DirectionalIndexByteEncoder encoder) {
+    encoder.writeString(stringIndexValue);
+  }
+
+  private void writeIndexMap(MapValue mapIndexValue, DirectionalIndexByteEncoder encoder) {
+    writeValueTypeLabel(encoder, INDEX_TYPE_MAP);
+    for (Map.Entry<String, Value> entry : mapIndexValue.getFieldsMap().entrySet()) {
+      String key = entry.getKey();
+      Value value = entry.getValue();
+      writeIndexString(key, encoder);
+      writeIndexValueAux(value, encoder);
+    }
+  }
+
+  private void writeIndexArray(ArrayValue arrayIndexValue, DirectionalIndexByteEncoder encoder) {
+    writeValueTypeLabel(encoder, INDEX_TYPE_ARRAY);
+    for (Value element : arrayIndexValue.getValuesList()) {
+      writeIndexValueAux(element, encoder);
+    }
+  }
+
+  private void writeIndexEntityRef(String referenceValue, DirectionalIndexByteEncoder encoder) {
+    writeValueTypeLabel(encoder, INDEX_TYPE_REFERENCE);
+
+    ResourcePath path = ResourcePath.fromString(referenceValue);
+
+    int numSegments = path.length();
+    for (int index = 6; index < numSegments; ++index) {
+      String segment = path.getSegment(index);
+
+      writeValueTypeLabel(encoder, INDEX_TYPE_REFERENCE_SEGMENT);
+      writeUnlabeledIndexString(segment, encoder);
+    }
+  }
+
+  private void writeValueTypeLabel(DirectionalIndexByteEncoder encoder, int typeOrder) {
+    encoder.writeLong(typeOrder);
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IntMath.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IntMath.java
@@ -1,0 +1,103 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.index;
+
+import static java.lang.Math.abs;
+import static java.math.RoundingMode.HALF_EVEN;
+import static java.math.RoundingMode.HALF_UP;
+
+import java.math.RoundingMode;
+
+/**
+ * A class for arithmetic on values of type {@code int}. Where possible, methods are defined and
+ * named analogously to their {@code BigInteger} counterparts.
+ *
+ * <p>The implementations of many methods in this class are based on material from Henry S. Warren,
+ * Jr.'s <i>Hacker's Delight</i>, (Addison Wesley, 2002).
+ *
+ * <p>Similar functionality for {@code long} and for {@link BigInteger} can be found in {@link
+ * LongMath} and {@link BigIntegerMath} respectively. For other common operations on {@code int}
+ * values, see {@link com.google.common.primitives.Ints}.
+ *
+ * @author Louis Wasserman
+ * @since 11.0
+ */
+public final class IntMath {
+  // Note: This code is copied from the backend. Code that is not used by Firestore was removed.
+
+  /**
+   * Returns the result of dividing {@code p} by {@code q}, rounding using the specified {@code
+   * RoundingMode}.
+   *
+   * @throws ArithmeticException if {@code q == 0}, or if {@code mode == UNNECESSARY} and {@code a}
+   *     is not an integer multiple of {@code b}
+   */
+  @SuppressWarnings("fallthrough")
+  public static int divide(int p, int q, RoundingMode mode) {
+    if (q == 0) {
+      throw new ArithmeticException("/ by zero"); // for GWT
+    }
+    int div = p / q;
+    int rem = p - q * div; // equal to p % q
+
+    if (rem == 0) {
+      return div;
+    }
+
+    /*
+     * Normal Java division rounds towards 0, consistently with RoundingMode.DOWN. We just have to
+     * deal with the cases where rounding towards 0 is wrong, which typically depends on the sign of
+     * p / q.
+     *
+     * signum is 1 if p and q are both nonnegative or both negative, and -1 otherwise.
+     */
+    int signum = 1 | ((p ^ q) >> (Integer.SIZE - 1));
+    boolean increment;
+    switch (mode) {
+      case UNNECESSARY:
+        // fall through
+      case DOWN:
+        increment = false;
+        break;
+      case UP:
+        increment = true;
+        break;
+      case CEILING:
+        increment = signum > 0;
+        break;
+      case FLOOR:
+        increment = signum < 0;
+        break;
+      case HALF_EVEN:
+      case HALF_DOWN:
+      case HALF_UP:
+        int absRem = abs(rem);
+        int cmpRemToHalfDivisor = absRem - (abs(q) - absRem);
+        // subtracting two nonnegative ints can't overflow
+        // cmpRemToHalfDivisor has the same sign as compare(abs(rem), abs(q) / 2).
+        if (cmpRemToHalfDivisor == 0) { // exactly on the half mark
+          increment = (mode == HALF_UP || (mode == HALF_EVEN & (div & 1) != 0));
+        } else {
+          increment = cmpRemToHalfDivisor > 0; // closer to the UP value
+        }
+        break;
+      default:
+        throw new AssertionError();
+    }
+    return increment ? div + signum : div;
+  }
+
+  private IntMath() {}
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/OrderedCodeReader.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/OrderedCodeReader.java
@@ -1,0 +1,262 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.index;
+
+import static com.google.firebase.firestore.index.OrderedCodeWriter.ESCAPE1;
+import static com.google.firebase.firestore.index.OrderedCodeWriter.ESCAPE2;
+import static com.google.firebase.firestore.index.OrderedCodeWriter.FF_BYTE;
+import static com.google.firebase.firestore.index.OrderedCodeWriter.NULL_BYTE;
+import static com.google.firebase.firestore.index.OrderedCodeWriter.SEPARATOR;
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_HIGH_SURROGATE;
+import static java.lang.Character.MIN_LOW_SURROGATE;
+import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
+import static java.lang.Character.MIN_SURROGATE;
+
+/**
+ * OrderedCodeReader is a minimal-allocation implementation of the reading behavior defined by
+ * {@link com.google.bigtable.util.OrderedCode}.
+ *
+ * <p>This class will throw {@link IllegalArgumentException} on invalid input.
+ */
+public class OrderedCodeReader {
+  // Note: This code is copied from the backend. Code that is not used by Firestore was removed.
+
+  /**
+   * This array maps encoding lengths to the header bits that overlap with the payload and need
+   * fixing during ReadSignedLongIncreasing.
+   */
+  private static final long[] LENGTH_TO_MASK = {
+    0L,
+    0x80L,
+    0xc000L,
+    0xe00000L,
+    0xf0000000L,
+    0xf800000000L,
+    0xfc0000000000L,
+    0xfe000000000000L,
+    0xff00000000000000L,
+    0x8000000000000000L,
+    0L
+  };
+
+  // Buffer state
+  private final byte[] buffer;
+  private int position;
+
+  private final StringBuilder stringBuilder = new StringBuilder();
+
+  /** Constructs an reader for bytes encoded in ordered code format. */
+  public OrderedCodeReader(byte[] buffer) {
+    this.buffer = buffer;
+  }
+
+  /** Reads an UTF-8 encoded string that was written in ascending form. */
+  public String readUtf8Ascending() {
+    stringBuilder.setLength(0);
+    int numBytes = findSeparatorAscending();
+    for (int i = 0; i < numBytes; ) {
+      byte b = readAscendingByte();
+      if (Utf8Bytes.isOneByte(b)) {
+        Utf8Bytes.handleOneByte(b, stringBuilder);
+        ++i;
+      } else if (Utf8Bytes.isTwoBytes(b)) {
+        Utf8Bytes.handleTwoBytes(b, readAscendingByte(), stringBuilder);
+        i += 2;
+      } else if (Utf8Bytes.isThreeBytes(b)) {
+        Utf8Bytes.handleThreeBytes(b, readAscendingByte(), readAscendingByte(), stringBuilder);
+        i += 3;
+      } else {
+        Utf8Bytes.handleFourBytes(
+            b, readAscendingByte(), readAscendingByte(), readAscendingByte(), stringBuilder);
+        i += 4;
+      }
+    }
+    readSeparatorAscending();
+    return stringBuilder.toString();
+  }
+
+  /** Reads an unsigned long that was encoded in ascending form. */
+  public long readUnsignedLongAscending() {
+    int len = buffer[position];
+    if (len > Long.BYTES) {
+      throw invalidOrderedCode();
+    }
+    ++position;
+    int end = position + len;
+    long result = 0;
+    while (position < end) {
+      result <<= 8;
+      result |= buffer[position++] & 0xff;
+    }
+    return result;
+  }
+
+  /** Return the position of the current encoder. Intended to be used with {@link #seek(int)}. */
+  public int position() {
+    return position;
+  }
+
+  /** Sets the position of the current encoder. Intended to be used with {@link #position()}. */
+  public void seek(int pos) {
+    position = pos;
+  }
+
+  /** Checks if there are remaining bytes left in buffer. */
+  public boolean hasRemainingBytes() {
+    return position < buffer.length;
+  }
+
+  /**
+   * Find the next ascending separator, return the number of decoded bytes until (but not including)
+   * the separator.
+   */
+  private int findSeparatorAscending() {
+    int numBytes = 0;
+    for (int i = position; i < buffer.length; ++i) {
+      if (buffer[i] == ESCAPE1 && buffer[i + 1] == SEPARATOR) {
+        return numBytes;
+      } else if (buffer[i] == ESCAPE1) {
+        ++i;
+      } else if (buffer[i] == ESCAPE2) {
+        ++i;
+      }
+      ++numBytes;
+    }
+    throw new IllegalArgumentException("Invalid encoded byte array");
+  }
+
+  /** Reads an ascending separator value. */
+  public void readSeparatorAscending() {
+    if (buffer[position] == ESCAPE1 && buffer[position + 1] == SEPARATOR) {
+      position += 2;
+      return;
+    }
+    throw invalidOrderedCode();
+  }
+
+  private byte readAscendingByte() {
+    byte b = buffer[position++];
+    if (b == ESCAPE1) {
+      b = buffer[position++];
+      // Separator is not valid to read here.
+      if (b != NULL_BYTE) {
+        throw invalidOrderedCode();
+      }
+      return ESCAPE1;
+    } else if (b == ESCAPE2) {
+      b = buffer[position++];
+      // Infinity is not valid to read here.
+      if (b != FF_BYTE) {
+        throw invalidOrderedCode();
+      }
+      return ESCAPE2;
+    } else {
+      return b;
+    }
+  }
+
+  private static IllegalArgumentException invalidOrderedCode() {
+    return new IllegalArgumentException("invalid ordered code bytes");
+  }
+
+  /** Utility methods for decoding bytes into {@link StringBuilder}. */
+  private static class Utf8Bytes {
+
+    /** Returns whether this is a single-byte codepoint (i.e., ASCII) with the form '0XXXXXXX'. */
+    private static boolean isOneByte(byte b) {
+      return b >= 0;
+    }
+
+    /**
+     * Returns whether this is a two-byte codepoint with the form '10XXXXXX' iff {@link
+     * #isOneByte(byte)} is false.
+     */
+    private static boolean isTwoBytes(byte b) {
+      return b < (byte) 0xE0;
+    }
+
+    /**
+     * Returns whether this is a three-byte codepoint with the form '110XXXXX' iff {@link
+     * #isTwoBytes(byte)} is false.
+     */
+    private static boolean isThreeBytes(byte b) {
+      return b < (byte) 0xF0;
+    }
+
+    private static void handleOneByte(byte byte1, StringBuilder builder) {
+      builder.append((char) byte1);
+    }
+
+    private static void handleTwoBytes(byte byte1, byte byte2, StringBuilder builder) {
+      char c = (char) (((byte1 & 0x1F) << 6) | trailingByteValue(byte2));
+      if (c < '\u0080') {
+        throw new IllegalArgumentException("invalid utf8");
+      }
+      builder.append(c);
+    }
+
+    public static boolean isSurrogate(char ch) {
+      return ch >= MIN_SURROGATE && ch < (MAX_SURROGATE + 1);
+    }
+
+    public static boolean isBmpCodePoint(int codePoint) {
+      return codePoint >>> 16 == 0;
+    }
+
+    public static char highSurrogate(int codePoint) {
+      return (char)
+          ((codePoint >>> 10) + (MIN_HIGH_SURROGATE - (MIN_SUPPLEMENTARY_CODE_POINT >>> 10)));
+    }
+
+    public static char lowSurrogate(int codePoint) {
+      return (char) ((codePoint & 0x3ff) + MIN_LOW_SURROGATE);
+    }
+
+    private static void handleThreeBytes(
+        byte byte1, byte byte2, byte byte3, StringBuilder builder) {
+      char c =
+          (char)
+              (((byte1 & 0x0F) << 12) | (trailingByteValue(byte2) << 6) | trailingByteValue(byte3));
+      if (c < 0x800 || isSurrogate(c)) {
+        throw new IllegalArgumentException("invalid utf8");
+      }
+      builder.append(c);
+    }
+
+    private static void handleFourBytes(
+        byte byte1, byte byte2, byte byte3, byte byte4, StringBuilder builder) {
+      int codepoint =
+          ((byte1 & 0x07) << 18)
+              | (trailingByteValue(byte2) << 12)
+              | (trailingByteValue(byte3) << 6)
+              | trailingByteValue(byte4);
+      if (isBmpCodePoint(codepoint)) {
+        throw new IllegalArgumentException("invalid utf8");
+      }
+      builder.append(highSurrogate(codepoint));
+      builder.append(lowSurrogate(codepoint));
+    }
+
+    /** Returns the actual value of the trailing byte (removes the prefix '10') for composition. */
+    private static int trailingByteValue(byte b) {
+      // Verify that the byte is of the form '10XXXXXX'.  (Type byte is signed.)
+      if (b > (byte) 0xBF) {
+        throw new IllegalArgumentException("invalid utf8");
+      }
+      return b & 0x3F;
+    }
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/OrderedCodeWriter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/OrderedCodeWriter.java
@@ -1,0 +1,348 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.index;
+
+import static java.lang.Character.MAX_SURROGATE;
+import static java.lang.Character.MIN_SURROGATE;
+
+import com.google.protobuf.ByteString;
+import java.math.RoundingMode;
+import java.util.Arrays;
+
+/**
+ * OrderedCodeWriter is a minimal-allocation implmentation of the writing behavior defined by {@link
+ * com.google.bigtable.util.OrderedCode}.
+ */
+public class OrderedCodeWriter {
+  // Note: This code is copied from the backend. Code that is not used by Firestore was removed.
+
+  public static final byte ESCAPE1 = 0x00;
+  public static final byte NULL_BYTE = (byte) 0xff; // Combined with ESCAPE1
+  public static final byte SEPARATOR = 0x01; // Combined with ESCAPE1
+
+  public static final byte ESCAPE2 = (byte) 0xff;
+  public static final byte INFINITY = (byte) 0xff; // Combined with ESCAPE2
+  public static final byte FF_BYTE = 0x00; // Combined with ESCAPE2
+
+  /**
+   * These constants are based on {@link
+   * com.google.storage.megastore.metadata.adapters.DoubleAdapter}, see
+   * OrderedCodeWriter::writeDoubleAscending for details.
+   */
+  public static final long DOUBLE_SIGN_MASK = 0x8000000000000000L;
+
+  public static final long DOUBLE_ALL_BITS = 0xFFFFFFFFFFFFFFFFL;
+  /**
+   * The default size of the buffer. This is arbitrary, but likely larger than most index values so
+   * that less copies of the underlying buffer will be made. For large values, a single copy will
+   * made to double the buffer length.
+   */
+  private static final int DEFAULT_BUFFER_SIZE = 1024;
+
+  /**
+   * This array maps encoding length to header bits in the first two bytes for SignedNumAscending
+   * encoding.
+   */
+  private static final byte[][] LENGTH_TO_HEADER_BITS = {
+    {0, 0},
+    {(byte) 0x80, 0},
+    {(byte) 0xc0, 0},
+    {(byte) 0xe0, 0},
+    {(byte) 0xf0, 0},
+    {(byte) 0xf8, 0},
+    {(byte) 0xfc, 0},
+    {(byte) 0xfe, 0},
+    {(byte) 0xff, 0},
+    {(byte) 0xff, (byte) 0x80},
+    {(byte) 0xff, (byte) 0xc0}
+  };
+
+  private byte[] buffer;
+  private int position = 0;
+
+  /** Creates a new writer with a default initial buffer size. */
+  public OrderedCodeWriter() {
+    buffer = new byte[DEFAULT_BUFFER_SIZE];
+  }
+
+  public void writeBytesAscending(ByteString value) {
+    for (int i = 0; i < value.size(); ++i) {
+      writeByteAscending(value.byteAt(i));
+    }
+    writeSeparatorAscending();
+  }
+
+  public void writeBytesDescending(ByteString value) {
+    for (int i = 0; i < value.size(); ++i) {
+      writeByteDescending(value.byteAt(i));
+    }
+    writeSeparatorDescending();
+  }
+
+  /**
+   * Writes utf8 bytes into this byte sequence, ascending.
+   *
+   * <p>This is a more efficent version of writeBytesAscending(str.getBytes(UTF_8));
+   */
+  public void writeUtf8Ascending(CharSequence sequence) {
+    int utf16Length = sequence.length();
+    for (int i = 0; i < utf16Length; i++) {
+      char c = sequence.charAt(i);
+      if (c < 0x80) {
+        writeByteAscending((byte) c);
+      } else if (c < 0x800) {
+        writeByteAscending((byte) ((0xF << 6) | (c >>> 6)));
+        writeByteAscending((byte) (0x80 | (0x3F & c)));
+      } else if ((c < MIN_SURROGATE || MAX_SURROGATE < c)) {
+        writeByteAscending((byte) ((0xF << 5) | (c >>> 12)));
+        writeByteAscending((byte) (0x80 | (0x3F & (c >>> 6))));
+        writeByteAscending((byte) (0x80 | (0x3F & c)));
+      } else {
+        final int codePoint = Character.codePointAt(sequence, i);
+        ++i; // Skip the low surrogate.
+        writeByteAscending((byte) ((0xF << 4) | (codePoint >>> 18)));
+        writeByteAscending((byte) (0x80 | (0x3F & (codePoint >>> 12))));
+        writeByteAscending((byte) (0x80 | (0x3F & (codePoint >>> 6))));
+        writeByteAscending((byte) (0x80 | (0x3F & codePoint)));
+      }
+    }
+    writeSeparatorAscending();
+  }
+
+  /**
+   * Writes utf8 bytes into this byte sequence, descending.
+   *
+   * <p>This is a more efficent version of writeBytesDescending(str.getBytes(UTF_8));
+   */
+  public void writeUtf8Descending(CharSequence sequence) {
+    int utf16Length = sequence.length();
+    for (int i = 0; i < utf16Length; i++) {
+      char c = sequence.charAt(i);
+      if (c < 0x80) {
+        writeByteDescending((byte) c);
+      } else if (c < 0x800) {
+        writeByteDescending((byte) ((0xF << 6) | (c >>> 6)));
+        writeByteDescending((byte) (0x80 | (0x3F & c)));
+      } else if ((c < MIN_SURROGATE || MAX_SURROGATE < c)) {
+        writeByteDescending((byte) ((0xF << 5) | (c >>> 12)));
+        writeByteDescending((byte) (0x80 | (0x3F & (c >>> 6))));
+        writeByteDescending((byte) (0x80 | (0x3F & c)));
+      } else {
+        final int codePoint = Character.codePointAt(sequence, i);
+        ++i; // Skip the low surrogate.
+        writeByteDescending((byte) ((0xF << 4) | (codePoint >>> 18)));
+        writeByteDescending((byte) (0x80 | (0x3F & (codePoint >>> 12))));
+        writeByteDescending((byte) (0x80 | (0x3F & (codePoint >>> 6))));
+        writeByteDescending((byte) (0x80 | (0x3F & codePoint)));
+      }
+    }
+    writeSeparatorDescending();
+  }
+
+  /** Writes an unsigned long in the ordered code format, ascending. */
+  public void writeUnsignedLongAscending(long value) {
+    // Values are encoded with a single byte length prefix, followed
+    // by the actual value in big-endian format with leading 0 bytes
+    // dropped.
+    int len = unsignedNumLength(value);
+    ensureAvailable(1 + len);
+    buffer[position++] = (byte) len; // Write the length
+    for (int i = position + len - 1; i >= position; --i) {
+      buffer[i] = (byte) (value & 0xff);
+      value >>>= 8;
+    }
+    position += len;
+  }
+
+  /** Writes an unsigned long in the ordered code format, descending. */
+  public void writeUnsignedLongDescending(long value) {
+    // Values are encoded with a complemented single byte length prefix,
+    // followed by the complement of the actual value in big-endian format with
+    // leading 0xff bytes dropped.
+    int len = unsignedNumLength(value);
+    ensureAvailable(1 + len);
+    buffer[position++] = (byte) ~len; // Write the length
+    for (int i = position + len - 1; i >= position; --i) {
+      buffer[i] = (byte) ~(value & 0xff);
+      value >>>= 8;
+    }
+    position += len;
+  }
+
+  /** Writes a signed long in the ordered code format, ascending. */
+  public void writeSignedLongAscending(long value) {
+    long val = value < 0 ? ~value : value;
+    if (val < 64) { // Fast path for encoding length == 1
+      ensureAvailable(1);
+      buffer[position++] = ((byte) (LENGTH_TO_HEADER_BITS[1][0] ^ value));
+      return;
+    }
+    int len = signedNumLength(val);
+    ensureAvailable(len);
+    // We should handle all encoding length == 1 above.
+    if (len < 2) {
+      throw new AssertionError(
+          String.format("Invalid length (%d) returned by signedNumLength", len));
+    }
+    byte signByte = value < 0 ? (byte) 0xff : 0;
+    int startIndex = position;
+    // Sign extend longs that are encoded as 9 or 10 bytes.
+    if (len == 10) {
+      startIndex += 2;
+      buffer[position] = signByte;
+      buffer[position + 1] = signByte;
+    } else if (len == 9) {
+      startIndex += 1;
+      buffer[position] = signByte;
+    }
+    // Encode the long big-endian
+    long x = value;
+    for (int i = len - 1 + position; i >= startIndex; --i) {
+      buffer[i] = (byte) (x & 0xffL);
+      x >>= 8;
+    }
+    // Encode the length in header bits.
+    buffer[position] ^= LENGTH_TO_HEADER_BITS[len][0];
+    buffer[position + 1] ^= LENGTH_TO_HEADER_BITS[len][1];
+    position += len;
+  }
+
+  /** Writes a signed long in the ordered code format, descending. */
+  public void writeSignedLongDescending(long value) {
+    writeSignedLongAscending(~value);
+  }
+
+  public void writeDoubleAscending(double val) {
+    // Based on com.google.storage.megastore.metadata.adapters.DoubleAdapter.
+    // This particular encoding has the following properties:
+    // The order matches the IEEE 754 floating-point comparison results with the
+    // following exceptions:
+    //   -0.0 < 0.0
+    //   all non-NaN < NaN
+    //   NaN = NaN
+    long v = Double.doubleToLongBits(val);
+    v ^= (v < 0) ? DOUBLE_ALL_BITS : DOUBLE_SIGN_MASK;
+    writeUnsignedLongAscending(v);
+  }
+
+  public void writeDoubleDescending(double val) {
+    // See note in #writeDoubleAscending
+    long v = Double.doubleToLongBits(val);
+    v ^= (v < 0) ? DOUBLE_ALL_BITS : DOUBLE_SIGN_MASK;
+    writeUnsignedLongDescending(v);
+  }
+
+  /** Resets the buffer such that it is the same as when it was newly constructed. */
+  public void reset() {
+    position = 0;
+  }
+
+  /** Makes a copy of the encoded bytes in this buffer. */
+  public byte[] encodedBytes() {
+    return Arrays.copyOf(buffer, position);
+  }
+
+  /**
+   * Writes a single byte ascending to the buffer, doing proper escaping as described in {@link
+   * OrderedCodeConstants}.
+   */
+  private void writeByteAscending(byte b) {
+    if (b == ESCAPE1) {
+      writeEscapedByteAscending(ESCAPE1);
+      writeEscapedByteAscending(NULL_BYTE);
+    } else if (b == ESCAPE2) {
+      writeEscapedByteAscending(ESCAPE2);
+      writeEscapedByteAscending(FF_BYTE);
+    } else {
+      writeEscapedByteAscending(b);
+    }
+  }
+
+  /**
+   * Writes a single byte descending to the buffer, doing proper escaping as described in {@link
+   * OrderedCodeConstants}.
+   */
+  private void writeByteDescending(byte b) {
+    if (b == ESCAPE1) {
+      writeEscapedByteDescending(ESCAPE1);
+      writeEscapedByteDescending(NULL_BYTE);
+    } else if (b == ESCAPE2) {
+      writeEscapedByteDescending(ESCAPE2);
+      writeEscapedByteDescending(FF_BYTE);
+    } else {
+      writeEscapedByteDescending(b);
+    }
+  }
+
+  private void writeSeparatorAscending() {
+    writeEscapedByteAscending(ESCAPE1);
+    writeEscapedByteAscending(SEPARATOR);
+  }
+
+  private void writeSeparatorDescending() {
+    writeEscapedByteDescending(ESCAPE1);
+    writeEscapedByteDescending(SEPARATOR);
+  }
+
+  private void writeEscapedByteAscending(byte b) {
+    ensureAvailable(1);
+    buffer[position++] = b;
+  }
+
+  private void writeEscapedByteDescending(byte b) {
+    ensureAvailable(1);
+    buffer[position++] = (byte) ~b;
+  }
+
+  private void ensureAvailable(int bytes) {
+    int minCapacity = bytes + position;
+    if (minCapacity <= buffer.length) {
+      return;
+    }
+    // Try doubling.
+    int newLength = buffer.length * 2;
+    // Still not big enough? Just allocate the right size.
+    if (newLength < minCapacity) {
+      newLength = minCapacity;
+    }
+    // Create the new buffer.
+    buffer = Arrays.copyOf(buffer, newLength);
+  }
+
+  private int signedNumLength(long n) {
+    // Handle negative numbers.
+    if (n < 0) {
+      n = ~n;
+    }
+    // Compute the number of bits.
+    int numBits = Long.SIZE - Long.numberOfLeadingZeros(n);
+    // Add a bit for sign.
+    ++numBits;
+    // Compute the number of encoded bytes.
+    int bitsPerEncodedByte = 7;
+    return IntMath.divide(numBits, bitsPerEncodedByte, RoundingMode.UP);
+  }
+
+  private int unsignedNumLength(long value) {
+    // This is just the number of bytes for the unsigned representation of the number.
+    int numBits = Long.SIZE - Long.numberOfLeadingZeros(value);
+    return IntMath.divide(numBits, Byte.SIZE, RoundingMode.UP);
+  }
+
+  public void seed(byte[] encodedBytes) {
+    ensureAvailable(encodedBytes.length);
+    for (byte b : encodedBytes) buffer[position++] = b;
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/package-info.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/package-info.java
@@ -1,0 +1,19 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @hide */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+package com.google.firebase.firestore.index;
+
+import androidx.annotation.RestrictTo;


### PR DESCRIPTION
This adds the Index Encoding code that the backend uses to encode field values to index entries. Datastore-only features are removed and otherwise unused methods were removed.