### PR TITLE
Check if debug log is enabled before generate dashboard URL

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerformance.java
@@ -192,7 +192,7 @@ public class FirebasePerformance implements FirebasePerformanceAttributable {
     gaugeManager.setApplicationContext(appContext);
 
     mPerformanceCollectionForceEnabledState = configResolver.getIsPerformanceCollectionEnabled();
-    if (isPerformanceCollectionEnabled()) {
+    if (logger.isLogcatEnabled() && isPerformanceCollectionEnabled()) {
       logger.info(
           String.format(
               "Firebase Performance Monitoring is successfully initialized! In a minute, visit the Firebase console to view your data: %s",


### PR DESCRIPTION
The PR will cut down the cost of generateDashboardURL and save ~10ms if debug log is disabled.