### PR TITLE
Don't send fatal uncaught exception if an NDK crash exists

### DIFF
--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/FirebaseCrashlyticsNdk.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/FirebaseCrashlyticsNdk.java
@@ -49,12 +49,18 @@ class FirebaseCrashlyticsNdk implements CrashlyticsNativeComponent {
   }
 
   private boolean installHandlerDuringPrepareSession;
+  private String currentSessionId;
   private SignalHandlerInstaller signalHandlerInstaller;
 
   FirebaseCrashlyticsNdk(
       @NonNull CrashpadController controller, boolean installHandlerDuringPrepareSession) {
     this.controller = controller;
     this.installHandlerDuringPrepareSession = installHandlerDuringPrepareSession;
+  }
+
+  @Override
+  public boolean hasCrashDataForCurrentSession() {
+    return currentSessionId != null && hasCrashDataForSession(currentSessionId);
   }
 
   @Override
@@ -74,6 +80,7 @@ class FirebaseCrashlyticsNdk implements CrashlyticsNativeComponent {
       long startedAtSeconds,
       @NonNull StaticSessionData sessionData) {
 
+    currentSessionId = sessionId;
     signalHandlerInstaller =
         () -> {
           Logger.getLogger().d("Initializing native session: " + sessionId);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsNativeComponent.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsNativeComponent.java
@@ -19,6 +19,8 @@ import com.google.firebase.crashlytics.internal.model.StaticSessionData;
 
 public interface CrashlyticsNativeComponent {
 
+  boolean hasCrashDataForCurrentSession();
+
   boolean hasCrashDataForSession(@NonNull String sessionId);
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsNativeComponentDeferredProxy.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsNativeComponentDeferredProxy.java
@@ -41,6 +41,12 @@ public final class CrashlyticsNativeComponentDeferredProxy implements Crashlytic
   }
 
   @Override
+  public boolean hasCrashDataForCurrentSession() {
+    CrashlyticsNativeComponent component = availableNativeComponent.get();
+    return component != null && component.hasCrashDataForCurrentSession();
+  }
+
+  @Override
   public boolean hasCrashDataForSession(@NonNull String sessionId) {
     CrashlyticsNativeComponent component = availableNativeComponent.get();
     return component != null && component.hasCrashDataForSession(sessionId);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -156,7 +156,8 @@ class CrashlyticsController {
           }
         };
     crashHandler =
-        new CrashlyticsUncaughtExceptionHandler(crashListener, settingsProvider, defaultHandler);
+        new CrashlyticsUncaughtExceptionHandler(
+            crashListener, settingsProvider, defaultHandler, nativeComponent);
     Thread.setDefaultUncaughtExceptionHandler(crashHandler);
   }
 


### PR DESCRIPTION
Our backend expects at most one fatal event per session. In some cases,
such as Unity, the native signal handler may cause an uncaught exception
to be thrown, after we have recorded the NDK crash. If this happens,
Crashlytics should ignore the uncaught exception and send the NDK
crash information as the fatal event.