### PR TITLE
Add GHA workflow for submitting release tags to metric service.

### DIFF
--- a/.github/workflows/health-metrics-release-diffing.yml
+++ b/.github/workflows/health-metrics-release-diffing.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
-      - uses: yifanyang/github-actions/health-metrics/release-diffing@master
+      - uses: FirebaseExtended/github-actions/health-metrics/release-diffing@master
         with:
           repo: ${{ github.repository }}
           ref: ${{ github.ref }}

--- a/.github/workflows/health-metrics-release-diffing.yml
+++ b/.github/workflows/health-metrics-release-diffing.yml
@@ -1,0 +1,18 @@
+name: [Health Metrics] Release Diffing
+
+on:
+  push:
+    tags: ['**']
+
+jobs:
+  tags-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - uses: yifanyang/github-actions/health-metrics/release-diffing@master
+        with:
+          repo: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          commit: ${{ github.sha }}


### PR DESCRIPTION
Add a GitHub Actions workflow file for submitting the tags information (name, commit sha1) to the SDK metric service.

The workflow involves calling a service on GCP, which requires authentication (via [`setup-gcloud`](https://github.com/google-github-actions/setup-gcloud) GitHub Action in our case). I will need to configure a [repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets) in this repository:
  -  name: `GCP_SA_KEY`
  -  value: base64 encoded service account file for `prow-uploader@fireescape-c4819.iam.gserviceaccount.com` (or other service account with proper permission)