### PR TITLE
Add Index Bounds to Queries

### DIFF
--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -155,6 +155,7 @@ dependencies {
     }
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
+    androidTestAnnotationProcessor 'com.google.auto.value:auto-value:1.6.5'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 
     testImplementation 'junit:junit:4.12'

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -159,7 +159,9 @@ public final class Target {
             Value cursorValue = startAt.getPosition().get(i);
             if (Values.compare(lowestValue, cursorValue) <= 0) {
               lowestValue = cursorValue;
-              before = before && startAt.isBefore();
+              // `before` is shared by all cursor values. If any cursor value is used, we set before
+              // to the cursor's value.
+              before = startAt.isBefore();
             }
             break;
           }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -113,13 +113,10 @@ public final class Target {
 
   /**
    * Returns a lower bound of field values that can be used as a starting point to scan the index
-   * defined by `fieldIndex`.
+   * defined by {@code fieldIndex}.
    *
    * <p>Unlike {@link #getUpperBound}, lower bounds always exist as the SDK can use {@code null} as
    * a starting point for missing boundary values.
-   *
-   * @param fieldIndex The index definition to generate a Bound for
-   * @return A bound that can be used for index scanning
    */
   public Bound getLowerBound(FieldIndex fieldIndex) {
     List<Value> values = new ArrayList<>();
@@ -164,6 +161,7 @@ public final class Target {
               lowestValue = cursorValue;
               before = before && startAt.isBefore();
             }
+            break;
           }
         }
       }
