### PR TITLE
Don't send placeholder FAC token to Cloud Functions 

### DIFF
--- a/firebase-functions/src/androidTest/java/com/google/firebase/functions/TestInternalAppCheckTokenProvider.java
+++ b/firebase-functions/src/androidTest/java/com/google/firebase/functions/TestInternalAppCheckTokenProvider.java
@@ -43,6 +43,23 @@ public class TestInternalAppCheckTokenProvider implements InternalAppCheckTokenP
         };
   }
 
+  public TestInternalAppCheckTokenProvider(String testToken, String error) {
+    this.testToken =
+        new AppCheckTokenResult() {
+          @NonNull
+          @Override
+          public String getToken() {
+            return testToken;
+          }
+
+          @Nullable
+          @Override
+          public FirebaseException getError() {
+            return new FirebaseException(error);
+          }
+        };
+  }
+
   @NonNull
   @Override
   public Task<AppCheckTokenResult> getToken(boolean forceRefresh) {

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseContextProvider.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseContextProvider.java
@@ -100,10 +100,10 @@ class FirebaseContextProvider implements ContextProvider {
         .onSuccessTask(
             result -> {
               if (result.getError() != null) {
-                Log.w(
-                    TAG,
-                    "Error getting App Check token; using placeholder token instead. Error: "
-                        + result.getError());
+                // If there was an error getting the App Check token, do NOT send the placeholder
+                // token. Only valid App Check tokens should be sent to the functions backend.
+                Log.w(TAG, "Error getting App Check token. Error: " + result.getError());
+                return Tasks.forResult(null);
               }
               return Tasks.forResult(result.getToken());
             });


### PR DESCRIPTION
If `AppCheckTokenResult` contains an error, do not send the placeholder token to backend requests.

See FirebaseExtended/flutterfire#6794 for more details.