### PR TITLE
Clarify the log statements so that it differentiates between sampling…

### DIFF
--- a/firebase-perf/src/test/java/com/google/firebase/perf/transport/RateLimiterTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/transport/RateLimiterTest.java
@@ -90,39 +90,39 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
 
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(TWO_TOKENS_PER_MINUTE, 2, mClock, mockConfigResolver, NETWORK, false);
     PerfMetric metric = PerfMetric.getDefaultInstance();
     // clock is 15 seconds, token count is 1.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 30 seconds, count is 1.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 45 seconds, count is 0.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 60 seconds, count is 1
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 75 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
     // clock is 90 seconds, count is 1
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 105 seconds, count is 0
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
     // clock is 120 seconds, count is 1,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 135 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
     // clock is 150 seconds, count is 1,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
   }
 
   /** An edge test case for Token Bucket algorithm. */
@@ -137,33 +137,33 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
 
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(TWO_TOKENS_PER_MINUTE, 2, mClock, mockConfigResolver, NETWORK, false);
     PerfMetric metric = PerfMetric.getDefaultInstance();
     // clock is 20 seconds, count before check is 2, 0 new tokens added, count after check is 1
     currentTime = currentTime.plusSeconds(20);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 40 seconds, count before check is 1, 1 new tokens added, count after check is 1
     currentTime = currentTime.plusSeconds(20);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 59 seconds, count before check is 1, 0 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(19);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 60 seconds, count before check is 0, 1 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 80 seconds, count before check is 0, 0 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(20);
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
     // clock is 130 seconds, count before check is 0, 2 new tokens added, count after check is 1
     currentTime = currentTime.plusSeconds(50);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 131 seconds, count before check is 1, 0 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 132 seconds, count before check is 0, 0 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
   }
 
   @Test
@@ -178,35 +178,35 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
 
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(TWO_TOKENS_PER_MINUTE, 2, mClock, mockConfigResolver, NETWORK, false);
     PerfMetric metric = PerfMetric.getDefaultInstance();
 
     // clock is 20 seconds, count before check is 2, 0 new tokens added, count after check is 1
     currentTime = currentTime.plusSeconds(20);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 40 seconds, count before check is 1, 1 new tokens added, count after check is 1
     currentTime = currentTime.plusSeconds(20);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 59 seconds, count before check is 1, 0 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(19);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 60 seconds, count before check is 0, 1 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
 
     // clock is 660 seconds, count before check is 0, 2 new tokens added, count after check is 1
     currentTime = currentTime.plusSeconds(600);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 661 seconds, count before check is 1, 0 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 662 seconds, count before check is 0, 0 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
     // clock is 663 seconds, count before check is 0, 0 new tokens added, count after check is 0
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
   }
 
   @Test
@@ -219,42 +219,42 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
 
     // allow 3 logs per second. token bucket capacity is 4.
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(THREE_TOKENS_PER_SECOND, 4, mClock, mockConfigResolver, NETWORK, false);
     PerfMetric metric = PerfMetric.getDefaultInstance();
 
     // clock is 0, token count starts at 4, none should be replenished
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isFalse();
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
 
     // clock is 1 second, 3 events should be allowed within the second
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isFalse();
 
     // the first burst has finished, and there are 1 event per second for the next 3 seconds
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
 
     // after 10 seconds, the second burst is here, but capacity = 4 events are allowed
     currentTime = currentTime.plusSeconds(10);
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isFalse();
-    assertThat(limiter.check(metric)).isFalse();
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
   }
 
   @Test
