### PR TITLE
Fireperf: create an activity with fragments in `dev-app` for testing

### DIFF
--- a/firebase-perf/dev-app/dev-app.gradle
+++ b/firebase-perf/dev-app/dev-app.gradle
@@ -96,9 +96,6 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.google.android.gms:play-services-tasks:17.2.0'
-
-    // 3rd party Deps
-    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
@@ -107,6 +104,10 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment:2.3.5'
     implementation 'androidx.navigation:navigation-ui:2.3.5'
     implementation 'com.google.android.material:material:1.4.0'
+
+    // 3rd party Deps
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     // Integration Test Deps
     androidTestImplementation 'junit:junit:4.13.1'

--- a/firebase-perf/dev-app/dev-app.gradle
+++ b/firebase-perf/dev-app/dev-app.gradle
@@ -99,6 +99,14 @@ dependencies {
 
     // 3rd party Deps
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata:2.4.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.4.0'
+    implementation 'androidx.navigation:navigation-fragment:2.3.5'
+    implementation 'androidx.navigation:navigation-ui:2.3.5'
+    implementation 'com.google.android.material:material:1.4.0'
 
     // Integration Test Deps
     androidTestImplementation 'junit:junit:4.13.1'

--- a/firebase-perf/dev-app/src/main/AndroidManifest.xml
+++ b/firebase-perf/dev-app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
             android:name=".FragmentActivity"
             android:exported="false"
             android:label="@string/title_activity_fragment"
-            android:theme="@style/Theme.MaterialComponents.DayNight.DarkActionBar" />
+            android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar" />
         <activity
             android:name=".PerfTestActivity"
             android:label="Perf Test App">

--- a/firebase-perf/dev-app/src/main/AndroidManifest.xml
+++ b/firebase-perf/dev-app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.googletest.firebase.perf.testapp">

--- a/firebase-perf/dev-app/src/main/AndroidManifest.xml
+++ b/firebase-perf/dev-app/src/main/AndroidManifest.xml
@@ -1,55 +1,56 @@
-<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
-
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="com.googletest.firebase.perf.testapp">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.googletest.firebase.perf.testapp">
 
-  <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
-  <application
-    android:allowBackup="true"
-    android:icon="@drawable/ic_launcher"
-    android:label="@string/app_name"
-    android:usesCleartextTraffic="true"
-    tools:targetApi="m">
+    <application
+        android:allowBackup="true"
+        android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name"
+        android:usesCleartextTraffic="true"
+        tools:targetApi="m">
+        <activity
+            android:name=".FragmentActivity"
+            android:exported="false"
+            android:label="@string/title_activity_fragment"
+            android:theme="@style/Theme.MaterialComponents.DayNight.DarkActionBar" />
+        <activity
+            android:name=".PerfTestActivity"
+            android:label="Perf Test App">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
-    <activity
-      android:label="Perf Test App"
-      android:name=".PerfTestActivity">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-    </activity>
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".AnotherActivity"
+            android:exported="true" />
 
-    <activity
-      android:exported="true"
-      android:name=".AnotherActivity" />
+        <meta-data
+            android:name="firebase_performance_logcat_enabled"
+            android:value="true" />
+        <meta-data
+            android:name="sessions_sampling_percentage"
+            android:value="100.0" />
 
-    <meta-data
-      android:name="firebase_performance_logcat_enabled"
-      android:value="true" />
+        <receiver
+            android:name=".FirebasePerfTestReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.googletest.firebase.perf.testapp.ACTION_START" />
+            </intent-filter>
+        </receiver>
 
-    <meta-data
-      android:name="sessions_sampling_percentage"
-      android:value="100.0" />
+        <service
+            android:name=".FirebasePerfTestService"
+            android:exported="true" />
 
-    <receiver
-      android:exported="true"
-      android:name=".FirebasePerfTestReceiver">
-      <intent-filter>
-        <action android:name="com.googletest.firebase.perf.testapp.ACTION_START" />
-      </intent-filter>
-    </receiver>
-
-    <service
-      android:exported="true"
-      android:name=".FirebasePerfTestService" />
-
-    <uses-library
-      android:name="org.apache.http.legacy"
-      android:required="false" />
-
-  </application>
+        <uses-library
+            android:name="org.apache.http.legacy"
+            android:required="false" />
+    </application>
 
 </manifest>

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -16,12 +16,18 @@ package com.googletest.firebase.perf.testapp;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
+import android.widget.Button;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
@@ -29,6 +35,7 @@ import androidx.navigation.ui.NavigationUI;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 public class FragmentActivity extends AppCompatActivity {
+  SharedViewModel model;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -53,9 +60,26 @@ public class FragmentActivity extends AppCompatActivity {
     NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
     NavigationUI.setupWithNavController(
         (BottomNavigationView) findViewById(R.id.nav_view), navController);
+    model = new ViewModelProvider(this).get(SharedViewModel.class);
   }
 
   @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    getMenuInflater().inflate(R.menu.menu, menu);
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    switch (item.getItemId()) {
+      case R.id.action_change_gif:
+        model.changeImage();
+      default:
+        return super.onOptionsItemSelected(item);
+    }
+  }
+
+    @Override
   protected void onStart() {
     super.onStart();
     Log.d(

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -71,6 +71,7 @@ public class FragmentActivity extends AppCompatActivity {
     switch (item.getItemId()) {
       case R.id.action_change_gif:
         model.changeImage();
+        return true;
       default:
         return super.onOptionsItemSelected(item);
     }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -33,28 +33,7 @@ public class FragmentActivity extends AppCompatActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    // Listening on FragmentManager's FragmentLifeCycleCallbacks
-    getSupportFragmentManager()
-        .registerFragmentLifecycleCallbacks(
-            new FragmentManager.FragmentLifecycleCallbacks() {
-              @Override
-              public void onFragmentViewCreated(
-                  @NonNull FragmentManager fm,
-                  @NonNull Fragment f,
-                  @NonNull View v,
-                  @Nullable Bundle savedInstanceState) {
-                super.onFragmentViewCreated(fm, f, v, savedInstanceState);
-                Log.d("FragmentManager", "View created " + f.getClass().getSimpleName());
-              }
-
-              @Override
-              public void onFragmentViewDestroyed(
-                  @NonNull FragmentManager fm, @NonNull Fragment f) {
-                super.onFragmentViewDestroyed(fm, f);
-                Log.d("FragmentManager", "View destroyed " + f.getClass().getSimpleName());
-              }
-            },
-            true);
+    registerListeners();
     setContentView(R.layout.activity_fragment);
     BottomNavigationView navView = findViewById(R.id.nav_view);
     // Passing each menu ID as a set of Ids because each
@@ -73,5 +52,83 @@ public class FragmentActivity extends AppCompatActivity {
     NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
     NavigationUI.setupWithNavController(
         (BottomNavigationView) findViewById(R.id.nav_view), navController);
+    // Listening on FragmentManager's FragmentLifeCycleCallbacks
+  }
+
+  private boolean decorViewCheck() {
+    View v = this.getWindow().getDecorView();
+    return v.isHardwareAccelerated();
+  }
+
+  private void registerListeners() {
+    getSupportFragmentManager()
+        .registerFragmentLifecycleCallbacks(
+            new FragmentManager.FragmentLifecycleCallbacks() {
+              @Override
+              public void onFragmentPreCreated(
+                  @NonNull FragmentManager fm,
+                  @NonNull Fragment f,
+                  @Nullable Bundle savedInstanceState) {
+                super.onFragmentPreCreated(fm, f, savedInstanceState);
+                Log.d(
+                    "FragmentManager",
+                    "Fragment precreated" + f.getClass().getSimpleName() + decorViewCheck());
+              }
+
+              @Override
+              public void onFragmentCreated(
+                  @NonNull FragmentManager fm,
+                  @NonNull Fragment f,
+                  @Nullable Bundle savedInstanceState) {
+                super.onFragmentCreated(fm, f, savedInstanceState);
+                Log.d(
+                    "FragmentManager",
+                    "Fragment created " + f.getClass().getSimpleName() + decorViewCheck());
+              }
+
+              @Override
+              public void onFragmentViewCreated(
+                  @NonNull FragmentManager fm,
+                  @NonNull Fragment f,
+                  @NonNull View v,
+                  @Nullable Bundle savedInstanceState) {
+                super.onFragmentViewCreated(fm, f, v, savedInstanceState);
+                Log.d(
+                    "FragmentManager",
+                    "View created " + f.getClass().getSimpleName() + decorViewCheck());
+              }
+
+              @Override
+              public void onFragmentStarted(@NonNull FragmentManager fm, @NonNull Fragment f) {
+                super.onFragmentStarted(fm, f);
+                Log.d(
+                    "FragmentManager",
+                    "View started " + f.getClass().getSimpleName() + decorViewCheck());
+              }
+
+              @Override
+              public void onFragmentResumed(@NonNull FragmentManager fm, @NonNull Fragment f) {
+                super.onFragmentResumed(fm, f);
+                Log.d(
+                    "FragmentManager",
+                    "View resumed " + f.getClass().getSimpleName() + decorViewCheck());
+              }
+
+              @Override
+              public void onFragmentStopped(@NonNull FragmentManager fm, @NonNull Fragment f) {
+                super.onFragmentStopped(fm, f);
+                Log.d("FragmentManager", "View stopped " + f.getClass().getSimpleName());
+              }
+
+              @Override
+              public void onFragmentViewDestroyed(
+                  @NonNull FragmentManager fm, @NonNull Fragment f) {
+                Log.d("FragmentManager", "View destroyed " + f.getClass().getSimpleName());
+                super.onFragmentViewDestroyed(fm, f);
+                //                              Log.d("FragmentManager", "View destroyed " +
+                // f.getClass().getSimpleName());
+              }
+            },
+            true);
   }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -32,8 +32,9 @@ public class FragmentActivity extends AppCompatActivity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+    // Listening on FragmentManager's FragmentLifeCycleCallbacks
     registerListeners();
+    super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_fragment);
     BottomNavigationView navView = findViewById(R.id.nav_view);
     // Passing each menu ID as a set of Ids because each
@@ -52,10 +53,29 @@ public class FragmentActivity extends AppCompatActivity {
     NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
     NavigationUI.setupWithNavController(
         (BottomNavigationView) findViewById(R.id.nav_view), navController);
-    // Listening on FragmentManager's FragmentLifeCycleCallbacks
   }
 
-  private boolean decorViewCheck() {
+  @Override
+  protected void onStart() {
+    super.onStart();
+    Log.d(
+        "FragmentActivity",
+        "onStart; View Hardware Accel: "
+            + decorViewAcceleratedFlag()
+            + ", FrameMetricsObservers won't be observing, only queued.");
+  }
+
+  @Override
+  public void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    Log.d(
+        "FragmentActivity",
+        "onAttachedToWindow; View Hardware Accel: "
+            + decorViewAcceleratedFlag()
+            + ", FrameMetricsObservers in queue and any new observers will start observing.");
+  }
+
+  private boolean decorViewAcceleratedFlag() {
     View v = this.getWindow().getDecorView();
     return v.isHardwareAccelerated();
   }
@@ -65,25 +85,12 @@ public class FragmentActivity extends AppCompatActivity {
         .registerFragmentLifecycleCallbacks(
             new FragmentManager.FragmentLifecycleCallbacks() {
               @Override
-              public void onFragmentPreCreated(
-                  @NonNull FragmentManager fm,
-                  @NonNull Fragment f,
-                  @Nullable Bundle savedInstanceState) {
-                super.onFragmentPreCreated(fm, f, savedInstanceState);
-                Log.d(
-                    "FragmentManager",
-                    "Fragment precreated" + f.getClass().getSimpleName() + decorViewCheck());
-              }
-
-              @Override
               public void onFragmentCreated(
                   @NonNull FragmentManager fm,
                   @NonNull Fragment f,
                   @Nullable Bundle savedInstanceState) {
                 super.onFragmentCreated(fm, f, savedInstanceState);
-                Log.d(
-                    "FragmentManager",
-                    "Fragment created " + f.getClass().getSimpleName() + decorViewCheck());
+                Log.d("FragmentManager", "Fragment created " + f.getClass().getSimpleName());
               }
 
               @Override
@@ -93,40 +100,32 @@ public class FragmentActivity extends AppCompatActivity {
                   @NonNull View v,
                   @Nullable Bundle savedInstanceState) {
                 super.onFragmentViewCreated(fm, f, v, savedInstanceState);
-                Log.d(
-                    "FragmentManager",
-                    "View created " + f.getClass().getSimpleName() + decorViewCheck());
+                Log.d("FragmentManager", "View created " + f.getClass().getSimpleName());
               }
 
               @Override
               public void onFragmentStarted(@NonNull FragmentManager fm, @NonNull Fragment f) {
                 super.onFragmentStarted(fm, f);
-                Log.d(
-                    "FragmentManager",
-                    "View started " + f.getClass().getSimpleName() + decorViewCheck());
+                Log.d("FragmentManager", "Fragment started " + f.getClass().getSimpleName());
               }
 
               @Override
               public void onFragmentResumed(@NonNull FragmentManager fm, @NonNull Fragment f) {
                 super.onFragmentResumed(fm, f);
-                Log.d(
-                    "FragmentManager",
-                    "View resumed " + f.getClass().getSimpleName() + decorViewCheck());
+                Log.d("FragmentManager", "Fragment resumed " + f.getClass().getSimpleName());
               }
 
               @Override
               public void onFragmentStopped(@NonNull FragmentManager fm, @NonNull Fragment f) {
                 super.onFragmentStopped(fm, f);
-                Log.d("FragmentManager", "View stopped " + f.getClass().getSimpleName());
+                Log.d("FragmentManager", "Fragment stopped " + f.getClass().getSimpleName());
               }
 
               @Override
               public void onFragmentViewDestroyed(
                   @NonNull FragmentManager fm, @NonNull Fragment f) {
-                Log.d("FragmentManager", "View destroyed " + f.getClass().getSimpleName());
                 super.onFragmentViewDestroyed(fm, f);
-                //                              Log.d("FragmentManager", "View destroyed " +
-                // f.getClass().getSimpleName());
+                Log.d("FragmentManager", "View destroyed " + f.getClass().getSimpleName());
               }
             },
             true);

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -22,6 +22,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
@@ -40,6 +41,8 @@ public class FragmentActivity extends AppCompatActivity {
     registerListeners();
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_fragment);
+    Toolbar toolbar = findViewById(R.id.toolbar_fragment_activity);
+    setSupportActionBar(toolbar);
     BottomNavigationView navView = findViewById(R.id.nav_view);
     // Passing each menu ID as a set of Ids because each
     // menu should be considered as top level destinations.

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -19,12 +19,9 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.ViewModelProvider;
@@ -79,7 +76,7 @@ public class FragmentActivity extends AppCompatActivity {
     }
   }
 
-    @Override
+  @Override
   protected void onStart() {
     super.onStart();
     Log.d(

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -1,0 +1,63 @@
+package com.googletest.firebase.perf.testapp;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+import androidx.navigation.ui.AppBarConfiguration;
+import androidx.navigation.ui.NavigationUI;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
+public class FragmentActivity extends AppCompatActivity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    // Listening on FragmentManager's FragmentLifeCycleCallbacks
+    getSupportFragmentManager()
+        .registerFragmentLifecycleCallbacks(
+            new FragmentManager.FragmentLifecycleCallbacks() {
+              @Override
+              public void onFragmentViewCreated(
+                  @NonNull FragmentManager fm,
+                  @NonNull Fragment f,
+                  @NonNull View v,
+                  @Nullable Bundle savedInstanceState) {
+                super.onFragmentViewCreated(fm, f, v, savedInstanceState);
+                Log.d("FragmentManager", "View created " + f.getClass().getSimpleName());
+              }
+
+              @Override
+              public void onFragmentViewDestroyed(
+                  @NonNull FragmentManager fm, @NonNull Fragment f) {
+                super.onFragmentViewDestroyed(fm, f);
+                Log.d("FragmentManager", "View destroyed " + f.getClass().getSimpleName());
+              }
+            },
+            true);
+    setContentView(R.layout.activity_fragment);
+    BottomNavigationView navView = findViewById(R.id.nav_view);
+    // Passing each menu ID as a set of Ids because each
+    // menu should be considered as top level destinations.
+    AppBarConfiguration appBarConfiguration =
+        new AppBarConfiguration.Builder(
+                R.id.navigation_home, R.id.navigation_dashboard, R.id.navigation_notifications)
+            .build();
+    NavController navController =
+        Navigation.findNavController(this, R.id.nav_host_fragment_activity_fragment);
+    // Listening on navigation events using NavController
+    navController.addOnDestinationChangedListener(
+        (controller, destination, arguments) -> {
+          Log.d("Navigation", destination.getLabel().toString() + "Fragment");
+        });
+    NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
+    NavigationUI.setupWithNavController(
+        (BottomNavigationView) findViewById(R.id.nav_view), navController);
+  }
+}

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/FragmentActivity.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.perf.testapp;
 
 import android.os.Bundle;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ListAdapter.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ListAdapter.java
@@ -41,8 +41,8 @@ public class ListAdapter extends RecyclerView.Adapter<ListAdapter.NumberViewHold
   @Override
   public NumberViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
     return new NumberViewHolder(
-            LayoutInflater.from(viewGroup.getContext())
-                    .inflate(R.layout.number_list_item, viewGroup, /* attachToRoot= */ false));
+        LayoutInflater.from(viewGroup.getContext())
+            .inflate(R.layout.number_list_item, viewGroup, /* attachToRoot= */ false));
   }
 
   @Override
@@ -93,4 +93,3 @@ public class ListAdapter extends RecyclerView.Adapter<ListAdapter.NumberViewHold
     }
   }
 }
