### PR TITLE
FAD reintroduce terminal states to UpdateStatus 

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
@@ -164,6 +164,7 @@ class UpdateApkClient {
       // check that file is actual JAR
       new JarFile(apkFile);
     } catch (Exception e) {
+      postUpdateProgress(totalSize, bytesDownloaded, UpdateStatus.DOWNLOAD_FAILED);
       setDownloadTaskCompletionError(
           new FirebaseAppDistributionException(
               Constants.ErrorMessages.NETWORK_ERROR,

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.CancellationTokenSource;
 import com.google.android.gms.tasks.Task;
@@ -280,5 +281,10 @@ class UpdateApkClient {
     } else {
       postUpdateProgress(fileLength, fileLength, UpdateStatus.INSTALL_FAILED);
     }
+  }
+
+  @RestrictTo(RestrictTo.Scope.TESTS)
+  void setCachedUpdateTask(UpdateTaskImpl updateTask) {
+    this.cachedUpdateTask = updateTask;
   }
 }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateStatus.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateStatus.java
@@ -28,9 +28,6 @@ public enum UpdateStatus {
   /** Download failed */
   DOWNLOAD_FAILED,
 
-  /** Update installed */
-  INSTALLED,
-
   /** Installation canceled */
   INSTALL_CANCELED,
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateStatus.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateStatus.java
@@ -25,6 +25,18 @@ public enum UpdateStatus {
   /** Download completed */
   DOWNLOADED,
 
+  /** Download failed */
+  DOWNLOAD_FAILED,
+
+  /** Update installed */
+  INSTALLED,
+
+  /** Installation canceled */
+  INSTALL_CANCELED,
+
+  /** Installation failed */
+  INSTALL_FAILED,
+
   /** AAB flow (directed to Play) */
   REDIRECTED_TO_PLAY,
 }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateApkClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateApkClientTest.java
@@ -30,7 +30,6 @@ import com.google.firebase.FirebaseOptions;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import javax.net.ssl.HttpsURLConnection;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +56,6 @@ public class UpdateApkClientTest {
   private UpdateApkClient updateApkClient;
   private TestActivity activity;
   private ShadowActivity shadowActivity;
-  private CountDownLatch latch;
   @Mock private File mockFile;
   @Mock private HttpsURLConnection mockHttpsUrlConnection;
 
@@ -90,13 +88,16 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenDownloadFails_setsNetworkError() throws Exception {
+    List<UpdateProgress> progressEvents = new ArrayList<>();
     UpdateTaskImpl updateTask = new UpdateTaskImpl();
+    updateTask.addOnProgressListener(progressEvents::add);
     doReturn(mockHttpsUrlConnection).when(updateApkClient).openHttpsUrlConnection(TEST_URL);
     // null inputStream causes download failure
     when(mockHttpsUrlConnection.getInputStream()).thenReturn(null);
     updateApkClient.updateApk(updateTask, TEST_URL, activity);
     // wait for error to be caught and set
     Thread.sleep(1000);
+
     assertFalse(updateTask.isSuccessful());
     assertTrue(updateTask.getException() instanceof FirebaseAppDistributionException);
     FirebaseAppDistributionException e =
@@ -109,7 +110,7 @@ public class UpdateApkClientTest {
   public void updateApk_whenInstallSuccessful_setsResult() throws Exception {
     List<UpdateProgress> progressEvents = new ArrayList<>();
     UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL, updateTask);
+    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL);
     updateTask.addOnProgressListener(progressEvents::add);
 
     updateApkClient.updateApk(updateTask, TEST_URL, activity);
@@ -121,7 +122,7 @@ public class UpdateApkClientTest {
         UpdateProgress.builder()
             .setApkBytesDownloaded(TEST_FILE_LENGTH)
             .setApkFileTotalBytes(TEST_FILE_LENGTH)
-            .setUpdateStatus(UpdateStatus.DOWNLOADED)
+            .setUpdateStatus(UpdateStatus.INSTALLED)
             .build(),
         progressEvents.get(0));
     assertTrue(updateTask.isSuccessful());
@@ -129,14 +130,18 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenInstallCancelled_setsError() throws Exception {
+    List<UpdateProgress> progressEvents = new ArrayList<>();
     UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL, updateTask);
+    updateTask.addOnProgressListener(progressEvents::add);
+    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL);
 
     updateApkClient.updateApk(updateTask, TEST_URL, activity);
     // sleep to wait for installTaskCompletionSource to be set
     Thread.sleep(1000);
     updateApkClient.setInstallationResult(RESULT_CANCELED);
 
+    assertEquals(1, progressEvents.size());
+    assertEquals(UpdateStatus.INSTALL_CANCELED, progressEvents.get(0).getUpdateStatus());
     assertFalse(updateTask.isSuccessful());
     assertTrue(updateTask.getException() instanceof FirebaseAppDistributionException);
     FirebaseAppDistributionException e =
@@ -147,14 +152,18 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenInstallFailed_setsError() throws Exception {
+    List<UpdateProgress> progressEvents = new ArrayList<>();
     UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL, updateTask);
+    updateTask.addOnProgressListener(progressEvents::add);
+    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL);
 
     updateApkClient.updateApk(updateTask, TEST_URL, activity);
     // sleep to wait for installTaskCompletionSource to be set
     Thread.sleep(1000);
     updateApkClient.setInstallationResult(RESULT_FAILED);
 
+    assertEquals(1, progressEvents.size());
+    assertEquals(UpdateStatus.INSTALL_FAILED, progressEvents.get(0).getUpdateStatus());
     assertFalse(updateTask.isSuccessful());
     assertTrue(updateTask.getException() instanceof FirebaseAppDistributionException);
     FirebaseAppDistributionException e =
@@ -165,9 +174,8 @@ public class UpdateApkClientTest {
 
   @Test
   public void downloadApk_whenCalledMultipleTimes_returnsSameTask() {
-    UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    Task<File> task1 = updateApkClient.downloadApk(TEST_URL, updateTask);
-    Task<File> task2 = updateApkClient.downloadApk(TEST_URL, updateTask);
+    Task<File> task1 = updateApkClient.downloadApk(TEST_URL);
+    Task<File> task2 = updateApkClient.downloadApk(TEST_URL);
     assertEquals(task1, task2);
   }
 }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateApkClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateApkClientTest.java
@@ -108,23 +108,13 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenInstallSuccessful_setsResult() throws Exception {
-    List<UpdateProgress> progressEvents = new ArrayList<>();
     UpdateTaskImpl updateTask = new UpdateTaskImpl();
     doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL);
-    updateTask.addOnProgressListener(progressEvents::add);
 
     updateApkClient.updateApk(updateTask, TEST_URL, activity);
     // sleep to wait for installTaskCompletionSource to be set
     Thread.sleep(1000);
     updateApkClient.setInstallationResult(RESULT_OK);
-    assertEquals(1, progressEvents.size());
-    assertEquals(
-        UpdateProgress.builder()
-            .setApkBytesDownloaded(TEST_FILE_LENGTH)
-            .setApkFileTotalBytes(TEST_FILE_LENGTH)
-            .setUpdateStatus(UpdateStatus.INSTALLED)
-            .build(),
-        progressEvents.get(0));
     assertTrue(updateTask.isSuccessful());
   }
 

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateApkClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateApkClientTest.java
@@ -88,9 +88,7 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenDownloadFails_setsNetworkError() throws Exception {
-    List<UpdateProgress> progressEvents = new ArrayList<>();
     UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    updateTask.addOnProgressListener(progressEvents::add);
     doReturn(mockHttpsUrlConnection).when(updateApkClient).openHttpsUrlConnection(TEST_URL);
     // null inputStream causes download failure
     when(mockHttpsUrlConnection.getInputStream()).thenReturn(null);


### PR DESCRIPTION
- Add back terminal states for UpdateStatus
- made the updateTaskImpl passed in to the updateApk method a class variable (cachedUpdateTask) inside updateApkClient since it is reused a lot and setInstallationResult would not be able to access it otherwise 
- Set terminal states in updateProgress in updateApkClient 
- Update APK tests to test for correct status being set 