### PR TITLE
Add headers to support Android-application restricted API keys

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForNewReleaseClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/CheckForNewReleaseClient.java
@@ -125,7 +125,8 @@ class CheckForNewReleaseClient {
       throws FirebaseAppDistributionException {
     try {
       AppDistributionReleaseInternal retrievedNewRelease =
-          firebaseAppDistributionTesterApiClient.fetchNewRelease(fid, appId, apiKey, authToken);
+          firebaseAppDistributionTesterApiClient.fetchNewRelease(
+              fid, appId, apiKey, authToken, firebaseApp.getApplicationContext());
 
       if (isNewerBuildVersion(retrievedNewRelease) || !isInstalledRelease(retrievedNewRelease)) {
         return retrievedNewRelease;

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/CheckForNewReleaseClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/CheckForNewReleaseClientTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
+import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.os.Bundle;
@@ -87,6 +88,7 @@ public class CheckForNewReleaseClientTest {
 
   private CheckForNewReleaseClient checkForNewReleaseClient;
   private ShadowPackageManager shadowPackageManager;
+  private Context applicationContext;
 
   @Mock private FirebaseInstallationsApi mockFirebaseInstallations;
   @Mock private FirebaseAppDistributionTesterApiClient mockFirebaseAppDistributionTesterApiClient;
@@ -117,6 +119,7 @@ public class CheckForNewReleaseClientTest {
 
     shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
+    applicationContext = ApplicationProvider.getApplicationContext();
 
     ApplicationInfo applicationInfo =
         ApplicationInfoBuilder.newBuilder()
@@ -161,7 +164,8 @@ public class CheckForNewReleaseClientTest {
 
   @Test
   public void checkForNewRelease_succeeds() throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(any(), any(), any(), any()))
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
+            any(), any(), any(), any(), any()))
         .thenReturn(TEST_RELEASE_NEWER_APK);
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
     when(mockFirebaseInstallations.getToken(false))
@@ -180,7 +184,8 @@ public class CheckForNewReleaseClientTest {
 
   @Test
   public void checkForNewRelease_nonAppDistroFailure() throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(any(), any(), any(), any()))
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
+            any(), any(), any(), any(), any()))
         .thenReturn(TEST_RELEASE_CURRENT);
     Exception expectedException = new Exception("test ex");
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forException(expectedException));
@@ -210,7 +215,8 @@ public class CheckForNewReleaseClientTest {
     FirebaseAppDistributionException expectedException =
         new FirebaseAppDistributionException(
             "test", FirebaseAppDistributionException.Status.UNKNOWN);
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(any(), any(), any(), any()))
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
+            any(), any(), any(), any(), any()))
         .thenThrow(expectedException);
 
     TestOnCompleteListener<AppDistributionReleaseInternal> onCompleteListener =
@@ -228,7 +234,7 @@ public class CheckForNewReleaseClientTest {
   public void getNewReleaseFromClient_whenNewReleaseIsNewerBuildThanInstalled_returnsRelease()
       throws Exception {
     when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext))
         .thenReturn(TEST_RELEASE_NEWER_APK);
 
     AppDistributionReleaseInternal release =
@@ -242,7 +248,7 @@ public class CheckForNewReleaseClientTest {
   @Test
   public void getNewReleaseFromClient_whenNewReleaseIsSameRelease_returnsNull() throws Exception {
     when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN))
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext))
         .thenReturn(TEST_RELEASE_CURRENT);
 
     doReturn(TEST_CODEHASH_2).when(checkForNewReleaseClient).extractApkCodeHash(any());