-

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ListAdapter.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ListAdapter.java
@@ -1,0 +1,96 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.googletest.firebase.perf.testapp;
+
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.recyclerview.widget.RecyclerView;
+import org.jetbrains.annotations.NotNull;
+
+/** The Adapter for the ScreenTraces test ListView. */
+public class ListAdapter extends RecyclerView.Adapter<ListAdapter.NumberViewHolder> {
+
+  private static final String LOG_TAG = ListAdapter.class.getSimpleName();
+  private final int numberOfItems;
+
+  /**
+   * Constructor for ListAdapter that accepts a number of items to display.
+   *
+   * @param numberOfItems Number of items to display in list
+   */
+  public ListAdapter(int numberOfItems) {
+    this.numberOfItems = numberOfItems;
+  }
+
+  @NotNull
+  @Override
+  public NumberViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
+    return new NumberViewHolder(
+            LayoutInflater.from(viewGroup.getContext())
+                    .inflate(R.layout.number_list_item, viewGroup, /* attachToRoot= */ false));
+  }
+
+  @Override
+  public void onBindViewHolder(@NotNull NumberViewHolder holder, int position) {
+    try {
+      if (position % 15 == 0) {
+        Thread.sleep(900);
+      } else if (position % 5 == 0) {
+        Thread.sleep(50);
+      }
+    } catch (InterruptedException e) {
+      Log.e(LOG_TAG, e.getMessage(), e);
+    }
+
+    holder.bind(position);
+  }
+
+  @Override
+  public int getItemCount() {
+    return numberOfItems;
+  }
+
+  /** Cache of the children views for a list item. */
+  static class NumberViewHolder extends RecyclerView.ViewHolder {
+
+    // Displays the position in the list, i.e 0 through getItemCount() - 1
+    TextView listItemNumberView;
+
+    /**
+     * Constructor for our ViewHolder.
+     *
+     * @param itemView The View that you inflated in {@link
+     *     ListAdapter#onCreateViewHolder(ViewGroup, int)}
+     */
+    NumberViewHolder(View itemView) {
+      super(itemView);
+
+      listItemNumberView = itemView.findViewById(R.id.tv_item_number);
+    }
+
+    /**
+     * Sets the new index number for the view as it is to be displayed.
+     *
+     * @param listIndex The new listIndex this view will displayed for.
+     */
+    void bind(int listIndex) {
+      listItemNumberView.setText(String.valueOf(listIndex));
+    }
+  }
+}
+

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/PerfTestActivity.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/PerfTestActivity.java
@@ -195,6 +195,10 @@ public class PerfTestActivity extends Activity {
         .setOnClickListener(logAllFirebaseRcKeysForFireperfNamespace);
   }
 
