### PR TITLE
Use more of the backend's ordering implementation

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -313,8 +313,10 @@ public class FirebaseFirestore {
             FieldPath fieldPath = FieldPath.fromServerFormat(field.getString("fieldPath"));
             if ("CONTAINS".equals(field.optString("arrayConfig"))) {
               fieldIndex = fieldIndex.withAddedField(fieldPath, FieldIndex.Segment.Kind.CONTAINS);
+            } else if ("ASCENDING".equals(field.optString("order"))) {
+              fieldIndex = fieldIndex.withAddedField(fieldPath, FieldIndex.Segment.Kind.ASCENDING);
             } else {
-              fieldIndex = fieldIndex.withAddedField(fieldPath, FieldIndex.Segment.Kind.ORDERED);
+              fieldIndex = fieldIndex.withAddedField(fieldPath, FieldIndex.Segment.Kind.DESCENDING);
             }
             parsedIndices.add(fieldIndex);
           }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/OrderBy.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/OrderBy.java
@@ -24,24 +24,17 @@ import com.google.firestore.v1.Value;
 public class OrderBy {
   /** The direction of the ordering */
   public enum Direction {
-    ASCENDING(1, "asc"),
-    DESCENDING(-1, "desc");
+    ASCENDING(1),
+    DESCENDING(-1);
 
     private final int comparisonModifier;
-    private final String shorthand;
 
-    Direction(int comparisonModifier, String canonicalString) {
+    Direction(int comparisonModifier) {
       this.comparisonModifier = comparisonModifier;
-      this.shorthand = canonicalString;
     }
 
     int getComparisonModifier() {
       return comparisonModifier;
-    }
-
-    /** Returns "asc" for ascending or "desc" for descending. */
-    public String canonicalString() {
-      return shorthand;
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Target.java
@@ -114,41 +114,41 @@ public final class Target {
     return endAt;
   }
 
-  /** Returns the list of values that are used in ARRAY_CONTAINS or ARRAY_CONTAINS_ANY filters. */
-  public List<Value> getArrayValues(FieldIndex fieldIndex) {
-    for (FieldIndex.Segment segment : fieldIndex.getArraySegments()) {
-      for (Filter filter : filters) {
-        if (filter.getField().equals(segment.getFieldPath())) {
-          FieldFilter fieldFilter = (FieldFilter) filter;
-          switch (fieldFilter.getOperator()) {
-            case ARRAY_CONTAINS_ANY:
-              return fieldFilter.getValue().getArrayValue().getValuesList();
-            case ARRAY_CONTAINS:
-              return Collections.singletonList(fieldFilter.getValue());
-            default:
-              // Remaining filters cannot be used as array filters.
-          }
+  /**
+   * Returns the list of values that are used in ARRAY_CONTAINS or ARRAY_CONTAINS_ANY filters.
+   * Returns {@code null} if there are no such filters.
+   */
+  public @Nullable List<Value> getArrayValues(FieldIndex fieldIndex) {
+    @Nullable FieldIndex.Segment segment = fieldIndex.getArraySegment();
+    if (segment == null) return null;
+
+    for (Filter filter : filters) {
+      if (filter.getField().equals(segment.getFieldPath())) {
+        FieldFilter fieldFilter = (FieldFilter) filter;
+        switch (fieldFilter.getOperator()) {
+          case ARRAY_CONTAINS_ANY:
+            return fieldFilter.getValue().getArrayValue().getValuesList();
+          case ARRAY_CONTAINS:
+            return Collections.singletonList(fieldFilter.getValue());
         }
       }
     }
 
-    return Collections.emptyList();
+    return null;
   }
 
   /**
    * Returns a lower bound of field values that can be used as a starting point to scan the index
-   * defined by {@code fieldIndex}.
-   *
-   * <p>Unlike {@link #getUpperBound}, lower bounds always exist as the SDK can use {@code null} as
-   * a starting point for missing boundary values.
+   * defined by {@code fieldIndex}. Returns {@code null} if no lower bound exists.
    */
+  @Nullable
   public Bound getLowerBound(FieldIndex fieldIndex) {
     List<Value> values = new ArrayList<>();
     boolean inclusive = true;
 
     // Go through all filters to find a value for the current field segment
     for (FieldIndex.Segment segment : fieldIndex.getDirectionalSegments()) {
-      Value segmentValue = Values.NULL_VALUE;
+      Value segmentValue = null;
       boolean segmentInclusive = true;
 
       for (Filter filter : filters) {
@@ -198,6 +198,11 @@ public final class Target {
         }
       }
 
+      if (segmentValue == null) {
+        // No lower bound exists
+        return null;
+      }
+
       values.add(segmentValue);
       inclusive &= segmentInclusive;
     }
@@ -207,11 +212,7 @@ public final class Target {
 
   /**
    * Returns an upper bound of field values that can be used as an ending point when scanning the
-   * index defined by {@code fieldIndex}.
-   *
-   * <p>Unlike {@link #getLowerBound}, upper bounds do not always exist since the Firestore does not
-   * define a maximum field value. The index scan should not use an upper bound if {@code null} is
-   * returned.
+   * index defined by {@code fieldIndex}. Returns {@code null} if no upper bound exists.
    */
   public @Nullable Bound getUpperBound(FieldIndex fieldIndex) {
     List<Value> values = new ArrayList<>();
@@ -319,7 +320,7 @@ public final class Target {
     builder.append("|ob:");
     for (OrderBy orderBy : getOrderBy()) {
       builder.append(orderBy.getField().canonicalString());
-      builder.append(orderBy.getDirection().canonicalString());
+      builder.append(orderBy.getDirection().equals(OrderBy.Direction.ASCENDING) ? "asc" : "desc");
     }
 
     // Add limit.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/DirectionalIndexByteEncoder.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/DirectionalIndexByteEncoder.java
@@ -27,4 +27,6 @@ public abstract class DirectionalIndexByteEncoder {
   public abstract void writeLong(long val);
 
   public abstract void writeDouble(double val);
+
+  public abstract void writeInfinity();
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/FirestoreIndexValueWriter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/FirestoreIndexValueWriter.java
@@ -43,6 +43,10 @@ public class FirestoreIndexValueWriter {
   public static final int INDEX_TYPE_MAP = 55;
   public static final int INDEX_TYPE_REFERENCE_SEGMENT = 60;
 
+  // A terminator that indicates that a truncatable value was not truncated.
+  // This must be smaller than all other type labels.
+  public static final int NOT_TRUNCATED = 2;
+
   public static final FirestoreIndexValueWriter INSTANCE = new FirestoreIndexValueWriter();
 
   private FirestoreIndexValueWriter() {}
@@ -59,6 +63,8 @@ public class FirestoreIndexValueWriter {
   /** Writes an index value. */
   public void writeIndexValue(Value value, DirectionalIndexByteEncoder encoder) {
     writeIndexValueAux(value, encoder);
+    // Write separator to split index values (see go/firestore-storage-format#encodings).
+    encoder.writeInfinity();
   }
 
   private void writeIndexValueAux(Value indexValue, DirectionalIndexByteEncoder encoder) {
@@ -77,7 +83,11 @@ public class FirestoreIndexValueWriter {
           break;
         }
         writeValueTypeLabel(encoder, INDEX_TYPE_NUMBER);
-        encoder.writeDouble(number);
+        if (number == -0.0) {
+          encoder.writeDouble(0.0); // -0.0, 0 and 0.0 are all considered the same
+        } else {
+          encoder.writeDouble(number);
+        }
         break;
       case INTEGER_VALUE:
         writeValueTypeLabel(encoder, INDEX_TYPE_NUMBER);
@@ -92,15 +102,15 @@ public class FirestoreIndexValueWriter {
         break;
       case STRING_VALUE:
         writeIndexString(indexValue.getStringValue(), encoder);
-
+        writeTruncationMarker(encoder);
         break;
       case BYTES_VALUE:
         writeValueTypeLabel(encoder, INDEX_TYPE_BLOB);
         encoder.writeBytes(indexValue.getBytesValue());
+        writeTruncationMarker(encoder);
         break;
       case REFERENCE_VALUE:
         writeIndexEntityRef(indexValue.getReferenceValue(), encoder);
-
         break;
       case GEO_POINT_VALUE:
         LatLng geoPoint = indexValue.getGeoPointValue();
@@ -110,9 +120,11 @@ public class FirestoreIndexValueWriter {
         break;
       case MAP_VALUE:
         writeIndexMap(indexValue.getMapValue(), encoder);
+        writeTruncationMarker(encoder);
         break;
       case ARRAY_VALUE:
         writeIndexArray(indexValue.getArrayValue(), encoder);
+        writeTruncationMarker(encoder);
         break;
       default:
         throw new IllegalArgumentException(
@@ -151,11 +163,9 @@ public class FirestoreIndexValueWriter {
     writeValueTypeLabel(encoder, INDEX_TYPE_REFERENCE);
 
     ResourcePath path = ResourcePath.fromString(referenceValue);
-
     int numSegments = path.length();
     for (int index = DOCUMENT_NAME_OFFSET; index < numSegments; ++index) {
       String segment = path.getSegment(index);
-
       writeValueTypeLabel(encoder, INDEX_TYPE_REFERENCE_SEGMENT);
       writeUnlabeledIndexString(segment, encoder);
     }
@@ -163,5 +173,11 @@ public class FirestoreIndexValueWriter {
 
   private void writeValueTypeLabel(DirectionalIndexByteEncoder encoder, int typeOrder) {
     encoder.writeLong(typeOrder);
+  }
+
+  private void writeTruncationMarker(DirectionalIndexByteEncoder encoder) {
+    // While the SDK does not implement truncation, the truncation marker is used to terminate
+    // all variable length values (which are strings, bytes, references, arrays and maps).
+    encoder.writeLong(NOT_TRUNCATED);
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexByteEncoder.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexByteEncoder.java
@@ -14,43 +14,91 @@
 
 package com.google.firebase.firestore.index;
 
+import com.google.firebase.firestore.model.FieldIndex;
 import com.google.protobuf.ByteString;
 
 /**
  * Implements {@link DirectionalIndexByteEncoder} using {@link OrderedCodeWriter} for the actual
  * encoding.
  */
-public class IndexByteEncoder extends DirectionalIndexByteEncoder {
-  // Note: This code is copied from the backend.
+public class IndexByteEncoder {
+
+  class AscendingIndexByteEncoder extends DirectionalIndexByteEncoder {
+
+    @Override
+    public void writeBytes(ByteString val) {
+      orderedCode.writeBytesAscending(val);
+    }
+
+    @Override
+    public void writeString(String val) {
+      orderedCode.writeUtf8Ascending(val);
+    }
+
+    @Override
+    public void writeLong(long val) {
+      orderedCode.writeSignedLongAscending(val);
+    }
+
+    @Override
+    public void writeDouble(double val) {
+      orderedCode.writeDoubleAscending(val);
+    }
+
+    @Override
+    public void writeInfinity() {
+      orderedCode.writeInfinityAscending();
+    }
+  }
+
+  class DescendingIndexByteEncoder extends DirectionalIndexByteEncoder {
+
+    @Override
+    public void writeBytes(ByteString val) {
+      orderedCode.writeBytesDescending(val);
+    }
+
+    @Override
+    public void writeString(String val) {
+      orderedCode.writeUtf8Descending(val);
+    }
+
+    @Override
+    public void writeLong(long val) {
+      orderedCode.writeSignedLongDescending(val);
+    }
+
+    @Override
+    public void writeDouble(double val) {
+      orderedCode.writeDoubleDescending(val);
+    }
+
+    @Override
+    public void writeInfinity() {
+      orderedCode.writeInfinityDescending();
+    }
+  }
 
   private final OrderedCodeWriter orderedCode;
+  private final AscendingIndexByteEncoder ascending;
+  private final DescendingIndexByteEncoder descending;
 
   public IndexByteEncoder() {
     this.orderedCode = new OrderedCodeWriter();
+    this.ascending = new AscendingIndexByteEncoder();
+    this.descending = new DescendingIndexByteEncoder();
   }
 
   public void seed(byte[] encodedBytes) {
     orderedCode.seed(encodedBytes);
   }
 
-  @Override
-  public void writeBytes(ByteString val) {
-    orderedCode.writeBytesAscending(val);
-  }
-
-  @Override
-  public void writeString(String val) {
-    orderedCode.writeUtf8Ascending(val);
-  }
-
-  @Override
-  public void writeLong(long val) {
-    orderedCode.writeSignedLongAscending(val);
-  }
-
-  @Override
-  public void writeDouble(double val) {
-    orderedCode.writeDoubleAscending(val);
+  public DirectionalIndexByteEncoder forKind(FieldIndex.Segment.Kind kind) {
+    if (kind.equals(FieldIndex.Segment.Kind.DESCENDING)) {
+      return descending;
+    } else {
+      return ascending;
+    }
   }
 
   public byte[] getEncodedBytes() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/OrderedCodeWriter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/OrderedCodeWriter.java
@@ -239,6 +239,24 @@ public class OrderedCodeWriter {
     writeUnsignedLongDescending(v);
   }
 
+  /**
+   * Writes the "infinity" byte sequence that sorts after all other byte sequences written in
+   * ascending order.
+   */
+  public void writeInfinityAscending() {
+    writeEscapedByteAscending(ESCAPE2);
+    writeEscapedByteAscending(INFINITY);
+  }
+
+  /**
+   * Writes the "infinity" byte sequence that sorts before all other byte sequences written in
+   * descending order.
+   */
+  public void writeInfinityDescending() {
+    writeEscapedByteDescending(ESCAPE2);
+    writeEscapedByteDescending(INFINITY);
+  }
+
   /** Resets the buffer such that it is the same as when it was newly constructed. */
   public void reset() {
     position = 0;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
@@ -303,8 +303,10 @@ public final class LocalSerializer {
       indexField.setFieldPath(segment.getFieldPath().canonicalString());
       if (segment.getKind() == FieldIndex.Segment.Kind.CONTAINS) {
         indexField.setArrayConfig(Index.IndexField.ArrayConfig.CONTAINS);
-      } else {
+      } else if (segment.getKind() == FieldIndex.Segment.Kind.ASCENDING) {
         indexField.setOrder(Index.IndexField.Order.ASCENDING);
+      } else {
+        indexField.setOrder(Index.IndexField.Order.DESCENDING);
       }
       index.addFields(indexField);
     }
@@ -316,12 +318,14 @@ public final class LocalSerializer {
       String collectionGroup, int indexId, Index index, int updateSeconds, int updateNanos) {
     FieldIndex fieldIndex = new FieldIndex(collectionGroup, indexId);
     for (Index.IndexField field : index.getFieldsList()) {
-      fieldIndex =
-          fieldIndex.withAddedField(
-              FieldPath.fromServerFormat(field.getFieldPath()),
-              field.getValueModeCase().equals(Index.IndexField.ValueModeCase.ARRAY_CONFIG)
-                  ? FieldIndex.Segment.Kind.CONTAINS
-                  : FieldIndex.Segment.Kind.ORDERED);
+      FieldPath fieldPath = FieldPath.fromServerFormat(field.getFieldPath());
+      FieldIndex.Segment.Kind kind =
+          field.getValueModeCase().equals(Index.IndexField.ValueModeCase.ARRAY_CONFIG)
+              ? FieldIndex.Segment.Kind.CONTAINS
+              : (field.getOrder().equals(Index.IndexField.Order.ASCENDING)
+                  ? FieldIndex.Segment.Kind.ASCENDING
+                  : FieldIndex.Segment.Kind.DESCENDING);
+      fieldIndex = fieldIndex.withAddedField(fieldPath, kind);
     }
     fieldIndex =
         fieldIndex.withVersion(new SnapshotVersion(new Timestamp(updateSeconds, updateNanos)));

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -25,6 +25,7 @@ import com.google.firebase.firestore.core.Bound;
 import com.google.firebase.firestore.core.FieldFilter;
 import com.google.firebase.firestore.core.Filter;
 import com.google.firebase.firestore.core.Target;
+import com.google.firebase.firestore.index.DirectionalIndexByteEncoder;
 import com.google.firebase.firestore.index.FirestoreIndexValueWriter;
 import com.google.firebase.firestore.index.IndexByteEncoder;
 import com.google.firebase.firestore.model.Document;
@@ -136,38 +137,24 @@ final class SQLiteIndexManager implements IndexManager {
                         row.getInt(2),
                         row.getInt(3));
 
-                List<Value> arrayValues = new ArrayList<>();
-                for (FieldIndex.Segment segment : fieldIndex.getArraySegments()) {
-                  Value value = document.getField(segment.getFieldPath());
+                @Nullable byte[] directionalValue = encodeDirectionalElements(fieldIndex, document);
+                if (directionalValue == null) {
+                  return;
+                }
+
+                @Nullable FieldIndex.Segment arraySegment = fieldIndex.getArraySegment();
+                if (arraySegment != null) {
+                  Value value = document.getField(arraySegment.getFieldPath());
                   if (!isArray(value)) {
                     return;
                   }
-                  arrayValues.addAll(value.getArrayValue().getValuesList());
-                }
 
-                List<Value> directionalValues = new ArrayList<>();
-                for (FieldIndex.Segment segment : fieldIndex.getDirectionalSegments()) {
-                  Value field = document.getField(segment.getFieldPath());
-                  if (field == null) {
-                    return;
+                  for (Value arrayValue : value.getArrayValue().getValuesList()) {
+                    addSingleEntry(
+                        documentKey, indexId, encodeArrayElement(arrayValue), directionalValue);
                   }
-                  directionalValues.add(field);
-                }
-
-                if (Logger.isDebugEnabled()) {
-                  Logger.debug(
-                      TAG,
-                      "Adding index values for document '%s' to index '%s'",
-                      documentKey,
-                      fieldIndex);
-                }
-
-                for (int i = 0; i < max(arrayValues.size(), 1); ++i) {
-                  addSingleEntry(
-                      documentKey,
-                      indexId,
-                      encode(i < arrayValues.size() ? arrayValues.get(i) : null),
-                      encode(directionalValues));
+                } else {
+                  addSingleEntry(documentKey, indexId, /* arrayValue= */ null, directionalValue);
                 }
               } catch (InvalidProtocolBufferException e) {
                 throw fail("Invalid index: " + e);
@@ -176,14 +163,18 @@ final class SQLiteIndexManager implements IndexManager {
   }
 
   private void addSingleEntry(
-      DocumentKey documentKey, int indexId, @Nullable Object arrayIndex, Object directionalIndex) {
+      DocumentKey documentKey, int indexId, @Nullable Object arrayValue, Object directionalValue) {
+    if (Logger.isDebugEnabled()) {
+      Logger.debug(
+          TAG, "Adding index values for document '%s' to index '%s'", documentKey, indexId);
+    }
     // TODO(indexing): Handle different values for different users
     db.execute(
         "INSERT INTO index_entries (index_id, array_value, directional_value, document_name) "
             + "VALUES(?, ?, ?, ?)",
         indexId,
-        arrayIndex,
-        directionalIndex,
+        arrayValue,
+        directionalValue,
         documentKey.toString());
   }
 
@@ -193,8 +184,8 @@ final class SQLiteIndexManager implements IndexManager {
     @Nullable FieldIndex fieldIndex = getMatchingIndex(target);
     if (fieldIndex == null) return null;
 
-    List<Value> arrayValues = target.getArrayValues(fieldIndex);
-    Bound lowerBound = target.getLowerBound(fieldIndex);
+    @Nullable List<Value> arrayValues = target.getArrayValues(fieldIndex);
+    @Nullable Bound lowerBound = target.getLowerBound(fieldIndex);
     @Nullable Bound upperBound = target.getUpperBound(fieldIndex);
 
     if (Logger.isDebugEnabled()) {
@@ -209,7 +200,7 @@ final class SQLiteIndexManager implements IndexManager {
     }
 
     Object[] lowerBoundValues = encodeBound(fieldIndex, target, lowerBound);
-    String lowerBoundOp = lowerBound.isInclusive() ? ">=" : ">";
+    String lowerBoundOp = lowerBound != null && lowerBound.isInclusive() ? ">=" : ">";
     Object[] upperBoundValues = encodeBound(fieldIndex, target, upperBound);
     String upperBoundOp = upperBound != null && upperBound.isInclusive() ? "<=" : "<";
 
@@ -235,27 +226,31 @@ final class SQLiteIndexManager implements IndexManager {
   private SQLitePersistence.Query generateQuery(
       Target target,
       int indexId,
-      List<Value> arrayValues,
-      Object[] lowerBounds,
+      @Nullable List<Value> arrayValues,
+      @Nullable Object[] lowerBounds,
       String lowerBoundOp,
       @Nullable Object[] upperBounds,
       String upperBoundOp) {
     // The number of total statements we union together. This is similar to a distributed normal
     // form, but adapted for array values. We create a single statement per value in an
     // ARRAY_CONTAINS or ARRAY_CONTAINS_ANY filter combined with the values from the query bounds.
-    int statementCount = max(arrayValues.size(), 1) * lowerBounds.length;
-    int bindsPerStatement = 2 + (arrayValues.isEmpty() ? 0 : 1) + (upperBounds != null ? 1 : 0);
-    Object[] bindArgs = new Object[statementCount * bindsPerStatement];
+    int statementCount =
+        (arrayValues != null ? arrayValues.size() : 1)
+            * max(
+                lowerBounds != null ? lowerBounds.length : 1,
+                upperBounds != null ? upperBounds.length : 1);
 
     // Build the statement. We always include the lower bound, and optionally include an array value
     // and an upper bound.
     StringBuilder statement = new StringBuilder();
     statement.append(
         "SELECT document_name, directional_value FROM index_entries WHERE index_id = ? ");
-    if (!arrayValues.isEmpty()) {
+    if (arrayValues != null) {
       statement.append("AND array_value = ? ");
     }
-    statement.append("AND directional_value ").append(lowerBoundOp).append(" ? ");
+    if (lowerBounds != null) {
+      statement.append("AND directional_value ").append(lowerBoundOp).append(" ? ");
+    }
     if (upperBounds != null) {
       statement.append("AND directional_value ").append(upperBoundOp).append(" ? ");
     }
@@ -263,45 +258,45 @@ final class SQLiteIndexManager implements IndexManager {
     // Create the UNION statement by repeating the above generated statement. We can then add
     // ordering and a limit clause.
     String sql = repeatSequence(statement, statementCount, " UNION ");
+    sql += " ORDER BY directional_value, document_name ";
     if (target.getLimit() != -1) {
-      String direction = target.getFirstOrderBy().getDirection().canonicalString();
-      sql += "ORDER BY directional_value " + direction + ", document_name " + direction + " ";
       sql += "LIMIT " + target.getLimit() + " ";
     }
 
     // Fill in the bind ("question marks") variables.
-    Iterator<Value> arrayValueIterator = arrayValues.iterator();
-    for (int offset = 0; offset < bindArgs.length; ) {
-      Object arrayValue = encode(arrayValueIterator.hasNext() ? arrayValueIterator.next() : null);
-      offset = fillBounds(bindArgs, offset, indexId, arrayValue, lowerBounds, upperBounds);
-    }
-
+    Object[] bindArgs = fillBounds(statementCount, indexId, arrayValues, lowerBounds, upperBounds);
     return db.query(sql).binding(bindArgs);
   }
 
-  /** Fills bindArgs starting at offset and returns the new offset. */
-  private int fillBounds(
-      Object[] bindArgs,
-      int offset,
+  /** Returns the bind arguments for all {@code statementCount} statements. */
+  private Object[] fillBounds(
+      int statementCount,
       int indexId,
-      @Nullable Object arrayValue,
-      Object[] lowerBounds,
+      @Nullable List<Value> arrayValues,
+      @Nullable Object[] lowerBounds,
       @Nullable Object[] upperBounds) {
-    hardAssert(
-        upperBounds == null || upperBounds.length == lowerBounds.length,
-        "Length of upper and lower bound should match");
-    // Add bind variables for each combination of arrayValue, lowerBound and upperBound.
-    for (int i = 0; i < lowerBounds.length; ++i) {
+    int bindsPerStatement =
+        1
+            + (arrayValues != null ? 1 : 0)
+            + (lowerBounds != null ? 1 : 0)
+            + (upperBounds != null ? 1 : 0);
+    int statementsPerArrayValue = statementCount / (arrayValues != null ? arrayValues.size() : 1);
+
+    Object[] bindArgs = new Object[statementCount * bindsPerStatement];
+    int offset = 0;
+    for (int i = 0; i < statementCount; ++i) {
       bindArgs[offset++] = indexId;
-      if (arrayValue != null) {
-        bindArgs[offset++] = arrayValue;
+      if (arrayValues != null) {
+        bindArgs[offset++] = encodeArrayElement(arrayValues.get(i / statementsPerArrayValue));
       }
-      bindArgs[offset++] = lowerBounds[i];
+      if (lowerBounds != null) {
+        bindArgs[offset++] = lowerBounds[i % statementsPerArrayValue];
+      }
       if (upperBounds != null) {
-        bindArgs[offset++] = upperBounds[i];
+        bindArgs[offset++] = upperBounds[i % statementsPerArrayValue];
       }
     }
-    return offset;
+    return bindArgs;
   }
 
   /**
@@ -348,18 +343,29 @@ final class SQLiteIndexManager implements IndexManager {
         activeIndices, (l, r) -> Integer.compare(l.segmentCount(), r.segmentCount()));
   }
 
-  /** Encodes a list of values to the index format. */
-  private Object encode(List<Value> values) {
+  /**
+   * Returns the byte encoded form of the directional values in the field index. Returns {@code
+   * null} if the document does not have all fields specified in the index.
+   */
+  private @Nullable byte[] encodeDirectionalElements(FieldIndex fieldIndex, Document document) {
     IndexByteEncoder encoder = new IndexByteEncoder();
-    for (Value value : values) {
-      FirestoreIndexValueWriter.INSTANCE.writeIndexValue(value, encoder);
+    for (FieldIndex.Segment segment : fieldIndex.getDirectionalSegments()) {
+      Value field = document.getField(segment.getFieldPath());
+      if (field == null) {
+        return null;
+      }
+      DirectionalIndexByteEncoder directionalEncoder = encoder.forKind(segment.getKind());
+      FirestoreIndexValueWriter.INSTANCE.writeIndexValue(field, directionalEncoder);
     }
     return encoder.getEncodedBytes();
   }
 
-  /** Encodes a value to the index format. */
-  private @Nullable Object encode(@Nullable Value value) {
-    return value != null ? encode(Collections.singletonList(value)) : null;
+  /** Encodes a single value to the ascending index format. */
+  private byte[] encodeArrayElement(Value value) {
+    IndexByteEncoder encoder = new IndexByteEncoder();
+    FirestoreIndexValueWriter.INSTANCE.writeIndexValue(
+        value, encoder.forKind(FieldIndex.Segment.Kind.ASCENDING));
+    return encoder.getEncodedBytes();
   }
 
   /**
@@ -378,9 +384,10 @@ final class SQLiteIndexManager implements IndexManager {
       Value value = position.next();
       for (IndexByteEncoder encoder : encoders) {
         if (isInFilter(target, segment.getFieldPath()) && isArray(value)) {
-          encoders = expandIndexValues(encoders, value);
+          encoders = expandIndexValues(encoders, segment, value);
         } else {
-          FirestoreIndexValueWriter.INSTANCE.writeIndexValue(value, encoder);
+          DirectionalIndexByteEncoder directionalEncoder = encoder.forKind(segment.getKind());
+          FirestoreIndexValueWriter.INSTANCE.writeIndexValue(value, directionalEncoder);
         }
       }
     }
@@ -403,14 +410,16 @@ final class SQLiteIndexManager implements IndexManager {
    * "a1").filter("b", "in", ["b1", "b2"]) becomes ["a1,b1", "a1,b2"]). A list of new encoders is
    * returned.
    */
-  private List<IndexByteEncoder> expandIndexValues(List<IndexByteEncoder> encoders, Value value) {
+  private List<IndexByteEncoder> expandIndexValues(
+      List<IndexByteEncoder> encoders, FieldIndex.Segment segment, Value value) {
     List<IndexByteEncoder> prefixes = new ArrayList<>(encoders);
     List<IndexByteEncoder> results = new ArrayList<>();
     for (Value arrayElement : value.getArrayValue().getValuesList()) {
       for (IndexByteEncoder prefix : prefixes) {
         IndexByteEncoder clonedEncoder = new IndexByteEncoder();
         clonedEncoder.seed(prefix.getEncodedBytes());
-        FirestoreIndexValueWriter.INSTANCE.writeIndexValue(arrayElement, clonedEncoder);
+        FirestoreIndexValueWriter.INSTANCE.writeIndexValue(
+            arrayElement, clonedEncoder.forKind(segment.getKind()));
         results.add(clonedEncoder);
       }
     }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.model;
 
+import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,8 +23,8 @@ import java.util.List;
  * An index definition for field indices in Firestore.
  *
  * <p>Every index is associated with a collection. The definition contains a list of fields and the
- * indexes kind (which can be {@link Segment.Kind#ORDERED} or {@link Segment.Kind#CONTAINS} for
- * ArrayContains/ArrayContainsAny queries.
+ * indexes kind (which can be {@link Segment.Kind#ASCENDING}, {@link Segment.Kind#DESCENDING} or
+ * {@link Segment.Kind#CONTAINS} for ArrayContains/ArrayContainsAny queries.
  *
  * <p>Unlike the backend, the SDK does not differentiate between collection or collection
  * group-scoped indices. Every index can be used for both single collection and collection group
@@ -37,7 +38,9 @@ public final class FieldIndex {
     /** The type of the index, e.g. for which type of query it can be used. */
     public enum Kind {
       /** Ordered index. Can be used for <, <=, ==, >=, >, !=, IN and NOT IN queries. */
-      ORDERED,
+      ASCENDING,
+      /** Ordered index. Can be used for <, <=, ==, >=, >, !=, IN and NOT IN queries. */
+      DESCENDING,
       /** Contains index. Can be used for ArrayContains and ArrayContainsAny */
       CONTAINS
     }
@@ -102,24 +105,24 @@ public final class FieldIndex {
     return version;
   }
 
-  public Iterable<Segment> getDirectionalSegments() {
+  public List<Segment> getDirectionalSegments() {
     List<Segment> filteredSegments = new ArrayList<>();
     for (Segment segment : segments) {
-      if (segment.getKind().equals(Segment.Kind.ORDERED)) {
+      if (!segment.getKind().equals(Segment.Kind.CONTAINS)) {
         filteredSegments.add(segment);
       }
     }
     return filteredSegments;
   }
 
-  public Iterable<Segment> getArraySegments() {
-    List<Segment> filteredSegments = new ArrayList<>();
+  public @Nullable Segment getArraySegment() {
     for (Segment segment : segments) {
       if (segment.getKind().equals(Segment.Kind.CONTAINS)) {
-        filteredSegments.add(segment);
+        // Firestore queries can only have a single ArrayContains/ArrayContainsAny statements.
+        return segment;
       }
     }
-    return filteredSegments;
+    return null;
   }
 
   /** Returns a new field index with additional index segment. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/TargetIndexMatcher.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/TargetIndexMatcher.java
@@ -16,27 +16,19 @@ package com.google.firebase.firestore.model;
 
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import androidx.annotation.Nullable;
 import com.google.firebase.firestore.core.FieldFilter;
 import com.google.firebase.firestore.core.Filter;
 import com.google.firebase.firestore.core.OrderBy;
 import com.google.firebase.firestore.core.Target;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * A light query planner for Firestore.
  *
  * <p>This class matches a {@link FieldIndex} against a Firestore Query {@link Target}. It
  * determines whether a given index can be used to serve the specified target.
- *
- * <p>Unlike the backend, the SDK only maintains two different index kinds and does not distinguish
- * between ascending and descending indices. Instead of ordering query results by their index order,
- * the SDK re-orders all query results locally, which reduces the number of indices it needs to
- * maintain.
  *
  * <p>The following table showcases some possible index configurations:
  *
@@ -50,7 +42,7 @@ import java.util.Set;
  *     <tbody>
  *         <tr>
  *             <td>where("a", "==", "a").where("b", "==", "b")</td>
- *             <td>a ORDERED, b ORDERED</td>
+ *             <td>a ASCENDING, b DESCENDING</td>
  *         </tr>
  *         <tr>
  *             <td>where("a", "==", "a").where("b", "==", "b")</td>
@@ -58,19 +50,19 @@ import java.util.Set;
  *        </tr>
  *        <tr>
  *             <td>where("a", "==", "a").where("b", "==", "b")</td>
- *             <td>b ORDERED</td>
+ *             <td>b DESCENDING</td>
  *        </tr>
  *        <tr>
  *             <td>where("a", ">=", "a").orderBy("a").orderBy("b")</td>
- *             <td>a ORDERED, b ORDERED</td>
+ *             <td>a ASCENDING, b ASCENDING</td>
  *        </tr>
  *        <tr>
  *             <td>where("a", ">=", "a").orderBy("a").orderBy("b")</td>
- *             <td>a ORDERED</td>
+ *             <td>a ASCENDING</td>
  *        </tr>
  *        <tr>
  *             <td>where("a", "array-contains", "a").orderBy("b")</td>
- *             <td>a CONTAINS, b ORDERED</td>
+ *             <td>a CONTAINS, b ASCENDING</td>
  *        </tr>
  *        <tr>
  *             <td>where("a", "array-contains", "a").orderBy("b")</td>
@@ -83,31 +75,16 @@ public class TargetIndexMatcher {
   // The collection ID (or collection group) of the query target.
   private final String collectionId;
 
-  // The list of filters per field. A target can have duplicate filters for a field.
-  private final Map<FieldPath, List<FieldFilter>> fieldFilterFields = new HashMap<>();
-
-  // The set of orderBy fields in the query target.
-  private final Set<FieldPath> orderByFields = new HashSet<>();
+  private final List<Filter> filters;
+  private final List<OrderBy> orderBys;
 
   public TargetIndexMatcher(Target target) {
     collectionId =
         target.getCollectionGroup() != null
             ? target.getCollectionGroup()
             : target.getPath().getLastSegment();
-
-    for (Filter filter : target.getFilters()) {
-      hardAssert(filter instanceof FieldFilter, "Only FieldFilters are supported");
-      List<FieldFilter> currentFilters = fieldFilterFields.get(filter.getField());
-      if (currentFilters == null) {
-        currentFilters = new ArrayList<>();
-        fieldFilterFields.put(filter.getField(), currentFilters);
-      }
-      currentFilters.add((FieldFilter) filter);
-    }
-
-    for (OrderBy orderBy : target.getOrderBy()) {
-      orderByFields.add(orderBy.getField());
-    }
+    filters = target.getFilters();
+    orderBys = target.getOrderBy();
   }
 
   /**
@@ -117,34 +94,76 @@ public class TargetIndexMatcher {
    */
   public boolean servedByIndex(FieldIndex index) {
     hardAssert(index.getCollectionGroup().equals(collectionId), "Collection IDs do not match");
-    for (int i = 0; i < index.segmentCount(); ++i) {
-      if (!canUseSegment(index.getSegment(i))) {
-        return false;
+
+    Iterator<Filter> filters = this.filters.iterator();
+    Iterator<OrderBy> orderBys = this.orderBys.iterator();
+
+    FieldFilter currentFilter = filters.hasNext() ? (FieldFilter) filters.next() : null;
+    OrderBy currentOrderBy = orderBys.hasNext() ? orderBys.next() : null;
+
+    // Validate that every segment of the index has a corresponding clause in the provided target.
+    // While a target can have additional filters and orderBy constraints, it cannot have fewer.
+    for (int i = 0; i < index.segmentCount(); ) {
+      FieldIndex.Segment segment = index.getSegment(i);
+
+      boolean consumedOrderBy = false;
+      boolean consumedFilter = false;
+
+      if (currentFilter != null && currentFilter.isInequality()) {
+        // An inequality filter requires a matching ordering constaint.
+        if (matchesFilter(currentFilter, segment) && matchesOrderBy(currentOrderBy, segment)) {
+          consumedOrderBy = true;
+          consumedFilter = true;
+        }
+      } else {
+        if (matchesFilter(currentFilter, segment)) {
+          consumedFilter = true;
+        }
+        if (matchesOrderBy(currentOrderBy, segment)) {
+          consumedOrderBy = true;
+        }
+      }
+
+      if (!consumedFilter && !consumedOrderBy) {
+        // The backend can use merge joins to serve queries with multiple equalities. This means
+        // that a query for "foo == 1 AND bar == 2" can skip "foo" and be served by "bar".
+        if (currentFilter != null && currentFilter.getOperator().equals(Filter.Operator.EQUAL)) {
+          currentFilter = filters.hasNext() ? (FieldFilter) filters.next() : null;
+        } else {
+          return false;
+        }
+      } else {
+        if (consumedFilter) {
+          currentFilter = filters.hasNext() ? (FieldFilter) filters.next() : null;
+        }
+
+        if (consumedOrderBy) {
+          currentOrderBy = orderBys.hasNext() ? orderBys.next() : null;
+        }
+        ++i;
       }
     }
+
     return true;
   }
 
-  private boolean canUseSegment(FieldIndex.Segment segment) {
-    List<FieldFilter> filters = fieldFilterFields.get(segment.getFieldPath());
-    if (filters != null) {
-      for (FieldFilter filter : filters) {
-        switch (filter.getOperator()) {
-          case ARRAY_CONTAINS:
-          case ARRAY_CONTAINS_ANY:
-            if (segment.getKind().equals(FieldIndex.Segment.Kind.CONTAINS)) {
-              return true;
-            }
-            break;
-          default:
-            if (segment.getKind().equals(FieldIndex.Segment.Kind.ORDERED)) {
-              return true;
-            }
-        }
-      }
+  private boolean matchesFilter(@Nullable FieldFilter filter, FieldIndex.Segment segment) {
+    if (filter == null || !filter.getField().equals(segment.getFieldPath())) {
+      return false;
     }
+    boolean isArrayOoperator =
+        filter.getOperator().equals(Filter.Operator.ARRAY_CONTAINS)
+            || filter.getOperator().equals(Filter.Operator.ARRAY_CONTAINS_ANY);
+    return segment.getKind().equals(FieldIndex.Segment.Kind.CONTAINS) == isArrayOoperator;
+  }
 
-    return orderByFields.contains(segment.getFieldPath())
-        && segment.getKind().equals(FieldIndex.Segment.Kind.ORDERED);
+  private boolean matchesOrderBy(@Nullable OrderBy orderBy, FieldIndex.Segment segment) {
+    if (orderBy == null || !orderBy.getField().equals(segment.getFieldPath())) {
+      return false;
+    }
+    return (segment.getKind().equals(FieldIndex.Segment.Kind.ASCENDING)
+            && orderBy.getDirection().equals(OrderBy.Direction.ASCENDING))
+        || (segment.getKind().equals(FieldIndex.Segment.Kind.DESCENDING)
+            && orderBy.getDirection().equals(OrderBy.Direction.DESCENDING));
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/TargetTest.java
@@ -56,7 +56,7 @@ public class TargetTest {
   public void equalsQueryBound() {
     Target target = query("c").filter(filter("foo", "==", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "bar");
@@ -69,7 +69,7 @@ public class TargetTest {
   public void lowerThanQueryBound() {
     Target target = query("c").filter(filter("foo", "<", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "");
@@ -82,7 +82,7 @@ public class TargetTest {
   public void lowerThanOrEqualsQueryBound() {
     Target target = query("c").filter(filter("foo", "<=", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "");
@@ -95,7 +95,7 @@ public class TargetTest {
   public void greaterThanQueryBound() {
     Target target = query("c").filter(filter("foo", ">", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, false, "bar");
@@ -108,7 +108,7 @@ public class TargetTest {
   public void greaterThanOrEqualsQueryBound() {
     Target target = query("c").filter(filter("foo", ">=", "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "bar");
@@ -156,10 +156,10 @@ public class TargetTest {
   public void orderByQueryBound() {
     Target target = query("c").orderBy(orderBy("foo")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
-    verifyBound(lowerBound, true, new Object[] {null});
+    assertNull(lowerBound);
 
     Bound upperBound = target.getUpperBound(index);
     assertNull(upperBound);
@@ -169,7 +169,7 @@ public class TargetTest {
   public void filterWithOrderByQueryBound() {
     Target target = query("c").filter(filter("foo", ">", "bar")).orderBy(orderBy("foo")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, false, "bar");
@@ -183,7 +183,7 @@ public class TargetTest {
     Target target =
         query("c").orderBy(orderBy("foo")).startAt(bound(/* inclusive= */ true, "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "bar");
@@ -205,8 +205,8 @@ public class TargetTest {
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
-            .withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED)
-            .withAddedField(field("b"), FieldIndex.Segment.Kind.ORDERED);
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "a1", "b1");
@@ -227,8 +227,8 @@ public class TargetTest {
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
-            .withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED)
-            .withAddedField(field("b"), FieldIndex.Segment.Kind.ORDERED);
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, false, "a2", "b1");
@@ -249,8 +249,8 @@ public class TargetTest {
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
-            .withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED)
-            .withAddedField(field("b"), FieldIndex.Segment.Kind.ORDERED);
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "a2", "b2");
@@ -264,10 +264,10 @@ public class TargetTest {
     Target target =
         query("c").orderBy(orderBy("foo")).endAt(bound(/* inclusive= */ true, "bar")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("foo"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
-    verifyBound(lowerBound, true, new Object[] {null});
+    assertNull(lowerBound);
 
     Bound upperBound = target.getUpperBound(index);
     verifyBound(upperBound, true, "bar");
@@ -286,8 +286,8 @@ public class TargetTest {
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
-            .withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED)
-            .withAddedField(field("b"), FieldIndex.Segment.Kind.ORDERED);
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "", "b2");
@@ -308,8 +308,8 @@ public class TargetTest {
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
-            .withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED)
-            .withAddedField(field("b"), FieldIndex.Segment.Kind.ORDERED);
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "", "b2");
@@ -330,8 +330,8 @@ public class TargetTest {
             .toTarget();
     FieldIndex index =
         new FieldIndex("c")
-            .withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED)
-            .withAddedField(field("b"), FieldIndex.Segment.Kind.ORDERED);
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "", "b1");
@@ -345,7 +345,7 @@ public class TargetTest {
     Target target =
         query("c").filter(filter("a", "==", "a")).filter(filter("b", "==", "b")).toTarget();
     FieldIndex index =
-        new FieldIndex("c").withAddedField(field("a"), FieldIndex.Segment.Kind.ORDERED);
+        new FieldIndex("c").withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING);
 
     Bound lowerBound = target.getLowerBound(index);
     verifyBound(lowerBound, true, "a");

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.firestore.local;
 
-import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.firebase.firestore.testutil.TestUtil.bound;
 import static com.google.firebase.firestore.testutil.TestUtil.doc;
 import static com.google.firebase.firestore.testutil.TestUtil.field;
@@ -24,6 +24,7 @@ import static com.google.firebase.firestore.testutil.TestUtil.map;
 import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
 import static com.google.firebase.firestore.testutil.TestUtil.path;
 import static com.google.firebase.firestore.testutil.TestUtil.query;
+import static com.google.firebase.firestore.testutil.TestUtil.wrap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -33,7 +34,10 @@ import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.MutableDocument;
 import com.google.firebase.firestore.model.SnapshotVersion;
+import com.google.firebase.firestore.model.Values;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -61,7 +65,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
 
   private void setUpSingleValueFilter() {
     indexManager.addFieldIndex(
-        new FieldIndex("coll").withAddedField(field("count"), FieldIndex.Segment.Kind.ORDERED));
+        new FieldIndex("coll").withAddedField(field("count"), FieldIndex.Segment.Kind.ASCENDING));
     addDoc("coll/doc1", map("count", 1));
     addDoc("coll/doc2", map("count", 2));
     addDoc("coll/doc3", map("count", 3));
@@ -83,7 +87,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   @Test
   public void addsDocuments() {
     indexManager.addFieldIndex(
-        new FieldIndex("coll").withAddedField(field("exists"), FieldIndex.Segment.Kind.ORDERED));
+        new FieldIndex("coll").withAddedField(field("exists"), FieldIndex.Segment.Kind.ASCENDING));
     addDoc("coll/doc1", map("exists", 1));
     addDoc("coll/doc2", map());
   }
@@ -98,7 +102,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   @Test
   public void testNestedFieldEqualityFilter() {
     indexManager.addFieldIndex(
-        new FieldIndex("coll").withAddedField(field("a.b"), FieldIndex.Segment.Kind.ORDERED));
+        new FieldIndex("coll").withAddedField(field("a.b"), FieldIndex.Segment.Kind.ASCENDING));
     addDoc("coll/doc1", map("a", map("b", 1)));
     addDoc("coll/doc2", map("a", map("b", 2)));
     Query query = query("coll").filter(filter("a.b", "==", 2));
@@ -249,7 +253,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   @Test
   public void testEqualityFilterWithNonMatchingType() {
     indexManager.addFieldIndex(
-        new FieldIndex("coll").withAddedField(field("value"), FieldIndex.Segment.Kind.ORDERED));
+        new FieldIndex("coll").withAddedField(field("value"), FieldIndex.Segment.Kind.ASCENDING));
     addDoc("coll/boolean", map("value", true));
     addDoc("coll/string", map("value", "true"));
     addDoc("coll/number", map("value", 1));
@@ -260,7 +264,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   @Test
   public void testCollectionGroup() {
     indexManager.addFieldIndex(
-        new FieldIndex("coll1").withAddedField(field("value"), FieldIndex.Segment.Kind.ORDERED));
+        new FieldIndex("coll1").withAddedField(field("value"), FieldIndex.Segment.Kind.ASCENDING));
     addDoc("coll1/doc1", map("value", true));
     addDoc("coll2/doc2/coll1/doc1", map("value", true));
     addDoc("coll2/doc2", map("value", true));
@@ -271,7 +275,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   @Test
   public void testLimitFilter() {
     indexManager.addFieldIndex(
-        new FieldIndex("coll").withAddedField(field("value"), FieldIndex.Segment.Kind.ORDERED));
+        new FieldIndex("coll").withAddedField(field("value"), FieldIndex.Segment.Kind.ASCENDING));
     addDoc("coll/doc1", map("value", 1));
     addDoc("coll/doc2", map("value", 1));
     addDoc("coll/doc3", map("value", 1));
@@ -283,7 +287,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   public void testLimitAppliesOrdering() {
     indexManager.addFieldIndex(
         new FieldIndex("coll")
-            .withAddedField(field("value"), FieldIndex.Segment.Kind.ORDERED)
+            .withAddedField(field("value"), FieldIndex.Segment.Kind.ASCENDING)
             .withAddedField(field("value"), FieldIndex.Segment.Kind.CONTAINS));
     addDoc("coll/doc1", map("value", Arrays.asList(1, "foo")));
     addDoc("coll/doc2", map("value", Arrays.asList(3, "foo")));
@@ -297,10 +301,257 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   }
 
   @Test
+  public void testAdvancedQueries() {
+    // This test compares local query results with those received from the Java Server SDK.
+
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("null"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("int"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("float"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("string"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("multi"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("array"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("array"), FieldIndex.Segment.Kind.DESCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("array"), FieldIndex.Segment.Kind.CONTAINS));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("map"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll")
+            .withAddedField(field("map.field"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll").withAddedField(field("prefix"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll")
+            .withAddedField(field("prefix"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("suffix"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll")
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll")
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.DESCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll")
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.ASCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.DESCENDING));
+    indexManager.addFieldIndex(
+        new FieldIndex("coll")
+            .withAddedField(field("a"), FieldIndex.Segment.Kind.DESCENDING)
+            .withAddedField(field("b"), FieldIndex.Segment.Kind.DESCENDING));
+
+    List<Map<String, Object>> data =
+        new ArrayList<Map<String, Object>>() {
+          {
+            add(map());
+            add(map("int", 1, "array", Arrays.asList(1, "foo")));
+            add(map("array", Arrays.asList(2, "foo")));
+            add(map("int", 3, "array", Arrays.asList(3, "foo")));
+            add(map("array", "foo"));
+            add(map("array", Collections.singletonList(1)));
+            add(map("float", -0.0, "string", "a"));
+            add(map("float", 0, "string", "ab"));
+            add(map("float", 0.0, "string", "b"));
+            add(map("float", Double.NaN));
+            add(map("multi", true));
+            add(map("multi", 1));
+            add(map("multi", "string"));
+            add(map("multi", Collections.emptyList()));
+            add(map("null", null));
+            add(map("prefix", Arrays.asList(1, 2), "suffix", null));
+            add(map("prefix", Collections.singletonList(1), "suffix", 2));
+            add(map("map", map()));
+            add(map("map", map("field", true)));
+            add(map("map", map("field", false)));
+            add(map("a", 0, "b", 0));
+            add(map("a", 0, "b", 1));
+            add(map("a", 1, "b", 0));
+            add(map("a", 1, "b", 1));
+          }
+        };
+
+    for (int i = 0; i < data.size(); ++i) {
+      addDoc("coll/" + Values.canonicalId(wrap(data.get(i))), data.get(i));
+    }
+
+    Query q = query("coll");
+
+    verifyResults(
+        q.orderBy(orderBy("int")), "coll/{array:[1,foo],int:1}", "coll/{array:[3,foo],int:3}");
+    verifyResults(q.filter(filter("float", "==", Double.NaN)), "coll/{float:NaN}");
+    verifyResults(
+        q.filter(filter("float", "==", -0.0)),
+        "coll/{float:-0.0,string:a}",
+        "coll/{float:0,string:ab}",
+        "coll/{float:0.0,string:b}");
+    verifyResults(
+        q.filter(filter("float", "==", 0)),
+        "coll/{float:-0.0,string:a}",
+        "coll/{float:0,string:ab}",
+        "coll/{float:0.0,string:b}");
+    verifyResults(
+        q.filter(filter("float", "==", 0.0)),
+        "coll/{float:-0.0,string:a}",
+        "coll/{float:0,string:ab}",
+        "coll/{float:0.0,string:b}");
+    verifyResults(q.filter(filter("string", "==", "a")), "coll/{float:-0.0,string:a}");
+    verifyResults(
+        q.filter(filter("string", ">", "a")),
+        "coll/{float:0,string:ab}",
+        "coll/{float:0.0,string:b}");
+    verifyResults(
+        q.filter(filter("string", ">=", "a")),
+        "coll/{float:-0.0,string:a}",
+        "coll/{float:0,string:ab}",
+        "coll/{float:0.0,string:b}");
+    verifyResults(
+        q.filter(filter("string", "<", "b")),
+        "coll/{float:-0.0,string:a}",
+        "coll/{float:0,string:ab}");
+    verifyResults(
+        q.filter(filter("string", "<", "coll")),
+        "coll/{float:-0.0,string:a}",
+        "coll/{float:0,string:ab}",
+        "coll/{float:0.0,string:b}");
+    verifyResults(
+        q.filter(filter("string", ">", "a")).filter(filter("string", "<", "b")),
+        "coll/{float:0,string:ab}");
+    verifyResults(
+        q.filter(filter("array", "array-contains", "foo")),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:[2,foo]}",
+        "coll/{array:[3,foo],int:3}");
+    verifyResults(
+        q.filter(filter("array", "array-contains-any", Arrays.asList(1, "foo"))),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:[2,foo]}",
+        "coll/{array:[3,foo],int:3}",
+        "coll/{array:[1]}");
+    verifyResults(q.filter(filter("multi", ">=", true)), "coll/{multi:true}");
+    verifyResults(q.filter(filter("multi", ">=", 0)), "coll/{multi:1}");
+    verifyResults(q.filter(filter("multi", ">=", "")), "coll/{multi:string}");
+    verifyResults(q.filter(filter("multi", ">=", Collections.emptyList())), "coll/{multi:[]}");
+    verifyResults(
+        q.orderBy(orderBy("array")).startAt(bound(true, Collections.singletonList(2))),
+        "coll/{array:[2,foo]}",
+        "coll/{array:[3,foo],int:3}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc")).startAt(bound(true, Collections.singletonList(2))),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:foo}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc"))
+            .startAt(bound(true, Collections.singletonList(2)))
+            .limitToFirst(2),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array")).startAt(bound(false, Collections.singletonList(2))),
+        "coll/{array:[2,foo]}",
+        "coll/{array:[3,foo],int:3}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc")).startAt(bound(false, Collections.singletonList(2))),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:foo}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc"))
+            .startAt(bound(false, Collections.singletonList(2)))
+            .limitToFirst(2),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array")).startAt(bound(false, Arrays.asList(2, "foo"))),
+        "coll/{array:[3,foo],int:3}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc")).startAt(bound(false, Arrays.asList(2, "foo"))),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:foo}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc"))
+            .startAt(bound(false, Arrays.asList(2, "foo")))
+            .limitToFirst(2),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array")).endAt(bound(true, Collections.singletonList(2))),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:foo}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc")).endAt(bound(true, Collections.singletonList(2))),
+        "coll/{array:[2,foo]}",
+        "coll/{array:[3,foo],int:3}");
+    verifyResults(
+        q.orderBy(orderBy("array")).endAt(bound(false, Collections.singletonList(2))),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:foo}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array"))
+            .endAt(bound(false, Collections.singletonList(2)))
+            .limitToFirst(2),
+        "coll/{array:foo}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc")).endAt(bound(false, Collections.singletonList(2))),
+        "coll/{array:[2,foo]}",
+        "coll/{array:[3,foo],int:3}");
+    verifyResults(
+        q.orderBy(orderBy("array")).endAt(bound(false, Arrays.asList(2, "foo"))),
+        "coll/{array:[1,foo],int:1}",
+        "coll/{array:foo}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array")).endAt(bound(false, Arrays.asList(2, "foo"))).limitToFirst(2),
+        "coll/{array:foo}",
+        "coll/{array:[1]}");
+    verifyResults(
+        q.orderBy(orderBy("array", "desc")).endAt(bound(false, Arrays.asList(2, "foo"))),
+        "coll/{array:[3,foo],int:3}");
+    verifyResults(q.orderBy(orderBy("a")).orderBy(orderBy("b")).limitToFirst(1), "coll/{a:0,b:0}");
+    verifyResults(
+        q.orderBy(orderBy("a", "desc")).orderBy(orderBy("b")).limitToFirst(1), "coll/{a:1,b:0}");
+    verifyResults(
+        q.orderBy(orderBy("a")).orderBy(orderBy("b", "desc")).limitToFirst(1), "coll/{a:0,b:1}");
+    verifyResults(
+        q.orderBy(orderBy("a", "desc")).orderBy(orderBy("b", "desc")).limitToFirst(1),
+        "coll/{a:1,b:1}");
+    verifyResults(q.filter(filter("null", "==", null)), "coll/{null:null}");
+    verifyResults(q.orderBy(orderBy("null")), "coll/{null:null}");
+    verifyResults(
+        q.filter(filter("prefix", "==", Arrays.asList(1, 2))), "coll/{prefix:[1,2],suffix:null}");
+    verifyResults(
+        q.filter(filter("prefix", "==", Collections.singletonList(1)))
+            .filter(filter("suffix", "==", 2)),
+        "coll/{prefix:[1],suffix:2}");
+    verifyResults(q.filter(filter("map", "==", map())), "coll/{map:{}}");
+    verifyResults(q.filter(filter("map", "==", map("field", true))), "coll/{map:{field:true}}");
+    verifyResults(q.filter(filter("map.field", "==", true)), "coll/{map:{field:true}}");
+    verifyResults(
+        q.orderBy(orderBy("map")),
+        "coll/{map:{}}",
+        "coll/{map:{field:true}}",
+        "coll/{map:{field:false}}");
+    verifyResults(
+        q.orderBy(orderBy("map.field")), "coll/{map:{field:true}}", "coll/{map:{field:false}}");
+  }
+
+  @Test
   public void testUpdateTime() {
     indexManager.addFieldIndex(
         new FieldIndex("coll1")
-            .withAddedField(field("value"), FieldIndex.Segment.Kind.ORDERED)
+            .withAddedField(field("value"), FieldIndex.Segment.Kind.ASCENDING)
             .withVersion(new SnapshotVersion(new Timestamp(10, 20))));
 
     List<FieldIndex> indexes = ((SQLiteIndexManager) indexManager).getFieldIndexes();
@@ -317,6 +568,6 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   private void verifyResults(Query query, String... documents) {
     Iterable<DocumentKey> results = indexManager.getDocumentsMatchingTarget(query.toTarget());
     List<DocumentKey> keys = Arrays.stream(documents).map(s -> key(s)).collect(Collectors.toList());
-    assertThat(results).containsExactlyElementsIn(keys);
+    assertWithMessage("Result for %s", query).that(results).containsExactlyElementsIn(keys);
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/TargetIndexMatcherTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/TargetIndexMatcherTest.java
@@ -60,8 +60,8 @@ public class TargetIndexMatcherTest {
   @Test
   public void canUseMergeJoin() {
     Query q = query("collId").filter(filter("a", "==", 1)).filter(filter("b", "==", 2));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
-    validateServesTarget(q, "b", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
+    validateServesTarget(q, "b", FieldIndex.Segment.Kind.ASCENDING);
 
     q =
         query("collId")
@@ -69,35 +69,35 @@ public class TargetIndexMatcherTest {
             .filter(filter("b", "==", 2))
             .orderBy(orderBy("__name__", "desc"));
     validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "__name__", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "__name__", FieldIndex.Segment.Kind.DESCENDING);
     validateServesTarget(
-        q, "b", FieldIndex.Segment.Kind.ORDERED, "__name__", FieldIndex.Segment.Kind.ORDERED);
+        q, "b", FieldIndex.Segment.Kind.ASCENDING, "__name__", FieldIndex.Segment.Kind.DESCENDING);
   }
 
   @Test
   public void canUsePartialIndex() {
     Query q = query("collId").orderBy(orderBy("a"));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
 
     q = query("collId").orderBy(orderBy("a")).orderBy(orderBy("b"));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
     validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "b", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "b", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
   public void cannotUseOverspecifiedIndex() {
     Query q = query("collId").orderBy(orderBy("a"));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
     validateDoesNotServeTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "b", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "b", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
   public void equalitiesWithDefaultOrder() {
     for (Query query : queriesWithEqualities) {
-      validateServesTarget(query, "a", FieldIndex.Segment.Kind.ORDERED);
-      validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ORDERED);
+      validateServesTarget(query, "a", FieldIndex.Segment.Kind.ASCENDING);
+      validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ASCENDING);
       validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.CONTAINS);
     }
   }
@@ -109,8 +109,8 @@ public class TargetIndexMatcherTest {
 
     queriesWithEqualitiesAndDescendingOrder.forEach(
         query -> {
-          validateServesTarget(query, "a", FieldIndex.Segment.Kind.ORDERED);
-          validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ORDERED);
+          validateServesTarget(query, "a", FieldIndex.Segment.Kind.ASCENDING);
+          validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ASCENDING);
           validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.CONTAINS);
         });
   }
@@ -122,8 +122,8 @@ public class TargetIndexMatcherTest {
 
     queriesWithEqualitiesAndDescendingOrder.forEach(
         query -> {
-          validateServesTarget(query, "a", FieldIndex.Segment.Kind.ORDERED);
-          validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ORDERED);
+          validateServesTarget(query, "a", FieldIndex.Segment.Kind.ASCENDING);
+          validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ASCENDING);
           validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.CONTAINS);
         });
   }
@@ -131,8 +131,8 @@ public class TargetIndexMatcherTest {
   @Test
   public void inequalitiesWithDefaultOrder() {
     for (Query query : queriesWithInequalities) {
-      validateServesTarget(query, "a", FieldIndex.Segment.Kind.ORDERED);
-      validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ORDERED);
+      validateServesTarget(query, "a", FieldIndex.Segment.Kind.ASCENDING);
+      validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ASCENDING);
       validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.CONTAINS);
     }
   }
@@ -144,8 +144,8 @@ public class TargetIndexMatcherTest {
 
     queriesWithInequalitiesAndDescendingOrder.forEach(
         query -> {
-          validateServesTarget(query, "a", FieldIndex.Segment.Kind.ORDERED);
-          validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ORDERED);
+          validateServesTarget(query, "a", FieldIndex.Segment.Kind.ASCENDING);
+          validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ASCENDING);
           validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.CONTAINS);
         });
   }
@@ -157,8 +157,8 @@ public class TargetIndexMatcherTest {
 
     queriesWithInequalitiesAndDescendingOrder.forEach(
         query -> {
-          validateServesTarget(query, "a", FieldIndex.Segment.Kind.ORDERED);
-          validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ORDERED);
+          validateServesTarget(query, "a", FieldIndex.Segment.Kind.DESCENDING);
+          validateDoesNotServeTarget(query, "b", FieldIndex.Segment.Kind.ASCENDING);
           validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.CONTAINS);
         });
   }
@@ -166,17 +166,17 @@ public class TargetIndexMatcherTest {
   @Test
   public void inequalityUsesSingleFieldIndex() {
     Query q = query("collId").filter(filter("a", ">", 1)).filter(filter("a", "<", 10));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
-  public void inQueryUsesMergeJoin() {
+  public void inQueryDoesNotUseMergeJoin() {
     Query q =
         query("collId").filter(filter("a", "in", Arrays.asList(1, 2))).filter(filter("b", "==", 5));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
-    validateServesTarget(q, "b", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
+    validateDoesNotServeTarget(q, "b", FieldIndex.Segment.Kind.ASCENDING);
     validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "b", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "b", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -206,8 +206,8 @@ public class TargetIndexMatcherTest {
   @Test
   public void withArrayContains() {
     for (Query query : queriesWithArrayContains) {
-      validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.ORDERED);
-      validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.ORDERED);
+      validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.ASCENDING);
+      validateDoesNotServeTarget(query, "a", FieldIndex.Segment.Kind.ASCENDING);
       validateServesTarget(query, "a", FieldIndex.Segment.Kind.CONTAINS);
     }
   }
@@ -224,50 +224,54 @@ public class TargetIndexMatcherTest {
         "a",
         FieldIndex.Segment.Kind.CONTAINS,
         "a",
-        FieldIndex.Segment.Kind.ORDERED);
+        FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
   public void withEqualityAndDescendingOrder() {
     Query q = query("collId").filter(filter("a", "==", 1)).orderBy(orderBy("__name__", "desc"));
     validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "__name__", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "__name__", FieldIndex.Segment.Kind.DESCENDING);
   }
 
   @Test
   public void withOrderBy() {
     Query q = query("collId").orderBy(orderBy("a"));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
+    validateDoesNotServeTarget(q, "a", FieldIndex.Segment.Kind.DESCENDING);
 
     q = query("collId").orderBy(orderBy("a", "desc"));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateDoesNotServeTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.DESCENDING);
 
     q = query("collId").orderBy(orderBy("a")).orderBy(orderBy("__name__"));
     validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "__name__", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "__name__", FieldIndex.Segment.Kind.ASCENDING);
+    validateDoesNotServeTarget(
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "__name__", FieldIndex.Segment.Kind.DESCENDING);
   }
 
   @Test
   public void withNotEquals() {
     Query q = query("collId").filter(filter("a", "!=", 1));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
 
     q = query("collId").filter(filter("a", "!=", 1)).orderBy(orderBy("a")).orderBy(orderBy("b"));
     validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "b", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "b", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
   public void withMultipleFilters() {
     Query queriesMultipleFilters =
         query("collId").filter(filter("a", "==", "a")).filter(filter("b", ">", "b"));
-    validateServesTarget(queriesMultipleFilters, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(queriesMultipleFilters, "a", FieldIndex.Segment.Kind.ASCENDING);
     validateServesTarget(
         queriesMultipleFilters,
         "a",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "b",
-        FieldIndex.Segment.Kind.ORDERED);
+        FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -275,13 +279,13 @@ public class TargetIndexMatcherTest {
     Query queriesMultipleFilters =
         query("collId").filter(filter("a", "==", "a")).filter(filter("b", ">", "b"));
 
-    validateServesTarget(queriesMultipleFilters, "b", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(queriesMultipleFilters, "b", FieldIndex.Segment.Kind.ASCENDING);
     validateDoesNotServeTarget(
         queriesMultipleFilters,
         "c",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "a",
-        FieldIndex.Segment.Kind.ORDERED);
+        FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -294,9 +298,9 @@ public class TargetIndexMatcherTest {
     validateServesTarget(
         queriesMultipleFilters,
         "a1",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "a2",
-        FieldIndex.Segment.Kind.ORDERED);
+        FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -306,7 +310,7 @@ public class TargetIndexMatcherTest {
             .filter(filter("a", ">=", 1))
             .filter(filter("a", "==", 5))
             .filter(filter("a", "<=", 10));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -315,7 +319,7 @@ public class TargetIndexMatcherTest {
         query("collId")
             .filter(filter("a", "not-in", Arrays.asList(1, 2, 3)))
             .filter(filter("a", ">=", 2));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -328,22 +332,19 @@ public class TargetIndexMatcherTest {
     validateServesTarget(
         q,
         "fff",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "bar",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.DESCENDING,
         "__name__",
-        FieldIndex.Segment.Kind.ORDERED);
-    // The field index can be used regardless of the order of segments since we only use the orderBy
-    // clause to filter out documents that do not contain field values for the specified fields. The
-    // ordering itself is done during View computation.
-    validateServesTarget(
+        FieldIndex.Segment.Kind.ASCENDING);
+    validateDoesNotServeTarget(
         q,
         "fff",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "__name__",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "bar",
-        FieldIndex.Segment.Kind.ORDERED);
+        FieldIndex.Segment.Kind.DESCENDING);
 
     q =
         query("collId")
@@ -353,19 +354,19 @@ public class TargetIndexMatcherTest {
     validateServesTarget(
         q,
         "foo",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "bar",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "__name__",
-        FieldIndex.Segment.Kind.ORDERED);
-    validateServesTarget(
+        FieldIndex.Segment.Kind.DESCENDING);
+    validateDoesNotServeTarget(
         q,
         "foo",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "__name__",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.DESCENDING,
         "bar",
-        FieldIndex.Segment.Kind.ORDERED);
+        FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -374,12 +375,12 @@ public class TargetIndexMatcherTest {
         query("collId")
             .filter(filter("a", "not-in", Arrays.asList(1, 2, 3)))
             .filter(filter("b", "in", Arrays.asList(1, 2, 3)));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
-    validateServesTarget(q, "b", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
+    validateDoesNotServeTarget(q, "b", FieldIndex.Segment.Kind.ASCENDING);
+    validateDoesNotServeTarget(
+        q, "b", FieldIndex.Segment.Kind.ASCENDING, "a", FieldIndex.Segment.Kind.ASCENDING);
     validateServesTarget(
-        q, "b", FieldIndex.Segment.Kind.ORDERED, "a", FieldIndex.Segment.Kind.ORDERED);
-    validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "b", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "b", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -392,11 +393,11 @@ public class TargetIndexMatcherTest {
     validateServesTarget(
         q,
         "foo",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "bar",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "qux",
-        FieldIndex.Segment.Kind.ORDERED);
+        FieldIndex.Segment.Kind.ASCENDING);
 
     q =
         query("collId")
@@ -408,13 +409,13 @@ public class TargetIndexMatcherTest {
     validateServesTarget(
         q,
         "aaa",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "qqq",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "ccc",
-        FieldIndex.Segment.Kind.ORDERED,
+        FieldIndex.Segment.Kind.ASCENDING,
         "fff",
-        FieldIndex.Segment.Kind.ORDERED);
+        FieldIndex.Segment.Kind.DESCENDING);
   }
 
   @Test
@@ -424,7 +425,7 @@ public class TargetIndexMatcherTest {
             .filter(filter("a", "==", 1))
             .filter(filter("b", "not-in", Arrays.asList(1, 2, 3)));
     validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "b", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "b", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
@@ -435,14 +436,14 @@ public class TargetIndexMatcherTest {
             .orderBy(orderBy("a"))
             .orderBy(orderBy("b"));
     validateServesTarget(
-        q, "a", FieldIndex.Segment.Kind.ORDERED, "b", FieldIndex.Segment.Kind.ORDERED);
+        q, "a", FieldIndex.Segment.Kind.ASCENDING, "b", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   @Test
   public void withInAndOrderBySameField() {
     Query q =
         query("collId").filter(filter("a", "in", Arrays.asList(1, 2, 3))).orderBy(orderBy("a"));
-    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ORDERED);
+    validateServesTarget(q, "a", FieldIndex.Segment.Kind.ASCENDING);
   }
 
   private void validateServesTarget(


### PR DESCRIPTION
This PR adds a bunch of test cases that verify the behavior of indexing when compared with a source of truth (the Java SDK - https://gist.github.com/schmidt-sebastian/4eab4300fa5d36d6c2eaefb6adc17b13).

To make these tests work, a bunch of things change:

- Ordering is now strictly enforced. The index entries are ordered by the direction specified in the index. This means that there are now two index formats (ascending, descending) instead of just one for directional queries.
- Like the backend, the SDK now only supports a single ArrayContains/ArrayContainsAny filter (for cosmetic rather than semantic reasons, can be lifted if the backend lifts its limit)
- Lower bounds can now be nullable too as they essentially act as upper bounds when the direction is DESCENDING
- All variable length index values are now terminated by a truncation indicator (which is always NO_TRUNCATION since the SDK does not truncate)
- All index values are separated by an INFINITY separator (as discussed in http://goto.google.com/firestore-storage-format#encodings)