### PR TITLE
Remove special handling in Mutations

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/DeleteMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/DeleteMutation.java
@@ -19,7 +19,6 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MutableDocument;
-import com.google.firebase.firestore.model.SnapshotVersion;
 
 /** Represents a Delete operation */
 public final class DeleteMutation extends Mutation {
@@ -72,7 +71,7 @@ public final class DeleteMutation extends Mutation {
     verifyKeyMatches(document);
 
     if (getPrecondition().isValidFor(document)) {
-      document.convertToNoDocument(SnapshotVersion.NONE);
+      document.convertToNoDocument(document.getVersion()).setHasLocalMutations();
     }
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/Mutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/Mutation.java
@@ -22,7 +22,6 @@ import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.model.MutableDocument;
 import com.google.firebase.firestore.model.ObjectValue;
-import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firestore.v1.Value;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -134,19 +133,6 @@ public abstract class Mutation {
     hardAssert(
         document.getKey().equals(getKey()),
         "Can only apply a mutation to a document with the same key");
-  }
-
-  /**
-   * Returns the version from the given document for use as the result of a mutation. Mutations are
-   * defined to return the version of the base document only if it is an existing document. Deleted
-   * and unknown documents have a post-mutation version of {@code SnapshotVersion.NONE}.
-   */
-  static SnapshotVersion getPostMutationVersion(MutableDocument document) {
-    if (document.isFoundDocument()) {
-      return document.getVersion();
-    } else {
-      return SnapshotVersion.NONE;
-    }
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/PatchMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/PatchMutation.java
@@ -138,7 +138,7 @@ public final class PatchMutation extends Mutation {
     value.setAll(getPatch());
     value.setAll(transformResults);
     document
-        .convertToFoundDocument(getPostMutationVersion(document), document.getData())
+        .convertToFoundDocument(document.getVersion(), document.getData())
         .setHasLocalMutations();
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/SetMutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/SetMutation.java
@@ -96,9 +96,7 @@ public final class SetMutation extends Mutation {
     Map<FieldPath, Value> transformResults = localTransformResults(localWriteTime, document);
     ObjectValue localValue = value.clone();
     localValue.setAll(transformResults);
-    document
-        .convertToFoundDocument(getPostMutationVersion(document), localValue)
-        .setHasLocalMutations();
+    document.convertToFoundDocument(document.getVersion(), localValue).setHasLocalMutations();
   }
 
   /** Returns the object value to use when setting the document. */

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutationTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/MutationTest.java
@@ -526,7 +526,7 @@ public class MutationTest {
 
     Mutation delete = deleteMutation("collection/key");
     delete.applyToLocalView(deletedDoc, Timestamp.now());
-    assertEquals(deletedDoc("collection/key", 0), deletedDoc);
+    assertEquals(deletedDoc("collection/key", 0).setHasLocalMutations(), deletedDoc);
   }
 
   @Test


### PR DESCRIPTION
I have been thinking more about our mutation code. I don't actually think there are any user visible mutations changes if a latency-compensated delete keeps the current version and has "localMutations" set. The only changes I see are in the local store tests, but the integration tests are unchanged.

Let me know if you can think of any problems.

This would further simplify https://github.com/firebase/firebase-android-sdk/pull/2962