### PR TITLE
Remove unnecessary task cancellation in the InstallApkClient

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/InstallApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/InstallApkClient.java
@@ -62,12 +62,6 @@ class InstallApkClient {
           && cachedInstallApkPath != null
           && !cachedInstallApkPath.isEmpty()) {
         startInstallActivity(cachedInstallApkPath, activity);
-      } else {
-        safeSetTaskException(
-            installTaskCompletionSource,
-            new FirebaseAppDistributionException(
-                Constants.ErrorMessages.APK_INSTALLATION_FAILED,
-                FirebaseAppDistributionException.Status.INSTALLATION_FAILURE));
       }
     }
   }


### PR DESCRIPTION
Removing task cancellation from `setCurrentActivity`. Previously, this logic was causing the Install task to fail if setCurrentActivity was called multiple times. With this change, `trySetInstallTaskError` is the only method that handles Install task cancellation