### PR TITLE
Plumb the executor through waitForDataCollectionPermission in Crashlytics

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -413,7 +413,7 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
 
     final DataCollectionArbiter arbiter = mock(DataCollectionArbiter.class);
     when(arbiter.isAutomaticDataCollectionEnabled()).thenReturn(false);
-    when(arbiter.waitForDataCollectionPermission())
+    when(arbiter.waitForDataCollectionPermission(any(Executor.class)))
         .thenReturn(new TaskCompletionSource<Void>().getTask());
     when(arbiter.waitForAutomaticDataCollectionEnabled())
         .thenReturn(new TaskCompletionSource<Void>().getTask());

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsControllerTest.java
@@ -142,7 +142,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
     when(mockSettingsJsonParser.parseSettingsJson(fetchedJson)).thenReturn(fetchedSettings);
 
     TaskCompletionSource<Void> dataCollectionPermission = new TaskCompletionSource<>();
-    when(mockDataCollectionArbiter.waitForDataCollectionPermission())
+    when(mockDataCollectionArbiter.waitForDataCollectionPermission(any(Executor.class)))
         .thenReturn(dataCollectionPermission.getTask());
 
     final SettingsRequest requestData = buildSettingsRequest();
@@ -187,7 +187,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
     when(mockSettingsJsonParser.parseSettingsJson(fetchedJson)).thenReturn(fetchedSettings);
 
     TaskCompletionSource<Void> dataCollectionPermission = new TaskCompletionSource<>();
-    when(mockDataCollectionArbiter.waitForDataCollectionPermission())
+    when(mockDataCollectionArbiter.waitForDataCollectionPermission(any(Executor.class)))
         .thenReturn(dataCollectionPermission.getTask());
 
     final SettingsRequest requestData = buildSettingsRequest();
@@ -270,7 +270,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
         .thenReturn(expiredCachedSettings);
 
     TaskCompletionSource<Void> dataCollectionPermission = new TaskCompletionSource<>();
-    when(mockDataCollectionArbiter.waitForDataCollectionPermission())
+    when(mockDataCollectionArbiter.waitForDataCollectionPermission(any(Executor.class)))
         .thenReturn(dataCollectionPermission.getTask());
 
     final SettingsRequest requestData = buildSettingsRequest();
@@ -323,7 +323,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
         .thenReturn(expiredCachedSettings);
 
     TaskCompletionSource<Void> dataCollectionPermission = new TaskCompletionSource<>();
-    when(mockDataCollectionArbiter.waitForDataCollectionPermission())
+    when(mockDataCollectionArbiter.waitForDataCollectionPermission(any(Executor.class)))
         .thenReturn(dataCollectionPermission.getTask());
 
     final SettingsRequest requestData = buildSettingsRequest();
@@ -360,7 +360,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
     when(mockCachedSettingsIo.readCachedSettings()).thenReturn(null);
 
     TaskCompletionSource<Void> dataCollectionPermission = new TaskCompletionSource<>();
-    when(mockDataCollectionArbiter.waitForDataCollectionPermission())
+    when(mockDataCollectionArbiter.waitForDataCollectionPermission(any(Executor.class)))
         .thenReturn(dataCollectionPermission.getTask());
 
     final SettingsRequest requestData = buildSettingsRequest();

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
@@ -24,6 +24,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.crashlytics.internal.Logger;
+import java.util.concurrent.Executor;
 
 // Determines whether automatic data collection is enabled.
 public class DataCollectionArbiter {
@@ -115,9 +116,11 @@ public class DataCollectionArbiter {
    * Returns a task which will be resolved when either: 1) automatic data collection has been
    * enabled, or 2) grantDataCollectionPermission has been called.
    */
-  public Task<Void> waitForDataCollectionPermission() {
+  public Task<Void> waitForDataCollectionPermission(Executor executor) {
     return Utils.race(
-        dataCollectionExplicitlyApproved.getTask(), waitForAutomaticDataCollectionEnabled());
+        executor,
+        dataCollectionExplicitlyApproved.getTask(),
+        waitForAutomaticDataCollectionEnabled());
   }
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsController.java
@@ -186,7 +186,7 @@ public class SettingsController implements SettingsDataProvider {
 
     // Kick off fetching fresh settings.
     return dataCollectionArbiter
-        .waitForDataCollectionPermission()
+        .waitForDataCollectionPermission(executor)
         .onSuccessTask(
             executor,
             new SuccessContinuation<Void, Void>() {


### PR DESCRIPTION
This resolves a concurrency issue in Crashlytics when racing two tasks on a background thread before the application is initialized. The race util would create a task on the main application thread, regardless of the executor. Since the application was not initialized yet, the race never completed. Now the race util has an overloaded method to accept the executor to avoid this problem.

Tested manually on a real device that was experiencing this issue.