### PR TITLE
Fix update app synchronization issues

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -44,7 +44,6 @@ public class FirebaseAppDistribution implements Application.ActivityLifecycleCal
 
   private Task<Void> cachedUpdateToLatestReleaseTask;
   private Task<AppDistributionRelease> cachedCheckForUpdateTask;
-  private UpdateTaskImpl cachedUpdateAppTask;
   private AppDistributionReleaseInternal cachedLatestRelease;
   private final SignInStorage signInStorage;
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
@@ -89,7 +89,7 @@ public class FirebaseAppDistributionException extends FirebaseException {
   }
 
   /** Get cached release when error was thrown */
-  @NonNull
+  @Nullable
   public AppDistributionRelease getRelease() {
     return release;
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/ReleaseUtils.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/ReleaseUtils.java
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import com.google.firebase.appdistribution.internal.AppDistributionReleaseInternal;
+
+class ReleaseUtils {
+  static AppDistributionRelease convertToAppDistributionRelease(
+      AppDistributionReleaseInternal internalRelease) {
+    if (internalRelease == null) {
+      return null;
+    }
+    long versionCode;
+    try {
+      versionCode = Long.parseLong(internalRelease.getBuildVersion());
+    } catch (NumberFormatException e) {
+      versionCode = 0;
+    }
+    return AppDistributionRelease.builder()
+        .setVersionCode(versionCode)
+        .setDisplayVersion(internalRelease.getDisplayVersion())
+        .setReleaseNotes(internalRelease.getReleaseNotes())
+        .setBinaryType(internalRelease.getBinaryType())
+        .build();
+  }
+}

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
@@ -24,7 +24,6 @@ import android.util.Log;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.CancellationTokenSource;
 import com.google.android.gms.tasks.Task;
@@ -43,8 +42,7 @@ import javax.net.ssl.HttpsURLConnection;
 
 /** Client class that handles updateApp functionality for APKs in {@link UpdateAppClient}. */
 class UpdateApkClient {
-
-  private final int UPDATE_INTERVAL_MS = 250;
+  private static final int UPDATE_INTERVAL_MS = 250;
   private static final String TAG = "FADUpdateAppClient";
   private static final String REQUEST_METHOD = "GET";
   private final FirebaseAppDistributionNotificationsManager appDistributionNotificationsManager;
@@ -53,13 +51,15 @@ class UpdateApkClient {
   private final Executor downloadExecutor;
   private TaskCompletionSource<Void> installTaskCompletionSource;
   private final FirebaseApp firebaseApp;
+
+  @GuardedBy("updateTaskLock")
   private UpdateTaskImpl cachedUpdateTask;
-  private boolean showDownloadInNotificationManager = false;
 
   @GuardedBy("activityLock")
   private Activity currentActivity;
 
   private final Object activityLock = new Object();
+  private final Object updateTaskLock = new Object();
 
   public UpdateApkClient(@NonNull FirebaseApp firebaseApp) {
     this.downloadExecutor = Executors.newSingleThreadExecutor();
@@ -68,20 +68,25 @@ class UpdateApkClient {
         new FirebaseAppDistributionNotificationsManager(firebaseApp);
   }
 
-  public void updateApk(
-      @NonNull UpdateTaskImpl updateTask,
-      @NonNull String downloadUrl,
-      @NonNull boolean showDownloadInNotificationManager) {
-    this.showDownloadInNotificationManager = showDownloadInNotificationManager;
-    this.cachedUpdateTask = updateTask;
-    downloadApk(downloadUrl)
+  public synchronized UpdateTaskImpl updateApk(
+      @NonNull String downloadUrl, boolean showDownloadNotificationManager) {
+    synchronized (updateTaskLock) {
+      if (cachedUpdateTask != null && !cachedUpdateTask.isComplete()) {
+        return cachedUpdateTask;
+      }
+
+      cachedUpdateTask = new UpdateTaskImpl();
+    }
+
+    downloadApk(downloadUrl, showDownloadNotificationManager)
         .addOnSuccessListener(
             downloadExecutor,
             file ->
                 install(file.getPath())
                     .addOnFailureListener(
                         e -> {
-                          postInstallationFailure(e, file.length());
+                          postInstallationFailure(
+                              e, file.length(), showDownloadNotificationManager);
                           setTaskCompletionErrorWithDefault(
                               e,
                               new FirebaseAppDistributionException(
@@ -97,11 +102,13 @@ class UpdateApkClient {
                       Constants.ErrorMessages.NETWORK_ERROR,
                       FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
             });
+
+    return cachedUpdateTask;
   }
 
   @VisibleForTesting
   @NonNull
-  Task<File> downloadApk(@NonNull String downloadUrl) {
+  Task<File> downloadApk(@NonNull String downloadUrl, boolean showDownloadNotificationManager) {
     if (downloadTaskCompletionSource != null
         && !downloadTaskCompletionSource.getTask().isComplete()) {
       return downloadTaskCompletionSource.getTask();
@@ -109,11 +116,12 @@ class UpdateApkClient {
 
     downloadTaskCompletionSource = new TaskCompletionSource<>();
 
-    makeApkDownloadRequest(downloadUrl);
+    makeApkDownloadRequest(downloadUrl, showDownloadNotificationManager);
     return downloadTaskCompletionSource.getTask();
   }
 
-  private void makeApkDownloadRequest(@NonNull String downloadUrl) {
+  private void makeApkDownloadRequest(
+      @NonNull String downloadUrl, boolean showDownloadNotificationManager) {
     downloadExecutor.execute(
         () -> {
           try {
@@ -126,9 +134,14 @@ class UpdateApkClient {
                       FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
             } else {
               long responseLength = connection.getContentLength();
-              postUpdateProgress(responseLength, 0, UpdateStatus.PENDING);
+              postUpdateProgress(
+                  responseLength, 0, UpdateStatus.PENDING, showDownloadNotificationManager);
               String fileName = getApplicationName() + ".apk";
-              downloadToDisk(connection.getInputStream(), responseLength, fileName);
+              downloadToDisk(
+                  connection.getInputStream(),
+                  responseLength,
+                  fileName,
+                  showDownloadNotificationManager);
             }
           } catch (IOException | FirebaseAppDistributionException e) {
             setDownloadTaskCompletionErrorWithDefault(
@@ -140,7 +153,8 @@ class UpdateApkClient {
         });
   }
 
-  private void downloadToDisk(InputStream input, long totalSize, String fileName) {
+  private void downloadToDisk(
+      InputStream input, long totalSize, String fileName, boolean showDownloadNotificationManager) {
 
     File apkFile = getApkFileForApp(fileName);
     apkFile.delete();
@@ -162,12 +176,20 @@ class UpdateApkClient {
         long currentTimeMs = System.currentTimeMillis();
         if (currentTimeMs - lastMsUpdated > UPDATE_INTERVAL_MS) {
           lastMsUpdated = currentTimeMs;
-          postUpdateProgress(totalSize, bytesDownloaded, UpdateStatus.DOWNLOADING);
+          postUpdateProgress(
+              totalSize,
+              bytesDownloaded,
+              UpdateStatus.DOWNLOADING,
+              showDownloadNotificationManager);
         }
       }
 
     } catch (IOException e) {
-      postUpdateProgress(totalSize, bytesDownloaded, UpdateStatus.DOWNLOAD_FAILED);
+      postUpdateProgress(
+          totalSize,
+          bytesDownloaded,
+          UpdateStatus.DOWNLOAD_FAILED,
+          showDownloadNotificationManager);
       setDownloadTaskCompletionError(
           new FirebaseAppDistributionException(
               Constants.ErrorMessages.NETWORK_ERROR,
@@ -178,7 +200,11 @@ class UpdateApkClient {
       // check that file is actual JAR
       new JarFile(apkFile);
     } catch (Exception e) {
-      postUpdateProgress(totalSize, bytesDownloaded, UpdateStatus.DOWNLOAD_FAILED);
+      postUpdateProgress(
+          totalSize,
+          bytesDownloaded,
+          UpdateStatus.DOWNLOAD_FAILED,
+          showDownloadNotificationManager);
       setDownloadTaskCompletionError(
           new FirebaseAppDistributionException(
               Constants.ErrorMessages.NETWORK_ERROR,
@@ -186,7 +212,8 @@ class UpdateApkClient {
     }
 
     // completion
-    postUpdateProgress(totalSize, totalSize, UpdateStatus.DOWNLOADED);
+    postUpdateProgress(
+        totalSize, totalSize, UpdateStatus.DOWNLOADED, showDownloadNotificationManager);
 
     downloadTaskCompletionSource.setResult(apkFile);
   }
@@ -257,7 +284,10 @@ class UpdateApkClient {
   void setInstallationResult(int resultCode) {
     if (resultCode == Activity.RESULT_OK) {
       installTaskCompletionSource.setResult(null);
-      cachedUpdateTask.setResult();
+
+      synchronized (updateTaskLock) {
+        cachedUpdateTask.setResult();
+      }
     } else if (resultCode == Activity.RESULT_CANCELED) {
       installTaskCompletionSource.setException(
           new FirebaseAppDistributionException(
@@ -272,8 +302,10 @@ class UpdateApkClient {
   }
 
   private void setTaskCompletionError(FirebaseAppDistributionException e) {
-    if (cachedUpdateTask != null && !cachedUpdateTask.isComplete()) {
-      cachedUpdateTask.setException(e);
+    synchronized (updateTaskLock) {
+      if (cachedUpdateTask != null && !cachedUpdateTask.isComplete()) {
+        cachedUpdateTask.setException(e);
+      }
     }
   }
 
@@ -287,24 +319,33 @@ class UpdateApkClient {
   }
 
   @VisibleForTesting
-  void postUpdateProgress(long totalBytes, long downloadedBytes, UpdateStatus status) {
-    cachedUpdateTask.updateProgress(
-        UpdateProgress.builder()
-            .setApkFileTotalBytes(totalBytes)
-            .setApkBytesDownloaded(downloadedBytes)
-            .setUpdateStatus(status)
-            .build());
-    if (showDownloadInNotificationManager) {
+  void postUpdateProgress(
+      long totalBytes,
+      long downloadedBytes,
+      UpdateStatus status,
+      boolean showDownloadNotificationManager) {
+    synchronized (updateTaskLock) {
+      cachedUpdateTask.updateProgress(
+          UpdateProgress.builder()
+              .setApkFileTotalBytes(totalBytes)
+              .setApkBytesDownloaded(downloadedBytes)
+              .setUpdateStatus(status)
+              .build());
+    }
+    if (showDownloadNotificationManager) {
       appDistributionNotificationsManager.updateNotification(totalBytes, downloadedBytes, status);
     }
   }
 
-  private void postInstallationFailure(Exception e, long fileLength) {
+  private void postInstallationFailure(
+      Exception e, long fileLength, boolean showDownloadNotificationManager) {
     if (e instanceof FirebaseAppDistributionException
         && ((FirebaseAppDistributionException) e).getErrorCode() == Status.INSTALLATION_CANCELED) {
-      postUpdateProgress(fileLength, fileLength, UpdateStatus.INSTALL_CANCELED);
+      postUpdateProgress(
+          fileLength, fileLength, UpdateStatus.INSTALL_CANCELED, showDownloadNotificationManager);
     } else {
-      postUpdateProgress(fileLength, fileLength, UpdateStatus.INSTALL_FAILED);
+      postUpdateProgress(
+          fileLength, fileLength, UpdateStatus.INSTALL_FAILED, showDownloadNotificationManager);
     }
   }
 
@@ -319,10 +360,5 @@ class UpdateApkClient {
     synchronized (activityLock) {
       this.currentActivity = activity;
     }
-  }
-
-  @RestrictTo(RestrictTo.Scope.TESTS)
-  void setCachedUpdateTask(UpdateTaskImpl updateTask) {
-    this.cachedUpdateTask = updateTask;
   }
 }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
@@ -103,7 +103,9 @@ class UpdateApkClient {
                       FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
             });
 
-    return cachedUpdateTask;
+    synchronized (updateTaskLock) {
+      return cachedUpdateTask;
+    }
   }
 
   @VisibleForTesting

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateAppClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateAppClient.java
@@ -34,7 +34,10 @@ public class UpdateAppClient {
   private Activity currentActivity;
 
   private final Object activityLock = new Object();
-  private UpdateTaskImpl cachedUpdateAppTask;
+  private final Object updateAabLock = new Object();
+
+  @GuardedBy("updateAabLock")
+  private UpdateTaskImpl cachedAabUpdateTask;
 
   public UpdateAppClient(@NonNull FirebaseApp firebaseApp) {
     this.updateApkClient = new UpdateApkClient(firebaseApp);
@@ -42,44 +45,44 @@ public class UpdateAppClient {
 
   @NonNull
   synchronized UpdateTask updateApp(
-      @NonNull AppDistributionReleaseInternal latestRelease,
-      @NonNull boolean showDownloadInNotificationManager) {
-
-    if (cachedUpdateAppTask != null && !cachedUpdateAppTask.isComplete()) {
-      return cachedUpdateAppTask;
-    }
-
-    cachedUpdateAppTask = new UpdateTaskImpl();
+      @Nullable AppDistributionReleaseInternal latestRelease,
+      boolean showDownloadInNotificationManager) {
 
     if (latestRelease == null) {
-      cachedUpdateAppTask.setException(
+      return getErrorUpdateTask(
           new FirebaseAppDistributionException(
               Constants.ErrorMessages.NOT_FOUND_ERROR, UPDATE_NOT_AVAILABLE));
-      return cachedUpdateAppTask;
     }
 
     if (latestRelease.getDownloadUrl() == null) {
-      cachedUpdateAppTask.setException(
+      return getErrorUpdateTask(
           new FirebaseAppDistributionException(
               Constants.ErrorMessages.DOWNLOAD_URL_NOT_FOUND,
               FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
-      return cachedUpdateAppTask;
     }
 
     if (latestRelease.getBinaryType() == BinaryType.AAB) {
-      redirectToPlayForAabUpdate(cachedUpdateAppTask, latestRelease.getDownloadUrl());
+      synchronized (updateAabLock) {
+        if (cachedAabUpdateTask != null && !cachedAabUpdateTask.isComplete()) {
+          return cachedAabUpdateTask;
+        }
+
+        cachedAabUpdateTask = new UpdateTaskImpl();
+        redirectToPlayForAabUpdate(latestRelease.getDownloadUrl());
+      }
+
+      return cachedAabUpdateTask;
     } else {
-      this.updateApkClient.updateApk(
-          cachedUpdateAppTask, latestRelease.getDownloadUrl(), showDownloadInNotificationManager);
+      return this.updateApkClient.updateApk(
+          latestRelease.getDownloadUrl(), showDownloadInNotificationManager);
     }
-    return cachedUpdateAppTask;
   }
 
-  private void redirectToPlayForAabUpdate(UpdateTaskImpl updateTask, String downloadUrl) {
+  private void redirectToPlayForAabUpdate(String downloadUrl) {
     Activity currentActivity = getCurrentActivity();
 
     if (currentActivity == null) {
-      updateTask.setException(
+      cachedAabUpdateTask.setException(
           new FirebaseAppDistributionException(
               Constants.ErrorMessages.APP_BACKGROUNDED,
               FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
@@ -91,13 +94,12 @@ public class UpdateAppClient {
     updateIntent.setData(uri);
     updateIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     currentActivity.startActivity(updateIntent);
-    updateTask.updateProgress(
+    cachedAabUpdateTask.updateProgress(
         UpdateProgress.builder()
             .setApkBytesDownloaded(-1)
             .setApkFileTotalBytes(-1)
             .setUpdateStatus(UpdateStatus.REDIRECTED_TO_PLAY)
             .build());
-    updateTask.setResult();
   }
 
   void setInstallationResult(int resultCode) {
@@ -116,5 +118,11 @@ public class UpdateAppClient {
       this.currentActivity = activity;
       this.updateApkClient.setCurrentActivity(activity);
     }
+  }
+
+  private UpdateTask getErrorUpdateTask(Exception e) {
+    UpdateTaskImpl updateTask = new UpdateTaskImpl();
+    updateTask.setException(e);
+    return updateTask;
   }
 }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateTaskImpl.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateTaskImpl.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Executor;
 /** Implementation of UpdateTask, the return type of updateApp. */
 class UpdateTaskImpl extends UpdateTask {
 
-  @NonNull private Task<Void> task;
+  @NonNull private final Task<Void> task;
 
   @Nullable
   @GuardedBy("lock")
@@ -41,7 +41,7 @@ class UpdateTaskImpl extends UpdateTask {
   @GuardedBy("lock")
   private UpdateProgress snapshot;
 
-  private TaskCompletionSource<Void> taskCompletionSource;
+  private final TaskCompletionSource<Void> taskCompletionSource;
 
   UpdateTaskImpl() {
     this.taskCompletionSource = new TaskCompletionSource<Void>();
@@ -153,21 +153,21 @@ class UpdateTaskImpl extends UpdateTask {
 
   @NonNull
   @Override
-  public Task<Void> addOnCompleteListener(@NonNull OnCompleteListener onCompleteListener) {
+  public Task<Void> addOnCompleteListener(@NonNull OnCompleteListener<Void> onCompleteListener) {
     return this.task.addOnCompleteListener(onCompleteListener);
   }
 
   @NonNull
   @Override
   public Task<Void> addOnCompleteListener(
-      @NonNull Executor executor, @NonNull OnCompleteListener onCompleteListener) {
+      @NonNull Executor executor, @NonNull OnCompleteListener<Void> onCompleteListener) {
     return this.task.addOnCompleteListener(executor, onCompleteListener);
   }
 
   @NonNull
   @Override
   public Task<Void> addOnCompleteListener(
-      @NonNull Activity activity, @NonNull OnCompleteListener onCompleteListener) {
+      @NonNull Activity activity, @NonNull OnCompleteListener<Void> onCompleteListener) {
     return this.task.addOnCompleteListener(activity, onCompleteListener);
   }
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateTaskImpl.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateTaskImpl.java
@@ -44,7 +44,7 @@ class UpdateTaskImpl extends UpdateTask {
   private final TaskCompletionSource<Void> taskCompletionSource;
 
   UpdateTaskImpl() {
-    this.taskCompletionSource = new TaskCompletionSource<Void>();
+    this.taskCompletionSource = new TaskCompletionSource<>();
     this.task = taskCompletionSource.getTask();
   }
 

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -390,4 +390,11 @@ public class FirebaseAppDistributionTest {
     firebaseAppDistribution.signOutTester();
     verify(mockSignInStorage).setSignInStatus(false);
   }
+
+  @Test
+  public void updateApp_appResume_tryResetAabUpdateTask() {
+    firebaseAppDistribution.onActivityResumed(activity);
+
+    verify(mockUpdateAppClient, times(1)).tryCancelAabUpdateTask();
+  }
 }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateApkClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateApkClientTest.java
@@ -42,7 +42,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowNotification;
 import org.robolectric.shadows.ShadowNotificationManager;
 
@@ -59,8 +58,6 @@ public class UpdateApkClientTest {
   private static final int RESULT_FAILED = 1;
 
   private UpdateApkClient updateApkClient;
-  private TestActivity activity;
-  private ShadowActivity shadowActivity;
   @Mock private File mockFile;
   @Mock private HttpsURLConnection mockHttpsUrlConnection;
 
@@ -82,9 +79,7 @@ public class UpdateApkClientTest {
                 .setApiKey(TEST_API_KEY)
                 .build());
 
-    activity = Robolectric.buildActivity(TestActivity.class).create().get();
-    shadowActivity = shadowOf(activity);
-
+    TestActivity activity = Robolectric.buildActivity(TestActivity.class).create().get();
     when(mockFile.getPath()).thenReturn(TEST_URL);
     when(mockFile.length()).thenReturn(TEST_FILE_LENGTH);
 
@@ -94,13 +89,10 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenDownloadFails_setsNetworkError() throws Exception {
-    List<UpdateProgress> progressEvents = new ArrayList<>();
-    UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    updateTask.addOnProgressListener(progressEvents::add);
     doReturn(mockHttpsUrlConnection).when(updateApkClient).openHttpsUrlConnection(TEST_URL);
     // null inputStream causes download failure
     when(mockHttpsUrlConnection.getInputStream()).thenReturn(null);
-    updateApkClient.updateApk(updateTask, TEST_URL, false);
+    UpdateTaskImpl updateTask = updateApkClient.updateApk(TEST_URL, false);
     // wait for error to be caught and set
     Thread.sleep(1000);
 
@@ -114,10 +106,8 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenInstallSuccessful_setsResult() throws Exception {
-    UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL);
-
-    updateApkClient.updateApk(updateTask, TEST_URL, false);
+    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL, false);
+    UpdateTaskImpl updateTask = updateApkClient.updateApk(TEST_URL, false);
     // sleep to wait for installTaskCompletionSource to be set
     Thread.sleep(1000);
     updateApkClient.setInstallationResult(RESULT_OK);
@@ -126,12 +116,12 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenInstallCancelled_setsError() throws Exception {
-    List<UpdateProgress> progressEvents = new ArrayList<>();
-    UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    updateTask.addOnProgressListener(progressEvents::add);
-    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL);
+    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL, false);
 
-    updateApkClient.updateApk(updateTask, TEST_URL, false);
+    UpdateTaskImpl updateTask = updateApkClient.updateApk(TEST_URL, false);
+    List<UpdateProgress> progressEvents = new ArrayList<>();
+    updateTask.addOnProgressListener(progressEvents::add);
+
     // sleep to wait for installTaskCompletionSource to be set
     Thread.sleep(1000);
     updateApkClient.setInstallationResult(RESULT_CANCELED);
@@ -148,12 +138,12 @@ public class UpdateApkClientTest {
 
   @Test
   public void updateApk_whenInstallFailed_setsError() throws Exception {
-    List<UpdateProgress> progressEvents = new ArrayList<>();
-    UpdateTaskImpl updateTask = new UpdateTaskImpl();
-    updateTask.addOnProgressListener(progressEvents::add);
-    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL);
+    doReturn(Tasks.forResult(mockFile)).when(updateApkClient).downloadApk(TEST_URL, false);
 
-    updateApkClient.updateApk(updateTask, TEST_URL, false);
+    UpdateTaskImpl updateTask = updateApkClient.updateApk(TEST_URL, false);
+    List<UpdateProgress> progressEvents = new ArrayList<>();
+    updateTask.addOnProgressListener(progressEvents::add);
+
     // sleep to wait for installTaskCompletionSource to be set
     Thread.sleep(1000);
     updateApkClient.setInstallationResult(RESULT_FAILED);
@@ -170,8 +160,8 @@ public class UpdateApkClientTest {
 
   @Test
   public void downloadApk_whenCalledMultipleTimes_returnsSameTask() {
-    Task<File> task1 = updateApkClient.downloadApk(TEST_URL);
-    Task<File> task2 = updateApkClient.downloadApk(TEST_URL);
+    Task<File> task1 = updateApkClient.downloadApk(TEST_URL, false);
+    Task<File> task2 = updateApkClient.downloadApk(TEST_URL, false);
     assertEquals(task1, task2);
   }
 
@@ -182,8 +172,8 @@ public class UpdateApkClientTest {
         (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
     ShadowNotificationManager shadowNotificationManager = shadowOf(notificationManager);
     // called from basic configuration
-    updateApkClient.updateApk(new UpdateTaskImpl(), TEST_URL, true);
-    updateApkClient.postUpdateProgress(1000, 900, UpdateStatus.DOWNLOADING);
+    updateApkClient.updateApk(TEST_URL, true);
+    updateApkClient.postUpdateProgress(1000, 900, UpdateStatus.DOWNLOADING, true);
 
     assertEquals(1, shadowNotificationManager.size());
     ShadowNotification shadowNotification =
@@ -199,8 +189,8 @@ public class UpdateApkClientTest {
         (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
     ShadowNotificationManager shadowNotificationManager = shadowOf(notificationManager);
     // called from basic configuration
-    updateApkClient.updateApk(new UpdateTaskImpl(), TEST_URL, true);
-    updateApkClient.postUpdateProgress(1000, 1000, UpdateStatus.DOWNLOAD_FAILED);
+    updateApkClient.updateApk(TEST_URL, true);
+    updateApkClient.postUpdateProgress(1000, 1000, UpdateStatus.DOWNLOAD_FAILED, true);
 
     assertEquals(1, shadowNotificationManager.size());
     ShadowNotification shadowNotification =
@@ -217,8 +207,8 @@ public class UpdateApkClientTest {
         (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
     ShadowNotificationManager shadowNotificationManager = shadowOf(notificationManager);
     // called from advanced configuration
-    updateApkClient.updateApk(new UpdateTaskImpl(), TEST_URL, false);
-    updateApkClient.postUpdateProgress(1000, 900, UpdateStatus.DOWNLOADING);
+    updateApkClient.updateApk(TEST_URL, false);
+    updateApkClient.postUpdateProgress(1000, 900, UpdateStatus.DOWNLOADING, false);
     assertEquals(0, shadowNotificationManager.size());
   }
 }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateAppClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/UpdateAppClientTest.java
@@ -28,8 +28,6 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.appdistribution.internal.AppDistributionReleaseInternal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,11 +39,9 @@ import org.robolectric.shadows.ShadowActivity;
 
 @RunWith(RobolectricTestRunner.class)
 public class UpdateAppClientTest {
-
   private static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
   private static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
   private static final String TEST_PROJECT_ID = "777777777777";
-  private static final Executor testExecutor = Executors.newSingleThreadExecutor();
 
   private static final AppDistributionReleaseInternal.Builder TEST_RELEASE_NEWER_AAB_INTERNAL =
       AppDistributionReleaseInternal.builder()
@@ -64,7 +60,6 @@ public class UpdateAppClientTest {
           .setDownloadUrl("https://test-url");
 
   private UpdateAppClient updateAppClient;
-  private com.google.firebase.appdistribution.FirebaseAppDistributionTest.TestActivity activity;
   private ShadowActivity shadowActivity;
 
   @Mock private OnProgressListener onProgressListener;
@@ -87,11 +82,8 @@ public class UpdateAppClientTest {
                 .setApiKey(TEST_API_KEY)
                 .build());
 
-    activity =
-        Robolectric.buildActivity(
-                com.google.firebase.appdistribution.FirebaseAppDistributionTest.TestActivity.class)
-            .create()
-            .get();
+    FirebaseAppDistributionTest.TestActivity activity =
+        Robolectric.buildActivity(FirebaseAppDistributionTest.TestActivity.class).create().get();
     shadowActivity = shadowOf(activity);
 
     this.updateAppClient = new UpdateAppClient(firebaseApp);
@@ -99,15 +91,12 @@ public class UpdateAppClientTest {
   }
 
   @Test
-  public void updateAppTask_whenAabReleaseAvailable_redirectsToPlay() throws Exception {
+  public void updateAppTask_whenAabReleaseAvailable_redirectsToPlay() {
     AppDistributionReleaseInternal latestRelease = TEST_RELEASE_NEWER_AAB_INTERNAL.build();
     List<UpdateProgress> progressEvents = new ArrayList<>();
 
-    TestOnCompleteListener<Void> onCompleteListener = new TestOnCompleteListener<>();
     UpdateTask updateTask = updateAppClient.updateApp(latestRelease, false);
-    updateTask.addOnCompleteListener(testExecutor, onCompleteListener);
     updateTask.addOnProgressListener(progressEvents::add);
-    onCompleteListener.await();
 
     assertThat(shadowActivity.getNextStartedActivity().getData())
         .isEqualTo(Uri.parse(latestRelease.getDownloadUrl()));
@@ -123,7 +112,7 @@ public class UpdateAppClientTest {
   }
 
   @Test
-  public void updateApp_whenCalledMultipleTimes_returnsSameUpdateTask() throws Exception {
+  public void updateApp_whenCalledMultipleTimes_returnsSameUpdateTask() {
     AppDistributionReleaseInternal latestRelease = TEST_RELEASE_NEWER_APK_INTERNAL.build();
     UpdateTask updateTask1 = updateAppClient.updateApp(latestRelease, false);
     UpdateTask updateTask2 = updateAppClient.updateApp(latestRelease, false);
@@ -131,7 +120,7 @@ public class UpdateAppClientTest {
   }
 
   @Test
-  public void updateAppTask_whenNoReleaseAvailable_throwsError() throws Exception {
+  public void updateAppTask_whenNoReleaseAvailable_throwsError() {
     UpdateTask updateTask = updateAppClient.updateApp(null, false);
     assertFalse(updateTask.isSuccessful());
     assertTrue(updateTask.getException() instanceof FirebaseAppDistributionException);


### PR DESCRIPTION
Making sure we don't use the same cached update task in the `UpdateAppClient` and the `UpdateApkClient` to avoid cross-class synchronization issues