+  public void openFragmentActivity(View view) {
+    startActivity(new Intent(this, FragmentActivity.class));
+  }
+
   private void readUrlsFromFile() {
     try {
       InputStream inputStream = getResources().openRawResource(R.raw.urls);

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/SharedViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/SharedViewModel.java
@@ -1,0 +1,23 @@
+package com.googletest.firebase.perf.testapp;
+
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class SharedViewModel extends ViewModel {
+    public static final String FIREBASE_LOGO_ANIMATION_GIF = "https://storage.googleapis.com/stgd/firebase/uST1OoQhwSPLeZ94ZPDAZ63Ayiq1/ce982c30-f114-11e9-9e62-1fe2556ebf85.gif";
+    public static final String FIREBASE_SPARKY_PINEAPPLE_GIF = "https://media.giphy.com/media/S3QB5UrHpH4Kq5wsax/giphy.gif";
+    private final MutableLiveData<String> imageSrc;
+
+    public SharedViewModel() {
+        imageSrc = new MutableLiveData<String>();
+        imageSrc.setValue(FIREBASE_LOGO_ANIMATION_GIF);
+    }
+
+    public void changeImage() {
+        imageSrc.setValue(imageSrc.getValue().equals(FIREBASE_LOGO_ANIMATION_GIF) ? FIREBASE_SPARKY_PINEAPPLE_GIF : FIREBASE_LOGO_ANIMATION_GIF);
+    }
+
+    public MutableLiveData<String> getImageSrc() {
+        return imageSrc;
+    }
+}

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/SharedViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/SharedViewModel.java
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.perf.testapp;
 
 import androidx.lifecycle.MutableLiveData;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/SharedViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/SharedViewModel.java
@@ -4,20 +4,25 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
 public class SharedViewModel extends ViewModel {
-    public static final String FIREBASE_LOGO_ANIMATION_GIF = "https://storage.googleapis.com/stgd/firebase/uST1OoQhwSPLeZ94ZPDAZ63Ayiq1/ce982c30-f114-11e9-9e62-1fe2556ebf85.gif";
-    public static final String FIREBASE_SPARKY_PINEAPPLE_GIF = "https://media.giphy.com/media/S3QB5UrHpH4Kq5wsax/giphy.gif";
-    private final MutableLiveData<String> imageSrc;
+  public static final String FIREBASE_LOGO_ANIMATION_GIF =
+      "https://storage.googleapis.com/stgd/firebase/uST1OoQhwSPLeZ94ZPDAZ63Ayiq1/ce982c30-f114-11e9-9e62-1fe2556ebf85.gif";
+  public static final String FIREBASE_SPARKY_PINEAPPLE_GIF =
+      "https://media.giphy.com/media/S3QB5UrHpH4Kq5wsax/giphy.gif";
+  private final MutableLiveData<String> imageSrc;
 
-    public SharedViewModel() {
-        imageSrc = new MutableLiveData<String>();
-        imageSrc.setValue(FIREBASE_LOGO_ANIMATION_GIF);
-    }
+  public SharedViewModel() {
+    imageSrc = new MutableLiveData<String>();
+    imageSrc.setValue(FIREBASE_LOGO_ANIMATION_GIF);
+  }
 
-    public void changeImage() {
-        imageSrc.setValue(imageSrc.getValue().equals(FIREBASE_LOGO_ANIMATION_GIF) ? FIREBASE_SPARKY_PINEAPPLE_GIF : FIREBASE_LOGO_ANIMATION_GIF);
-    }
+  public void changeImage() {
+    imageSrc.setValue(
+        imageSrc.getValue().equals(FIREBASE_LOGO_ANIMATION_GIF)
+            ? FIREBASE_SPARKY_PINEAPPLE_GIF
+            : FIREBASE_LOGO_ANIMATION_GIF);
+  }
 
-    public MutableLiveData<String> getImageSrc() {
-        return imageSrc;
-    }
+  public MutableLiveData<String> getImageSrc() {
+    return imageSrc;
+  }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
@@ -25,7 +25,6 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
-
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.googletest.firebase.perf.testapp.R;
@@ -56,12 +55,20 @@ public class DashboardFragment extends Fragment {
     // Gif loading for testing
     sharedViewModel = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
     final ImageView imageView = root.findViewById(R.id.img_dashboard);
-    sharedViewModel.getImageSrc().observe(getViewLifecycleOwner(), new Observer<String>() {
-        @Override
-        public void onChanged(String s) {
-            Glide.with(requireActivity()).load(s).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).into(imageView);
-        }
-    });
+    sharedViewModel
+        .getImageSrc()
+        .observe(
+            getViewLifecycleOwner(),
+            new Observer<String>() {
+              @Override
+              public void onChanged(String s) {
+                Glide.with(requireActivity())
+                    .load(s)
+                    .diskCacheStrategy(DiskCacheStrategy.NONE)
+                    .skipMemoryCache(true)
+                    .into(imageView);
+              }
+            });
     return root;
   }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
@@ -18,17 +18,23 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.googletest.firebase.perf.testapp.R;
+import com.googletest.firebase.perf.testapp.SharedViewModel;
 
 public class DashboardFragment extends Fragment {
 
   private DashboardViewModel dashboardViewModel;
+  private SharedViewModel sharedViewModel;
 
   public View onCreateView(
       @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -47,6 +53,15 @@ public class DashboardFragment extends Fragment {
                 textView.setText(s);
               }
             });
+    // Gif loading for testing
+    sharedViewModel = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
+    final ImageView imageView = root.findViewById(R.id.img_dashboard);
+    sharedViewModel.getImageSrc().observe(getViewLifecycleOwner(), new Observer<String>() {
+        @Override
+        public void onChanged(String s) {
+            Glide.with(requireActivity()).load(s).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).into(imageView);
+        }
+    });
     return root;
   }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
