### PR TITLE
Fireperf: remove the redundant PerfSession.create during cold start

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/provider/FirebasePerfProvider.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/provider/FirebasePerfProvider.java
@@ -76,7 +76,10 @@ public class FirebasePerfProvider extends ContentProvider {
     // possible.
     // There is code in SessionManager that prevents us from resetting the session twice in case
     // of app cold start.
+    // Solution 1
     SessionManager.getInstance().updatePerfSession(ApplicationProcessState.FOREGROUND);
+    // Solution 2
+    SessionManager.getInstance().logMetadataAndStartOrStopCollectingGauges(ApplicationProcessState.FOREGROUND);
   }
 
   /** Called before {@link Application#onCreate()}. */


### PR DESCRIPTION
b/201549215

Best solution would be to not create a `PerfSession` in `SessionManager`'s constructor. But worried if `SessionManager` is garbage collected, would it be recreated without a `PerfSession`? 

Basically the question is: does Android garbage collect singletons (without killing entire app process)? I think not, I think Android will just kill the entire App process, which wouldn't be a problem. But I couldn't be conclusive. 