### PR TITLE
Fireperf: create a random delay before initiating a remote config fetch. 

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import com.google.android.gms.common.util.VisibleForTesting;
 import com.google.firebase.inject.Provider;
 import com.google.firebase.perf.logging.AndroidLogger;
+import com.google.firebase.perf.provider.FirebasePerfProvider;
 import com.google.firebase.perf.util.Optional;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
@@ -93,7 +94,8 @@ public class RemoteConfigManager {
         firebaseRemoteConfig == null
             ? new ConcurrentHashMap<>()
             : new ConcurrentHashMap<>(firebaseRemoteConfig.getAll());
-    this.appStartTimeInMs = getCurrentSystemTimeMillis();
+    this.appStartTimeInMs =
+        TimeUnit.MICROSECONDS.toMillis(FirebasePerfProvider.getAppStartTime().getMicros());
     this.appStartConfigFetchDelayInMs = appStartConfigFetchDelayInMs;
   }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -27,10 +27,10 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigValue;
 import com.google.firebase.remoteconfig.RemoteConfigComponent;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -50,7 +50,7 @@ public class RemoteConfigManager {
       TimeUnit.HOURS.toMillis(12);
   private static final long FETCH_NEVER_HAPPENED_TIMESTAMP_MS = 0;
   private static final long MIN_APP_START_CONFIG_FETCH_DELAY_MS = 5000;
-  private static final long RANDOM_APP_START_CONFIG_FETCH_DELAY_MS = 25000;
+  private static final int RANDOM_APP_START_CONFIG_FETCH_DELAY_MS = 25000;
 
   private final ConcurrentHashMap<String, FirebaseRemoteConfigValue> allRcConfigMap;
   private final Executor executor;
@@ -79,7 +79,7 @@ public class RemoteConfigManager {
         executor,
         firebaseRemoteConfig,
         MIN_APP_START_CONFIG_FETCH_DELAY_MS
-            + ThreadLocalRandom.current().nextLong(RANDOM_APP_START_CONFIG_FETCH_DELAY_MS));
+            + new Random().nextInt(RANDOM_APP_START_CONFIG_FETCH_DELAY_MS));
   }
 
   @VisibleForTesting

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -78,7 +78,8 @@ public class RemoteConfigManager {
     this(
         executor,
         firebaseRemoteConfig,
-        MIN_APP_START_CONFIG_FETCH_DELAY_MS + new Random().nextInt(RANDOM_APP_START_CONFIG_FETCH_DELAY_MS));
+        MIN_APP_START_CONFIG_FETCH_DELAY_MS
+            + new Random().nextInt(RANDOM_APP_START_CONFIG_FETCH_DELAY_MS));
   }
 
   @VisibleForTesting
@@ -298,10 +299,11 @@ public class RemoteConfigManager {
 
   /**
    * Triggers a fetch and async activate from Firebase Remote Config if:
+   *
    * <ol>
-   * <li>Firebase Remote Config is available,
-   * <li>Time-since-app-start has passed a randomized delay-time, and
-   * <li>At least 12 hours have passed since the previous fetch.
+   *   <li>Firebase Remote Config is available,
+   *   <li>Time-since-app-start has passed a randomized delay-time (b/187985523), and
+   *   <li>At least 12 hours have passed since the previous fetch.
    * </ol>
    */
   private void triggerRemoteConfigFetchIfNecessary() {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -49,7 +49,8 @@ public class RemoteConfigManager {
   private static final long TIME_AFTER_WHICH_A_FETCH_IS_CONSIDERED_STALE_MS =
       TimeUnit.HOURS.toMillis(12);
   private static final long FETCH_NEVER_HAPPENED_TIMESTAMP_MS = 0;
-  private static final long MIN_APP_START_CONFIG_FETCH_DELAY = 5000;
+  private static final long MIN_APP_START_CONFIG_FETCH_DELAY_MS = 5000;
+  private static final int RANDOM_APP_START_CONFIG_FETCH_DELAY_MS = 25000;
 
   private final ConcurrentHashMap<String, FirebaseRemoteConfigValue> allRcConfigMap;
   private final Executor executor;
@@ -77,7 +78,7 @@ public class RemoteConfigManager {
     this(
         executor,
         firebaseRemoteConfig,
-        MIN_APP_START_CONFIG_FETCH_DELAY + new Random().nextInt(25000));
+        MIN_APP_START_CONFIG_FETCH_DELAY_MS + new Random().nextInt(RANDOM_APP_START_CONFIG_FETCH_DELAY_MS));
   }
 
   @VisibleForTesting
@@ -296,8 +297,12 @@ public class RemoteConfigManager {
   }
 
   /**
-   * Triggers a fetch and async activate from Firebase Remote Config if Firebase Remote Config is
-   * available, and at least 12 hours have passed since the previous fetch.
+   * Triggers a fetch and async activate from Firebase Remote Config if:
+   * <ol>
+   * <li>Firebase Remote Config is available,
+   * <li>Time-since-app-start has passed a randomized delay-time, and
+   * <li>At least 12 hours have passed since the previous fetch.
+   * </ol>
    */
   private void triggerRemoteConfigFetchIfNecessary() {
     if (!isFirebaseRemoteConfigAvailable()) {

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
@@ -27,6 +27,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.inject.Provider;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.provider.FirebasePerfProvider;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigInfo;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
@@ -808,8 +809,10 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
                 appStartConfigFetchDelay));
 
     // Simulate time fast forward to some time before fetch time is up
+    long appStartTimeInMs =
+        TimeUnit.MICROSECONDS.toMillis(FirebasePerfProvider.getAppStartTime().getMicros());
     when(remoteConfigManagerPartialMock.getCurrentSystemTimeMillis())
-        .thenReturn(System.currentTimeMillis() + appStartConfigFetchDelay - 2000);
+        .thenReturn(appStartTimeInMs + appStartConfigFetchDelay - 2000);
 
     simulateFirebaseRemoteConfigLastFetchStatus(
         FirebaseRemoteConfig.LAST_FETCH_STATUS_NO_FETCH_YET);
@@ -833,8 +836,10 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
                 appStartConfigFetchDelay));
 
     // Simulate time fast forward to 2s after fetch delay time is up