@@ -1,0 +1,38 @@
+package com.googletest.firebase.perf.testapp.ui.dashboard;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProvider;
+import com.googletest.firebase.perf.testapp.R;
+
+public class DashboardFragment extends Fragment {
+
+  private DashboardViewModel dashboardViewModel;
+
+  public View onCreateView(
+      @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    dashboardViewModel =
+        new ViewModelProvider(this, new ViewModelProvider.NewInstanceFactory())
+            .get(DashboardViewModel.class);
+    View root = inflater.inflate(R.layout.fragment_dashboard, container, false);
+    final TextView textView = root.findViewById(R.id.text_dashboard);
+    dashboardViewModel
+        .getText()
+        .observe(
+            getViewLifecycleOwner(),
+            new Observer<String>() {
+              @Override
+              public void onChanged(@Nullable String s) {
+                textView.setText(s);
+              }
+            });
+    return root;
+  }
+}

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardFragment.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.perf.testapp.ui.dashboard;
 
 import android.os.Bundle;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardViewModel.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardViewModel.java
@@ -1,0 +1,19 @@
+package com.googletest.firebase.perf.testapp.ui.dashboard;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class DashboardViewModel extends ViewModel {
+
+  private MutableLiveData<String> mText;
+
+  public DashboardViewModel() {
+    mText = new MutableLiveData<>();
+    mText.setValue("This is dashboard fragment");
+  }
+
+  public LiveData<String> getText() {
+    return mText;
+  }
+}

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/dashboard/DashboardViewModel.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.perf.testapp.ui.dashboard;
 
 import androidx.lifecycle.LiveData;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
