### PR TITLE
Remove index_value from primary key of index_entries

### DIFF
--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -155,6 +155,7 @@ dependencies {
     }
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
+    androidTestAnnotationProcessor 'com.google.auto.value:auto-value:1.6.5'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 
     testImplementation 'junit:junit:4.12'

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -367,7 +367,7 @@ class SQLiteSchema {
                   + "index_value BLOB, " // field value pairs
                   + "uid TEXT, " // user id or null if there are no pending mutations
                   + "document_id TEXT, "
-                  + "PRIMARY KEY (index_id, index_value, uid, document_id))");
+                  + "PRIMARY KEY (index_id, uid, document_id))");
         });
   }
 


### PR DESCRIPTION
We can remove `index_value` from the composite key since every `index_id` should correspond to a single `index_value`.