### PR TITLE
Add proguard rule to exclude FirebaseCrashlyticsNdk from obfuscation

### DIFF
--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk-proguard.txt
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk-proguard.txt
@@ -15,5 +15,8 @@
 # Prevent FirebaseCrashlytics from being obfuscated, because the Crashlytics
 # native libraries call FirebaseCrashlytics public methods dynamically via JNI.
 -keep public class com.google.firebase.crashlytics.FirebaseCrashlytics { public *; }
+
+# These FirebaseCrashlyticsNdk classes have APIs accessed via reflection and/or JNI:
+-keep public class com.google.firebase.crashlytics.ndk.FirebaseCrashlyticsNdk { public *; }
 -keep public class com.google.firebase.crashlytics.ndk.CrashpadMain { public *; }
 -keep public class com.google.firebase.crashlytics.ndk.JniNativeApi { native <methods>; }


### PR DESCRIPTION
com.google.firebase.crashlytics.ndk.FirebaseCrashlyticsNdk contains
public methods accessed via the Crashlytics Unity SDK.