@@ -256,7 +262,8 @@ public class CheckForNewReleaseClientTest {
 
   @Test
   public void handleNewReleaseFromClient_whenNewAabIsAvailable_returnsRelease() throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(any(), any(), any(), any()))
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
+            any(), any(), any(), any(), any()))
         .thenReturn(
             AppDistributionReleaseInternal.builder()
                 .setBuildVersion(TEST_RELEASE_CURRENT.getBuildVersion())
@@ -285,7 +292,8 @@ public class CheckForNewReleaseClientTest {
   @Test
   public void handleNewReleaseFromClient_whenNewReleaseIsSameAsInstalledAab_returnsNull()
       throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(any(), any(), any(), any()))
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
+            any(), any(), any(), any(), any()))
         .thenReturn(
             AppDistributionReleaseInternal.builder()
                 .setBuildVersion(TEST_RELEASE_CURRENT.getBuildVersion())

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTesterApiClientTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.appdistribution.internal.AppDistributionReleaseInternal;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -45,6 +47,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
   private static final String INVALID_RESPONSE = "InvalidResponse";
 
   private FirebaseAppDistributionTesterApiClient firebaseAppDistributionTesterApiClient;
+  private Context applicationContext;
   @Mock private HttpsURLConnection mockHttpsURLConnection;
 
   @Before
@@ -59,6 +62,8 @@ public class FirebaseAppDistributionTesterApiClientTest {
     Mockito.doReturn(mockHttpsURLConnection)
         .when(firebaseAppDistributionTesterApiClient)
         .openHttpsUrlConnection(TEST_APP_ID_1, TEST_FID_1);
+
+    applicationContext = ApplicationProvider.getApplicationContext();
   }
 
   @Test
@@ -69,7 +74,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
     when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
     AppDistributionReleaseInternal release =
         firebaseAppDistributionTesterApiClient.fetchNewRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext);
     assertEquals(release.getBinaryType(), BinaryType.APK);
     assertEquals(release.getBuildVersion(), "3");
     assertEquals(release.getDisplayVersion(), "3.0");
@@ -86,7 +91,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
     when(mockHttpsURLConnection.getInputStream()).thenReturn(response);
     AppDistributionReleaseInternal release =
         firebaseAppDistributionTesterApiClient.fetchNewRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext);
     assertEquals(release.getBinaryType(), BinaryType.AAB);
     assertEquals(release.getBuildVersion(), "3");
     assertEquals(release.getDisplayVersion(), "3.0");
@@ -105,7 +110,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
             FirebaseAppDistributionException.class,
             () ->
                 firebaseAppDistributionTesterApiClient.fetchNewRelease(
-                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
+                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext));
 
     assertEquals(FirebaseAppDistributionException.Status.AUTHENTICATION_FAILURE, ex.getErrorCode());
     assertEquals("Failed to authenticate the tester", ex.getMessage());
@@ -121,7 +126,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
             FirebaseAppDistributionException.class,
             () ->
                 firebaseAppDistributionTesterApiClient.fetchNewRelease(
-                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
+                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext));
 
     assertEquals(FirebaseAppDistributionException.Status.AUTHENTICATION_FAILURE, ex.getErrorCode());
     assertEquals("Failed to authorize the tester", ex.getMessage());
@@ -137,7 +142,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
             FirebaseAppDistributionException.class,
             () ->
                 firebaseAppDistributionTesterApiClient.fetchNewRelease(
-                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
+                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext));
 
     assertEquals(FirebaseAppDistributionException.Status.AUTHENTICATION_FAILURE, ex.getErrorCode());
     assertEquals("Tester or release not found", ex.getMessage());
@@ -153,7 +158,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
             FirebaseAppDistributionException.class,
             () ->
                 firebaseAppDistributionTesterApiClient.fetchNewRelease(
-                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
+                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext));
 
     assertEquals(FirebaseAppDistributionException.Status.NETWORK_FAILURE, ex.getErrorCode());
     assertEquals("Failed to fetch releases due to timeout", ex.getMessage());
@@ -169,7 +174,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
             FirebaseAppDistributionException.class,
             () ->
                 firebaseAppDistributionTesterApiClient.fetchNewRelease(
-                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
+                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext));
 
     assertEquals(FirebaseAppDistributionException.Status.NETWORK_FAILURE, ex.getErrorCode());
     assertEquals("Failed to fetch releases due to unknown network error", ex.getMessage());
@@ -185,7 +190,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
             FirebaseAppDistributionException.class,
             () ->
                 firebaseAppDistributionTesterApiClient.fetchNewRelease(
-                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN));
+                    TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext));
 
     assertEquals(FirebaseAppDistributionException.Status.UNKNOWN, ex.getErrorCode());
     assertEquals("Error parsing service response", ex.getMessage());


### PR DESCRIPTION
API requests have to contain additional “X-Android-Package”, “X-Android-Cert” headers for Android-application restricted keys