### PR TITLE
Implement Fine-grained control over the unknown sources UI

### DIFF
--- a/firebase-app-distribution/src/main/AndroidManifest.xml
+++ b/firebase-app-distribution/src/main/AndroidManifest.xml
@@ -29,7 +29,10 @@
                 android:name="com.google.firebase.components:com.google.firebase.appdistribution.FirebaseAppDistributionRegistrar"
                 android:value="com.google.firebase.components.ComponentRegistrar" />
         </service>
-        <activity android:name=".InstallActivity" android:exported="true"/>
+        <!-- The launch mode for Install Activity is singleTask to ensure that after the unknown sources UI
+        or the installation flow is complete, the Install Activity does not get recreated which causes loss of state
+         See here for more info - https://developer.android.com/guide/components/activities/tasks-and-back-stack#ManifestForTasks -->
+        <activity android:name=".InstallActivity" android:launchMode="singleTask"/>
 
         <activity android:name=".SignInResultActivity" android:exported="true">
             <intent-filter>

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/InstallActivity.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/InstallActivity.java
@@ -14,12 +14,12 @@
 
 package com.google.firebase.appdistribution;
 
+import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Bundle;
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.annotation.NonNull;
+import android.os.Build;
+import android.provider.Settings;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.FileProvider;
@@ -29,24 +29,105 @@ import java.io.File;
  * Activity opened during installation in {@link UpdateAppClient} after APK download is finished.
  */
 public class InstallActivity extends AppCompatActivity {
+  private static final String TAG = "InstallActivity: ";
+  private boolean unknownSourceEnablementInProgress = false;
+  private boolean installInProgress = false;
 
   @Override
-  protected void onCreate(@NonNull Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    ActivityResultLauncher<Intent> mStartForResult =
-        registerForActivityResult(
-            new ActivityResultContracts.StartActivityForResult(),
-            activityResult -> {
-              int resultCode = activityResult.getResultCode();
-              getFirebaseAppDistributionInstance().setInstallationResult(resultCode);
-              finish();
-            });
+  public void onResume() {
+    super.onResume();
+    // Since we kick-off installation with FLAG_ACTIVITY_NEW_TASK (in a new task), we won't be able
+    // to figure out if installation failed or was cancelled.
+    // If we re-enter InstallActivity after install is already kicked off, we can assume that either
+    // installation failure or user cancelled the install.
+    if (installInProgress) {
+      LogWrapper.getInstance()
+          .e(
+              TAG
+                  + "Activity resumed when installation already in progress. Installation was either cancelled or failed");
+      getFirebaseAppDistributionInstance().setInstallationResult(Activity.RESULT_CANCELED);
+      finish();
+      return;
+    }
+
+    if (!isUnknownSourcesEnabled()) {
+      // See comment about install progress above. Same applies to unknown sources UI.
+      if (unknownSourceEnablementInProgress) {
+        LogWrapper.getInstance()
+            .e(
+                TAG
+                    + "Unknown sources enablement is already in progress. It was either cancelled or failed");
+        getFirebaseAppDistributionInstance().setInstallationResult(Activity.RESULT_CANCELED);
+        finish();
+        return;
+      }
+
+      unknownSourceEnablementInProgress = true;
+      showUnknownSourcesUi();
+      return;
+    }
+
+    startInstallActivity();
+  }
+
+  private boolean isUnknownSourcesEnabled() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      return this.getPackageManager().canRequestPackageInstalls();
+    } else {
+      try {
+        return Settings.Secure.getInt(getContentResolver(), Settings.Secure.INSTALL_NON_MARKET_APPS)
+            == 1;
+      } catch (Settings.SettingNotFoundException e) {
+        LogWrapper.getInstance().e(TAG + "Unable to determine if unknown sources is enabled.", e);
+        return true;
+      }
+    }
+  }
+
+  private void showUnknownSourcesUi() {
+    AlertDialog alertDialog = new AlertDialog.Builder(this).create();
+    alertDialog.setTitle(getString(R.string.unknown_sources_dialog_title));
+    alertDialog.setMessage(getString(R.string.unknown_sources_dialog_description));
+    alertDialog.setButton(
+        AlertDialog.BUTTON_POSITIVE,
+        getString(R.string.unknown_sources_yes_button),
+        (dialogInterface, i) -> startActivity(getUnknownSourcesIntent()));
+    alertDialog.setButton(
+        AlertDialog.BUTTON_NEGATIVE,
+        getString(R.string.update_no_button),
+        (dialogInterface, i) -> {
+          LogWrapper.getInstance().v(TAG + "Unknown sources dialog cancelled");
+          getFirebaseAppDistributionInstance().setInstallationResult(Activity.RESULT_CANCELED);
+          dialogInterface.dismiss();
+          finish();
+        });
+
+    alertDialog.show();
+  }
+
+  private Intent getUnknownSourcesIntent() {
+    Intent intent;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      intent = new Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES);
+      intent.setData(Uri.parse("package:" + getPackageName()));
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      LogWrapper.getInstance().v(TAG + "Starting unknown sources in new task");
+    } else {
+      intent = new Intent(Settings.ACTION_SECURITY_SETTINGS);
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    }
+
+    return intent;
+  }
+
+  private void startInstallActivity() {
+    installInProgress = true;
     Intent originalIntent = getIntent();
     String path = originalIntent.getStringExtra("INSTALL_PATH");
     Intent intent = new Intent(Intent.ACTION_VIEW);
-    intent.putExtra(Intent.EXTRA_RETURN_RESULT, true);
     File apkFile = new File(path);
-    String APK_MIME_TYPE = "application/vnd.android.package-archive";
+    String APK_MIME_TYPE =
+        "application/vnd.a./gradlew :<firebase-project>:googleJavaFormat\nndroid.package-archive";
 
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
       Uri apkUri =
@@ -61,7 +142,9 @@ public class InstallActivity extends AppCompatActivity {
       intent.setDataAndType(Uri.fromFile(apkFile), APK_MIME_TYPE);
     }
 
-    mStartForResult.launch(intent);
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    LogWrapper.getInstance().v("Kicking off install as new activity");
+    startActivity(intent);
   }
 
   @VisibleForTesting