@@ -175,14 +173,11 @@ public final class Target {
 
   /**
    * Returns an upper bound of field values that can be used as an ending point when scanning the
-   * index defined by `fieldIndex`.
+   * index defined by {@code fieldIndex}.
    *
    * <p>Unlike {@link #getLowerBound}, upper bounds do not always exist since the Firestore does not
    * define a maximum field value. The index scan should not use an upper bound if {@code null} is
    * returned.
-   *
-   * @param fieldIndex The index definition to generate a Bound for
-   * @return A bound that can be used for index scanning
    */
   public @Nullable Bound getUpperBound(FieldIndex fieldIndex) {
     List<Value> values = new ArrayList<>();
@@ -224,12 +219,11 @@ public final class Target {
           OrderBy orderBy = this.orderBys.get(i);
           if (orderBy.getField().equals(segment.getFieldPath())) {
             Value cursorValue = endAt.getPosition().get(i);
-            if (largestValue == null) {
+            if (largestValue == null || Values.compare(largestValue, cursorValue) > 0) {
               largestValue = cursorValue;
-            } else if (Values.compare(largestValue, cursorValue) > 0) {
-              largestValue = cursorValue;
+              before = endAt.isBefore();
             }
-            before = endAt.isBefore();
+            break;
           }
         }
       }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -157,7 +157,7 @@ public final class Target {
           OrderBy orderBy = this.orderBys.get(i);
           if (orderBy.getField().equals(segment.getFieldPath())) {
             Value cursorValue = startAt.getPosition().get(i);
-            if (Values.compare(lowestValue, cursorValue) < 0) {
+            if (Values.compare(lowestValue, cursorValue) <= 0) {
               lowestValue = cursorValue;
               before = before && startAt.isBefore();
             }
@@ -203,10 +203,11 @@ public final class Target {
             case ARRAY_CONTAINS:
             case LESS_THAN_OR_EQUAL:
               largestValue = fieldFilter.getValue();
+              before = true;
               break;
             case LESS_THAN:
               largestValue = fieldFilter.getValue();
-              before = true;
+              before = false;
               break;
           }
         }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -17,7 +17,11 @@ package com.google.firebase.firestore.core;
 import androidx.annotation.Nullable;
 import com.google.firebase.firestore.core.OrderBy.Direction;
 import com.google.firebase.firestore.model.DocumentKey;
+import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
+import com.google.firebase.firestore.model.Values;
+import com.google.firestore.v1.Value;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -31,7 +35,7 @@ public final class Target {
 
   private @Nullable String memoizedCannonicalId;
 
-  private final List<OrderBy> orderBy;
+  private final List<OrderBy> orderBys;
   private final List<Filter> filters;
 
   private final ResourcePath path;
@@ -55,13 +59,13 @@ public final class Target {
       ResourcePath path,
       @Nullable String collectionGroup,
       List<Filter> filters,
-      List<OrderBy> orderBy,
+      List<OrderBy> orderBys,
       long limit,
       @Nullable Bound startAt,
       @Nullable Bound endAt) {
     this.path = path;
     this.collectionGroup = collectionGroup;
-    this.orderBy = orderBy;
+    this.orderBys = orderBys;
     this.filters = filters;
     this.limit = limit;
     this.startAt = startAt;
@@ -107,8 +111,146 @@ public final class Target {
     return endAt;
   }
 
+  /**
+   * Returns a lower bound of field values that can be used as a starting point to scan the index
+   * defined by `fieldIndex`.
+   *
+   * <p>Unlike {@link #getUpperBound}, lower bounds always exist as the SDK can use {@code null} as
+   * a starting point for missing boundary values.
+   *
+   * @param fieldIndex The index definition to generate a Bound for
+   * @return A bound that can be used for index scanning
+   */
+  public Bound getLowerBound(FieldIndex fieldIndex) {
+    List<Value> values = new ArrayList<>();
+    boolean before = true;
+
+    // Go through all filters to find a value for the current field segment
+    for (FieldIndex.Segment segment : fieldIndex) {
+      Value lowestValue = Values.NULL_VALUE;
+      for (Filter filter : filters) {
+        if (filter.getField().equals(segment.getFieldPath())) {
+          FieldFilter fieldFilter = (FieldFilter) filter;
+          switch (fieldFilter.getOperator()) {
+            case LESS_THAN:
+            case NOT_IN:
+            case NOT_EQUAL:
+            case LESS_THAN_OR_EQUAL:
+              // These filters cannot be used as a lower bound. Skip.
+              break;
+            case EQUAL:
+            case IN:
+            case ARRAY_CONTAINS_ANY:
+            case ARRAY_CONTAINS:
+            case GREATER_THAN_OR_EQUAL:
+              lowestValue = fieldFilter.getValue();
+              break;
+            case GREATER_THAN:
+              lowestValue = fieldFilter.getValue();
+              before = false;
+              break;
+          }
+        }
+      }
+
+      // If there is a startAt bound, compare the values against the existing boundary to see
+      // if we can narrow the scope.
+      if (startAt != null) {
+        for (int i = 0; i < orderBys.size(); ++i) {
+          OrderBy orderBy = this.orderBys.get(i);
+          if (orderBy.getField().equals(segment.getFieldPath())) {
+            Value cursorValue = startAt.getPosition().get(i);
+            if (Values.compare(lowestValue, cursorValue) < 0) {
+              lowestValue = cursorValue;
+              before = before && startAt.isBefore();
+            }
+          }
+        }
+      }
+      values.add(lowestValue);
+    }
+
+    return new Bound(values, before);
+  }
+
+  /**
+   * Returns an upper bound of field values that can be used as an ending point when scanning the
+   * index defined by `fieldIndex`.
+   *
+   * <p>Unlike {@link #getLowerBound}, upper bounds do not always exist since the Firestore does not
+   * define a maximum field value. The index scan should not use an upper bound if {@code null} is
+   * returned.
+   *
+   * @param fieldIndex The index definition to generate a Bound for
+   * @return A bound that can be used for index scanning
+   */
+  public @Nullable Bound getUpperBound(FieldIndex fieldIndex) {
+    List<Value> values = new ArrayList<>();
+    boolean before = false;
+
+    for (FieldIndex.Segment segment : fieldIndex) {
+      @Nullable Value largestValue = null;
+
+      // Go through all filters to find a value for the current field segment
+      for (Filter filter : filters) {
+        if (filter.getField().equals(segment.getFieldPath())) {
+          FieldFilter fieldFilter = (FieldFilter) filter;
+          switch (fieldFilter.getOperator()) {
+            case GREATER_THAN:
+            case NOT_IN:
+            case NOT_EQUAL:
+            case GREATER_THAN_OR_EQUAL:
+              // These filters cannot be used as an upper bound. Skip.
+              break;
+            case EQUAL:
+            case IN:
+            case ARRAY_CONTAINS_ANY:
+            case ARRAY_CONTAINS:
+            case LESS_THAN_OR_EQUAL:
+              largestValue = fieldFilter.getValue();
+              break;
+            case LESS_THAN:
+              largestValue = fieldFilter.getValue();
+              before = true;
+              break;
+          }
+        }
+      }
+
+      // If there is an endAt bound, compare the values against the existing boundary to see
+      // if we can narrow the scope.
+      if (endAt != null) {
+        for (int i = 0; i < orderBys.size(); ++i) {
+          OrderBy orderBy = this.orderBys.get(i);
+          if (orderBy.getField().equals(segment.getFieldPath())) {
+            Value cursorValue = endAt.getPosition().get(i);
+            if (largestValue == null) {
+              largestValue = cursorValue;
+            } else if (Values.compare(largestValue, cursorValue) > 0) {
+              largestValue = cursorValue;
+            }
+            before = endAt.isBefore();
+          }
+        }
+      }
+
+      if (largestValue == null) {
+        // No upper bound exists
+        return null;
+      }
+
+      values.add(largestValue);
+    }
+
+    if (values.isEmpty()) {
+      return null;
+    }
+
+    return new Bound(values, before);
+  }
+
   public List<OrderBy> getOrderBy() {
-    return this.orderBy;
+    return this.orderBys;
   }
 
   /** Returns a canonical string representing this target. */
@@ -177,7 +319,7 @@ public final class Target {
     if (limit != target.limit) {
       return false;
     }
-    if (!orderBy.equals(target.orderBy)) {
+    if (!orderBys.equals(target.orderBys)) {
       return false;
     }
     if (!filters.equals(target.filters)) {
@@ -194,7 +336,7 @@ public final class Target {
 
   @Override
   public int hashCode() {
-    int result = orderBy.hashCode();
+    int result = orderBys.hashCode();
     result = 31 * result + (collectionGroup != null ? collectionGroup.hashCode() : 0);
     result = 31 * result + filters.hashCode();
     result = 31 * result + path.hashCode();
@@ -223,13 +365,13 @@ public final class Target {
       }
     }
 
-    if (!orderBy.isEmpty()) {
+    if (!orderBys.isEmpty()) {
       builder.append(" order by ");
-      for (int i = 0; i < orderBy.size(); i++) {
+      for (int i = 0; i < orderBys.size(); i++) {
         if (i > 0) {
           builder.append(", ");
         }
-        builder.append(orderBy.get(i));
+        builder.append(orderBys.get(i));
       }
     }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
@@ -60,7 +60,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, "bar");
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, false, "bar");
+    verifyBound(upperBound, true, "bar");
   }
 
   @Test
@@ -73,7 +73,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, new Object[] {null});
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, true, "bar");
+    verifyBound(upperBound, false, "bar");
   }
 
   @Test
@@ -86,7 +86,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, new Object[] {null});
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, false, "bar");
+    verifyBound(upperBound, true, "bar");
   }
 
   @Test
@@ -125,7 +125,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, "bar");
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, false, "bar");
+    verifyBound(upperBound, true, "bar");
   }
 
   @Test

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
@@ -1,0 +1,250 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.core;
+
+import static com.google.firebase.firestore.testutil.TestUtil.field;
+import static com.google.firebase.firestore.testutil.TestUtil.filter;
+import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
+import static com.google.firebase.firestore.testutil.TestUtil.query;
+import static com.google.firebase.firestore.testutil.TestUtil.wrap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.firebase.firestore.model.FieldIndex;
+import com.google.firebase.firestore.model.Values;
+import com.google.firestore.v1.Value;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class TargetTest {
+
+  @Test
+  public void emptyQueryBound() {
+    Target target = query("c").toTarget();
+    FieldIndex index = new FieldIndex("c");
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true);
+
+    Bound upperBound = target.getUpperBound(index);
+    assertNull(upperBound);
+  }
+
+  @Test
+  public void equalsQueryBound() {
+    Target target = query("c").filter(filter("foo", "==", "bar")).toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, "bar");
+
+    Bound upperBound = target.getUpperBound(index);
+    verifyBound(upperBound, false, "bar");
+  }
+
+  @Test
+  public void lowerThanQueryBound() {
+    Target target = query("c").filter(filter("foo", "<", "bar")).toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, new Object[] {null});
+
+    Bound upperBound = target.getUpperBound(index);
+    verifyBound(upperBound, true, "bar");
+  }
+
+  @Test
+  public void lowerThanOrEqualsQueryBound() {
+    Target target = query("c").filter(filter("foo", "<=", "bar")).toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, new Object[] {null});
+
+    Bound upperBound = target.getUpperBound(index);
+    verifyBound(upperBound, false, "bar");
+  }
+
+  @Test
+  public void greaterThanQueryBound() {
+    Target target = query("c").filter(filter("foo", ">", "bar")).toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, false, "bar");
+
+    Bound upperBound = target.getUpperBound(index);
+    assertNull(upperBound);
+  }
+
+  @Test
+  public void greaterThanOrEqualsQueryBound() {
+    Target target = query("c").filter(filter("foo", ">=", "bar")).toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, "bar");
+
+    Bound upperBound = target.getUpperBound(index);
+    assertNull(upperBound);
+  }
+
+  @Test
+  public void containsQueryBound() {
+    Target target = query("c").filter(filter("foo", "array-contains", "bar")).toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, "bar");
+
+    Bound upperBound = target.getUpperBound(index);
+    verifyBound(upperBound, false, "bar");
+  }
+
+  @Test
+  public void orderByQueryBound() {
+    Target target = query("c").orderBy(orderBy("foo")).toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, new Object[] {null});
+
+    Bound upperBound = target.getUpperBound(index);
+    assertNull(upperBound);
+  }
+
+  @Test
+  public void filterWithOrderByQueryBound() {
+    Target target = query("c").filter(filter("foo", ">", "bar")).orderBy(orderBy("foo")).toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, false, "bar");
+
+    Bound upperBound = target.getUpperBound(index);
+    assertNull(upperBound);
+  }
+
+  @Test
+  public void startAtQueryBound() {
+    Target target =
+        query("c")
+            .orderBy(orderBy("foo"))
+            .startAt(new Bound(Collections.singletonList(wrap("bar")), true))
+            .toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, "bar");
+
+    Bound upperBound = target.getUpperBound(index);
+    assertNull(upperBound);
+  }
+
+  @Test
+  public void startAtWithFilterQueryBound() {
+    // Tests that the startAt and the filter get merged to form a narrow bound
+    Target target =
+        query("c")
+            .filter(filter("a", ">=", "a1"))
+            .filter(filter("b", "==", "b1"))
+            .orderBy(orderBy("a"))
+            .orderBy(orderBy("b"))
+            .startAt(new Bound(Arrays.asList(wrap("a1"), wrap("b2")), true))
+            .toTarget();
+    FieldIndex index =
+        new FieldIndex("c")
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ORDERED);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, "a1", "b2");
+
+    Bound upperBound = target.getUpperBound(index);
+    assertNull(upperBound);
+  }
+
+  @Test
+  public void endAtQueryBound() {
+    Target target =
+        query("c")
+            .orderBy(orderBy("foo"))
+            .endAt(new Bound(Collections.singletonList(wrap("bar")), true))
+            .toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, new Object[] {null});
+
+    Bound upperBound = target.getUpperBound(index);
+    verifyBound(upperBound, true, "bar");
+  }
+
+  @Test
+  public void endAtWithFilterQueryBound() {
+    // Tests that the endAt and the filter get merged to form a narrow bound
+    Target target =
+        query("c")
+            .filter(filter("a", "<=", "a2"))
+            .filter(filter("b", "==", "b2"))
+            .orderBy(orderBy("a"))
+            .orderBy(orderBy("b"))
+            .endAt(new Bound(Arrays.asList(wrap("a1"), wrap("b1")), true))
+            .toTarget();
+    FieldIndex index =
+        new FieldIndex("c")
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ORDERED);
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true, null, "b2");
+
+    Bound upperBound = target.getUpperBound(index);
+    verifyBound(upperBound, true, "a1", "b1");
+  }
+
+  private void verifyBound(Bound bound, boolean before, Object... values) {
+    assertEquals("before", before, bound.isBefore());
+    List<Value> position = bound.getPosition();
+    assertEquals("size", values.length, position.size());
+    for (int i = 0; i < values.length; ++i) {
+      Value expectedValue = wrap(values[i]);
+      assertTrue(
+          String.format(
+              "Values should be equal: Expected: %s, Actual: %s",
+              Values.canonicalId(expectedValue), Values.canonicalId(position.get(i))),
+          Values.equals(position.get(i), expectedValue));
+    }
+  }
+}

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
@@ -319,7 +319,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, null, "b1");
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, false, "a1", "b1");
+    verifyBound(upperBound, true, "a1", "b1");
   }
 
   @Test
@@ -333,7 +333,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, "a");
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, false, "a");
+    verifyBound(upperBound, true, "a");
   }
 
   private void verifyBound(Bound bound, boolean before, Object... values) {


### PR DESCRIPTION
This adds functionality to `Target` to compute boundaries for Index scans. 

See how this is used in the prototype: https://github.com/firebase/firebase-android-sdk/pull/2654/files#diff-979270768a3e2798683bf7702f4e84ade098aa967d60d90c9c741d41fc64754dR191 Note that the prototype uses multiple methods instead of the API in this PR.