### PR TITLE
Index Evaluation

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Bound.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Bound.java
@@ -132,6 +132,17 @@ public final class Bound {
 
   @Override
   public String toString() {
-    return "Bound{before=" + before + ", position=" + position + '}';
+    StringBuilder builder = new StringBuilder();
+    builder.append("Bound(before=");
+    builder.append(before);
+    builder.append(", position=");
+    for (int i = 0; i < position.size(); i++) {
+      if (i > 0) {
+        builder.append(" and ");
+      }
+      builder.append(Values.canonicalId(position.get(i)));
+    }
+    builder.append(")");
+    return builder.toString();
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FieldFilter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FieldFilter.java
@@ -137,7 +137,7 @@ public class FieldFilter extends Filter {
 
   @Override
   public String toString() {
-    return field.canonicalString() + " " + operator + " " + value;
+    return field.canonicalString() + " " + operator + " " + Values.canonicalId(value);
   }
 
   @Override

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -20,6 +20,7 @@ import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.model.Values;
+import com.google.firestore.v1.ArrayValue;
 import com.google.firestore.v1.Value;
 import java.util.ArrayList;
 import java.util.List;
@@ -130,10 +131,15 @@ public final class Target {
           FieldFilter fieldFilter = (FieldFilter) filter;
           switch (fieldFilter.getOperator()) {
             case LESS_THAN:
-            case NOT_IN:
             case NOT_EQUAL:
             case LESS_THAN_OR_EQUAL:
               // These filters cannot be used as a lower bound. Skip.
+              break;
+            case NOT_IN:
+              lowestValue =
+                  Value.newBuilder()
+                      .setArrayValue(ArrayValue.newBuilder().addValues(Values.NULL_VALUE))
+                      .build();
               break;
             case EQUAL:
             case IN:

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -217,11 +217,11 @@ public final class Target {
             case ARRAY_CONTAINS:
             case LESS_THAN_OR_EQUAL:
               largestValue = fieldFilter.getValue();
-              before = true;
+              before = false;
               break;
             case LESS_THAN:
               largestValue = fieldFilter.getValue();
-              before = false;
+              before = true;
               break;
           }
         }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -131,8 +131,11 @@ public final class Target {
           FieldFilter fieldFilter = (FieldFilter) filter;
           switch (fieldFilter.getOperator()) {
             case LESS_THAN:
-            case NOT_EQUAL:
             case LESS_THAN_OR_EQUAL:
+              // TODO(indexing): Implement type clamping. Only field values with the same type
+              // should match the query.
+              break;
+            case NOT_EQUAL:
               // These filters cannot be used as a lower bound. Skip.
               break;
             case NOT_IN:
@@ -199,11 +202,14 @@ public final class Target {
         if (filter.getField().equals(segment.getFieldPath())) {
           FieldFilter fieldFilter = (FieldFilter) filter;
           switch (fieldFilter.getOperator()) {
-            case GREATER_THAN:
             case NOT_IN:
             case NOT_EQUAL:
-            case GREATER_THAN_OR_EQUAL:
               // These filters cannot be used as an upper bound. Skip.
+              break;
+            case GREATER_THAN_OR_EQUAL:
+            case GREATER_THAN:
+              // TODO(indexing): Implement type clamping. Only field values with the same type
+              // should match the query.
               break;
             case EQUAL:
             case IN:
@@ -364,7 +370,7 @@ public final class Target {
         if (i > 0) {
           builder.append(" and ");
         }
-        builder.append(filters.get(i).toString());
+        builder.append(filters.get(i));
       }
     }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexByteEncoder.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexByteEncoder.java
@@ -1,0 +1,63 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.index;
+
+import com.google.protobuf.ByteString;
+
+/**
+ * Implements {@link DirectionalIndexByteEncoder} using {@link OrderedCodeWriter} for the actual
+ * encoding.
+ */
+public class IndexByteEncoder extends DirectionalIndexByteEncoder {
+  // Note: This code is copied from the backend.
+
+  private final OrderedCodeWriter orderedCode;
+
+  public IndexByteEncoder() {
+    this.orderedCode = new OrderedCodeWriter();
+  }
+
+  public void seed(byte[] encodedBytes) {
+    orderedCode.seed(encodedBytes);
+  }
+
+  @Override
+  public void writeBytes(ByteString val) {
+    orderedCode.writeBytesAscending(val);
+  }
+
+  @Override
+  public void writeString(String val) {
+    orderedCode.writeUtf8Ascending(val);
+  }
+
+  @Override
+  public void writeLong(long val) {
+    orderedCode.writeSignedLongAscending(val);
+  }
+
+  @Override
+  public void writeDouble(double val) {
+    orderedCode.writeDoubleAscending(val);
+  }
+
+  public byte[] getEncodedBytes() {
+    return orderedCode.encodedBytes();
+  }
+
+  public void reset() {
+    orderedCode.reset();
+  }
+}

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
@@ -23,13 +23,13 @@ public class IndexEntry {
   private final int indexId;
   private final byte[] indexValue;
   private final String uid;
-  private final String documentId;
+  private final String documentName;
 
-  public IndexEntry(int indexId, byte[] indexValue, String uid, String documentId) {
+  public IndexEntry(int indexId, byte[] indexValue, String uid, String documentName) {
     this.indexId = indexId;
     this.indexValue = indexValue;
     this.uid = uid;
-    this.documentId = documentId;
+    this.documentName = documentName;
   }
 
   public int getIndexId() {
@@ -44,7 +44,7 @@ public class IndexEntry {
     return uid;
   }
 
-  public String getDocumentId() {
-    return documentId;
+  public String getDocumentName() {
+    return documentName;
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
@@ -117,23 +117,23 @@ public class IndexBackfiller {
             + "index_id, "
             + "index_value, "
             + "uid, "
-            + "document_id) VALUES(?, ?, ?, ?)",
+            + "document_name) VALUES(?, ?, ?, ?)",
         entry.getIndexId(),
         entry.getIndexValue(),
         entry.getUid(),
-        entry.getDocumentId());
+        entry.getDocumentName());
   }
 
   @VisibleForTesting
-  void removeIndexEntry(int indexId, String uid, String documentId) {
+  void removeIndexEntry(int indexId, String uid, String documentName) {
     persistence.execute(
         "DELETE FROM index_entries "
             + "WHERE index_id = ? "
             + "AND uid = ?"
-            + "AND document_id = ?",
+            + "AND document_name = ?",
         indexId,
         uid,
-        documentId);
+        documentName);
     ;
   }
 
@@ -141,7 +141,7 @@ public class IndexBackfiller {
   @VisibleForTesting
   IndexEntry getIndexEntry(int indexId) {
     return persistence
-        .query("SELECT index_value, uid, document_id FROM index_entries WHERE index_id = ?")
+        .query("SELECT index_value, uid, document_name FROM index_entries WHERE index_id = ?")
         .binding(indexId)
         .firstValue(
             row ->

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
@@ -14,9 +14,14 @@
 
 package com.google.firebase.firestore.local;
 
+import androidx.annotation.Nullable;
+import com.google.firebase.firestore.core.Target;
+import com.google.firebase.firestore.model.Document;
+import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Represents a set of indexes that are used to execute queries efficiently.
@@ -41,6 +46,9 @@ public interface IndexManager {
    */
   List<ResourcePath> getCollectionParents(String collectionId);
 
+  /** Adds index entries for all indexed fields in the given document. */
+  void addIndexEntries(Document document);
+
   /**
    * Adds a field path index.
    *
@@ -48,4 +56,11 @@ public interface IndexManager {
    * execution once values are persisted.
    */
   void addFieldIndex(FieldIndex index);
+
+  /**
+   * Returns the documents that match the given target based on the configured indices. Returns
+   * {@code null} if there is no active index to serve this target.
+   */
+  @Nullable
+  Set<DocumentKey> getDocumentsMatchingTarget(Target target);
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
@@ -23,6 +23,7 @@ import com.google.firebase.firestore.core.Query.LimitType;
 import com.google.firebase.firestore.core.Target;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
+import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.model.MutableDocument;
 import com.google.firebase.firestore.model.ObjectValue;
 import com.google.firebase.firestore.model.SnapshotVersion;
@@ -308,5 +309,19 @@ public final class LocalSerializer {
     }
 
     return index.build();
+  }
+
+  public FieldIndex decodeFieldIndex(String collection_group, int indexId, Index index) {
+    FieldIndex fieldIndex = new FieldIndex(collection_group, indexId);
+    for (Index.IndexField field : index.getFieldsList()) {
+      fieldIndex =
+          fieldIndex.withAddedField(
+              FieldPath.fromServerFormat(field.getFieldPath()),
+              field.getValueModeCase().equals(Index.IndexField.ValueModeCase.ARRAY_CONFIG)
+                  ? FieldIndex.Segment.Kind.CONTAINS
+                  : FieldIndex.Segment.Kind.ORDERED);
+    }
+
+    return fieldIndex;
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryIndexManager.java
@@ -15,6 +15,10 @@ package com.google.firebase.firestore.local;
 
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import androidx.annotation.Nullable;
+import com.google.firebase.firestore.core.Target;
+import com.google.firebase.firestore.model.Document;
+import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
 import java.util.ArrayList;
@@ -22,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /** An in-memory implementation of IndexManager. */
 class MemoryIndexManager implements IndexManager {
@@ -39,8 +44,20 @@ class MemoryIndexManager implements IndexManager {
   }
 
   @Override
+  public void addIndexEntries(Document document) {
+    // Field indices are not supported with memory persistence.
+  }
+
+  @Override
   public void addFieldIndex(FieldIndex index) {
     // Field indices are not supported with memory persistence.
+  }
+
+  @Override
+  @Nullable
+  public Set<DocumentKey> getDocumentsMatchingTarget(Target target) {
+    // Field indices are not supported with memory persistence.
+    return null;
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -110,8 +110,8 @@ final class SQLiteIndexManager implements IndexManager {
 
   @Override
   public void addIndexEntries(Document document) {
-    ResourcePath documentPath = document.getKey().getPath();
-    String collectionGroup = documentPath.getSegment(documentPath.length() - 2);
+    DocumentKey documentKey = document.getKey();
+    String collectionGroup = documentKey.getCollectionGroup();
     db.query(
             "SELECT index_id, index_proto FROM index_configuration WHERE collection_group = ? AND active = 1")
         .binding(collectionGroup)
@@ -127,10 +127,10 @@ final class SQLiteIndexManager implements IndexManager {
                 if (values == null) return;
 
                 if (Logger.isDebugEnabled()) {
-                  Logger.warn(
+                  Logger.debug(
                       TAG,
                       "Adding index values for document '%s' to index '%s'",
-                      documentPath,
+                      documentKey,
                       fieldIndex);
                 }
 
@@ -144,7 +144,7 @@ final class SQLiteIndexManager implements IndexManager {
                           + "document_name) VALUES(?, ?, ?)",
                       indexId,
                       encoded,
-                      documentPath.canonicalString());
+                      documentKey.toString());
                 }
               } catch (InvalidProtocolBufferException e) {
                 throw fail("Invalid index: " + e);
@@ -176,6 +176,8 @@ final class SQLiteIndexManager implements IndexManager {
     if (fieldIndex == null) return null;
 
     Bound lowerBound = target.getLowerBound(fieldIndex);
+    String lowerBoundOp = lowerBound.isBefore() ? ">=" : ">"; // `startAt()` versus `startAfter()`
+
     @Nullable Bound upperBound = target.getUpperBound(fieldIndex);
 
     if (Logger.isDebugEnabled()) {
@@ -200,13 +202,15 @@ final class SQLiteIndexManager implements IndexManager {
           lowerBoundValues.size() == upperBoundValues.size(),
           "Expected upper and lower bound size to match");
 
+      String upperBoundOp = upperBound.isBefore() ? "<" : "<="; // `endBefore()` versus `endAt()`
+
       // TODO(indexing): To avoid reading the same documents multiple times, we should ideally only
       // send one query that combines all clauses.
       for (int i = 0; i < lowerBoundValues.size(); ++i) {
         db.query(
                 String.format(
                     "SELECT document_name from index_entries WHERE index_id = ? AND index_value %s ? AND index_value %s ?",
-                    lowerBound.isBefore() ? ">=" : ">", upperBound.isBefore() ? "<=" : "<"))
+                    lowerBoundOp, upperBoundOp))
             .binding(fieldIndex.getIndexId(), lowerBoundValues.get(i), upperBoundValues.get(i))
             .forEach(
                 row -> result.add(DocumentKey.fromPath(ResourcePath.fromString(row.getString(0)))));
@@ -218,7 +222,7 @@ final class SQLiteIndexManager implements IndexManager {
         db.query(
                 String.format(
                     "SELECT document_name from index_entries WHERE index_id = ? AND index_value %s  ?",
-                    lowerBound.isBefore() ? ">=" : ">"))
+                    lowerBoundOp))
             .binding(fieldIndex.getIndexId(), lowerBoundValue)
             .forEach(
                 row -> result.add(DocumentKey.fromPath(ResourcePath.fromString(row.getString(0)))));
@@ -259,15 +263,14 @@ final class SQLiteIndexManager implements IndexManager {
                 throw fail("Failed to decode index: " + e);
               }
             });
-    ;
 
     if (activeIndices.isEmpty()) {
       return null;
     }
 
     // Return the index with the most number of segments
-    Collections.sort(activeIndices, (l, r) -> Integer.compare(r.segmentCount(), l.segmentCount()));
-    return activeIndices.get(0);
+    return Collections.max(
+        activeIndices, (l, r) -> Integer.compare(l.segmentCount(), r.segmentCount()));
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -14,12 +14,30 @@
 
 package com.google.firebase.firestore.local;
 
+import static com.google.firebase.firestore.util.Assert.fail;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import androidx.annotation.Nullable;
+import com.google.firebase.firestore.core.Bound;
+import com.google.firebase.firestore.core.FieldFilter;
+import com.google.firebase.firestore.core.Filter;
+import com.google.firebase.firestore.core.Target;
+import com.google.firebase.firestore.index.FirestoreIndexValueWriter;
+import com.google.firebase.firestore.index.IndexByteEncoder;
+import com.google.firebase.firestore.model.Document;
+import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
+import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.model.ResourcePath;
+import com.google.firebase.firestore.model.TargetIndexMatcher;
+import com.google.firestore.admin.v1.Index;
+import com.google.firestore.v1.Value;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /** A persisted implementation of IndexManager. */
 final class SQLiteIndexManager implements IndexManager {
@@ -78,13 +96,244 @@ final class SQLiteIndexManager implements IndexManager {
     db.execute(
         "INSERT OR IGNORE INTO index_configuration ("
             + "index_id, "
-            + "collection_id, "
+            + "collection_group, "
             + "index_proto, "
             + "active) VALUES(?, ?, ?, ?)",
         currentMax + 1,
         index.getCollectionId(),
         encodeFieldIndex(index),
         true);
+  }
+
+  @Override
+  public void addIndexEntries(Document document) {
+    String collectionGroup = document.getKey().getPath().popLast().canonicalString();
+    db.query(
+            "SELECT index_id, index_proto FROM index_configuration WHERE collection_group = ? AND active = 1")
+        .binding(collectionGroup)
+        .forEach(
+            row -> {
+              try {
+                int indexId = row.getInt(0);
+                FieldIndex fieldIndex =
+                    serializer.decodeFieldIndex(
+                        collectionGroup, row.getInt(0), Index.parseFrom(row.getBlob(1)));
+
+                List<Value> values = extractFieldValue(document, fieldIndex);
+                if (values == null) return;
+
+                List<byte[]> encodeValues = encodeDocumentValues(fieldIndex, values);
+                for (byte[] encoded : encodeValues) {
+                  // TODO(indexing): Handle different values for different users
+                  db.execute(
+                      "INSERT OR IGNORE INTO index_entries ("
+                          + "index_id, "
+                          + "index_value, "
+                          + "document_name) VALUES(?, ?, ?)",
+                      indexId,
+                      encoded,
+                      document.getKey().getPath().canonicalString());
+                }
+              } catch (InvalidProtocolBufferException e) {
+                throw fail("Invalid index: " + e);
+              }
+            });
+  }
+
+  /**
+   * Returns the list of values for all fields indexed by the provided field index. Returns {@code
+   * null} if one or more of the fields are not set.
+   */
+  @Nullable
+  private List<Value> extractFieldValue(Document document, FieldIndex fieldIndex) {
+    List<Value> values = new ArrayList<>();
+    for (FieldIndex.Segment segment : fieldIndex) {
+      Value field = document.getField(segment.getFieldPath());
+      if (field == null) {
+        return null;
+      }
+      values.add(field);
+    }
+    return values;
+  }
+
+  @Override
+  @Nullable
+  public Set<DocumentKey> getDocumentsMatchingTarget(Target target) {
+    @Nullable FieldIndex fieldIndex = getMatchingIndex(target);
+    if (fieldIndex == null) return null;
+
+    Bound lowerBound = target.getLowerBound(fieldIndex);
+    @Nullable Bound upperBound = target.getUpperBound(fieldIndex);
+
+    Set<DocumentKey> result = new HashSet<>();
+
+    if (upperBound != null) {
+      List<byte[]> lowerBoundValues =
+          encodeTargetValues(fieldIndex, target, lowerBound.getPosition());
+      List<byte[]> upperBoundValues =
+          encodeTargetValues(fieldIndex, target, upperBound.getPosition());
+
+      hardAssert(
+          lowerBoundValues.size() == upperBoundValues.size(),
+          "Expected upper and lower bound size to match");
+
+      // TODO(indexing): To avoid reading the same documents multiple times, we should ideally only
+      // send one query that combines all clauses.
+      for (int i = 0; i < lowerBoundValues.size(); ++i) {
+        db.query(
+                String.format(
+                    "SELECT document_name from index_entries WHERE index_id = ? AND index_value %s ? AND index_value %s ?",
+                    lowerBound.isBefore() ? ">=" : ">", upperBound.isBefore() ? "<=" : "<"))
+            .binding(fieldIndex.getIndexId(), lowerBoundValues.get(i), upperBoundValues.get(i))
+            .forEach(
+                row -> result.add(DocumentKey.fromPath(ResourcePath.fromString(row.getString(0)))));
+      }
+    } else {
+      List<byte[]> lowerBoundValues =
+          encodeTargetValues(fieldIndex, target, lowerBound.getPosition());
+      for (byte[] lowerBoundValue : lowerBoundValues) {
+        db.query(
+                String.format(
+                    "SELECT document_name from index_entries WHERE index_id = ? AND index_value %s  ?",
+                    lowerBound.isBefore() ? ">=" : ">"))
+            .binding(fieldIndex.getIndexId(), lowerBoundValue)
+            .forEach(
+                row -> result.add(DocumentKey.fromPath(ResourcePath.fromString(row.getString(0)))));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns an index that can be used to serve the provided target. Returns {@code null} if no
+   * index is configured.
+   */
+  private @Nullable FieldIndex getMatchingIndex(Target target) {
+    TargetIndexMatcher targetIndexMatcher = new TargetIndexMatcher(target);
+    String collectionGroup =
+        target.getCollectionGroup() != null
+            ? target.getCollectionGroup()
+            : target.getPath().getLastSegment();
+
+    List<FieldIndex> activeIndices = new ArrayList<>();
+
+    db.query(
+            "SELECT index_id, index_proto FROM index_configuration WHERE collection_group = ? AND active = 1")
+        .binding(collectionGroup)
+        .forEach(
+            row -> {
+              try {
+                FieldIndex fieldIndex =
+                    serializer.decodeFieldIndex(
+                        collectionGroup, row.getInt(0), Index.parseFrom(row.getBlob(1)));
+                boolean matches = targetIndexMatcher.servedByIndex(fieldIndex);
+                if (matches) {
+                  activeIndices.add(fieldIndex);
+                }
+              } catch (InvalidProtocolBufferException e) {
+                throw fail("Failed to decode index: " + e);
+              }
+            });
+    ;
+
+    if (activeIndices.isEmpty()) {
+      return null;
+    }
+
+    // Return the index with the most number of segments
+    Collections.sort(activeIndices, (l, r) -> Integer.compare(r.segmentCount(), l.segmentCount()));
+    return activeIndices.get(0);
+  }
+
+  /**
+   * Encodes the given field values according to the specification in {@code fieldIndex}. For
+   * CONTAINS indices, a list of possible values is returned.
+   */
+  private List<byte[]> encodeDocumentValues(FieldIndex fieldIndex, List<Value> values) {
+    List<IndexByteEncoder> encoders = new ArrayList<>();
+    encoders.add(new IndexByteEncoder());
+    for (int i = 0; i < fieldIndex.segmentCount(); ++i) {
+      FieldIndex.Segment segment = fieldIndex.getSegment(i);
+      Value value = values.get(i);
+      for (IndexByteEncoder encoder : encoders) {
+        if (segment.getKind() == FieldIndex.Segment.Kind.CONTAINS) {
+          encoders = expandIndexValues(encoders, value);
+        } else {
+          hardAssert(
+              segment.getKind() == FieldIndex.Segment.Kind.ORDERED,
+              "Only ORDERED and CONTAINS are supported");
+          FirestoreIndexValueWriter.INSTANCE.writeIndexValue(value, encoder);
+        }
+      }
+    }
+    return getEncodedBytes(encoders);
+  }
+
+  /**
+   * Encodes the given field values according to the specification in {@code target}. For IN and
+   * ArrayContainsAny queries, a list of possible values is returned.
+   */
+  private List<byte[]> encodeTargetValues(
+      FieldIndex fieldIndex, Target target, List<Value> values) {
+    List<IndexByteEncoder> encoders = new ArrayList<>();
+    encoders.add(new IndexByteEncoder());
+    for (int i = 0; i < fieldIndex.segmentCount(); ++i) {
+      FieldIndex.Segment segment = fieldIndex.getSegment(i);
+      Value value = values.get(i);
+      for (IndexByteEncoder encoder : encoders) {
+        if (isMultiValueFilter(target, segment.getFieldPath())) {
+          encoders = expandIndexValues(encoders, value);
+        } else {
+          FirestoreIndexValueWriter.INSTANCE.writeIndexValue(value, encoder);
+        }
+      }
+    }
+    return getEncodedBytes(encoders);
+  }
+
+  /** Returns the byte representation for all encoders. */
+  private List<byte[]> getEncodedBytes(List<IndexByteEncoder> encoders) {
+    List<byte[]> result = new ArrayList<>();
+    for (IndexByteEncoder encoder : encoders) {
+      result.add(encoder.getEncodedBytes());
+    }
+    return result;
+  }
+
+  /**
+   * Creates a separate encoder for each element of an array.
+   *
+   * <p>The method appends each value to all existing encoders (e.g. filter("a", "==", "a1").filter("b", "in", ["b1", "b2"]) becomes ["a1,b1", "a1,b2"]). A list of new encoders is
+   * returned.
+   */
+  private List<IndexByteEncoder> expandIndexValues(List<IndexByteEncoder> encoders, Value value) {
+    List<IndexByteEncoder> prefixes = new ArrayList<>(encoders);
+    List<IndexByteEncoder> results = new ArrayList<>();
+    for (Value arrayElement : value.getArrayValue().getValuesList()) {
+      for (IndexByteEncoder prefix : prefixes) {
+        IndexByteEncoder clonedEncoder = new IndexByteEncoder();
+        clonedEncoder.seed(prefix.getEncodedBytes());
+        FirestoreIndexValueWriter.INSTANCE.writeIndexValue(arrayElement, clonedEncoder);
+        results.add(clonedEncoder);
+      }
+    }
+    return results;
+  }
+
+  private boolean isMultiValueFilter(Target target, FieldPath fieldPath) {
+    for (Filter filter : target.getFilters()) {
+      if (filter.getField().equals(fieldPath))
+        switch (((FieldFilter) filter).getOperator()) {
+          case ARRAY_CONTAINS_ANY:
+          case NOT_IN:
+          case IN:
+            return true;
+          default:
+            return false;
+        }
+    }
+    return false;
   }
 
   private byte[] encodeFieldIndex(FieldIndex fieldIndex) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -354,7 +354,7 @@ class SQLiteSchema {
           db.execSQL(
               "CREATE TABLE index_configuration ("
                   + "index_id INTEGER, "
-                  + "collection_id TEXT, " // collection id
+                  + "collection_group TEXT, "
                   + "index_proto BLOB, " // V1 Admin index proto
                   + "active INTEGER, " // whether index is active
                   + "update_time_seconds INTEGER, " // time of last document update added to index
@@ -366,8 +366,8 @@ class SQLiteSchema {
                   + "index_id INTEGER, "
                   + "index_value BLOB, " // field value pairs
                   + "uid TEXT, " // user id or null if there are no pending mutations
-                  + "document_id TEXT, "
-                  + "PRIMARY KEY (index_id, index_value, uid, document_id))");
+                  + "document_name TEXT, "
+                  + "PRIMARY KEY (index_id, index_value, uid, document_name))");
         });
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/DocumentKey.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/DocumentKey.java
@@ -108,6 +108,11 @@ public final class DocumentKey implements Comparable<DocumentKey> {
     return path;
   }
 
+  /** Returns the collection group (i.e. the name of the parent collection) for this key. */
+  public String getCollectionGroup() {
+    return path.getSegment(path.length() - 2);
+  }
+
   /** Returns true if the document is in the specified collectionId. */
   public boolean hasCollectionId(String collectionId) {
     return path.length() >= 2 && path.segments.get(path.length() - 2).equals(collectionId);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
@@ -57,21 +57,36 @@ public final class FieldIndex implements Iterable<FieldIndex.Segment> {
   }
 
   private final String collectionId;
+  private final int indexId;
   private final List<Segment> segments;
 
-  public FieldIndex(String collectionId) {
+  public FieldIndex(String collectionId, int indexId) {
     this.collectionId = collectionId;
     this.segments = new ArrayList<>();
+    this.indexId = indexId;
   }
 
-  FieldIndex(String collectionId, List<Segment> segments) {
+  public FieldIndex(String collectionId) {
+    this(collectionId, -1);
+  }
+
+  FieldIndex(String collectionId, int indexId, List<Segment> segments) {
     this.collectionId = collectionId;
     this.segments = segments;
+    this.indexId = indexId;
   }
 
   /** The collection ID this index applies to. */
   public String getCollectionId() {
     return collectionId;
+  }
+
+  /**
+   * The index ID. Returns -1 if the index ID is not available (e.g. the index has not yet been
+   * persisted).
+   */
+  public int getIndexId() {
+    return indexId;
   }
 
   public Segment getSegment(int index) {
@@ -80,15 +95,6 @@ public final class FieldIndex implements Iterable<FieldIndex.Segment> {
 
   public int segmentCount() {
     return segments.size();
-  }
-
-  /**
-   * Returns a new field index that only contains the first `size` segments.
-   *
-   * @throws IndexOutOfBoundsException if size > segmentCount
-   */
-  public FieldIndex prefix(int size) {
-    return new FieldIndex(collectionId, segments.subList(0, size));
   }
 
   @NonNull
@@ -101,7 +107,7 @@ public final class FieldIndex implements Iterable<FieldIndex.Segment> {
   public FieldIndex withAddedField(FieldPath fieldPath, Segment.Kind kind) {
     List<Segment> newSegments = new ArrayList<>(segments);
     newSegments.add(new AutoValue_FieldIndex_Segment(fieldPath, kind));
-    return new FieldIndex(collectionId, newSegments);
+    return new FieldIndex(collectionId, indexId, newSegments);
   }
 
   @Override

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryTest.java
@@ -15,6 +15,7 @@
 package com.google.firebase.firestore.core;
 
 import static com.google.firebase.firestore.model.DocumentKey.KEY_FIELD_NAME;
+import static com.google.firebase.firestore.testutil.TestUtil.bound;
 import static com.google.firebase.firestore.testutil.TestUtil.doc;
 import static com.google.firebase.firestore.testutil.TestUtil.filter;
 import static com.google.firebase.firestore.testutil.TestUtil.map;
@@ -35,7 +36,6 @@ import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.testutil.ComparatorTester;
 import com.google.firebase.firestore.testutil.TestUtil;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -620,10 +620,10 @@ public class QueryTest {
     query = baseQuery.limitToFirst(1);
     assertFalse(query.matchesAllDocuments());
 
-    query = baseQuery.startAt(new Bound(Collections.emptyList(), true));
+    query = baseQuery.startAt(bound(true));
     assertFalse(query.matchesAllDocuments());
 
-    query = baseQuery.endAt(new Bound(Collections.emptyList(), true));
+    query = baseQuery.endAt(bound(true));
     assertFalse(query.matchesAllDocuments());
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.core;
 
+import static com.google.firebase.firestore.testutil.TestUtil.bound;
 import static com.google.firebase.firestore.testutil.TestUtil.field;
 import static com.google.firebase.firestore.testutil.TestUtil.filter;
 import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
@@ -26,8 +27,6 @@ import static org.junit.Assert.assertTrue;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.Values;
 import com.google.firestore.v1.Value;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -156,11 +155,7 @@ public class TargetTest {
 
   @Test
   public void startAtQueryBound() {
-    Target target =
-        query("c")
-            .orderBy(orderBy("foo"))
-            .startAt(new Bound(Collections.singletonList(wrap("bar")), true))
-            .toTarget();
+    Target target = query("c").orderBy(orderBy("foo")).startAt(bound(true, "bar")).toTarget();
     FieldIndex index =
         new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
 
@@ -180,7 +175,7 @@ public class TargetTest {
             .filter(filter("b", "==", "b1"))
             .orderBy(orderBy("a"))
             .orderBy(orderBy("b"))
-            .startAt(new Bound(Arrays.asList(wrap("a1"), wrap("b2")), true))
+            .startAt(bound(true, "a1", "b2"))
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
@@ -202,7 +197,7 @@ public class TargetTest {
             .filter(filter("b", "==", "b1"))
             .orderBy(orderBy("a"))
             .orderBy(orderBy("b"))
-            .startAt(new Bound(Arrays.asList(wrap("a1"), wrap("b2")), false))
+            .startAt(bound(false, "a1", "b2"))
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
@@ -224,7 +219,7 @@ public class TargetTest {
             .filter(filter("b", "==", "b2"))
             .orderBy(orderBy("a"))
             .orderBy(orderBy("b"))
-            .startAt(new Bound(Arrays.asList(wrap("a1"), wrap("b1")), false))
+            .startAt(bound(false, "a1", "b1"))
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
@@ -240,11 +235,7 @@ public class TargetTest {
 
   @Test
   public void endAtQueryBound() {
-    Target target =
-        query("c")
-            .orderBy(orderBy("foo"))
-            .endAt(new Bound(Collections.singletonList(wrap("bar")), true))
-            .toTarget();
+    Target target = query("c").orderBy(orderBy("foo")).endAt(bound(true, "bar")).toTarget();
     FieldIndex index =
         new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
 
@@ -264,7 +255,7 @@ public class TargetTest {
             .filter(filter("b", "==", "b2"))
             .orderBy(orderBy("a"))
             .orderBy(orderBy("b"))
-            .endAt(new Bound(Arrays.asList(wrap("a1"), wrap("b1")), false))
+            .endAt(bound(false, "a1", "b1"))
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
@@ -286,7 +277,7 @@ public class TargetTest {
             .filter(filter("b", "==", "b2"))
             .orderBy(orderBy("a"))
             .orderBy(orderBy("b"))
-            .endAt(new Bound(Arrays.asList(wrap("a1"), wrap("b1")), true))
+            .endAt(bound(true, "a1", "b1"))
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
@@ -308,7 +299,7 @@ public class TargetTest {
             .filter(filter("b", "==", "b1"))
             .orderBy(orderBy("a"))
             .orderBy(orderBy("b"))
-            .endAt(new Bound(Arrays.asList(wrap("a2"), wrap("b2")), true))
+            .endAt(bound(false, "a2", "b2"))
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
@@ -59,7 +59,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, "bar");
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, true, "bar");
+    verifyBound(upperBound, false, "bar");
   }
 
   @Test
@@ -72,7 +72,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, new Object[] {null});
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, false, "bar");
+    verifyBound(upperBound, true, "bar");
   }
 
   @Test
@@ -85,7 +85,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, new Object[] {null});
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, true, "bar");
+    verifyBound(upperBound, false, "bar");
   }
 
   @Test
@@ -124,7 +124,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, "bar");
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, true, "bar");
+    verifyBound(upperBound, false, "bar");
   }
 
   @Test
@@ -310,7 +310,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, null, "b1");
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, true, "a1", "b1");
+    verifyBound(upperBound, false, "a1", "b1");
   }
 
   @Test
@@ -324,7 +324,7 @@ public class TargetTest {
     verifyBound(lowerBound, true, "a");
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, true, "a");
+    verifyBound(upperBound, false, "a");
   }
 
   private void verifyBound(Bound bound, boolean before, Object... values) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexManagerTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexManagerTestCase.java
@@ -42,7 +42,7 @@ public abstract class IndexManagerTestCase {
   @Rule public TestName name = new TestName();
 
   private Persistence persistence;
-  private IndexManager indexManager;
+  protected IndexManager indexManager;
 
   @Before
   public void setUp() {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexBackfillerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexBackfillerTest.java
@@ -65,7 +65,7 @@ public class SQLiteIndexBackfillerTest {
   @Test
   public void addAndRemoveIndexEntry() {
     IndexEntry testEntry =
-        new IndexEntry(1, "TEST_BLOB".getBytes(), "sample-uid", "sample-documentId");
+        new IndexEntry(1, "TEST_BLOB".getBytes(), "sample-uid", "coll/sample-documentId");
     persistence.runTransaction(
         "testAddAndRemoveIndexEntry",
         () -> {
@@ -73,10 +73,10 @@ public class SQLiteIndexBackfillerTest {
           IndexEntry entry = backfiller.getIndexEntry(1);
           assertNotNull(entry);
           assertEquals("TEST_BLOB", new String(entry.getIndexValue()));
-          assertEquals("sample-documentId", entry.getDocumentId());
+          assertEquals("coll/sample-documentId", entry.getDocumentName());
           assertEquals("sample-uid", entry.getUid());
 
-          backfiller.removeIndexEntry(1, "sample-uid", "sample-documentId");
+          backfiller.removeIndexEntry(1, "sample-uid", "coll/sample-documentId");
           entry = backfiller.getIndexEntry(1);
           assertNull(entry);
         });

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
@@ -14,6 +14,26 @@
 
 package com.google.firebase.firestore.local;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.firestore.testutil.TestUtil.bound;
+import static com.google.firebase.firestore.testutil.TestUtil.doc;
+import static com.google.firebase.firestore.testutil.TestUtil.field;
+import static com.google.firebase.firestore.testutil.TestUtil.filter;
+import static com.google.firebase.firestore.testutil.TestUtil.key;
+import static com.google.firebase.firestore.testutil.TestUtil.map;
+import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
+import static com.google.firebase.firestore.testutil.TestUtil.query;
+
+import com.google.firebase.firestore.core.Query;
+import com.google.firebase.firestore.model.DocumentKey;
+import com.google.firebase.firestore.model.FieldIndex;
+import com.google.firebase.firestore.model.MutableDocument;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -21,8 +41,183 @@ import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class SQLiteIndexManagerTest extends IndexManagerTestCase {
+  /** Current state of indexing support. Used for restoring after test run. */
+  private static final boolean supportsIndexing = Persistence.INDEXING_SUPPORT_ENABLED;
+
+  @BeforeClass
+  public static void beforeClass() {
+    Persistence.INDEXING_SUPPORT_ENABLED = true;
+  }
+
+  @BeforeClass
+  public static void afterClass() {
+    Persistence.INDEXING_SUPPORT_ENABLED = supportsIndexing;
+  }
+
+  private void setUpSingleValueFilter() {
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("count"), FieldIndex.Segment.Kind.ORDERED));
+    addDoc("coll/doc1", map("count", 1));
+    addDoc("coll/doc2", map("count", 2));
+    addDoc("coll/doc3", map("count", 3));
+  }
+
+  private void setUpArrayValueFilter() {
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("values"), FieldIndex.Segment.Kind.CONTAINS));
+    addDoc("coll/doc1", map("values", Arrays.asList(1, 2, 3)));
+    addDoc("coll/doc2", map("values", Arrays.asList(4, 5, 6)));
+    addDoc("coll/doc3", map("values", Arrays.asList(7, 8, 9)));
+  }
+
   @Override
   Persistence getPersistence() {
     return PersistenceTestHelpers.createSQLitePersistence();
+  }
+
+  @Test
+  public void testEqualityFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", "==", 2));
+    verifyResults(query, "coll/doc2");
+  }
+
+  @Test
+  public void testNotEqualityFilter() {
+    // TODO(indexing): Optimize != filters. We currently return all documents and do not exclude
+    // the documents with the provided value.
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", "!=", 2));
+    verifyResults(query, "coll/doc1", "coll/doc2", "coll/doc3");
+  }
+
+  @Test
+  public void testLessThanFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", "<", 2));
+    verifyResults(query, "coll/doc1");
+  }
+
+  @Test
+  public void testLessThanOrEqualsFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", "<=", 2));
+    verifyResults(query, "coll/doc1", "coll/doc2");
+  }
+
+  @Test
+  public void testGreaterThanOrEqualsFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", ">=", 2));
+    verifyResults(query, "coll/doc2", "coll/doc3");
+  }
+
+  @Test
+  public void testGreaterThanFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", ">", 2));
+    verifyResults(query, "coll/doc3");
+  }
+
+  @Test
+  public void testRangeFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", ">", 1)).filter(filter("count", "<", 3));
+    verifyResults(query, "coll/doc2");
+  }
+
+  @Test
+  public void testStartAtFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").orderBy(orderBy("count")).startAt(bound(true, 2));
+    verifyResults(query, "coll/doc2", "coll/doc3");
+  }
+
+  @Test
+  public void testStartAfterFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").orderBy(orderBy("count")).startAt(bound(false, 2));
+    verifyResults(query, "coll/doc3");
+  }
+
+  @Test
+  public void testEndAtFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").orderBy(orderBy("count")).endAt(bound(true, 2));
+    verifyResults(query, "coll/doc1", "coll/doc2");
+  }
+
+  @Test
+  public void testEndBeforeFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").orderBy(orderBy("count")).endAt(bound(false, 2));
+    verifyResults(query, "coll/doc1");
+  }
+
+  @Test
+  public void testRangeWithBoundFilter() {
+    setUpSingleValueFilter();
+    Query startAt =
+        query("coll")
+            .filter(filter("count", ">=", 1))
+            .filter(filter("count", "<=", 3))
+            .orderBy(orderBy("count"))
+            .startAt(bound(false, 1))
+            .endAt(bound(true, 2));
+    verifyResults(startAt, "coll/doc2");
+  }
+
+  @Test
+  public void testInFilter() {
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", "in", Arrays.asList(1, 2)));
+    verifyResults(query, "coll/doc1", "coll/doc2");
+  }
+
+  @Test
+  public void testNotInFilter() {
+    // TODO(indexing): Optimize not-in filters. We currently return all documents and do not exclude
+    // the documents with the provided values.
+    setUpSingleValueFilter();
+    Query query = query("coll").filter(filter("count", "not-in", Arrays.asList(1, 2)));
+    verifyResults(query, "coll/doc1", "coll/doc2", "coll/doc3");
+  }
+
+  @Test
+  public void testArrayContainsFilter() {
+    setUpArrayValueFilter();
+    Query query = query("coll").filter(filter("values", "array-contains", 1));
+    verifyResults(query, "coll/doc1");
+  }
+
+  @Test
+  public void testArrayContainsAnyFilter() {
+    setUpArrayValueFilter();
+    Query query =
+        query("coll").filter(filter("values", "array-contains-any", Arrays.asList(1, 2, 4)));
+    verifyResults(query, "coll/doc1", "coll/doc2");
+  }
+
+  @Test
+  public void testArrayContainsDoesNotMatchNonArray() {
+    // Set up two field indices. This causes two index entries to be written, but our query should
+    // only use one index.
+    setUpArrayValueFilter();
+    setUpSingleValueFilter();
+    addDoc("coll/nonmatching", map("values", 1));
+    Query query =
+            query("coll").filter(filter("values", "array-contains-any", Arrays.asList(1)));
+    verifyResults(query, "coll/doc1");
+  }
+
+  private void addDoc(String key, Map<String, Object> data) {
+    MutableDocument count1Doc = doc(key, 1, data);
+    indexManager.addIndexEntries(count1Doc);
+  }
+
+  private void verifyResults(Query query, String... documents) {
+    Iterable<DocumentKey> results = indexManager.getDocumentsMatchingTarget(query.toTarget());
+    List<DocumentKey> keys = Arrays.stream(documents).map(s -> key(s)).collect(Collectors.toList());
+    assertThat(results).containsExactlyElementsIn(keys);
   }
 }

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -39,6 +39,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.TestAccessHelper;
 import com.google.firebase.firestore.UserDataReader;
 import com.google.firebase.firestore.UserDataWriter;
+import com.google.firebase.firestore.core.Bound;
 import com.google.firebase.firestore.core.FieldFilter;
 import com.google.firebase.firestore.core.Filter.Operator;
 import com.google.firebase.firestore.core.OrderBy;
@@ -89,6 +90,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** A set of utilities for tests */
@@ -284,6 +286,10 @@ public class TestUtil {
       throw new IllegalArgumentException("Unknown direction: " + dir);
     }
     return OrderBy.getInstance(direction, field(key));
+  }
+
+  public static Bound bound(boolean before, Object... values) {
+    return new Bound(Arrays.stream(values).map(v -> wrap(v)).collect(Collectors.toList()), before);
   }
 
   public static void testEquality(List<List<Integer>> equalityGroups) {


### PR DESCRIPTION
This PR adds the code that is needed to add documents to the Index and to run queries against the Index.

Couple changes from previous PRs:
- The schema now uses collection_groups and no longer collection_ids. This was true before but it also now reflected in the names.
- Since we use collection groups, the schema actually needs to contain the relative path of the document rather than just the document ID.