### PR TITLE
Increase connected check timeout for Firestore to 30m

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/device/FirebaseTestLabExtension.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/device/FirebaseTestLabExtension.java
@@ -16,12 +16,14 @@ package com.google.firebase.gradle.plugins.ci.device;
 
 import java.util.Collections;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.SetProperty;
 
 public class FirebaseTestLabExtension {
   private final SetProperty<String> devices;
+  private String timeout;
   private boolean enabled;
 
   @Inject
@@ -41,10 +43,19 @@ public class FirebaseTestLabExtension {
     devices.add(device);
   }
 
+  public void timeout(String timeout) {
+    this.timeout = timeout;
+  }
+
   Set<String> getDevices() {
     if (devices.get().isEmpty()) {
       return Collections.singleton("model=Pixel2,version=27,locale=en,orientation=portrait");
     }
     return devices.get();
+  }
+
+  @Nullable
+  public String getTimeout() {
+    return timeout;
   }
 }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/device/FirebaseTestServer.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/device/FirebaseTestServer.java
@@ -89,6 +89,9 @@ public class FirebaseTestServer extends TestServer {
             .flatMap(device -> ImmutableList.of("--device", device).stream())
             .collect(Collectors.toList()));
 
+    Optional.ofNullable(extension.getTimeout())
+        .ifPresent(timeout -> args.add("--timeout", timeout));
+
     Optional.ofNullable(System.getenv("FTL_RESULTS_BUCKET"))
         .map(Environment::expand)
         .ifPresent(bucket -> args.add("--results-bucket", bucket));

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -20,6 +20,10 @@ plugins {
 firebaseLibrary {
     testLab.enabled = true
     publishSources = true
+    testLab {
+        enabled = true
+        timeout = '30m'
+    }
 }
 
 protobuf {

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -18,7 +18,6 @@ plugins {
 }
 
 firebaseLibrary {
-    testLab.enabled = true
     publishSources = true
     testLab {
         enabled = true


### PR DESCRIPTION
This change seems to be required to get the conformance tests to pass - see https://github.com/firebase/firebase-android-sdk/pull/2861