### PR TITLE
Lazy initialize ScheduledExecutorService in GaugeManager

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/CpuGaugeCollector.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/CpuGaugeCollector.java
@@ -75,7 +75,7 @@ public class CpuGaugeCollector {
 
   /* This is populated by CpuGaugeCollector but it's drained by GaugeManager.*/
   public final ConcurrentLinkedQueue<CpuMetricReading> cpuMetricReadings;
-  private final ScheduledExecutorService cpuMetricCollectorExecutor;
+  private ScheduledExecutorService cpuMetricCollectorExecutor;
   private final String procFileName;
   private final long clockTicksPerSecond;
 
@@ -84,7 +84,7 @@ public class CpuGaugeCollector {
 
   private CpuGaugeCollector() {
     cpuMetricReadings = new ConcurrentLinkedQueue<>();
-    cpuMetricCollectorExecutor = Executors.newSingleThreadScheduledExecutor();
+//    cpuMetricCollectorExecutor = Executors.newSingleThreadScheduledExecutor();
 
     int pid = android.os.Process.myPid();
     procFileName = "/proc/" + Integer.toString(pid) + "/stat";
@@ -169,6 +169,9 @@ public class CpuGaugeCollector {
       long cpuMetricCollectionRate, Timer referenceTime) {
     this.cpuMetricCollectionRateMs = cpuMetricCollectionRate;
     try {
+      if (cpuMetricCollectorExecutor == null) {
+        cpuMetricCollectorExecutor = Executors.newSingleThreadScheduledExecutor();
+      }
       cpuMetricCollectorJob =
           cpuMetricCollectorExecutor.scheduleAtFixedRate(
               () -> {
@@ -187,6 +190,9 @@ public class CpuGaugeCollector {
 
   private synchronized void scheduleCpuMetricCollectionOnce(Timer referenceTime) {
     try {
+      if (cpuMetricCollectorExecutor == null) {
+        cpuMetricCollectorExecutor = Executors.newSingleThreadScheduledExecutor();
+      }
       @SuppressWarnings("FutureReturnValueIgnored")
       ScheduledFuture unusedFuture =
           cpuMetricCollectorExecutor.schedule(

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
@@ -50,7 +50,7 @@ public class GaugeManager {
   private static final long APPROX_NUMBER_OF_DATA_POINTS_PER_GAUGE_METRIC = 20;
   private static final long INVALID_GAUGE_COLLECTION_FREQUENCY = -1;
 
-  private final ScheduledExecutorService gaugeManagerExecutor;
+  private ScheduledExecutorService gaugeManagerExecutor;
   private final ConfigResolver configResolver;
   private final CpuGaugeCollector cpuGaugeCollector;
   private final MemoryGaugeCollector memoryGaugeCollector;
@@ -64,7 +64,7 @@ public class GaugeManager {
 
   private GaugeManager() {
     this(
-        Executors.newSingleThreadScheduledExecutor(),
+        null,
         TransportManager.getInstance(),
         ConfigResolver.getInstance(),
         null,
@@ -133,6 +133,9 @@ public class GaugeManager {
     final ApplicationProcessState applicationProcessStateForScheduledTask = applicationProcessState;
 
     try {
+      if (gaugeManagerExecutor == null) {
+        gaugeManagerExecutor = Executors.newSingleThreadScheduledExecutor();
+      }
       gaugeManagerDataCollectionJob =
           gaugeManagerExecutor.scheduleAtFixedRate(
               () -> {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/MemoryGaugeCollector.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/MemoryGaugeCollector.java
@@ -48,7 +48,7 @@ public class MemoryGaugeCollector {
   // this value is set for the memoryMetricCollectionRateMs, we do not collect Memory Metrics.
   private static final int UNSET_MEMORY_METRIC_COLLECTION_RATE = -1;
 
-  private final ScheduledExecutorService memoryMetricCollectorExecutor;
+  private ScheduledExecutorService memoryMetricCollectorExecutor;
   /* This is populated by MemoryGaugeCollector but it's drained by GaugeManager.*/
   public final ConcurrentLinkedQueue<AndroidMemoryReading> memoryMetricReadings;
   private final Runtime runtime;
@@ -57,7 +57,7 @@ public class MemoryGaugeCollector {
   private long memoryMetricCollectionRateMs = UNSET_MEMORY_METRIC_COLLECTION_RATE;
 
   private MemoryGaugeCollector() {
-    this(Executors.newSingleThreadScheduledExecutor(), Runtime.getRuntime());
+    this(null, Runtime.getRuntime());
   }
 
   @VisibleForTesting
@@ -129,6 +129,9 @@ public class MemoryGaugeCollector {
     this.memoryMetricCollectionRateMs = memoryMetricCollectionRate;
 
     try {
+      if (memoryMetricCollectorExecutor == null) {
+        memoryMetricCollectorExecutor = Executors.newSingleThreadScheduledExecutor();
+      }
       memoryMetricCollectorJob =
           memoryMetricCollectorExecutor.scheduleAtFixedRate(
               () -> {
@@ -147,6 +150,9 @@ public class MemoryGaugeCollector {
 
   private synchronized void scheduleMemoryMetricCollectionOnce(Timer referenceTime) {
     try {
+      if (memoryMetricCollectorExecutor == null) {
+        memoryMetricCollectorExecutor = Executors.newSingleThreadScheduledExecutor();
+      }
       @SuppressWarnings("FutureReturnValueIgnored")
       ScheduledFuture unusedFuture =
           memoryMetricCollectorExecutor.schedule(


### PR DESCRIPTION
As per b/201001743, the goal is to "Optimize SessionManager getInstance() to check of session enabled flags before initializing gaugeManager". 

The problem is `SessionManager` depends on `GaugeManager` which depends on `CpuGaugeCollector` and `MemoryGaugeCollector`. All of which are **singletons**.  All the singletons' `static getInstance()` are called in the parent's constructor, which is overloaded with another constructor for manual dependency injection, for unit testing purposes. Thus as soon as `SessionManager` initializes, `GaugeManager` and its dependencies all initialize themselves. This is hard to fix without a massive refactor for everything in the dependency graph to use dagger 2 (my limited understanding). 

What this draft PR does is just trying to make the most expensive initialization lazy, which is Executors.newSingleThreadScheduledExecutor(), in each constructor of `GaugeManager`, `CpuGaugeCollector` and `MemoryGaugeCollector`. 