### PR TITLE
Add validation for checking if a Screen Trace has non-positive totalFrames

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidator.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidator.java
@@ -50,6 +50,11 @@ final class FirebasePerfTraceValidator extends PerfMetricValidator {
         return false;
       }
     }
+
+    if (!isValidScreenTrace(traceMetric)) {
+      logger.warn("Invalid Screen Trace:" + traceMetric.getName());
+      return false;
+    }
     return true;
   }
 
@@ -102,6 +107,17 @@ final class FirebasePerfTraceValidator extends PerfMetricValidator {
       }
     }
     return true;
+  }
+
+  private boolean isValidScreenTrace(@NonNull TraceMetric trace) {
+    if (!trace.getName().startsWith(Constants.SCREEN_TRACE_PREFIX)) {
+      return true;
+    }
+    Long totalFrames = trace.getCountersMap().get(Constants.CounterNames.FRAMES_TOTAL.toString());
+    if (totalFrames != null) {
+      return totalFrames.compareTo(0L) > 0;
+    }
+    return false;
   }
 
   private boolean isValidTrace(@Nullable TraceMetric trace, int deep) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidator.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidator.java
@@ -135,16 +135,16 @@ final class FirebasePerfTraceValidator extends PerfMetricValidator {
       logger.warn("clientStartTimeUs is null.");
       return false;
     }
+    if (isScreenTrace(trace) && !isValidScreenTrace(trace)) {
+      logger.warn("non-positive totalFrames in screen trace " + trace.getName());
+      return false;
+    }
     for (TraceMetric subtrace : trace.getSubtracesList()) {
       if (!isValidTrace(subtrace, deep + 1)) {
         return false;
       }
     }
     if (!hasValidAttributes(trace.getCustomAttributesMap())) {
-      return false;
-    }
-    if (isScreenTrace(trace) && !isValidScreenTrace(trace)) {
-      logger.warn("non-positive totalFrames in screen trace " + trace.getName());
       return false;
     }
     return true;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidator.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidator.java
@@ -50,11 +50,6 @@ final class FirebasePerfTraceValidator extends PerfMetricValidator {
         return false;
       }
     }
-
-    if (!isValidScreenTrace(traceMetric)) {
-      logger.warn("Invalid Screen Trace:" + traceMetric.getName());
-      return false;
-    }
     return true;
   }
 
@@ -109,15 +104,13 @@ final class FirebasePerfTraceValidator extends PerfMetricValidator {
     return true;
   }
 
+  private boolean isScreenTrace(@NonNull TraceMetric trace) {
+    return trace.getName().startsWith(Constants.SCREEN_TRACE_PREFIX);
+  }
+
   private boolean isValidScreenTrace(@NonNull TraceMetric trace) {
-    if (!trace.getName().startsWith(Constants.SCREEN_TRACE_PREFIX)) {
-      return true;
-    }
     Long totalFrames = trace.getCountersMap().get(Constants.CounterNames.FRAMES_TOTAL.toString());
-    if (totalFrames != null) {
-      return totalFrames.compareTo(0L) > 0;
-    }
-    return false;
+    return totalFrames != null && totalFrames.compareTo(0L) > 0;
   }
 
   private boolean isValidTrace(@Nullable TraceMetric trace, int deep) {
@@ -148,6 +141,10 @@ final class FirebasePerfTraceValidator extends PerfMetricValidator {
       }
     }
     if (!hasValidAttributes(trace.getCustomAttributesMap())) {
+      return false;
+    }
+    if (isScreenTrace(trace) && !isValidScreenTrace(trace)) {
+      logger.warn("non-positive totalFrames in screen trace " + trace.getName());
       return false;
     }
     return true;

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidatorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidatorTest.java
@@ -160,6 +160,14 @@ public class FirebasePerfTraceValidatorTest extends FirebasePerformanceTestBase 
   }
 
   @Test
+  public void testNonPositiveScreenTraceTotalFrames() {
+    TraceMetric.Builder trace = createValidTraceMetric().setName(Constants.SCREEN_TRACE_PREFIX + "TestActivity");
+    assertThat(new FirebasePerfTraceValidator(trace.build()).isValidPerfMetric()).isFalse();
+    trace.putCounters(Constants.CounterNames.FRAMES_TOTAL.toString(), 0L);
+    assertThat(new FirebasePerfTraceValidator(trace.build()).isValidPerfMetric()).isFalse();
+  }
+
+  @Test
   public void testInvalidCustomAttribute() {
     TraceMetric.Builder trace = createValidTraceMetric().putCustomAttributes("_test", "value");
     assertThat(new FirebasePerfTraceValidator(trace.build()).isValidPerfMetric()).isFalse();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidatorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfTraceValidatorTest.java
@@ -160,8 +160,9 @@ public class FirebasePerfTraceValidatorTest extends FirebasePerformanceTestBase 
   }
 
   @Test
-  public void testNonPositiveScreenTraceTotalFrames() {
-    TraceMetric.Builder trace = createValidTraceMetric().setName(Constants.SCREEN_TRACE_PREFIX + "TestActivity");
+  public void screenTrace_shouldNotAllowNonPositiveTotalFrames() {
+    TraceMetric.Builder trace =
+        createValidTraceMetric().setName(Constants.SCREEN_TRACE_PREFIX + "TestActivity");
     assertThat(new FirebasePerfTraceValidator(trace.build()).isValidPerfMetric()).isFalse();
     trace.putCounters(Constants.CounterNames.FRAMES_TOTAL.toString(), 0L);
     assertThat(new FirebasePerfTraceValidator(trace.build()).isValidPerfMetric()).isFalse();


### PR DESCRIPTION
This is to fix a part of b/197734449, where we "found validation failures due to screen traces having 0 or undefined number of total frames" being generated and sent to the backend. 

This PR adds a validation in the SDK that drops screen traces from being sent to the backend when there is no totalFrames metrics or when the metrics is <= 0. 

The exact cause of why zero frames are being recorded is unknown, I suspect it had something to do with us not calling FrameMetricsAggregator.remove(activity), which was removed due to not having good check for hardware acceleration ([context](https://github.com/firebase/firebase-android-sdk/pull/2736)). That could be investigated more in the future, b/150558546 may be useful, just putting that down as a record. 