### PR TITLE
Speed up SpecTest

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/Datastore.java
@@ -92,10 +92,19 @@ public class Datastore {
     this.databaseInfo = databaseInfo;
     this.workerQueue = workerQueue;
     this.serializer = new RemoteSerializer(databaseInfo.getDatabaseId());
+    this.channel =
+        initializeChannel(
+            databaseInfo, workerQueue, credentialsProvider, context, metadataProvider);
+  }
 
-    channel =
-        new FirestoreChannel(
-            workerQueue, context, credentialsProvider, databaseInfo, metadataProvider);
+  FirestoreChannel initializeChannel(
+      DatabaseInfo databaseInfo,
+      AsyncQueue workerQueue,
+      CredentialsProvider credentialsProvider,
+      Context context,
+      @Nullable GrpcMetadataProvider metadataProvider) {
+    return new FirestoreChannel(
+        workerQueue, context, credentialsProvider, databaseInfo, metadataProvider);
   }
 
   void shutdown() {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/MockDatastore.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/remote/MockDatastore.java
@@ -17,6 +17,8 @@ package com.google.firebase.firestore.remote;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import android.content.Context;
+import androidx.annotation.Nullable;
+import com.google.firebase.firestore.auth.CredentialsProvider;
 import com.google.firebase.firestore.core.DatabaseInfo;
 import com.google.firebase.firestore.local.TargetData;
 import com.google.firebase.firestore.model.SnapshotVersion;
@@ -217,6 +219,19 @@ public class MockDatastore extends Datastore {
     super(databaseInfo, workerQueue, new EmptyCredentialsProvider(), context, null);
     this.serializer = new RemoteSerializer(getDatabaseInfo().getDatabaseId());
   }
+
+  @Override
+  FirestoreChannel initializeChannel(
+      DatabaseInfo databaseInfo,
+      AsyncQueue workerQueue,
+      CredentialsProvider credentialsProvider,
+      Context context,
+      @Nullable GrpcMetadataProvider metadataProvider) {
+    return null;
+  }
+
+  @Override
+  void shutdown() {}
 
   @Override
   WatchStream createWatchStream(WatchStream.Callback listener) {


### PR DESCRIPTION
The teardown of the GRPC channel takes almost one second, and we don't use it at all during the Spec Test run. This change changes the runtime from 2:30 minutes to 8 seconds for me.