@@ -18,17 +18,23 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.googletest.firebase.perf.testapp.R;
+import com.googletest.firebase.perf.testapp.SharedViewModel;
 
 public class HomeFragment extends Fragment {
 
   private HomeViewModel homeViewModel;
+  private SharedViewModel sharedViewModel;
 
   public View onCreateView(
       @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -47,6 +53,15 @@ public class HomeFragment extends Fragment {
                 textView.setText(s);
               }
             });
+    // Gif loading for testing
+    sharedViewModel = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
+    final ImageView imageView = root.findViewById(R.id.img_home);
+    sharedViewModel.getImageSrc().observe(getViewLifecycleOwner(), new Observer<String>() {
+      @Override
+      public void onChanged(String s) {
+        Glide.with(requireActivity()).load(s).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).into(imageView);
+      }
+    });
     return root;
   }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
@@ -25,7 +25,6 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
-
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.googletest.firebase.perf.testapp.R;
@@ -56,12 +55,20 @@ public class HomeFragment extends Fragment {
     // Gif loading for testing
     sharedViewModel = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
     final ImageView imageView = root.findViewById(R.id.img_home);
-    sharedViewModel.getImageSrc().observe(getViewLifecycleOwner(), new Observer<String>() {
-      @Override
-      public void onChanged(String s) {
-        Glide.with(requireActivity()).load(s).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).into(imageView);
-      }
-    });
+    sharedViewModel
+        .getImageSrc()
+        .observe(
+            getViewLifecycleOwner(),
+            new Observer<String>() {
+              @Override
+              public void onChanged(String s) {
+                Glide.with(requireActivity())
+                    .load(s)
+                    .diskCacheStrategy(DiskCacheStrategy.NONE)
+                    .skipMemoryCache(true)
+                    .into(imageView);
+              }
+            });
     return root;
   }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.perf.testapp.ui.home;
 
 import android.os.Bundle;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeFragment.java
