### PR TITLE
Update PendingDynamicLinkData to Nullable

### DIFF
--- a/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/FirebaseDynamicLinks.java
+++ b/firebase-dynamic-links/src/main/java/com/google/firebase/dynamiclinks/FirebaseDynamicLinks.java
@@ -98,7 +98,7 @@ public abstract class FirebaseDynamicLinks {
    *
    * <p>If a dynamic link, the call will also send FirebaseAnalytics dynamic link event.
    */
-  @NonNull
+  @Nullable
   public abstract Task<PendingDynamicLinkData> getDynamicLink(@NonNull Intent intent);
 
   /**
@@ -117,7 +117,7 @@ public abstract class FirebaseDynamicLinks {
    *     previously captured or is in the Uri.
    *     <p>{@link Task#isSuccessful()} will only be false when a processing error occurs.
    */
-  @NonNull
+  @Nullable
   public abstract Task<PendingDynamicLinkData> getDynamicLink(@NonNull Uri dynamicLinkUri);
 
   /**


### PR DESCRIPTION
Updating PendingDynamicLinkData to Nullable, to define if there's Dynamic Link or not. If it's null then it's not dynamic link. If it's not, then there's Dynamic Link