### PR TITLE
Fix messaging tests disabled in the move to GitHub.

### DIFF
--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -112,7 +112,7 @@ dependencies {
     testImplementation 'com.google.android.gms:play-services-cloud-messaging:17.0.0'
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "org.robolectric:robolectric:4.6.1"
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
@@ -131,4 +131,5 @@ dependencies {
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'androidx.test.ext:truth:1.2.0'
     testImplementation 'androidx.test.services:test-services:1.2.0'
+    testImplementation 'androidx.core:core:1.6.0'
 }

--- a/firebase-messaging/src/test/AndroidManifest.xml
+++ b/firebase-messaging/src/test/AndroidManifest.xml
@@ -33,5 +33,14 @@
                 android:name="com.google.firebase.components:com.google.firebase.analytics.connector.internal.AnalyticsConnectorRegistrar"
                 tools:node="remove" />
         </service>
+
+        <activity
+            android:name="com.google.firebase.messaging.FirebaseMessagingServiceRoboTest$MyTestActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="click_action" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/firebase-messaging/src/test/java/com/google/firebase/iid/FirebaseInstanceIdWithFcmReceiverRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/iid/FirebaseInstanceIdWithFcmReceiverRoboTest.java
@@ -125,7 +125,7 @@ public class FirebaseInstanceIdWithFcmReceiverRoboTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.O)
+  @Config(sdk = VERSION_CODES.O)
   public void testStartsService_oButAppNotTargetingO() throws Exception {
     setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 26);
     context.getApplicationInfo().targetSdkVersion = VERSION_CODES.N_MR1;

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/CommonNotificationBuilderRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/CommonNotificationBuilderRoboTest.java
@@ -33,7 +33,6 @@ import com.google.firebase.messaging.testing.Bundles;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -321,16 +320,17 @@ public class CommonNotificationBuilderRoboTest {
 
   @Test
   public void createNotificationInfo_withInvalidEventTime() {
+    long startTime = System.currentTimeMillis();
     String eventTime = "invalid_event_time";
-    int eventTimeExpected = 0;
-
     Bundle data = Bundles.of(KEY_EVENT_TIME, eventTime);
 
     DisplayNotificationInfo notificationInfo =
         CommonNotificationBuilder.createNotificationInfo(appContext, new NotificationParams(data));
 
     assertThat(notificationInfo.notificationBuilder.getNotification().when)
-        .isEqualTo(eventTimeExpected);
+        .isGreaterThan(startTime);
+    assertThat(notificationInfo.notificationBuilder.getNotification().when)
+        .isLessThan(System.currentTimeMillis());
   }
 
   @Test
@@ -409,7 +409,6 @@ public class CommonNotificationBuilderRoboTest {
   }
 
   @Test
-  @Ignore // notificationInfo.notificationBuilder.getNotification().visibility no longer accessible
   public void createNotificationInfo_withValidVisibility() {
     // VISIBILITY_PUBLIC, see:
     // https://developer.android.com/reference/android/support/v4/app/NotificationCompat.html#visibility_public
@@ -421,12 +420,11 @@ public class CommonNotificationBuilderRoboTest {
         CommonNotificationBuilder.createNotificationInfo(appContext, new NotificationParams(data));
 
     // verify
-    assertThat(notificationInfo.notificationBuilder.build().visibility)
+    assertThat(NotificationCompat.getVisibility(notificationInfo.notificationBuilder.build()))
         .isEqualTo(expectedVisibility);
   }
 
   @Test
-  @Ignore // notificationInfo.notificationBuilder.getNotification().visibility no longer accessible
   public void createNotificationInfo_withInvalidVisibility() {
     // set up
     String invalidVisibility = "a";
@@ -437,11 +435,11 @@ public class CommonNotificationBuilderRoboTest {
         CommonNotificationBuilder.createNotificationInfo(appContext, new NotificationParams(data));
 
     // verify never set
-    assertThat(notificationInfo.notificationBuilder.build().visibility).isEqualTo(0);
+    assertThat(NotificationCompat.getVisibility(notificationInfo.notificationBuilder.build()))
+        .isEqualTo(0);
   }
 
   @Test
-  @Ignore // notificationInfo.notificationBuilder.getNotification().visibility no longer accessible
   public void createNotificationInfo_withInvalidVisibility_outOfBoundVisibility() {
     // set up
     String invalidVisibility = "123";
@@ -452,7 +450,8 @@ public class CommonNotificationBuilderRoboTest {
         CommonNotificationBuilder.createNotificationInfo(appContext, new NotificationParams(data));
 
     // verify never set
-    assertThat(notificationInfo.notificationBuilder.build().visibility).isEqualTo(0);
+    assertThat(NotificationCompat.getVisibility(notificationInfo.notificationBuilder.build()))
+        .isEqualTo(0);
   }
 
   @Test

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/DisplayNotificationRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/DisplayNotificationRoboTest.java
@@ -58,7 +58,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.json.JSONArray;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -231,7 +230,6 @@ public class DisplayNotificationRoboTest {
    */
   @Config(sdk = Build.VERSION_CODES.O)
   @Test
-  @Ignore
   public void testAdaptiveIcon_viaParameter() {
     Bundle data = new Bundle();
     data.putString(KEY_ICON, "adaptive_icon");
@@ -247,7 +245,6 @@ public class DisplayNotificationRoboTest {
   /** Test that an adaptive icon is detected and avoided, when passed via metadata (on Android O) */
   @Config(sdk = Build.VERSION_CODES.O)
   @Test
-  @Ignore
   public void testAdaptiveIcon_viaMetadata() {
     Bundle metadata = new Bundle();
     metadata.putInt(
@@ -272,7 +269,6 @@ public class DisplayNotificationRoboTest {
    */
   @Config(sdk = Build.VERSION_CODES.O)
   @Test
-  @Ignore
   public void testAdaptiveIcon_viaDefaultIcon() {
     setApplicationIcon(
         context.getPackageName(), com.google.firebase.messaging.test.R.drawable.adaptive_icon);
@@ -309,7 +305,6 @@ public class DisplayNotificationRoboTest {
   /** Test that a non adaptive icon is ok on Android O. */
   @Config(sdk = Build.VERSION_CODES.O)
   @Test
-  @Ignore
   public void testNonAdaptiveIcon_AndroidO() {
     setApplicationIcon(
         context.getPackageName(), com.google.firebase.messaging.test.R.drawable.gcm_icon);
@@ -329,7 +324,6 @@ public class DisplayNotificationRoboTest {
   /** Test that a non adaptive icon with gradient is ok on Android O. */
   @Config(sdk = Build.VERSION_CODES.O)
   @Test
-  @Ignore
   public void testNonAdaptiveIconWithGradient_AndroidO() {
     setApplicationIcon(
         context.getPackageName(), com.google.firebase.messaging.test.R.drawable.icon_with_gradient);
@@ -481,7 +475,6 @@ public class DisplayNotificationRoboTest {
   /** Test that a valid notification with color is displayed. */
   @Test
   @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
-  @Ignore
   public void testColor() {
     final String color = "#123456";
     Bundle data = new Bundle();
@@ -496,7 +489,6 @@ public class DisplayNotificationRoboTest {
 
   @Test
   @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
-  @Ignore
   public void testNoColor() {
     Bundle data = new Bundle();
     data.putString(KEY_TITLE, "title 123");
@@ -511,7 +503,6 @@ public class DisplayNotificationRoboTest {
   /** Test that the user can choose the default color via AndroidManifest metadata. */
   @Test
   @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
-  @Ignore
   public void testColorFromMetadata() {
     Bundle metadata = new Bundle();
     metadata.putInt(

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingRoboTest.java
@@ -54,7 +54,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -370,7 +369,6 @@ public final class FirebaseMessagingRoboTest {
 
   @Test
   @Config(sdk = VERSION_CODES.Q)
-  @Ignore
   public void isProxyNotificationEnabledDefaultsToTrueForNewerDevices() {
     FirebaseMessaging messaging =
         new FirebaseMessaging(
@@ -388,8 +386,7 @@ public final class FirebaseMessagingRoboTest {
   }
 
   @Test
-  @Config(maxSdk = VERSION_CODES.P)
-  @Ignore
+  @Config(sdk = VERSION_CODES.O)
   public void isProxyNotificationEnabledDefaultsToFalseForOlderDevices() {
     FirebaseMessaging messaging =
         new FirebaseMessaging(
@@ -407,16 +404,14 @@ public final class FirebaseMessagingRoboTest {
   }
 
   @Test
-  @Config(maxSdk = VERSION_CODES.P)
-  @Ignore
+  @Config(sdk = VERSION_CODES.O)
   public void setEnableProxyNotificationFailsOnOlderDevices() throws Exception {
     Tasks.await(FirebaseMessaging.getInstance().setNotificationDelegationEnabled(true));
     assertThat(FirebaseMessaging.getInstance().isNotificationDelegationEnabled()).isFalse();
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.Q)
-  @Ignore
+  @Config(sdk = VERSION_CODES.Q)
   public void setEnableProxyNotificationWorksOnNewerDevices() throws Exception {
     Tasks.await(FirebaseMessaging.getInstance().setNotificationDelegationEnabled(false));
     Tasks.await(FirebaseMessaging.getInstance().setNotificationDelegationEnabled(true));
@@ -424,14 +419,14 @@ public final class FirebaseMessagingRoboTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.Q)
+  @Config(sdk = VERSION_CODES.Q)
   public void setDisableProxyNotificationWorksOnNewerDevices() throws Exception {
     Tasks.await(FirebaseMessaging.getInstance().setNotificationDelegationEnabled(false));
     assertThat(FirebaseMessaging.getInstance().isNotificationDelegationEnabled()).isFalse();
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.Q)
+  @Config(sdk = VERSION_CODES.Q)
   public void proxyNotificationEnabledIsFalseWhenUserSetsAnotherNotificationDelegate()
       throws Exception {
     Tasks.await(FirebaseMessaging.getInstance().setNotificationDelegationEnabled(true));
@@ -441,8 +436,7 @@ public final class FirebaseMessagingRoboTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.Q)
-  @Ignore
+  @Config(sdk = VERSION_CODES.Q)
   public void proxyNotificationEnabledIsTrueWhenGMSCoreIsSetAsNotificationDelegate()
       throws Exception {
     Tasks.await(FirebaseMessaging.getInstance().setNotificationDelegationEnabled(false));
@@ -452,7 +446,7 @@ public final class FirebaseMessagingRoboTest {
   }
 
   @Test
-  @Config(minSdk = VERSION_CODES.Q)
+  @Config(sdk = VERSION_CODES.Q)
   public void proxyNotificationEnabledIsFalseWhenUidIsWrong() throws Exception {
     // Set the app's uid so that ProxyNotificationInitializer.allowedToUse() returns false.
     context.getApplicationInfo().uid = Binder.getCallingUid() + 1;

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingServiceRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingServiceRoboTest.java
@@ -74,7 +74,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
@@ -401,7 +400,6 @@ public class FirebaseMessagingServiceRoboTest {
 
   /** Test that a notification logs the correct event on tap. */
   @Test
-  @Ignore
   public void testNotification_clickAnalytics() throws Exception {
     FirebaseMessaging.getInstance(firebaseApp); // register activity lifecycle friends
     simulateNotificationMessageWithAnalytics();
@@ -432,7 +430,6 @@ public class FirebaseMessagingServiceRoboTest {
 
   /** Test that a notification does not re-log events when the activity is recreated. */
   @Test
-  @Ignore
   public void testNotification_clickAnalytics_recreateActivity() throws Exception {
     FirebaseMessaging.getInstance(firebaseApp); // register activity lifecycle friends
     simulateNotificationMessageWithAnalytics();

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/MessagingAnalyticsRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/MessagingAnalyticsRoboTest.java
@@ -54,7 +54,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -180,7 +179,6 @@ public class MessagingAnalyticsRoboTest {
    * Test that if there is no manifest nor run-time specification of whether FCM should export
    * delivery metrics to big query, the expected behavior is to not upload the metrics.
    */
-  @Ignore
   @Test
   public void testShouldExportDeliveryMetricsToBigQuery_noneManifestNoneSetter() {
     assertManifestFieldWithValue(MANIFEST_DELIVERY_METRICS_EXPORT_TO_BIG_QUERY_ENABLED, null);
@@ -318,7 +316,6 @@ public class MessagingAnalyticsRoboTest {
    * flag should override the compile-time flag.
    */
   @Test
-  @Ignore
   public void testShouldExportDeliveryMetricsToBigQuery_falseManifestTrueSetter() throws Exception {
     editManifestApplicationMetadata()
         .putBoolean(MANIFEST_DELIVERY_METRICS_EXPORT_TO_BIG_QUERY_ENABLED, false);
@@ -451,7 +448,6 @@ public class MessagingAnalyticsRoboTest {
 
   /* Notifications with FROM != "/topics/%" DO NOT report to Analytics Param.TOPIC */
   @Test
-  @Ignore
   public void testTopicsApiPopulatesParamTopic_fromComposerUiWithFromNotATopic() {
     Intent intent = createTestAnalyticsIntent();
 
@@ -837,7 +833,6 @@ public class MessagingAnalyticsRoboTest {
   }
 
   @Test
-  @Ignore
   public void getInstanceId_withIntentTo() {
     Bundle extras = new Bundle();
     extras.putString(MessagePayloadKeys.TO, "installation_id");

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/WakeLockHolderRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/WakeLockHolderRoboTest.java
@@ -38,13 +38,13 @@ public class WakeLockHolderRoboTest {
 
   @Test
   public void testStartWakefulService_InitsWakeLock() throws Exception {
-    WakeLockHolder.startWakefulService(context, new Intent("Any_Action"));
+    WakeLockHolder.startWakefulService(context, newIntent("Any_Action"));
     assertThat(ShadowPowerManager.getLatestWakeLock()).isNotNull();
   }
 
   @Test
   public void testStartWakefulService_AcquiresWakeLock() throws Exception {
-    Intent intent = new Intent("Any_Action");
+    Intent intent = newIntent("Any_Action");
 
     WakeLockHolder.startWakefulService(context, intent);
 
@@ -53,7 +53,7 @@ public class WakeLockHolderRoboTest {
 
   @Test
   public void testCompleteWakefulIntent_ReleasesWakeLockIfPresent() throws Exception {
-    Intent intent = new Intent("Any_Action");
+    Intent intent = newIntent("Any_Action");
 
     WakeLockHolder.startWakefulService(context, intent);
     WakeLock wl = ShadowPowerManager.getLatestWakeLock();
@@ -64,16 +64,16 @@ public class WakeLockHolderRoboTest {
 
   @Test
   public void testCompleteWakefulIntent_ReleasesWakeLockMultipleTimesTest() throws Exception {
-    Intent intent1 = new Intent("1");
+    Intent intent1 = newIntent("1");
     WakeLockHolder.startWakefulService(context, intent1);
     WakeLock wl = ShadowPowerManager.getLatestWakeLock();
     assertThat(wl.isHeld()).isTrue(); // WL Count = 1
 
-    Intent intent2 = new Intent("2");
+    Intent intent2 = newIntent("2");
     WakeLockHolder.startWakefulService(context, intent2);
     assertThat(wl.isHeld()).isTrue(); // WL Count = 2
 
-    Intent intent3 = new Intent("3");
+    Intent intent3 = newIntent("3");
     WakeLockHolder.startWakefulService(context, intent3);
     assertThat(wl.isHeld()).isTrue(); // WL Count = 3
 
@@ -83,7 +83,7 @@ public class WakeLockHolderRoboTest {
     WakeLockHolder.completeWakefulIntent(intent2);
     assertThat(wl.isHeld()).isTrue(); // WL Count = 1
 
-    Intent intent4 = new Intent("4");
+    Intent intent4 = newIntent("4");
     WakeLockHolder.startWakefulService(context, intent4);
     assertThat(wl.isHeld()).isTrue(); // WL Count = 2
 
@@ -96,7 +96,7 @@ public class WakeLockHolderRoboTest {
 
   @Test
   public void testCompleteWakefulIntent_doesNotCrashOnDuplicateCalls() throws Exception {
-    Intent intent = new Intent("1");
+    Intent intent = newIntent("1");
     WakeLockHolder.startWakefulService(context, intent);
     WakeLock wl = ShadowPowerManager.getLatestWakeLock();
     WakeLockHolder.completeWakefulIntent(intent); // Normal case
@@ -106,7 +106,7 @@ public class WakeLockHolderRoboTest {
 
   @Test
   public void testStartWakefulService_createsWakefulIntent() throws Exception {
-    Intent intent = new Intent();
+    Intent intent = newIntent(null);
 
     WakeLockHolder.startWakefulService(context, intent);
 
@@ -115,7 +115,7 @@ public class WakeLockHolderRoboTest {
 
   @Test
   public void testCompleteWakefulIntent_removesWakefulMarker() throws Exception {
-    Intent intent = new Intent();
+    Intent intent = newIntent(null);
 
     WakeLockHolder.startWakefulService(context, intent);
     WakeLockHolder.completeWakefulIntent(intent);
@@ -125,12 +125,12 @@ public class WakeLockHolderRoboTest {
 
   @Test
   public void testOnlyWakefulIntentsCauseWakeLockToBeReleased() throws Exception {
-    Intent intent = new Intent("1");
+    Intent intent = newIntent("1");
     WakeLockHolder.startWakefulService(context, intent);
     WakeLock wl = ShadowPowerManager.getLatestWakeLock();
     assertThat(wl.isHeld()).isTrue();
 
-    WakeLockHolder.completeWakefulIntent(new Intent("2"));
+    WakeLockHolder.completeWakefulIntent(newIntent("2"));
     assertThat(wl.isHeld()).isTrue();
 
     WakeLockHolder.completeWakefulIntent(intent);
@@ -139,7 +139,7 @@ public class WakeLockHolderRoboTest {
 
   @Test
   public void testStartWakefulService_multipleCallsOnlyAcquiresWakeLockOnce() throws Exception {
-    Intent intent = new Intent("1");
+    Intent intent = newIntent("1");
     WakeLockHolder.startWakefulService(context, intent); // Called once
     WakeLock wl = ShadowPowerManager.getLatestWakeLock();
     assertThat(wl.isHeld()).isTrue();
@@ -150,5 +150,9 @@ public class WakeLockHolderRoboTest {
     WakeLockHolder.completeWakefulIntent(intent);
     // Should be false since the same intent should not acquire wakelock more than once.
     assertThat(wl.isHeld()).isFalse();
+  }
+
+  private Intent newIntent(String action) {
+    return new Intent(action).setPackage(context.getPackageName());
   }
 }


### PR DESCRIPTION
* Removed @Ignore for all tests that were disabled in the move to GitHub.* Updated robolectric version to include notification delegate support. Also updated createNotificationInfo_withInvalidEventTime and WakeLockHolderRoboTest tests to pass with the updated robolectric version.
* Limited tests using minSdk/maxSdk to sdk instead to fix OutOfMemoryErrors that seem to be due to running the tests on too many API levels. It could also be due to a specific platform level causing issues.
* Updated androidx.core version to include NotificationCompat.getVisibility() to replace CommonNotificationBuilderRoboTest usage of Notification.visibility.
* Added MyTestActivity to the test AndroidManifest.xml to enable FirebaseMessagingServiceRoboTest's use of the Activity.