@@ -1,0 +1,38 @@
+package com.googletest.firebase.perf.testapp.ui.home;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProvider;
+import com.googletest.firebase.perf.testapp.R;
+
+public class HomeFragment extends Fragment {
+
+  private HomeViewModel homeViewModel;
+
+  public View onCreateView(
+      @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    homeViewModel =
+        new ViewModelProvider(this, new ViewModelProvider.NewInstanceFactory())
+            .get(HomeViewModel.class);
+    View root = inflater.inflate(R.layout.fragment_home, container, false);
+    final TextView textView = root.findViewById(R.id.text_home);
+    homeViewModel
+        .getText()
+        .observe(
+            getViewLifecycleOwner(),
+            new Observer<String>() {
+              @Override
+              public void onChanged(@Nullable String s) {
+                textView.setText(s);
+              }
+            });
+    return root;
+  }
+}

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeViewModel.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeViewModel.java
@@ -1,0 +1,19 @@
+package com.googletest.firebase.perf.testapp.ui.home;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class HomeViewModel extends ViewModel {
+
+  private MutableLiveData<String> mText;
+
+  public HomeViewModel() {
+    mText = new MutableLiveData<>();
+    mText.setValue("This is home fragment");
+  }
+
+  public LiveData<String> getText() {
+    return mText;
+  }
+}

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/home/HomeViewModel.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.perf.testapp.ui.home;
 
 import androidx.lifecycle.LiveData;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
@@ -25,12 +25,18 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.googletest.firebase.perf.testapp.ListAdapter;
 import com.googletest.firebase.perf.testapp.R;
 import com.googletest.firebase.perf.testapp.SharedViewModel;
 
 public class NotificationsFragment extends Fragment {
+
+  public static int NUM_LIST_ITEMS = 100;
 
   private NotificationsViewModel notificationsViewModel;
   private SharedViewModel sharedViewModel;
@@ -69,6 +75,15 @@ public class NotificationsFragment extends Fragment {
                     .into(imageView);
               }
             });
+
+    // Recycler View setup
+    RecyclerView numbersList = root.findViewById(R.id.rv_fragment_notifications);
+    LinearLayoutManager layoutManager = new LinearLayoutManager(requireActivity());
+    ListAdapter listAdapter = new ListAdapter(NUM_LIST_ITEMS);
+
+    numbersList.setLayoutManager(layoutManager);
+    numbersList.setHasFixedSize(true);
+    numbersList.setAdapter(listAdapter);
     return root;
   }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
@@ -27,7 +27,6 @@ import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.googletest.firebase.perf.testapp.ListAdapter;
@@ -36,7 +35,7 @@ import com.googletest.firebase.perf.testapp.SharedViewModel;
 
 public class NotificationsFragment extends Fragment {
 
-  public static int NUM_LIST_ITEMS = 100;
+  public static final int NUM_LIST_ITEMS = 100;
 
   private NotificationsViewModel notificationsViewModel;
   private SharedViewModel sharedViewModel;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
@@ -18,17 +18,23 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.googletest.firebase.perf.testapp.R;
+import com.googletest.firebase.perf.testapp.SharedViewModel;
 
 public class NotificationsFragment extends Fragment {
 
   private NotificationsViewModel notificationsViewModel;
+  private SharedViewModel sharedViewModel;
 
   public View onCreateView(
       @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -47,6 +53,15 @@ public class NotificationsFragment extends Fragment {
                 textView.setText(s);
               }
             });
+    // Gif loading for testing
+    sharedViewModel = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
+    final ImageView imageView = root.findViewById(R.id.img_notifications);
+    sharedViewModel.getImageSrc().observe(getViewLifecycleOwner(), new Observer<String>() {
+      @Override
+      public void onChanged(String s) {
+        Glide.with(requireActivity()).load(s).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).into(imageView);
+      }
+    });
     return root;
   }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