@@ -267,37 +267,37 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
 
     // allow 3 logs per second. token bucket capacity is 2.
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(THREE_TOKENS_PER_SECOND, 2, mClock, mockConfigResolver, NETWORK, false);
     PerfMetric metric = PerfMetric.getDefaultInstance();
 
     // clock is 0, token count starts at 2, none should be replenished
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isFalse();
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
 
     // clock is 1 second, 2 events should be allowed within the second due to capacity cap
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isFalse();
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
 
     // the first burst has finished, and there are 1 event per second for the next 3 seconds
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     currentTime = currentTime.plusSeconds(1);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
 
     // the second burst is here, but only capacity = 2 events are allowed
     currentTime = currentTime.plusSeconds(10);
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isTrue();
-    assertThat(limiter.check(metric)).isFalse();
-    assertThat(limiter.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isFalse();
+    assertThat(limiterImpl.check(metric)).isFalse();
   }
 
   /**
@@ -321,8 +321,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
     PerfMetric metric = PerfMetric.getDefaultInstance();
     // if PerfMetric object has neither TraceMetric or NetworkRequestMetric field set, always return
-    // false.
-    assertThat(limiter.check(metric)).isFalse();
+    // true.
+    assertThat(limiter.isEventRateLimited(metric)).isTrue();
 
     PerfMetric trace =
         PerfMetric.newBuilder().setTraceMetric(TraceMetric.getDefaultInstance()).build();
@@ -332,44 +332,44 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             .build();
     // clock is 15 seconds, token count is 1.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isTrue();
-    assertThat(limiter.check(network)).isTrue();
+    assertThat(limiter.isEventRateLimited(trace)).isFalse();
+    assertThat(limiter.isEventRateLimited(network)).isFalse();
     // clock is 30 seconds, count is 0.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isTrue();
-    assertThat(limiter.check(network)).isTrue();
+    assertThat(limiter.isEventRateLimited(trace)).isFalse();
+    assertThat(limiter.isEventRateLimited(network)).isFalse();
     // clock is 45 seconds, count is 0.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isTrue();
-    assertThat(limiter.check(network)).isTrue();
+    assertThat(limiter.isEventRateLimited(trace)).isFalse();
+    assertThat(limiter.isEventRateLimited(network)).isFalse();
     // clock is 60 seconds, count is 0
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isTrue();
-    assertThat(limiter.check(network)).isTrue();
+    assertThat(limiter.isEventRateLimited(trace)).isFalse();
+    assertThat(limiter.isEventRateLimited(network)).isFalse();
     // clock is 75 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isFalse();
-    assertThat(limiter.check(network)).isFalse();
+    assertThat(limiter.isEventRateLimited(trace)).isTrue();
+    assertThat(limiter.isEventRateLimited(network)).isTrue();
     // clock is 90 seconds, count is 0
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isTrue();
-    assertThat(limiter.check(network)).isTrue();
+    assertThat(limiter.isEventRateLimited(trace)).isFalse();
+    assertThat(limiter.isEventRateLimited(network)).isFalse();
     // clock is 105 seconds, count is 0
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isFalse();
-    assertThat(limiter.check(network)).isFalse();
+    assertThat(limiter.isEventRateLimited(trace)).isTrue();
+    assertThat(limiter.isEventRateLimited(network)).isTrue();
     // clock is 120 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isTrue();
-    assertThat(limiter.check(network)).isTrue();
+    assertThat(limiter.isEventRateLimited(trace)).isFalse();
+    assertThat(limiter.isEventRateLimited(network)).isFalse();
     // clock is 135 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isFalse();
-    assertThat(limiter.check(network)).isFalse();
+    assertThat(limiter.isEventRateLimited(trace)).isTrue();
+    assertThat(limiter.isEventRateLimited(network)).isTrue();
     // clock is 150 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(trace)).isTrue();
-    assertThat(limiter.check(network)).isTrue();
+    assertThat(limiter.isEventRateLimited(trace)).isFalse();
+    assertThat(limiter.isEventRateLimited(network)).isFalse();
   }
 
   @Test
@@ -506,7 +506,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     when(mockConfigResolver.getRateLimitSec()).thenReturn(60L);
     when(mockConfigResolver.getRateLimitSec()).thenReturn(60L);
 
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(
             /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
@@ -515,18 +515,18 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             NETWORK,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate().getTokensPerSeconds()).isEqualTo(2.0);
-    assertThat(limiter.getForegroundRate().getTokensPerSeconds()).isEqualTo(700.0d / 60L);
-    assertThat(limiter.getForegroundCapacity()).isEqualTo(700L);
-    assertThat(limiter.getBackgroundRate().getTokensPerSeconds()).isEqualTo(60.0d / 60L);
-    assertThat(limiter.getBackgroundCapacity()).isEqualTo(60L);
+    assertThat(limiterImpl.getRate().getTokensPerSeconds()).isEqualTo(2.0);
+    assertThat(limiterImpl.getForegroundRate().getTokensPerSeconds()).isEqualTo(700.0d / 60L);
+    assertThat(limiterImpl.getForegroundCapacity()).isEqualTo(700L);
+    assertThat(limiterImpl.getBackgroundRate().getTokensPerSeconds()).isEqualTo(60.0d / 60L);
+    assertThat(limiterImpl.getBackgroundCapacity()).isEqualTo(60L);
   }
 
   @Test
   public void getRateFromNetworkParams_defaultValues_worksCorrectly() {
     makeConfigResolverReturnDefaultValues();
 
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(
             /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
@@ -535,12 +535,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             NETWORK,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate().getTokensPerSeconds()).isEqualTo(2.0);
-
-    assertThat(limiter.getForegroundRate().getTokensPerSeconds()).isEqualTo(700.0d / 600);
-    assertThat(limiter.getForegroundCapacity()).isEqualTo(700L);
-    assertThat(limiter.getBackgroundRate().getTokensPerSeconds()).isEqualTo(70.0d / 600);
-    assertThat(limiter.getBackgroundCapacity()).isEqualTo(70L);
+    assertThat(limiterImpl.getRate().getTokensPerSeconds()).isEqualTo(2.0);
+    assertThat(limiterImpl.getForegroundRate().getTokensPerSeconds()).isEqualTo(700.0d / 600);
+    assertThat(limiterImpl.getForegroundCapacity()).isEqualTo(700L);
+    assertThat(limiterImpl.getBackgroundRate().getTokensPerSeconds()).isEqualTo(70.0d / 600);
+    assertThat(limiterImpl.getBackgroundCapacity()).isEqualTo(70L);
   }
 
   @Test
@@ -551,7 +550,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     when(mockConfigResolver.getRateLimitSec()).thenReturn(60L);
     when(mockConfigResolver.getRateLimitSec()).thenReturn(60L);
 
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(
             /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
@@ -560,18 +559,18 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             TRACE,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate().getTokensPerSeconds()).isEqualTo(2.0);
-    assertThat(limiter.getForegroundRate().getTokensPerSeconds()).isEqualTo(600.0d / 60L);
-    assertThat(limiter.getForegroundCapacity()).isEqualTo(600L);
-    assertThat(limiter.getBackgroundRate().getTokensPerSeconds()).isEqualTo(60.0d / 60L);
-    assertThat(limiter.getBackgroundCapacity()).isEqualTo(60L);
+    assertThat(limiterImpl.getRate().getTokensPerSeconds()).isEqualTo(2.0);
+    assertThat(limiterImpl.getForegroundRate().getTokensPerSeconds()).isEqualTo(600.0d / 60L);
+    assertThat(limiterImpl.getForegroundCapacity()).isEqualTo(600L);
+    assertThat(limiterImpl.getBackgroundRate().getTokensPerSeconds()).isEqualTo(60.0d / 60L);
+    assertThat(limiterImpl.getBackgroundCapacity()).isEqualTo(60L);
   }
 
   @Test
   public void getRateFromTraceParams_defaultValues_worksCorrectly() {
     makeConfigResolverReturnDefaultValues();
 
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(
             /* rate= */ TWO_TOKENS_PER_SECOND,
             /* capacity= */ 2,
