### PR TITLE
Fireperf: fix incorrect `sessionId`s for `_fs` and `_bs` traces

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -174,7 +174,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
         // no more activity in foreground, app goes to background.
         stopTime = clock.getTime();
         sendSessionLog(Constants.TraceNames.FOREGROUND_TRACE_NAME.toString(), resumeTime, stopTime);
-        // order is important to avoid b/204362742
+        // order is important to transport _fs before triggering a sessionId change b/204362742
         updateAppState(ApplicationProcessState.BACKGROUND);
       }
     }
@@ -198,7 +198,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
       } else {
         // case 2: app switch from background to foreground.
         sendSessionLog(Constants.TraceNames.BACKGROUND_TRACE_NAME.toString(), stopTime, resumeTime);
-        // order is important to avoid b/204362742
+        // order is important to transport _bs before triggering a sessionId change b/204362742
         updateAppState(ApplicationProcessState.FOREGROUND);
       }
     } else {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -174,7 +174,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
         // no more activity in foreground, app goes to background.
         stopTime = clock.getTime();
         sendSessionLog(Constants.TraceNames.FOREGROUND_TRACE_NAME.toString(), resumeTime, stopTime);
-        // order is important to transport _fs before triggering a sessionId change b/204362742
+        // order is important to complete _fs before triggering a sessionId change b/204362742
         updateAppState(ApplicationProcessState.BACKGROUND);
       }
     }
@@ -198,7 +198,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
       } else {
         // case 2: app switch from background to foreground.
         sendSessionLog(Constants.TraceNames.BACKGROUND_TRACE_NAME.toString(), stopTime, resumeTime);
-        // order is important to transport _bs before triggering a sessionId change b/204362742
+        // order is important to complete _bs before triggering a sessionId change b/204362742
         updateAppState(ApplicationProcessState.FOREGROUND);
       }
     } else {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -463,6 +463,11 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   }
 
   @VisibleForTesting
+  void setStopTime(Timer timer) {
+    stopTime = timer;
+  }
+
+  @VisibleForTesting
   Timer getResumeTime() {
     return resumeTime;
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -173,8 +173,9 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
       if (activityToResumedMap.isEmpty()) {
         // no more activity in foreground, app goes to background.
         stopTime = clock.getTime();
-        updateAppState(ApplicationProcessState.BACKGROUND);
         sendSessionLog(Constants.TraceNames.FOREGROUND_TRACE_NAME.toString(), resumeTime, stopTime);
+        // order is important to avoid b/204362742
+        updateAppState(ApplicationProcessState.BACKGROUND);
       }
     }
   }
@@ -189,14 +190,16 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
       // The first resumed activity means app comes to foreground.
       resumeTime = clock.getTime();
       activityToResumedMap.put(activity, true);
-      updateAppState(ApplicationProcessState.FOREGROUND);
       if (isColdStart) {
         // case 1: app startup.
+        updateAppState(ApplicationProcessState.FOREGROUND);
         sendAppColdStartUpdate();
         isColdStart = false;
       } else {
         // case 2: app switch from background to foreground.
         sendSessionLog(Constants.TraceNames.BACKGROUND_TRACE_NAME.toString(), stopTime, resumeTime);
+        // order is important to avoid b/204362742
+        updateAppState(ApplicationProcessState.FOREGROUND);
       }
     } else {
       // case 3: app already in foreground, current activity is replaced by another activity.

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateUpdateHandler.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateUpdateHandler.java
@@ -15,6 +15,7 @@
 package com.google.firebase.perf.application;
 
 import androidx.annotation.NonNull;
+import com.google.android.gms.common.util.VisibleForTesting;
 import com.google.firebase.perf.application.AppStateMonitor.AppStateCallback;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import java.lang.ref.WeakReference;
@@ -98,5 +99,10 @@ public abstract class AppStateUpdateHandler implements AppStateCallback {
    */
   public ApplicationProcessState getAppState() {
     return currentAppState;
+  }
+
+  @VisibleForTesting
+  public WeakReference<AppStateCallback> getAppStateCallback() {
+    return appStateCallback;
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
@@ -38,6 +38,7 @@ import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.config.DeviceCacheManager;
 import com.google.firebase.perf.metrics.NetworkRequestMetricBuilder;
 import com.google.firebase.perf.metrics.Trace;
+import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.session.gauges.GaugeManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
@@ -45,6 +46,7 @@ import com.google.firebase.perf.util.Constants;
 import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
+import com.google.firebase.perf.v1.PerfSession;
 import com.google.firebase.perf.v1.TraceMetric;
 import com.google.testing.timing.FakeDirectExecutorService;
 import java.lang.ref.WeakReference;
@@ -764,6 +766,32 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
     // Activity comes to Foreground
     monitor.onActivityResumed(activity1);
     verify(mockInitializer1, times(1)).onAppColdStart();
+  }
+
+  @Test
+  public void updatePerfSession_isAfterSendingForegroundOrBackgroundSession() {
+    AppStateMonitor monitor = new AppStateMonitor(transportManager, clock);
+    monitor.registerForAppState(SessionManager.getInstance().getAppStateCallback());
+    monitor.setStopTime(new Timer(currentTime));
+    monitor.setIsColdStart(false);
+    // Mandatory due to circular dependencies of singletons AppStateMonitor and SessionManager
+    AppStateMonitor.getInstance().setIsColdStart(false);
+
+    // Foreground -> Background, sends _fs
+    PerfSession currentSession = SessionManager.getInstance().perfSession().build();
+    monitor.onActivityResumed(activity1);
+
+    verify(transportManager, times(1)).log(argTraceMetric.capture(), eq(FOREGROUND_BACKGROUND));
+    PerfSession sentSession = argTraceMetric.getValue().getPerfSessions(0);
+    Assert.assertEquals(currentSession, sentSession);
+
+    // Background -> Foreground, sends _bs
+    currentSession = SessionManager.getInstance().perfSession().build();
+    monitor.onActivityStopped(activity1);
+
+    verify(transportManager, times(2)).log(argTraceMetric.capture(), eq(FOREGROUND_BACKGROUND));
+    sentSession = argTraceMetric.getValue().getPerfSessions(0);
+    Assert.assertEquals(currentSession, sentSession);
   }
 
   private static Activity createFakeActivity(boolean isHardwareAccelerated) {


### PR DESCRIPTION
b/204362742

## TLDR
`_fs` and `_bs` traces are using the next sessionId instead of the current sessionId because we call `updateAppState` ([line 176](https://github.com/firebase/firebase-android-sdk/pull/3122/files#diff-eb968bff71b0337966fe331ee130c0ad812d5fed5e8b15c7e676a565bb0074c5L176)) before sending `_fs` or `_bs` traces ([line 177](https://github.com/firebase/firebase-android-sdk/pull/3122/files#diff-eb968bff71b0337966fe331ee130c0ad812d5fed5e8b15c7e676a565bb0074c5L177)).  One of the callbacks of `updateAppState` is `SessionManager` which updates the sessionId, thus `_fs` and `_bs` uses the next session's sessionId. 

This fix simply changes the order of methods, delaying `updateAppState` until session trace is sent. 