--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/UpdateApkClient.java
@@ -84,25 +84,24 @@ class UpdateApkClient {
     }
 
     downloadApk(newRelease, showDownloadNotificationManager)
-        .addOnSuccessListener(
+        // Using onSuccess task to ensure that all install errors get cascaded to the Failure
+        // listener down below
+        .onSuccessTask(
             downloadExecutor,
-            file ->
-                install(file.getPath())
-                    .addOnFailureListener(
-                        e -> {
-                          LogWrapper.getInstance().e(TAG + "Newest release failed to install.", e);
-                          postInstallationFailure(
-                              e, file.length(), showDownloadNotificationManager);
-                          setTaskCompletionErrorWithDefault(
-                              e,
-                              new FirebaseAppDistributionException(
-                                  Constants.ErrorMessages.NETWORK_ERROR,
-                                  FirebaseAppDistributionException.Status.INSTALLATION_FAILURE));
-                        }))
+            (file -> {
+              if (file == null) {
+                LogWrapper.getInstance().e(TAG + "Download file not found or invalid");
+                return Tasks.forException(
+                    new FirebaseAppDistributionException(
+                        Constants.ErrorMessages.NETWORK_ERROR, Status.DOWNLOAD_FAILURE));
+              }
+              return install(file.getPath());
+            }))
         .addOnFailureListener(
             downloadExecutor,
             e -> {
-              LogWrapper.getInstance().e(TAG + "Newest release failed to download.", e);
+              LogWrapper.getInstance()
+                  .e(TAG + "Download or Installation failure for newest release.", e);
               setTaskCompletionErrorWithDefault(
                   e,
                   new FirebaseAppDistributionException(
@@ -308,7 +307,6 @@ class UpdateApkClient {
     CancellationTokenSource installCancellationTokenSource = new CancellationTokenSource();
     this.installTaskCompletionSource =
         new TaskCompletionSource<>(installCancellationTokenSource.getToken());
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     currentActivity.startActivity(intent);
     LogWrapper.getInstance().v(TAG + "Prompting user with install activity ");
     return installTaskCompletionSource.getTask();
@@ -321,15 +319,10 @@ class UpdateApkClient {
       synchronized (updateTaskLock) {
         cachedUpdateTask.setResult();
       }
-    } else if (resultCode == Activity.RESULT_CANCELED) {
-      installTaskCompletionSource.setException(
-          new FirebaseAppDistributionException(
-              Constants.ErrorMessages.UPDATE_CANCELED,
-              FirebaseAppDistributionException.Status.INSTALLATION_CANCELED));
     } else {
       installTaskCompletionSource.setException(
           new FirebaseAppDistributionException(
-              "Installation failed with result code: " + resultCode,
+              "Installation failed or cancelled",
               FirebaseAppDistributionException.Status.INSTALLATION_FAILURE));
     }
   }

--- a/firebase-app-distribution/src/main/res/values/strings.xml
+++ b/firebase-app-distribution/src/main/res/values/strings.xml
@@ -27,5 +27,7 @@
   <string name="download_failed">Download failed</string>
   <string name="notifications_channel_name">App Distribution App Update Downloads</string>
   <string name="notifications_channel_description">Shows download progress of in-app updates from App Distribution SDK</string>
-
+  <string name="unknown_sources_dialog_title">Enable Unknown Sources</string>
+  <string name="unknown_sources_dialog_description">To install the update enable unknown sources</string>
+  <string name="unknown_sources_yes_button">Settings</string>
 </resources>


### PR DESCRIPTION
* Fix nextdoor bug that causes multiple installation prompts to show up for Android 11 by explicitly checking and prompting the Unknown Sources UI
* Switch Installation intent to use FLAG_ACTIVITY_NEW_TASK to show an "Open" button after the installation is complete
* Fix an issue setting task exception in UpdateApkClient that was causing a crash