@@ -580,12 +579,12 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             TRACE,
             /* isLogcatEnabled= */ false);
 
-    assertThat(limiter.getRate().getTokensPerSeconds()).isEqualTo(2.0);
+    assertThat(limiterImpl.getRate().getTokensPerSeconds()).isEqualTo(2.0);
 
-    assertThat(limiter.getForegroundRate().getTokensPerSeconds()).isEqualTo(300.0d / 600);
-    assertThat(limiter.getForegroundCapacity()).isEqualTo(300L);
-    assertThat(limiter.getBackgroundRate().getTokensPerSeconds()).isEqualTo(30.0d / 600);
-    assertThat(limiter.getBackgroundCapacity()).isEqualTo(30L);
+    assertThat(limiterImpl.getForegroundRate().getTokensPerSeconds()).isEqualTo(300.0d / 600);
+    assertThat(limiterImpl.getForegroundCapacity()).isEqualTo(300L);
+    assertThat(limiterImpl.getBackgroundRate().getTokensPerSeconds()).isEqualTo(30.0d / 600);
+    assertThat(limiterImpl.getBackgroundCapacity()).isEqualTo(30L);
   }
 
   /**
@@ -598,41 +597,43 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
 
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
-    RateLimiterImpl limiter =
+    RateLimiterImpl limiterImpl =
         new RateLimiterImpl(TWO_TOKENS_PER_MINUTE, 2, mClock, mockConfigResolver, TRACE, false);
     PerfMetric metric = PerfMetric.getDefaultInstance();
     // clock is 15 seconds, token count is 1.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 30 seconds, count is 0.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 45 seconds, count is 0.
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 60 seconds, count is 0
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
+
     // change rate to 4/minute
-    limiter.setRate(FOUR_TOKENS_PER_MINUTE);
+    limiterImpl.setRate(FOUR_TOKENS_PER_MINUTE);
+
     // clock is 75 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 90 seconds, count is 0
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 105 seconds, count is 0
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 120 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 135 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
     // clock is 150 seconds, count is 0,
     currentTime = currentTime.plusSeconds(15);
-    assertThat(limiter.check(metric)).isTrue();
+    assertThat(limiterImpl.check(metric)).isTrue();
   }
 
   /**
@@ -667,7 +668,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void testBackgroundTraceWithCountersIsNotRateLimited() {
+  public void testBackgroundTraceWithCountersIsNotRateLimitApplicable() {
     makeConfigResolverReturnDefaultValues();
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
@@ -680,11 +681,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
                     .setName(Constants.TraceNames.BACKGROUND_TRACE_NAME.toString()))
             .build();
 
-    assertThat(limiter.isRateLimited(metric)).isFalse();
+    assertThat(limiter.isRateLimitApplicable(metric)).isFalse();
   }
 
   @Test
-  public void testBackgroundTraceWithoutCountersIsRateLimited() {
+  public void testBackgroundTraceWithoutCountersIsRateLimitApplicable() {
     makeConfigResolverReturnDefaultValues();
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
@@ -696,11 +697,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
                     .setName(Constants.TraceNames.BACKGROUND_TRACE_NAME.toString()))
             .build();
 
-    assertThat(limiter.isRateLimited(metric)).isTrue();
+    assertThat(limiter.isRateLimitApplicable(metric)).isTrue();
   }
 
   @Test
-  public void testForegroundTraceWithCountersIsNotRateLimited() {
+  public void testForegroundTraceWithCountersIsNotRateLimitApplicable() {
     makeConfigResolverReturnDefaultValues();
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
@@ -713,11 +714,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
                     .setName(TraceNames.FOREGROUND_TRACE_NAME.toString()))
             .build();
 
-    assertThat(limiter.isRateLimited(metric)).isFalse();
+    assertThat(limiter.isRateLimitApplicable(metric)).isFalse();
   }
 
   @Test
-  public void testForegroundTraceWithoutCountersIsRateLimited() {
+  public void testForegroundTraceWithoutCountersIsRateLimitApplicable() {
     makeConfigResolverReturnDefaultValues();
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
@@ -728,11 +729,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
                 TraceMetric.newBuilder().setName(TraceNames.FOREGROUND_TRACE_NAME.toString()))
             .build();
 
-    assertThat(limiter.isRateLimited(metric)).isTrue();
+    assertThat(limiter.isRateLimitApplicable(metric)).isTrue();
   }
 
   @Test
-  public void testGaugeMetricIsNotRateLimited() {
+  public void testGaugeMetricIsNotRateLimitApplicable() {
     makeConfigResolverReturnDefaultValues();
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
@@ -740,11 +741,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     PerfMetric metric =
         PerfMetric.newBuilder().setGaugeMetric(GaugeMetric.getDefaultInstance()).build();
 
-    assertThat(limiter.isRateLimited(metric)).isFalse();
+    assertThat(limiter.isRateLimitApplicable(metric)).isFalse();
   }
 
   @Test
-  public void testTraceMetricNoSpecialNameIsRateLimited() {
+  public void testTraceMetricNoSpecialNameIsRateLimitApplicable() {
     makeConfigResolverReturnDefaultValues();
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
@@ -754,11 +755,11 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             .setTraceMetric(TraceMetric.newBuilder().setName("devInstrumentedTrace"))
             .build();
 
-    assertThat(limiter.isRateLimited(metric)).isTrue();
+    assertThat(limiter.isRateLimitApplicable(metric)).isTrue();
   }
 
   @Test
-  public void testNetworkRequestMetricIsRateLimited() {
+  public void testNetworkRequestMetricIsRateLimitApplicable() {
     makeConfigResolverReturnDefaultValues();
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, mockConfigResolver);
@@ -768,7 +769,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
             .setNetworkRequestMetric(NetworkRequestMetric.getDefaultInstance())
             .build();
 
-    assertThat(limiter.isRateLimited(metric)).isTrue();
+    assertThat(limiter.isRateLimitApplicable(metric)).isTrue();
   }
 
   @Test
@@ -794,7 +795,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
                     .addAllPerfSessions(Arrays.asList(createVerbosePerfSessions())))
             .build();
 
-    assertThat(limiter.check(trace)).isTrue();
+    assertThat(limiter.isEventSampled(trace)).isTrue();
   }
 
   @Test
@@ -820,7 +821,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
                     .addAllPerfSessions(Arrays.asList(createVerbosePerfSessions())))
             .build();
 
-    assertThat(limiter.check(network)).isTrue();
+    assertThat(limiter.isEventSampled(network)).isTrue();
   }
 
   @Test
@@ -846,7 +847,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
                     .addAllPerfSessions(Arrays.asList(createNonVerbosePerfSessions())))
             .build();
 
-    assertThat(limiter.check(trace)).isFalse();
+    assertThat(limiter.isEventSampled(trace)).isFalse();
   }
 
   @Test
@@ -872,7 +873,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
                     .addAllPerfSessions(Arrays.asList(createNonVerbosePerfSessions())))
             .build();
 
-    assertThat(limiter.check(network)).isFalse();
+    assertThat(limiter.isEventSampled(network)).isFalse();
   }
 
   @Test
@@ -896,7 +897,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     PerfMetric gauge =
         PerfMetric.newBuilder().setGaugeMetric(GaugeMetric.getDefaultInstance()).build();
 
-    assertThat(limiter.check(gauge)).isTrue();
+    assertThat(limiter.isEventSampled(gauge)).isTrue();
   }
 
   /**


### PR DESCRIPTION
… and rate limited.

- Split up RateLimiter.check() to have separate methods for sampling and ratelimiting.
- Updated some test variable namings to differentiate between
RateLimiter/RateLimiterImpl.