### PR TITLE
Add ordering to Index implementation

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/OrderBy.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/OrderBy.java
@@ -24,17 +24,24 @@ import com.google.firestore.v1.Value;
 public class OrderBy {
   /** The direction of the ordering */
   public enum Direction {
-    ASCENDING(1),
-    DESCENDING(-1);
+    ASCENDING(1, "asc"),
+    DESCENDING(-1, "desc");
 
     private final int comparisonModifier;
+    private final String shorthand;
 
-    Direction(int comparisonModifier) {
+    Direction(int comparisonModifier, String canonicalString) {
       this.comparisonModifier = comparisonModifier;
+      this.shorthand = canonicalString;
     }
 
     int getComparisonModifier() {
       return comparisonModifier;
+    }
+
+    /** Returns "asc" for ascending or "desc" for descending. */
+    public String canonicalString() {
+      return shorthand;
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -114,7 +114,7 @@ public final class Target {
     return endAt;
   }
 
-  /** Returns the list of values that are used in ARRAY_CONTAINS and ARRAY_CONTAINS_ANY filter. */
+  /** Returns the list of values that are used in ARRAY_CONTAINS or ARRAY_CONTAINS_ANY filters. */
   public List<Value> getArrayValues(FieldIndex fieldIndex) {
     for (FieldIndex.Segment segment : fieldIndex.getArraySegments()) {
       for (Filter filter : filters) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -172,7 +172,7 @@ public final class Target {
               filterInclusive = false;
               break;
             default:
-              // Remaining filters cannot be used as upper bounds.
+              // Remaining filters cannot be used as lower bounds.
           }
 
           if (max(segmentValue, filterValue) == filterValue) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -18,14 +18,13 @@ import static com.google.firebase.firestore.model.Values.max;
 import static com.google.firebase.firestore.model.Values.min;
 
 import androidx.annotation.Nullable;
-import com.google.firebase.firestore.core.OrderBy.Direction;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.model.Values;
-import com.google.firestore.v1.ArrayValue;
 import com.google.firestore.v1.Value;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -115,6 +114,27 @@ public final class Target {
     return endAt;
   }
 
+  /** Returns the list of values that are used in ARRAY_CONTAINS and ARRAY_CONTAINS_ANY filter. */
+  public List<Value> getArrayValues(FieldIndex fieldIndex) {
+    for (FieldIndex.Segment segment : fieldIndex.getArraySegments()) {
+      for (Filter filter : filters) {
+        if (filter.getField().equals(segment.getFieldPath())) {
+          FieldFilter fieldFilter = (FieldFilter) filter;
+          switch (fieldFilter.getOperator()) {
+            case ARRAY_CONTAINS_ANY:
+              return fieldFilter.getValue().getArrayValue().getValuesList();
+            case ARRAY_CONTAINS:
+              return Collections.singletonList(fieldFilter.getValue());
+            default:
+              // Remaining filters cannot be used as array filters.
+          }
+        }
+      }
+    }
+
+    return Collections.emptyList();
+  }
+
   /**
    * Returns a lower bound of field values that can be used as a starting point to scan the index
    * defined by {@code fieldIndex}.
@@ -127,7 +147,7 @@ public final class Target {
     boolean inclusive = true;
 
     // Go through all filters to find a value for the current field segment
-    for (FieldIndex.Segment segment : fieldIndex) {
+    for (FieldIndex.Segment segment : fieldIndex.getDirectionalSegments()) {
       Value segmentValue = Values.NULL_VALUE;
       boolean segmentInclusive = true;
 
@@ -142,19 +162,8 @@ public final class Target {
             case LESS_THAN_OR_EQUAL:
               filterValue = Values.getLowerBound(fieldFilter.getValue().getValueTypeCase());
               break;
-            case NOT_EQUAL:
-              filterValue = Values.NULL_VALUE;
-              break;
-            case NOT_IN:
-              filterValue =
-                  Value.newBuilder()
-                      .setArrayValue(ArrayValue.newBuilder().addValues(Values.NULL_VALUE))
-                      .build();
-              break;
             case EQUAL:
             case IN:
-            case ARRAY_CONTAINS_ANY:
-            case ARRAY_CONTAINS:
             case GREATER_THAN_OR_EQUAL:
               filterValue = fieldFilter.getValue();
               break;
@@ -162,6 +171,8 @@ public final class Target {
               filterValue = fieldFilter.getValue();
               filterInclusive = false;
               break;
+            default:
+              // Remaining filters cannot be used as upper bounds.
           }
 
           if (max(segmentValue, filterValue) == filterValue) {
@@ -206,7 +217,7 @@ public final class Target {
     List<Value> values = new ArrayList<>();
     boolean inclusive = true;
 
-    for (FieldIndex.Segment segment : fieldIndex) {
+    for (FieldIndex.Segment segment : fieldIndex.getDirectionalSegments()) {
       @Nullable Value segmentValue = null;
       boolean segmentInclusive = true;
 
@@ -218,10 +229,6 @@ public final class Target {
           boolean filterInclusive = true;
 
           switch (fieldFilter.getOperator()) {
-            case NOT_IN:
-            case NOT_EQUAL:
-              // These filters cannot be used as an upper bound. Skip.
-              break;
             case GREATER_THAN_OR_EQUAL:
             case GREATER_THAN:
               filterValue = Values.getUpperBound(fieldFilter.getValue().getValueTypeCase());
@@ -229,8 +236,6 @@ public final class Target {
               break;
             case EQUAL:
             case IN:
-            case ARRAY_CONTAINS_ANY:
-            case ARRAY_CONTAINS:
             case LESS_THAN_OR_EQUAL:
               filterValue = fieldFilter.getValue();
               break;
@@ -238,6 +243,8 @@ public final class Target {
               filterValue = fieldFilter.getValue();
               filterInclusive = false;
               break;
+            default:
+              // Remaining filters cannot be used as upper bounds.
           }
 
           if (min(segmentValue, filterValue) == filterValue) {
@@ -283,6 +290,11 @@ public final class Target {
     return this.orderBys;
   }
 
+  /** Returns the first order by (which always exists). */
+  public OrderBy getFirstOrderBy() {
+    return this.orderBys.get(0);
+  }
+
   /** Returns a canonical string representing this target. */
   public String getCanonicalId() {
     if (memoizedCannonicalId != null) {
@@ -307,7 +319,7 @@ public final class Target {
     builder.append("|ob:");
     for (OrderBy orderBy : getOrderBy()) {
       builder.append(orderBy.getField().canonicalString());
-      builder.append(orderBy.getDirection().equals(Direction.ASCENDING) ? "asc" : "desc");
+      builder.append(orderBy.getDirection().canonicalString());
     }
 
     // Add limit.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
@@ -21,13 +21,16 @@ package com.google.firebase.firestore.index;
 // TODO(indexing)
 public class IndexEntry {
   private final int indexId;
-  private final byte[] indexValue;
+  private final byte[] arrayValue;
+  private final byte[] directionalValue;
   private final String uid;
   private final String documentName;
 
-  public IndexEntry(int indexId, byte[] indexValue, String uid, String documentName) {
+  public IndexEntry(
+      int indexId, byte[] arrayValue, byte[] directionalValue, String uid, String documentName) {
     this.indexId = indexId;
-    this.indexValue = indexValue;
+    this.arrayValue = arrayValue;
+    this.directionalValue = directionalValue;
     this.uid = uid;
     this.documentName = documentName;
   }
@@ -36,8 +39,12 @@ public class IndexEntry {
     return indexId;
   }
 
-  public byte[] getIndexValue() {
-    return indexValue;
+  public byte[] getArrayValue() {
+    return arrayValue;
+  }
+
+  public byte[] getDirectionalValue() {
+    return directionalValue;
   }
 
   public String getUid() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
@@ -115,11 +115,13 @@ public class IndexBackfiller {
     persistence.execute(
         "INSERT OR IGNORE INTO index_entries ("
             + "index_id, "
-            + "index_value, "
+            + "array_value, "
+            + "directional_value, "
             + "uid, "
-            + "document_name) VALUES(?, ?, ?, ?)",
+            + "document_name) VALUES(?, ?, ?, ?, ?)",
         entry.getIndexId(),
-        entry.getIndexValue(),
+        entry.getArrayValue(),
+        entry.getDirectionalValue(),
         entry.getUid(),
         entry.getDocumentName());
   }
@@ -141,12 +143,18 @@ public class IndexBackfiller {
   @VisibleForTesting
   IndexEntry getIndexEntry(int indexId) {
     return persistence
-        .query("SELECT index_value, uid, document_name FROM index_entries WHERE index_id = ?")
+        .query(
+            "SELECT array_value, directional_value, uid, document_name FROM index_entries WHERE index_id = ?")
         .binding(indexId)
         .firstValue(
             row ->
                 row == null
                     ? null
-                    : new IndexEntry(indexId, row.getBlob(0), row.getString(1), row.getString(2)));
+                    : new IndexEntry(
+                        indexId,
+                        row.getBlob(0),
+                        row.getBlob(1),
+                        row.getString(2),
+                        row.getString(3)));
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
@@ -297,7 +297,8 @@ public final class LocalSerializer {
     // queries against each collection separately.
     index.setQueryScope(Index.QueryScope.COLLECTION_GROUP);
 
-    for (FieldIndex.Segment segment : fieldIndex) {
+    for (int i = 0; i < fieldIndex.segmentCount(); ++i) {
+      FieldIndex.Segment segment = fieldIndex.getSegment(i);
       Index.IndexField.Builder indexField = Index.IndexField.newBuilder();
       indexField.setFieldPath(segment.getFieldPath().canonicalString());
       if (segment.getKind() == FieldIndex.Segment.Kind.CONTAINS) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -14,9 +14,11 @@
 
 package com.google.firebase.firestore.local;
 
+import static com.google.firebase.firestore.model.Values.isArray;
 import static com.google.firebase.firestore.util.Assert.fail;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 import static com.google.firebase.firestore.util.Util.repeatSequence;
+import static java.lang.Math.max;
 
 import androidx.annotation.Nullable;
 import com.google.firebase.firestore.core.Bound;
@@ -38,6 +40,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -98,7 +101,7 @@ final class SQLiteIndexManager implements IndexManager {
             .firstValue(input -> input.isNull(0) ? 0 : input.getInt(0));
 
     db.execute(
-        "INSERT OR IGNORE INTO index_configuration ("
+        "INSERT INTO index_configuration ("
             + "index_id, "
             + "collection_group, "
             + "index_proto, "
@@ -133,8 +136,23 @@ final class SQLiteIndexManager implements IndexManager {
                         row.getInt(2),
                         row.getInt(3));
 
-                List<Value> values = extractFieldValue(document, fieldIndex);
-                if (values == null) return;
+                List<Value> arrayValues = new ArrayList<>();
+                for (FieldIndex.Segment segment : fieldIndex.getArraySegments()) {
+                  Value value = document.getField(segment.getFieldPath());
+                  if (!isArray(value)) {
+                    return;
+                  }
+                  arrayValues.addAll(value.getArrayValue().getValuesList());
+                }
+
+                List<Value> directionalValues = new ArrayList<>();
+                for (FieldIndex.Segment segment : fieldIndex.getDirectionalSegments()) {
+                  Value field = document.getField(segment.getFieldPath());
+                  if (field == null) {
+                    return;
+                  }
+                  directionalValues.add(field);
+                }
 
                 if (Logger.isDebugEnabled()) {
                   Logger.debug(
@@ -144,17 +162,12 @@ final class SQLiteIndexManager implements IndexManager {
                       fieldIndex);
                 }
 
-                Object[] encodeValues = encodeDocumentValues(fieldIndex, values);
-                for (Object encoded : encodeValues) {
-                  // TODO(indexing): Handle different values for different users
-                  db.execute(
-                      "INSERT OR IGNORE INTO index_entries ("
-                          + "index_id, "
-                          + "index_value, "
-                          + "document_name) VALUES(?, ?, ?)",
+                for (int i = 0; i < max(arrayValues.size(), 1); ++i) {
+                  addSingleEntry(
+                      documentKey,
                       indexId,
-                      encoded,
-                      documentKey.toString());
+                      encode(i < arrayValues.size() ? arrayValues.get(i) : null),
+                      encode(directionalValues));
                 }
               } catch (InvalidProtocolBufferException e) {
                 throw fail("Invalid index: " + e);
@@ -162,21 +175,16 @@ final class SQLiteIndexManager implements IndexManager {
             });
   }
 
-  /**
-   * Returns the list of values for all fields indexed by the provided field index. Returns {@code
-   * null} if one or more of the fields are not set.
-   */
-  @Nullable
-  private List<Value> extractFieldValue(Document document, FieldIndex fieldIndex) {
-    List<Value> values = new ArrayList<>();
-    for (FieldIndex.Segment segment : fieldIndex) {
-      Value field = document.getField(segment.getFieldPath());
-      if (field == null) {
-        return null;
-      }
-      values.add(field);
-    }
-    return values;
+  private void addSingleEntry(
+      DocumentKey documentKey, int indexId, @Nullable Object arrayIndex, Object directionalIndex) {
+    // TODO(indexing): Handle different values for different users
+    db.execute(
+        "INSERT INTO index_entries (index_id, array_value, directional_value, document_name) "
+            + "VALUES(?, ?, ?, ?)",
+        indexId,
+        arrayIndex,
+        directionalIndex,
+        documentKey.toString());
   }
 
   @Override
@@ -185,87 +193,108 @@ final class SQLiteIndexManager implements IndexManager {
     @Nullable FieldIndex fieldIndex = getMatchingIndex(target);
     if (fieldIndex == null) return null;
 
+    List<Value> arrayValues = target.getArrayValues(fieldIndex);
     Bound lowerBound = target.getLowerBound(fieldIndex);
     @Nullable Bound upperBound = target.getUpperBound(fieldIndex);
 
     if (Logger.isDebugEnabled()) {
       Logger.debug(
           TAG,
-          "Using index '%s' to execute '%s' (Lower bound: %s, Upper bound: %s)",
+          "Using index '%s' to execute '%s' (Arrays: %s, Lower bound: %s, Upper bound: %s)",
           fieldIndex,
           target,
+          arrayValues,
           lowerBound,
           upperBound);
     }
 
-    Set<DocumentKey> result = new HashSet<>();
-    SQLitePersistence.Query query;
-
-    Object[] lowerBoundValues = encodeTargetValues(fieldIndex, target, lowerBound.getPosition());
+    Object[] lowerBoundValues = encodeBound(fieldIndex, target, lowerBound);
     String lowerBoundOp = lowerBound.isInclusive() ? ">=" : ">";
-    if (upperBound != null) {
-      Object[] upperBoundValues = encodeTargetValues(fieldIndex, target, upperBound.getPosition());
-      String upperBoundOp = upperBound.isInclusive() ? "<=" : "<";
-      query =
-          generateQuery(
-              fieldIndex.getIndexId(),
-              lowerBoundValues,
-              lowerBoundOp,
-              upperBoundValues,
-              upperBoundOp);
-    } else {
-      query = generateQuery(fieldIndex.getIndexId(), lowerBoundValues, lowerBoundOp);
-    }
+    Object[] upperBoundValues = encodeBound(fieldIndex, target, upperBound);
+    String upperBoundOp = upperBound != null && upperBound.isInclusive() ? "<=" : "<";
 
+    SQLitePersistence.Query query =
+        generateQuery(
+            target,
+            fieldIndex.getIndexId(),
+            arrayValues,
+            lowerBoundValues,
+            lowerBoundOp,
+            upperBoundValues,
+            upperBoundOp);
+
+    Set<DocumentKey> result = new HashSet<>();
     query.forEach(
         row -> result.add(DocumentKey.fromPath(ResourcePath.fromString(row.getString(0)))));
-
-    // TODO(indexing): Add limit handling
 
     Logger.debug(TAG, "Index scan returned %s documents", result.size());
     return result;
   }
 
   /** Returns a SQL query on 'index_entries' that unions all bounds. */
-  private SQLitePersistence.Query generateQuery(int indexId, Object[] bounds, String op) {
-    String statement =
-        String.format(
-            "SELECT document_name FROM index_entries WHERE index_id = ? AND index_value %s ?", op);
-    String sql = repeatSequence(statement, bounds.length, " UNION ");
-
-    Object[] bingArgs = new Object[bounds.length * 2];
-    for (int i = 0; i < bounds.length; ++i) {
-      bingArgs[i * 2] = indexId;
-      bingArgs[i * 2 + 1] = bounds[i];
-    }
-
-    return db.query(sql).binding(bingArgs);
-  }
-
-  /** Returns a SQL query on 'index_entries' that unions all bounds. */
   private SQLitePersistence.Query generateQuery(
+      Target target,
       int indexId,
+      List<Value> arrayValues,
       Object[] lowerBounds,
       String lowerBoundOp,
-      Object[] upperBounds,
+      @Nullable Object[] upperBounds,
       String upperBoundOp) {
-    String statement =
-        String.format(
-            "SELECT document_name FROM index_entries WHERE index_id = ? AND index_value %s ? AND index_value %s ?",
-            lowerBoundOp, upperBoundOp);
-    String sql = repeatSequence(statement, lowerBounds.length * upperBounds.length, " UNION ");
+    int statementCount =
+        max(arrayValues.size(), 1)
+            * lowerBounds.length
+            * (upperBounds == null ? 1 : upperBounds.length);
+    int bindsPerStatement = 2 + (arrayValues.isEmpty() ? 0 : 1) + (upperBounds != null ? 1 : 0);
+    Object[] bindArgs = new Object[statementCount * bindsPerStatement];
 
-    Object[] bingArgs = new Object[lowerBounds.length * upperBounds.length * 3];
-    int i = 0;
-    for (Object value1 : lowerBounds) {
-      for (Object value2 : upperBounds) {
-        bingArgs[i++] = indexId;
-        bingArgs[i++] = value1;
-        bingArgs[i++] = value2;
-      }
+    StringBuilder statement = new StringBuilder();
+    statement.append(
+        "SELECT document_name, directional_value FROM index_entries WHERE index_id = ? ");
+    if (!arrayValues.isEmpty()) {
+      statement.append("AND array_value = ? ");
+    }
+    statement.append("AND directional_value ").append(lowerBoundOp).append(" ? ");
+    if (upperBounds != null) {
+      statement.append("AND directional_value ").append(upperBoundOp).append(" ? ");
     }
 
-    return db.query(sql).binding(bingArgs);
+    String sql = repeatSequence(statement, statementCount, " UNION ");
+    if (target.getLimit() != -1) {
+      String direction = target.getFirstOrderBy().getDirection().canonicalString();
+      sql += "ORDER BY directional_value " + direction + ", document_name " + direction + " ";
+      sql += "LIMIT " + target.getLimit() + " ";
+    }
+
+    Iterator<Value> arrayValueIterator = arrayValues.iterator();
+    for (int offset = 0; offset < bindArgs.length; ) {
+      Object arrayValue = encode(arrayValueIterator.hasNext() ? arrayValueIterator.next() : null);
+      offset = fillBounds(bindArgs, offset, indexId, arrayValue, lowerBounds, upperBounds);
+    }
+
+    return db.query(sql).binding(bindArgs);
+  }
+
+  /** Fills bindArgs starting at offset and returns the new offset. */
+  private int fillBounds(
+      Object[] bindArgs,
+      int offset,
+      int indexId,
+      @Nullable Object arrayValue,
+      Object[] lowerBounds,
+      @Nullable Object[] upperBounds) {
+    for (Object lower : lowerBounds) {
+      for (int i = 0; i < (upperBounds != null ? upperBounds.length : 1); ++i) {
+        bindArgs[offset++] = indexId;
+        if (arrayValue != null) {
+          bindArgs[offset++] = arrayValue;
+        }
+        bindArgs[offset++] = lower;
+        if (upperBounds != null) {
+          bindArgs[offset++] = upperBounds[i];
+        }
+      }
+    }
+    return offset;
   }
 
   /**
@@ -312,42 +341,36 @@ final class SQLiteIndexManager implements IndexManager {
         activeIndices, (l, r) -> Integer.compare(l.segmentCount(), r.segmentCount()));
   }
 
-  /**
-   * Encodes the given field values according to the specification in {@code fieldIndex}. For
-   * CONTAINS indices, a list of possible values is returned.
-   */
-  private Object[] encodeDocumentValues(FieldIndex fieldIndex, List<Value> values) {
-    List<IndexByteEncoder> encoders = new ArrayList<>();
-    encoders.add(new IndexByteEncoder());
-    for (int i = 0; i < fieldIndex.segmentCount(); ++i) {
-      FieldIndex.Segment segment = fieldIndex.getSegment(i);
-      Value value = values.get(i);
-      for (IndexByteEncoder encoder : encoders) {
-        if (segment.getKind() == FieldIndex.Segment.Kind.CONTAINS) {
-          encoders = expandIndexValues(encoders, value);
-        } else {
-          hardAssert(
-              segment.getKind() == FieldIndex.Segment.Kind.ORDERED,
-              "Only ORDERED and CONTAINS are supported");
-          FirestoreIndexValueWriter.INSTANCE.writeIndexValue(value, encoder);
-        }
-      }
+  /** Encodes a list of values to the index format. */
+  private Object encode(List<Value> values) {
+    IndexByteEncoder encoder = new IndexByteEncoder();
+    for (Value value : values) {
+      FirestoreIndexValueWriter.INSTANCE.writeIndexValue(value, encoder);
     }
-    return getEncodedBytes(encoders);
+    return encoder.getEncodedBytes();
+  }
+
+  /** Encodes a value to the index format. */
+  private @Nullable Object encode(@Nullable Value value) {
+    return value != null ? encode(Collections.singletonList(value)) : null;
   }
 
   /**
-   * Encodes the given field values according to the specification in {@code target}. For IN and
-   * ArrayContainsAny queries, a list of possible values is returned.
+   * Encodes the given field values according to the specification in {@code target}. For IN
+   * queries, a list of possible values is returned.
    */
-  private Object[] encodeTargetValues(FieldIndex fieldIndex, Target target, List<Value> values) {
+  private @Nullable Object[] encodeBound(
+      FieldIndex fieldIndex, Target target, @Nullable Bound bound) {
+    if (bound == null) return null;
+
     List<IndexByteEncoder> encoders = new ArrayList<>();
     encoders.add(new IndexByteEncoder());
-    for (int i = 0; i < fieldIndex.segmentCount(); ++i) {
-      FieldIndex.Segment segment = fieldIndex.getSegment(i);
-      Value value = values.get(i);
+
+    Iterator<Value> position = bound.getPosition().iterator();
+    for (FieldIndex.Segment segment : fieldIndex.getDirectionalSegments()) {
+      Value value = position.next();
       for (IndexByteEncoder encoder : encoders) {
-        if (isMultiValueFilter(target, segment.getFieldPath())) {
+        if (isInFilter(target, segment.getFieldPath()) && isArray(value)) {
           encoders = expandIndexValues(encoders, value);
         } else {
           FirestoreIndexValueWriter.INSTANCE.writeIndexValue(value, encoder);
@@ -387,17 +410,12 @@ final class SQLiteIndexManager implements IndexManager {
     return results;
   }
 
-  private boolean isMultiValueFilter(Target target, FieldPath fieldPath) {
+  private boolean isInFilter(Target target, FieldPath fieldPath) {
     for (Filter filter : target.getFilters()) {
-      if (filter.getField().equals(fieldPath))
-        switch (((FieldFilter) filter).getOperator()) {
-          case ARRAY_CONTAINS_ANY:
-          case NOT_IN:
-          case IN:
-            return true;
-          default:
-            return false;
-        }
+      if (filter.getField().equals(fieldPath)) {
+        Filter.Operator operator = ((FieldFilter) filter).getOperator();
+        return operator.equals(Filter.Operator.IN) || operator.equals(Filter.Operator.NOT_IN);
+      }
     }
     return false;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -256,7 +256,7 @@ final class SQLiteIndexManager implements IndexManager {
     StringBuilder statement = new StringBuilder();
     statement.append(
         "SELECT document_name, directional_value FROM index_entries WHERE index_id = ? ");
-    statement.append(arrayValues.isEmpty() ? "AND array_value IS NULL ": "AND array_value = ? ");
+    statement.append(arrayValues.isEmpty() ? "AND array_value IS NULL " : "AND array_value = ? ");
     statement.append("AND directional_value ").append(lowerBoundOp).append(" ? ");
     if (upperBounds != null) {
       statement.append("AND directional_value ").append(upperBoundOp).append(" ? ");

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -240,24 +240,30 @@ final class SQLiteIndexManager implements IndexManager {
       String lowerBoundOp,
       @Nullable Object[] upperBounds,
       String upperBoundOp) {
+    // The number of total statements we union together. This is similar to a distributed normal
+    // form, but adapted for array values. We create a single statement per value in an
+    // ARRAY_CONTAINS or ARRAY_CONTAINS_ANY filter combined with the values from the query bounds.
     int statementCount =
         max(arrayValues.size(), 1)
             * lowerBounds.length
             * (upperBounds == null ? 1 : upperBounds.length);
+    // The number of "question marks" per single statement
     int bindsPerStatement = 2 + (arrayValues.isEmpty() ? 0 : 1) + (upperBounds != null ? 1 : 0);
     Object[] bindArgs = new Object[statementCount * bindsPerStatement];
 
+    // Build the statement. We always include the lower bound, and optionally include an array value
+    // and an upper bound.
     StringBuilder statement = new StringBuilder();
     statement.append(
         "SELECT document_name, directional_value FROM index_entries WHERE index_id = ? ");
-    if (!arrayValues.isEmpty()) {
-      statement.append("AND array_value = ? ");
-    }
+    statement.append(arrayValues.isEmpty() ? "AND array_value IS NULL ": "AND array_value = ? ");
     statement.append("AND directional_value ").append(lowerBoundOp).append(" ? ");
     if (upperBounds != null) {
       statement.append("AND directional_value ").append(upperBoundOp).append(" ? ");
     }
 
+    // Create the UNION statement by repeating the above generated statement. We can then add
+    // ordering and a limit clause.
     String sql = repeatSequence(statement, statementCount, " UNION ");
     if (target.getLimit() != -1) {
       String direction = target.getFirstOrderBy().getDirection().canonicalString();
@@ -265,6 +271,7 @@ final class SQLiteIndexManager implements IndexManager {
       sql += "LIMIT " + target.getLimit() + " ";
     }
 
+    // Fill in the bind ("question marks") variables.
     Iterator<Value> arrayValueIterator = arrayValues.iterator();
     for (int offset = 0; offset < bindArgs.length; ) {
       Object arrayValue = encode(arrayValueIterator.hasNext() ? arrayValueIterator.next() : null);
@@ -282,6 +289,7 @@ final class SQLiteIndexManager implements IndexManager {
       @Nullable Object arrayValue,
       Object[] lowerBounds,
       @Nullable Object[] upperBounds) {
+    // Add bind variables for each combination of arrayValue, lowerBound and upperBound.
     for (Object lower : lowerBounds) {
       for (int i = 0; i < (upperBounds != null ? upperBounds.length : 1); ++i) {
         bindArgs[offset++] = indexId;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -364,10 +364,11 @@ class SQLiteSchema {
           db.execSQL(
               "CREATE TABLE index_entries ("
                   + "index_id INTEGER, "
-                  + "index_value BLOB, " // field value pairs
+                  + "array_value BLOB, " // index values for ArrayContains/ArrayContainsAny
+                  + "directional_value BLOB, " // index values for equality and inequalities
                   + "uid TEXT, " // user id or null if there are no pending mutations
                   + "document_name TEXT, "
-                  + "PRIMARY KEY (index_id, index_value, uid, document_name))");
+                  + "PRIMARY KEY (index_id, array_value, directional_value, uid, document_name))");
         });
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
@@ -14,10 +14,8 @@
 
 package com.google.firebase.firestore.model;
 
-import androidx.annotation.NonNull;
 import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -31,14 +29,14 @@ import java.util.List;
  * group-scoped indices. Every index can be used for both single collection and collection group
  * queries.
  */
-public final class FieldIndex implements Iterable<FieldIndex.Segment> {
+public final class FieldIndex {
 
   /** An index component consisting of field path and index type. */
   @AutoValue
   public abstract static class Segment {
     /** The type of the index, e.g. for which type of query it can be used. */
     public enum Kind {
-      /** Ascending index. Can be used for <, <=, ==, >=, >, !=, IN and NOT IN queries. */
+      /** Ordered index. Can be used for <, <=, ==, >=, >, !=, IN and NOT IN queries. */
       ORDERED,
       /** Contains index. Can be used for ArrayContains and ArrayContainsAny */
       CONTAINS
@@ -104,10 +102,24 @@ public final class FieldIndex implements Iterable<FieldIndex.Segment> {
     return version;
   }
 
-  @NonNull
-  @Override
-  public Iterator<Segment> iterator() {
-    return segments.iterator();
+  public Iterable<Segment> getDirectionalSegments() {
+    List<Segment> filteredSegments = new ArrayList<>();
+    for (Segment segment : segments) {
+      if (segment.getKind().equals(Segment.Kind.ORDERED)) {
+        filteredSegments.add(segment);
+      }
+    }
+    return filteredSegments;
+  }
+
+  public Iterable<Segment> getArraySegments() {
+    List<Segment> filteredSegments = new ArrayList<>();
+    for (Segment segment : segments) {
+      if (segment.getKind().equals(Segment.Kind.CONTAINS)) {
+        filteredSegments.add(segment);
+      }
+    }
+    return filteredSegments;
   }
 
   /** Returns a new field index with additional index segment. */

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.core;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.firestore.testutil.TestUtil.blob;
 import static com.google.firebase.firestore.testutil.TestUtil.bound;
 import static com.google.firebase.firestore.testutil.TestUtil.field;
@@ -28,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.Values;
 import com.google.firestore.v1.Value;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,7 +56,7 @@ public class TargetTest {
   public void equalsQueryBound() {
     Target target = query("c").filter(filter("foo", "==", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "bar");
@@ -67,7 +69,7 @@ public class TargetTest {
   public void lowerThanQueryBound() {
     Target target = query("c").filter(filter("foo", "<", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "");
@@ -80,7 +82,7 @@ public class TargetTest {
   public void lowerThanOrEqualsQueryBound() {
     Target target = query("c").filter(filter("foo", "<=", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "");
@@ -93,7 +95,7 @@ public class TargetTest {
   public void greaterThanQueryBound() {
     Target target = query("c").filter(filter("foo", ">", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, false, "bar");
@@ -106,7 +108,7 @@ public class TargetTest {
   public void greaterThanOrEqualsQueryBound() {
     Target target = query("c").filter(filter("foo", ">=", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "bar");
@@ -116,16 +118,38 @@ public class TargetTest {
   }
 
   @Test
-  public void containsQueryBound() {
+  public void arrayContainsQueryBound() {
     Target target = query("c").filter(filter("foo", "array-contains", "bar")).toTarget();
     FieldIndex index =
         new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
 
+    List<Value> arrayValues = target.getArrayValues(index);
+    assertThat(arrayValues).containsExactly(wrap("bar"));
+
     Bound lowerBound = target.getLowerBound(index);
-    verifyBound(lowerBound, true, "bar");
+    verifyBound(lowerBound, true);
 
     Bound upperBound = target.getUpperBound(index);
-    verifyBound(upperBound, true, "bar");
+    assertNull(upperBound);
+  }
+
+  @Test
+  public void arrayContainsAnyQueryBound() {
+    Target target =
+        query("c")
+            .filter(filter("foo", "array-contains-any", Arrays.asList("bar", "baz")))
+            .toTarget();
+    FieldIndex index =
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+
+    List<Value> arrayValues = target.getArrayValues(index);
+    assertThat(arrayValues).containsExactly(wrap("bar"), wrap("baz"));
+
+    Bound lowerBound = target.getLowerBound(index);
+    verifyBound(lowerBound, true);
+
+    Bound upperBound = target.getUpperBound(index);
+    assertNull(upperBound);
   }
 
   @Test
@@ -240,7 +264,7 @@ public class TargetTest {
     Target target =
         query("c").orderBy(orderBy("foo")).endAt(bound(/* inclusive= */ true, "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.CONTAINS);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, new Object[] {null});
@@ -321,7 +345,7 @@ public class TargetTest {
     Target target =
         query("c").filter(filter("a", "==", "a")).filter(filter("b", "==", "b")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("a"), FieldIndex.Segment.Kind.CONTAINS);
+        new FieldIndex("c").withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "a");

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexBackfillerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexBackfillerTest.java
@@ -65,14 +65,16 @@ public class SQLiteIndexBackfillerTest {
   @Test
   public void addAndRemoveIndexEntry() {
     IndexEntry testEntry =
-        new IndexEntry(1, "TEST_BLOB".getBytes(), "sample-uid", "coll/sample-documentId");
+        new IndexEntry(
+            1, "FOO".getBytes(), "BAR".getBytes(), "sample-uid", "coll/sample-documentId");
     persistence.runTransaction(
         "testAddAndRemoveIndexEntry",
         () -> {
           backfiller.addIndexEntry(testEntry);
           IndexEntry entry = backfiller.getIndexEntry(1);
           assertNotNull(entry);
-          assertEquals("TEST_BLOB", new String(entry.getIndexValue()));
+          assertEquals("FOO", new String(entry.getArrayValue()));
+          assertEquals("BAR", new String(entry.getDirectionalValue()));
           assertEquals("coll/sample-documentId", entry.getDocumentName());
           assertEquals("sample-uid", entry.getUid());
 


### PR DESCRIPTION
This PR adds `limit()` support to our query engine. Unfortunately, this means that we have to enforce ordering as we need to filter the "best n" matches directly in the database layer. 

This again changes our indexing format. This test is a good example as to why:

```
  @Test
  public void testLimitAppliesOrdering() {
    indexManager.addFieldIndex(
        new FieldIndex("coll")
            .withAddedField(field("value"), FieldIndex.Segment.Kind.ORDERED)
            .withAddedField(field("value"), FieldIndex.Segment.Kind.CONTAINS));
    addDoc("coll/doc1", map("value", Arrays.asList(1, "foo")));
    addDoc("coll/doc2", map("value", Arrays.asList(3, "foo")));
    addDoc("coll/doc3", map("value", Arrays.asList(2, "foo")));
    Query query =
        query("coll")
            .filter(filter("value", "array-contains", "foo"))
            .orderBy(orderBy("value"))
            .limitToFirst(2);
    verifyResults(query, "coll/doc1", "coll/doc3");
  }
```

This filters by the new "array_value" column and then sorts by "directional_value". "array_value" contains one value per array element while "directional_value" contains the full array as is. 
