### PR TITLE
Migrate AnnotationValue#toString to auto-common's AnnotationValues.toString

### DIFF
--- a/encoders/firebase-encoders-processor/firebase-encoders-processor.gradle
+++ b/encoders/firebase-encoders-processor/firebase-encoders-processor.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'com.squareup:javapoet:1.13.0'
     compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.google.guava:guava:28.1-jre'
-
+    implementation 'com.google.auto:auto-common:1.1.2'
     implementation "com.google.auto.value:auto-value-annotations:1.6.6"
 
     annotationProcessor "com.google.auto.value:auto-value:1.6.5"

--- a/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
+++ b/encoders/firebase-encoders-processor/src/main/java/com/google/firebase/encoders/processor/EncodableProcessor.java
@@ -15,6 +15,7 @@
 package com.google.firebase.encoders.processor;
 
 import androidx.annotation.VisibleForTesting;
+import com.google.auto.common.AnnotationValues;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ArrayListMultimap;
@@ -290,7 +291,8 @@ public class EncodableProcessor extends AbstractProcessor {
                       ClassName.get((TypeElement) desc.type().getAnnotationType().asElement()));
               codeBuilder.add(".withProperty($T.builder()\n", annotationBuilder);
               for (AnnotationProperty property : desc.properties()) {
-                codeBuilder.add("$>.$L($L)\n$<", property.name(), property.value());
+                codeBuilder.add(
+                    "$>.$L($L)\n$<", property.name(), AnnotationValues.toString(property.value()));
               }
               codeBuilder.add("$>.build())\n$<");
             }


### PR DESCRIPTION

This change will cause the string representation to use qualified names e.g. @com.google.Foo(value = com.google.Bar.BAZ). The latest versions of javac no longer use qualified names in the implementation of AnnotationValue#toString, so you get something like @Foo(value = Bar.BAZ).

This change is important primarily for code that uses the toString() representation in generated source code, since simple names may fail to compile unless additional imports are added. It is still worth considering for code that uses the string representation in diagnostics or assertion messages, since it makes it clearer which type is being referred to.