### PR TITLE
Fix a ConcurrentModificationException in ObjectValue overlays

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/ObjectValue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/ObjectValue.java
@@ -123,11 +123,13 @@ public final class ObjectValue implements Cloneable {
    * <p>This method applies any outstanding modifications and memoizes the result. Further
    * invocations are based on this memoized result.
    */
-  private synchronized Value buildProto() {
-    MapValue mergedResult = applyOverlay(FieldPath.EMPTY_PATH, overlayMap);
-    if (mergedResult != null) {
-      partialValue = Value.newBuilder().setMapValue(mergedResult).build();
-      overlayMap.clear();
+  private Value buildProto() {
+    synchronized (overlayMap) {
+      MapValue mergedResult = applyOverlay(FieldPath.EMPTY_PATH, overlayMap);
+      if (mergedResult != null) {
+        partialValue = Value.newBuilder().setMapValue(mergedResult).build();
+        overlayMap.clear();
+      }
     }
     return partialValue;
   }


### PR DESCRIPTION
I observed ConcurrentModificationException in some race conditions. Following stack trace logged via Crashlystics;
```
java.util.HashMap$HashIterator.nextNode (HashMap.java:1441)
java.util.HashMap$EntryIterator.next (HashMap.java:1475)
java.util.HashMap$EntryIterator.next (HashMap.java:1473)
com.google.firebase.firestore.model.ObjectValue.applyOverlay (ObjectValue.java:221)
com.google.firebase.firestore.model.ObjectValue.buildProto (ObjectValue.java:127)
com.google.firebase.firestore.model.ObjectValue.getFieldsMap (ObjectValue.java:64)
com.google.firebase.firestore.DocumentSnapshot.getData (DocumentSnapshot.java:148)
com.google.firebase.firestore.DocumentSnapshot.getData (DocumentSnapshot.java:132)
```

It seems that rapid setting/getting overlays in ObjectValue could result ConcurrentModificationException.