### PR TITLE
Remove the early registration for TransportFactory

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfRegistrar.java
@@ -49,7 +49,6 @@ public class FirebasePerfRegistrar implements ComponentRegistrar {
             .add(Dependency.required(FirebaseApp.class))
             .add(Dependency.requiredProvider(RemoteConfigComponent.class))
             .add(Dependency.required(FirebaseInstallationsApi.class))
-            .add(Dependency.requiredProvider(TransportFactory.class))
             .factory(FirebasePerfRegistrar::providesFirebasePerformance)
             .build(),
         /**
@@ -69,8 +68,7 @@ public class FirebasePerfRegistrar implements ComponentRegistrar {
                 new FirebasePerformanceModule(
                     container.get(FirebaseApp.class),
                     container.get(FirebaseInstallationsApi.class),
-                    container.getProvider(RemoteConfigComponent.class),
-                    container.getProvider(TransportFactory.class)))
+                    container.getProvider(RemoteConfigComponent.class)))
             .build();
 
     return component.getFirebasePerformance();


### PR DESCRIPTION
Remove the early registration for TransportFactory since we use that only after onActivityResume().

This could save time in the content provider phase of app start.