### PR TITLE
Remove shared index entries

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -68,7 +68,7 @@ final class SQLiteIndexManager implements IndexManager {
 
   private final SQLitePersistence db;
   private final LocalSerializer serializer;
-  private final User user;
+  private final String uid;
   private final Map<String, Map<Integer, FieldIndex>> memoizedIndexes;
 
   private boolean started = false;
@@ -77,7 +77,7 @@ final class SQLiteIndexManager implements IndexManager {
   SQLiteIndexManager(SQLitePersistence persistence, LocalSerializer serializer, User user) {
     this.db = persistence;
     this.serializer = serializer;
-    this.user = user;
+    this.uid = user.isAuthenticated() ? user.getUid() : "";
     this.memoizedIndexes = new HashMap<>();
   }
 
@@ -376,7 +376,7 @@ final class SQLiteIndexManager implements IndexManager {
         "INSERT INTO index_entries (index_id, uid, array_value, directional_value, document_name) "
             + "VALUES(?, ?, ?, ?, ?)",
         indexId,
-        user.getUid(),
+        uid,
         arrayValue,
         directionalValue,
         document.getKey().toString());
@@ -504,7 +504,7 @@ final class SQLiteIndexManager implements IndexManager {
     int offset = 0;
     for (int i = 0; i < statementCount; ++i) {
       bindArgs[offset++] = indexId;
-      bindArgs[offset++] = user.getUid();
+      bindArgs[offset++] = uid;
       if (arrayValues != null) {
         bindArgs[offset++] = encodeSingleElement(arrayValues.get(i / statementsPerArrayValue));
       }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -376,7 +376,7 @@ final class SQLiteIndexManager implements IndexManager {
         "INSERT INTO index_entries (index_id, uid, array_value, directional_value, document_name) "
             + "VALUES(?, ?, ?, ?, ?)",
         indexId,
-        document.hasLocalMutations() ? user.getUid() : null,
+        user.getUid(),
         arrayValue,
         directionalValue,
         document.getKey().toString());
@@ -450,7 +450,7 @@ final class SQLiteIndexManager implements IndexManager {
     // and an upper bound.
     StringBuilder statement = new StringBuilder();
     statement.append("SELECT document_name, directional_value FROM index_entries ");
-    statement.append("WHERE index_id = ?  AND (uid IS NULL or uid = ?) ");
+    statement.append("WHERE index_id = ? AND uid = ? ");
     if (arrayValues != null) {
       statement.append("AND array_value = ? ");
     }


### PR DESCRIPTION
This PR makes it so that all index entries are scoped to a user, which removes shared index entries for documents that are not mutated. For apps that use multiple users this means that we will keep more index entries, but in the general case it means that we keep one less (instead of keeping the unmodified value + the modified value for single user indices, we now just keep one).

This means that each index now has a different backfill state per user. If a new user signs in, we need to start backfill from zero. We likely need an additional data structure for that.