### PR TITLE
Move FirestoreRegistrar into the public API

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreRegistrar.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirestoreRegistrar.java
@@ -37,7 +37,6 @@ import java.util.List;
  * @hide
  */
 @Keep
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class FirestoreRegistrar implements ComponentRegistrar {
   @Override
   @Keep


### PR DESCRIPTION
It is currently not possible to draw a dependency on Firestore via components, outside the scope of this library. I'm fairly certain that this is all that's blocking it- but await feedback from others.

@vkryachko @schmidt-sebastian 