+    long appStartTimeInMs =
+        TimeUnit.MICROSECONDS.toMillis(FirebasePerfProvider.getAppStartTime().getMicros());
     when(remoteConfigManagerPartialMock.getCurrentSystemTimeMillis())
-        .thenReturn(System.currentTimeMillis() + appStartConfigFetchDelay + 2000);
+        .thenReturn(appStartTimeInMs + appStartConfigFetchDelay + 2000);
 
     simulateFirebaseRemoteConfigLastFetchStatus(
         FirebaseRemoteConfig.LAST_FETCH_STATUS_NO_FETCH_YET);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
@@ -883,9 +883,11 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
     when(mockFirebaseRemoteConfig.fetchAndActivate()).thenReturn(fakeTask);
     when(mockFirebaseRemoteConfig.getAll()).thenReturn(configs);
     if (initializeFrc) {
-      return new RemoteConfigManager(fakeExecutor, mockFirebaseRemoteConfig, appStartConfigFetchDelayInMs);
+      return new RemoteConfigManager(
+          fakeExecutor, mockFirebaseRemoteConfig, appStartConfigFetchDelayInMs);
     } else {
-      return new RemoteConfigManager(fakeExecutor, /* firebaseRemoteConfig= */ null, appStartConfigFetchDelayInMs);
+      return new RemoteConfigManager(
+          fakeExecutor, /* firebaseRemoteConfig= */ null, appStartConfigFetchDelayInMs);
     }
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
@@ -878,14 +878,14 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
       Task<Boolean> fakeTask,
       boolean initializeFrc,
       Map<String, FirebaseRemoteConfigValue> configs,
-      long fetchDelay) {
+      long appStartConfigFetchDelayInMs) {
     simulateFirebaseRemoteConfigLastFetchStatus(FirebaseRemoteConfig.LAST_FETCH_STATUS_SUCCESS);
     when(mockFirebaseRemoteConfig.fetchAndActivate()).thenReturn(fakeTask);
     when(mockFirebaseRemoteConfig.getAll()).thenReturn(configs);
     if (initializeFrc) {
-      return new RemoteConfigManager(fakeExecutor, mockFirebaseRemoteConfig, fetchDelay);
+      return new RemoteConfigManager(fakeExecutor, mockFirebaseRemoteConfig, appStartConfigFetchDelayInMs);
     } else {
-      return new RemoteConfigManager(fakeExecutor, /* firebaseRemoteConfig= */ null, fetchDelay);
+      return new RemoteConfigManager(fakeExecutor, /* firebaseRemoteConfig= */ null, appStartConfigFetchDelayInMs);
     }
   }
 


### PR DESCRIPTION
**Rationale**:
This is required to ensure that a remote notification does not trigger multiple config fetches from remote config at the same time. Internal bug reference: b/187985523

iOS version of the same change https://github.com/firebase/firebase-ios-sdk/pull/8593