@@ -25,7 +25,6 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
-
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.googletest.firebase.perf.testapp.R;
@@ -56,12 +55,20 @@ public class NotificationsFragment extends Fragment {
     // Gif loading for testing
     sharedViewModel = new ViewModelProvider(requireActivity()).get(SharedViewModel.class);
     final ImageView imageView = root.findViewById(R.id.img_notifications);
-    sharedViewModel.getImageSrc().observe(getViewLifecycleOwner(), new Observer<String>() {
-      @Override
-      public void onChanged(String s) {
-        Glide.with(requireActivity()).load(s).diskCacheStrategy(DiskCacheStrategy.NONE).skipMemoryCache(true).into(imageView);
-      }
-    });
+    sharedViewModel
+        .getImageSrc()
+        .observe(
+            getViewLifecycleOwner(),
+            new Observer<String>() {
+              @Override
+              public void onChanged(String s) {
+                Glide.with(requireActivity())
+                    .load(s)
+                    .diskCacheStrategy(DiskCacheStrategy.NONE)
+                    .skipMemoryCache(true)
+                    .into(imageView);
+              }
+            });
     return root;
   }
 }

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
@@ -1,0 +1,38 @@
+package com.googletest.firebase.perf.testapp.ui.notifications;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProvider;
+import com.googletest.firebase.perf.testapp.R;
+
+public class NotificationsFragment extends Fragment {
+
+  private NotificationsViewModel notificationsViewModel;
+
+  public View onCreateView(
+      @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    notificationsViewModel =
+        new ViewModelProvider(this, new ViewModelProvider.NewInstanceFactory())
+            .get(NotificationsViewModel.class);
+    View root = inflater.inflate(R.layout.fragment_notifications, container, false);
+    final TextView textView = root.findViewById(R.id.text_notifications);
+    notificationsViewModel
+        .getText()
+        .observe(
+            getViewLifecycleOwner(),
+            new Observer<String>() {
+              @Override
+              public void onChanged(@Nullable String s) {
+                textView.setText(s);
+              }
+            });
+    return root;
+  }
+}

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsFragment.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.perf.testapp.ui.notifications;
 
 import android.os.Bundle;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsViewModel.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsViewModel.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.perf.testapp.ui.notifications;
 
 import androidx.lifecycle.LiveData;

--- a/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsViewModel.java
+++ b/firebase-perf/dev-app/src/main/java/com/googletest/firebase/perf/testapp/ui/notifications/NotificationsViewModel.java
@@ -1,0 +1,19 @@
+package com.googletest.firebase.perf.testapp.ui.notifications;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class NotificationsViewModel extends ViewModel {
+
+  private MutableLiveData<String> mText;
+
+  public NotificationsViewModel() {
+    mText = new MutableLiveData<>();
+    mText.setValue("This is notifications fragment");
+  }
+
+  public LiveData<String> getText() {
+    return mText;
+  }
+}

--- a/firebase-perf/dev-app/src/main/res/drawable/ic_dashboard_black_24dp.xml
+++ b/firebase-perf/dev-app/src/main/res/drawable/ic_dashboard_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,13h8L11,3L3,3v10zM3,21h8v-6L3,15v6zM13,21h8L21,11h-8v10zM13,3v6h8L21,3h-8z" />
+</vector>

--- a/firebase-perf/dev-app/src/main/res/drawable/ic_home_black_24dp.xml
+++ b/firebase-perf/dev-app/src/main/res/drawable/ic_home_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z" />
+</vector>

--- a/firebase-perf/dev-app/src/main/res/drawable/ic_notifications_black_24dp.xml
+++ b/firebase-perf/dev-app/src/main/res/drawable/ic_notifications_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
+</vector>

--- a/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="?attr/actionBarSize">
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="0dp"
+        android:layout_marginEnd="0dp"
+        android:background="?android:attr/windowBackground"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:menu="@menu/bottom_nav_menu" />
+
+    <fragment
+        android:id="@+id/nav_host_fragment_activity_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toTopOf="@id/nav_view"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/mobile_navigation" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2021 Google Inc. All Rights Reserved. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"

--- a/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
@@ -21,8 +21,8 @@
     <fragment
         android:id="@+id/nav_host_fragment_activity_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:defaultNavHost="true"
         app:layout_constraintBottom_toTopOf="@id/nav_view"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
@@ -6,9 +6,12 @@
     android:layout_height="match_parent" >
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/container_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent" >
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" >
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar_fragment_activity"
             android:layout_width="match_parent"
@@ -38,7 +41,7 @@
         app:layout_constraintBottom_toTopOf="@id/nav_view"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/container_toolbar"
         app:navGraph="@navigation/mobile_navigation" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
@@ -3,8 +3,19 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingTop="?attr/actionBarSize">
+    android:layout_height="match_parent" >
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent" >
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_fragment_activity"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:menu="@menu/menu"
+            style="@style/Widget.MaterialComponents.Toolbar.Primary" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/nav_view"

--- a/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/activity_fragment.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_dashboard.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_dashboard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.dashboard.DashboardFragment">
+
+    <TextView
+        android:id="@+id/text_dashboard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:gravity="center_horizontal" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_dashboard.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_dashboard.xml
@@ -15,9 +15,19 @@
         android:layout_marginEnd="8dp"
         android:textAlignment="center"
         android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/img_dashboard"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         android:gravity="center_horizontal" />
+
+    <ImageView
+        android:id="@+id/img_dashboard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_dashboard.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_dashboard.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2021 Google Inc. All Rights Reserved. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_dashboard.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_dashboard.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_home.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.home.HomeFragment">
+
+    <TextView
+        android:id="@+id/text_home"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:gravity="center_horizontal"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_home.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_home.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2021 Google Inc. All Rights Reserved. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_home.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_home.xml
@@ -16,8 +16,18 @@
         android:textAlignment="center"
         android:gravity="center_horizontal"
         android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/img_home"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/img_home"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_home.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_home.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.notifications.NotificationsFragment">
+
+    <TextView
+        android:id="@+id/text_notifications"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:gravity="center_horizontal" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
@@ -15,10 +15,10 @@
         android:layout_marginEnd="8dp"
         android:textAlignment="center"
         android:textSize="20sp"
-        app:layout_constraintBottom_toTopOf="@id/img_notifications"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/img_notifications"
         android:gravity="center_horizontal" />
 
     <ImageView
@@ -26,8 +26,18 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
+        app:layout_constraintBottom_toTopOf="@+id/rv_fragment_notifications"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/text_notifications" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_fragment_notifications"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@id/img_notifications" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
@@ -15,9 +15,19 @@
         android:layout_marginEnd="8dp"
         android:textAlignment="center"
         android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/img_notifications"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         android:gravity="center_horizontal" />
+
+    <ImageView
+        android:id="@+id/img_notifications"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2021 Google Inc. All Rights Reserved. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/fragment_notifications.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/firebase-perf/dev-app/src/main/res/layout/main_activity.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/main_activity.xml
@@ -11,6 +11,14 @@
     android:orientation="vertical">
 
     <Button
+        android:id="@+id/activityFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:onClick="openFragmentActivity"
+        android:text="Fragment Activity"
+        android:textAllCaps="false" />
+
+    <Button
       android:id="@+id/init"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"

--- a/firebase-perf/dev-app/src/main/res/layout/number_list_item.xml
+++ b/firebase-perf/dev-app/src/main/res/layout/number_list_item.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tv_item_number"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical|start"
+        android:fontFamily="monospace"
+        android:textSize="42sp"
+        tools:text="#42" />
+</FrameLayout>

--- a/firebase-perf/dev-app/src/main/res/menu/bottom_nav_menu.xml
+++ b/firebase-perf/dev-app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/navigation_home"
+        android:icon="@drawable/ic_home_black_24dp"
+        android:title="@string/title_home" />
+
+    <item
+        android:id="@+id/navigation_dashboard"
+        android:icon="@drawable/ic_dashboard_black_24dp"
+        android:title="@string/title_dashboard" />
+
+    <item
+        android:id="@+id/navigation_notifications"
+        android:icon="@drawable/ic_notifications_black_24dp"
+        android:title="@string/title_notifications" />
+
+</menu>

--- a/firebase-perf/dev-app/src/main/res/menu/bottom_nav_menu.xml
+++ b/firebase-perf/dev-app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2021 Google Inc. All Rights Reserved. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item

--- a/firebase-perf/dev-app/src/main/res/menu/bottom_nav_menu.xml
+++ b/firebase-perf/dev-app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item

--- a/firebase-perf/dev-app/src/main/res/menu/menu.xml
+++ b/firebase-perf/dev-app/src/main/res/menu/menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools" tools:context=".FragmentActivity">
+    <item
+        android:id="@+id/action_change_gif"
+        android:icon="@android:drawable/ic_popup_sync"
+        android:title="TODO"
+        app:showAsAction="always"/>
+</menu>

--- a/firebase-perf/dev-app/src/main/res/navigation/mobile_navigation.xml
+++ b/firebase-perf/dev-app/src/main/res/navigation/mobile_navigation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2021 Google Inc. All Rights Reserved. -->
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/firebase-perf/dev-app/src/main/res/navigation/mobile_navigation.xml
+++ b/firebase-perf/dev-app/src/main/res/navigation/mobile_navigation.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/mobile_navigation"
+    app:startDestination="@+id/navigation_home">
+
+    <fragment
+        android:id="@+id/navigation_home"
+        android:name="com.googletest.firebase.perf.testapp.ui.home.HomeFragment"
+        android:label="@string/title_home"
+        tools:layout="@layout/fragment_home" />
+
+    <fragment
+        android:id="@+id/navigation_dashboard"
+        android:name="com.googletest.firebase.perf.testapp.ui.dashboard.DashboardFragment"
+        android:label="@string/title_dashboard"
+        tools:layout="@layout/fragment_dashboard" />
+
+    <fragment
+        android:id="@+id/navigation_notifications"
+        android:name="com.googletest.firebase.perf.testapp.ui.notifications.NotificationsFragment"
+        android:label="@string/title_notifications"
+        tools:layout="@layout/fragment_notifications" />
+</navigation>

--- a/firebase-perf/dev-app/src/main/res/navigation/mobile_navigation.xml
+++ b/firebase-perf/dev-app/src/main/res/navigation/mobile_navigation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?> <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/firebase-perf/dev-app/src/main/res/values/dimens.xml
+++ b/firebase-perf/dev-app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="activity_horizontal_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">16dp</dimen>
+</resources>

--- a/firebase-perf/dev-app/src/main/res/values/dimens.xml
+++ b/firebase-perf/dev-app/src/main/res/values/dimens.xml
@@ -1,4 +1,4 @@
-<!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+<!-- Copyright 2021 Google Inc. All Rights Reserved. -->
 
 <resources>
     <!-- Default screen margins, per the Android Design guidelines. -->

--- a/firebase-perf/dev-app/src/main/res/values/dimens.xml
+++ b/firebase-perf/dev-app/src/main/res/values/dimens.xml
@@ -1,3 +1,5 @@
+<!-- Copyright 2020 Google Inc. All Rights Reserved. -->
+
 <resources>
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>

--- a/firebase-perf/dev-app/src/main/res/values/strings.xml
+++ b/firebase-perf/dev-app/src/main/res/values/strings.xml
@@ -1,5 +1,9 @@
 <!-- Copyright 2020 Google Inc. All Rights Reserved. -->
 
 <resources>
-  <string name="app_name">FireperfDevApp</string>
+    <string name="app_name">FireperfDevApp</string>
+    <string name="title_activity_fragment">FragmentActivity</string>
+    <string name="title_home">Home</string>
+    <string name="title_dashboard">Dashboard</string>
+    <string name="title_notifications">Notifications</string>
 </resources>


### PR DESCRIPTION
b/208271486: while working on Fragment performance measurement, we need an activity with multiple fragments to test on, in the dev-app.

## Current changes
This adds a button to the main activity that starts a new `FragmentActivity` which uses `Navigation` component with 3 fragments. 

## Testing Listeners
There are also preliminary listeners added to the `FragmentActivity.onCreate()` that we could possibly utilize in our performance measurements, namely `getSupportFragmentManager().registerFragmentLifecycleCallbacks(...)` and `Navigation.findNavController(...).addOnDestinationChangedListener(...)`.

Filter by keyword "Fragment" in logcat and navigate around to see the behaviour of each lifecycle callback. 

## Observation
Navigation component uses something called `NavHostFragment` as a container to swap different fragments into the view. But `NavHostFragment` itself is a `Fragment`, so perhaps we want to exclude that from measurements. 