### PR TITLE
Store per-user state for indexes

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -44,7 +44,6 @@ import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.model.ResourcePath;
-import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firebase.firestore.remote.FirestoreChannel;
 import com.google.firebase.firestore.remote.GrpcMetadataProvider;
 import com.google.firebase.firestore.util.AsyncQueue;
@@ -340,7 +339,8 @@ public class FirebaseFirestore {
             }
           }
 
-          parsedIndices.add(FieldIndex.create(-1, collectionGroup, segments, SnapshotVersion.NONE));
+          parsedIndices.add(
+              FieldIndex.create(-1, collectionGroup, segments, FieldIndex.IndexState.DEFAULT));
         }
       }
     } catch (JSONException e) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -340,7 +340,8 @@ public class FirebaseFirestore {
           }
 
           parsedIndices.add(
-              FieldIndex.create(-1, collectionGroup, segments, FieldIndex.IndexState.DEFAULT));
+              FieldIndex.create(
+                  FieldIndex.UNKNOWN_ID, collectionGroup, segments, FieldIndex.INITIAL_STATE));
         }
       }
     } catch (JSONException e) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
@@ -18,7 +18,6 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import com.google.firebase.Timestamp;
 import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.model.Document;
@@ -27,10 +26,11 @@ import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
 import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firebase.firestore.util.AsyncQueue;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
 /** Implements the steps for backfilling indexes. */
@@ -44,13 +44,16 @@ public class IndexBackfiller {
 
   private final Scheduler scheduler;
   private final Persistence persistence;
+  private final RemoteDocumentCache remoteDocumentCache;
   private LocalDocumentsView localDocumentsView;
   private IndexManager indexManager;
   private int maxDocumentsToProcess = MAX_DOCUMENTS_TO_PROCESS;
+  private long currentSequenceNumber = -1;
 
   public IndexBackfiller(Persistence persistence, AsyncQueue asyncQueue) {
     this.persistence = persistence;
     this.scheduler = new Scheduler(asyncQueue);
+    this.remoteDocumentCache = persistence.getRemoteDocumentCache();
   }
 
   public void setLocalDocumentsView(LocalDocumentsView localDocumentsView) {
@@ -131,7 +134,7 @@ public class IndexBackfiller {
     return persistence.runTransaction(
         "Backfill Indexes",
         () -> {
-          // TODO(indexing): Handle field indexes that are removed by the user.
+          currentSequenceNumber = indexManager.getHighestSequenceNumber() + 1;
           int documentsProcessed = writeIndexEntries(localDocumentsView);
           return new Results(/* hasRun= */ true, documentsProcessed);
         });
@@ -140,11 +143,10 @@ public class IndexBackfiller {
   /** Writes index entries until the cap is reached. Returns the number of documents processed. */
   private int writeIndexEntries(LocalDocumentsView localDocumentsView) {
     int documentsProcessed = 0;
-    Timestamp startingTimestamp = Timestamp.now();
 
     while (documentsProcessed < maxDocumentsToProcess) {
       int documentsRemaining = maxDocumentsToProcess - documentsProcessed;
-      String collectionGroup = indexManager.getNextCollectionGroupToUpdate(startingTimestamp);
+      String collectionGroup = indexManager.getNextCollectionGroupToUpdate(currentSequenceNumber);
       if (collectionGroup == null) {
         break;
       }
@@ -160,42 +162,61 @@ public class IndexBackfiller {
       LocalDocumentsView localDocumentsView, String collectionGroup, int entriesRemainingUnderCap) {
     Query query = new Query(ResourcePath.EMPTY, collectionGroup);
 
-    // Use the earliest updateTime of all field indexes as the base updateTime.
-    SnapshotVersion earliestUpdateTime =
-        getEarliestUpdateTime(indexManager.getFieldIndexes(collectionGroup));
+    // Use the earliest readTime of all field indexes as the base readtime.
+    SnapshotVersion earliestReadTime =
+        getEarliestReadTime(indexManager.getFieldIndexes(collectionGroup));
 
     // TODO(indexing): Use limit queries to only fetch the required number of entries.
     // TODO(indexing): Support mutation batch Ids when sorting and writing indexes.
     ImmutableSortedMap<DocumentKey, Document> documents =
-        localDocumentsView.getDocumentsMatchingQuery(query, earliestUpdateTime);
+        localDocumentsView.getDocumentsMatchingQuery(query, earliestReadTime);
 
-    Queue<Document> oldestDocuments = getOldestDocuments(documents, entriesRemainingUnderCap);
+    List<Document> oldestDocuments = getOldestDocuments(documents, entriesRemainingUnderCap);
     indexManager.updateIndexEntries(oldestDocuments);
+
+    SnapshotVersion latestReadTime = getPostUpdateReadTime(oldestDocuments, earliestReadTime);
+    indexManager.updateCollectionGroup(collectionGroup, currentSequenceNumber, latestReadTime);
     return oldestDocuments.size();
   }
 
-  /** Returns up to {@code count} documents sorted by read time. */
-  private Queue<Document> getOldestDocuments(
-      ImmutableSortedMap<DocumentKey, Document> documents, int count) {
-    Queue<Document> oldestDocuments =
-        new PriorityQueue<>(count + 1, (l, r) -> r.getReadTime().compareTo(l.getReadTime()));
-    for (Map.Entry<DocumentKey, Document> entry : documents) {
-      oldestDocuments.add(entry.getValue());
-      if (oldestDocuments.size() > count) {
-        oldestDocuments.poll();
-      }
-    }
-    return oldestDocuments;
+  /** Returns the new read time for the index. */
+  private SnapshotVersion getPostUpdateReadTime(
+      List<Document> documents, SnapshotVersion currentReadTime) {
+    SnapshotVersion latestReadTime =
+        documents.isEmpty()
+            ? remoteDocumentCache.getLatestReadTime()
+            : documents.get(documents.size() - 1).getReadTime();
+    // Make sure the index does not go back in time
+    latestReadTime =
+        latestReadTime.compareTo(currentReadTime) > 0 ? latestReadTime : currentReadTime;
+    return latestReadTime;
   }
 
-  private SnapshotVersion getEarliestUpdateTime(Collection<FieldIndex> fieldIndexes) {
+  /** Returns up to {@code count} documents sorted by read time. */
+  private List<Document> getOldestDocuments(
+      ImmutableSortedMap<DocumentKey, Document> documents, int count) {
+    List<Document> oldestDocuments = new ArrayList<>();
+    for (Map.Entry<DocumentKey, Document> entry : documents) {
+      oldestDocuments.add(entry.getValue());
+    }
+    Collections.sort(
+        oldestDocuments,
+        (l, r) -> {
+          int cmp = l.getReadTime().compareTo(r.getReadTime());
+          if (cmp != 0) return cmp;
+          return l.getKey().compareTo(r.getKey());
+        });
+    return oldestDocuments.subList(0, Math.min(count, oldestDocuments.size()));
+  }
+
+  private SnapshotVersion getEarliestReadTime(Collection<FieldIndex> fieldIndexes) {
     SnapshotVersion lowestVersion = null;
     for (FieldIndex fieldIndex : fieldIndexes) {
       lowestVersion =
           lowestVersion == null
-              ? fieldIndex.getUpdateTime()
-              : fieldIndex.getUpdateTime().compareTo(lowestVersion) < 0
-                  ? fieldIndex.getUpdateTime()
+              ? fieldIndex.getIndexState().getReadTime()
+              : fieldIndex.getIndexState().getReadTime().compareTo(lowestVersion) < 0
+                  ? fieldIndex.getIndexState().getReadTime()
                   : lowestVersion;
     }
     return lowestVersion;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
@@ -178,7 +178,12 @@ public class IndexBackfiller {
     return oldestDocuments.size();
   }
 
-  /** Returns the new read time for the index. */
+  /**
+   * Returns the new read time for the index.
+   *
+   * @param documents a list of documents sorted by read time (ascending)
+   * @param currentReadTime the current read time of the index
+   */
   private SnapshotVersion getPostUpdateReadTime(
       List<Document> documents, SnapshotVersion currentReadTime) {
     SnapshotVersion latestReadTime =

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
@@ -15,12 +15,12 @@
 package com.google.firebase.firestore.local;
 
 import androidx.annotation.Nullable;
-import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.core.Target;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
+import com.google.firebase.firestore.model.SnapshotVersion;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -87,14 +87,22 @@ public interface IndexManager {
   /** Returns the documents that match the given target based on the provided index. */
   Set<DocumentKey> getDocumentsMatchingTarget(FieldIndex fieldIndex, Target target);
 
-  /** Returns the next collection group to update. */
+  /**
+   * Returns the next collection group to update. Returns {@code null} if no group exists or the
+   * next collection group is already at {@code maxSequenceNumber}.
+   */
   @Nullable
-  String getNextCollectionGroupToUpdate(Timestamp lastUpdateTime);
+  String getNextCollectionGroupToUpdate(long maxSequenceNumber);
+
+  /** Updates the sequence number for the collection group and sets its latest read time. */
+  void updateCollectionGroup(String collectionGroup, long sequenceNumber, SnapshotVersion readTime);
 
   /**
    * Updates the index entries for the provided documents and corresponding field indexes until the
-   * cap is reached. Updates the field indexes in persistence with the latest read time that was
-   * processed.
+   * cap is reached.
    */
   void updateIndexEntries(Collection<Document> documents);
+
+  /** Returns the largest currently used sequence number (as used by the backfiller). */
+  long getHighestSequenceNumber();
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
@@ -87,22 +87,16 @@ public interface IndexManager {
   /** Returns the documents that match the given target based on the provided index. */
   Set<DocumentKey> getDocumentsMatchingTarget(FieldIndex fieldIndex, Target target);
 
-  /**
-   * Returns the next collection group to update. Returns {@code null} if no group exists or the
-   * next collection group is already at {@code maxSequenceNumber}.
-   */
+  /** Returns the next collection group to update. Returns {@code null} if no group exists. */
   @Nullable
-  String getNextCollectionGroupToUpdate(long maxSequenceNumber);
+  String getNextCollectionGroupToUpdate();
 
-  /** Updates the sequence number for the collection group and sets its latest read time. */
-  void updateCollectionGroup(String collectionGroup, long sequenceNumber, SnapshotVersion readTime);
+  /** Sets the collection group's latest read time. */
+  void updateCollectionGroup(String collectionGroup, SnapshotVersion readTime);
 
   /**
    * Updates the index entries for the provided documents and corresponding field indexes until the
    * cap is reached.
    */
   void updateIndexEntries(Collection<Document> documents);
-
-  /** Returns the largest currently used sequence number (as used by the backfiller). */
-  long getHighestSequenceNumber();
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexManager.java
@@ -91,7 +91,13 @@ public interface IndexManager {
   @Nullable
   String getNextCollectionGroupToUpdate();
 
-  /** Sets the collection group's latest read time. */
+  /**
+   * Sets the collection group's latest read time.
+   *
+   * <p>This method updates the read time for all field indices for the collection group and
+   * increments their sequence number. Subsequent calls to {@link #getNextCollectionGroupToUpdate()}
+   * will return a different collection group (unless only one collection group is configured).
+   */
   void updateCollectionGroup(String collectionGroup, SnapshotVersion readTime);
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexedQueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexedQueryEngine.java
@@ -84,7 +84,7 @@ public class IndexedQueryEngine implements QueryEngine {
       ImmutableSortedMap<DocumentKey, Document> indexedDocuments =
           localDocuments.getDocuments(keys);
       ImmutableSortedMap<DocumentKey, Document> additionalDocuments =
-          localDocuments.getDocumentsMatchingQuery(query, fieldIndex.getUpdateTime());
+          localDocuments.getDocumentsMatchingQuery(query, fieldIndex.getIndexState().getReadTime());
       for (Map.Entry<DocumentKey, Document> entry : additionalDocuments) {
         indexedDocuments = indexedDocuments.insert(entry.getKey(), entry.getValue());
       }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryIndexManager.java
@@ -16,12 +16,12 @@ package com.google.firebase.firestore.local;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import androidx.annotation.Nullable;
-import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.core.Target;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.ResourcePath;
+import com.google.firebase.firestore.model.SnapshotVersion;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -79,10 +79,17 @@ class MemoryIndexManager implements IndexManager {
     return Collections.emptySet();
   }
 
+  @Nullable
   @Override
-  public String getNextCollectionGroupToUpdate(Timestamp startingTimestamp) {
+  public String getNextCollectionGroupToUpdate(long maxSequenceNumber) {
     // Field indices are not supported with memory persistence.
     return null;
+  }
+
+  @Override
+  public void updateCollectionGroup(
+      String collectionGroup, long sequenceNumber, SnapshotVersion readTime) {
+    // Field indices are not supported with memory persistence.
   }
 
   @Override
@@ -100,6 +107,12 @@ class MemoryIndexManager implements IndexManager {
   @Override
   public void updateIndexEntries(Collection<Document> documents) {
     // Field indices are not supported with memory persistence.
+  }
+
+  @Override
+  public long getHighestSequenceNumber() {
+    // Field indices are not supported with memory persistence.
+    return -1;
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryIndexManager.java
@@ -81,14 +81,13 @@ class MemoryIndexManager implements IndexManager {
 
   @Nullable
   @Override
-  public String getNextCollectionGroupToUpdate(long maxSequenceNumber) {
+  public String getNextCollectionGroupToUpdate() {
     // Field indices are not supported with memory persistence.
     return null;
   }
 
   @Override
-  public void updateCollectionGroup(
-      String collectionGroup, long sequenceNumber, SnapshotVersion readTime) {
+  public void updateCollectionGroup(String collectionGroup, SnapshotVersion readTime) {
     // Field indices are not supported with memory persistence.
   }
 
@@ -107,12 +106,6 @@ class MemoryIndexManager implements IndexManager {
   @Override
   public void updateIndexEntries(Collection<Document> documents) {
     // Field indices are not supported with memory persistence.
-  }
-
-  @Override
-  public long getHighestSequenceNumber() {
-    // Field indices are not supported with memory persistence.
-    return -1;
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
@@ -79,4 +79,7 @@ interface RemoteDocumentCache {
    */
   ImmutableSortedMap<DocumentKey, MutableDocument> getAllDocumentsMatchingQuery(
       Query query, SnapshotVersion sinceReadTime);
+
+  /** Returns the latest read time of any document in the cache. */
+  SnapshotVersion getLatestReadTime();
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -21,7 +21,6 @@ import static com.google.firebase.firestore.util.Util.repeatSequence;
 import static java.lang.Math.max;
 
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.core.Bound;
@@ -50,6 +49,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.Set;
 
 /** A persisted implementation of IndexManager. */
@@ -69,16 +70,22 @@ final class SQLiteIndexManager implements IndexManager {
   private final SQLitePersistence db;
   private final LocalSerializer serializer;
   private final User user;
-  private final Map<String, Map<Integer, FieldIndex>> memoizedIndexes;
+  private final Map<String, Map<Integer, FieldIndex>> memoizedIndexes = new HashMap<>();
+  private final Queue<FieldIndex> nextIndexToUpdate =
+      new PriorityQueue<>(
+          10,
+          (l, r) ->
+              Long.compare(
+                  l.getIndexState().getSequenceNumber(), r.getIndexState().getSequenceNumber()));
 
   private boolean started = false;
-  private int memoizedMaxId = -1;
+  private int memoizedMaxIndexId = -1;
+  private long memoizedMaxSequenceNumber = -1;
 
   SQLiteIndexManager(SQLitePersistence persistence, LocalSerializer serializer, User user) {
     this.db = persistence;
     this.serializer = serializer;
     this.user = user;
-    this.memoizedIndexes = new HashMap<>();
   }
 
   @Override
@@ -88,9 +95,23 @@ final class SQLiteIndexManager implements IndexManager {
       return;
     }
 
+    Map<Integer, FieldIndex.IndexState> indexStates = new HashMap<>();
+
+    // Fetch all index states if persisted for the user.
     db.query(
-            "SELECT index_id, collection_group, index_proto, update_time_seconds, "
-                + "update_time_nanos FROM index_configuration")
+            "SELECT index_id, sequence_number, read_time_seconds, read_time_nanos "
+                + "FROM index_state WHERE uid = ?")
+        .forEach(
+            row -> {
+              int indexId = row.getInt(1);
+              long sequenceNumber = row.getLong(1);
+              SnapshotVersion readTime =
+                  new SnapshotVersion(new Timestamp(row.getLong(2), row.getInt(3)));
+              indexStates.put(indexId, FieldIndex.IndexState.create(sequenceNumber, readTime));
+            });
+
+    // Fetch all indices and combine with user's index state if available.
+    db.query("SELECT index_id, collection_group, index_proto FROM index_configuration")
         .forEach(
             row -> {
               try {
@@ -98,11 +119,12 @@ final class SQLiteIndexManager implements IndexManager {
                 String collectionGroup = row.getString(1);
                 List<FieldIndex.Segment> segments =
                     serializer.decodeFieldIndexSegments(Index.parseFrom(row.getBlob(2)));
-                SnapshotVersion updateTime =
-                    new SnapshotVersion(new Timestamp(row.getLong(3), row.getInt(4)));
-
+                FieldIndex.IndexState indexState =
+                    indexStates.containsKey(indexId)
+                        ? indexStates.get(indexId)
+                        : FieldIndex.IndexState.DEFAULT;
                 FieldIndex fieldIndex =
-                    FieldIndex.create(indexId, collectionGroup, segments, updateTime);
+                    FieldIndex.create(indexId, collectionGroup, segments, indexState);
                 memoizeIndex(fieldIndex);
               } catch (InvalidProtocolBufferException e) {
                 throw fail("Failed to decode index: " + e);
@@ -147,27 +169,19 @@ final class SQLiteIndexManager implements IndexManager {
   public void addFieldIndex(FieldIndex index) {
     hardAssert(started, "IndexManager not started");
 
-    int nextIndexId = memoizedMaxId + 1;
+    int nextIndexId = memoizedMaxIndexId + 1;
     index =
         FieldIndex.create(
-            nextIndexId, index.getCollectionGroup(), index.getSegments(), index.getUpdateTime());
+            nextIndexId, index.getCollectionGroup(), index.getSegments(), index.getIndexState());
 
     db.execute(
         "INSERT INTO index_configuration ("
             + "index_id, "
             + "collection_group, "
-            + "index_proto, "
-            + "update_time_seconds, "
-            + "update_time_nanos) VALUES(?, ?, ?, ?, ?)",
+            + "index_proto) VALUES(?, ?, ?)",
         nextIndexId,
         index.getCollectionGroup(),
-        encodeSegments(index),
-        index.getUpdateTime().getTimestamp().getSeconds(),
-        index.getUpdateTime().getTimestamp().getNanoseconds());
-
-    // TODO(indexing): Use a 0-counter rather than the timestamp.
-    setCollectionGroupUpdateTime(index.getCollectionGroup(), SnapshotVersion.NONE.getTimestamp());
-
+        encodeSegments(index));
     memoizeIndex(index);
   }
 
@@ -175,89 +189,39 @@ final class SQLiteIndexManager implements IndexManager {
   public void deleteFieldIndex(FieldIndex index) {
     db.execute("DELETE FROM index_configuration WHERE index_id = ?", index.getIndexId());
     db.execute("DELETE FROM index_entries WHERE index_id = ?", index.getIndexId());
+    db.execute("DELETE FROM index_state WHERE index_id = ?", index.getIndexState());
 
+    nextIndexToUpdate.remove(index);
     Map<Integer, FieldIndex> collectionIndices = memoizedIndexes.get(index.getCollectionGroup());
     if (collectionIndices != null) {
       collectionIndices.remove(index.getIndexId());
     }
   }
 
-  private void updateFieldIndex(FieldIndex index) {
-    db.execute(
-        "REPLACE INTO index_configuration ("
-            + "index_id, "
-            + "collection_group, "
-            + "index_proto, "
-            + "update_time_seconds, "
-            + "update_time_nanos) VALUES(?, ?, ?, ?, ?)",
-        index.getIndexId(),
-        index.getCollectionGroup(),
-        encodeSegments(index),
-        index.getUpdateTime().getTimestamp().getSeconds(),
-        index.getUpdateTime().getTimestamp().getNanoseconds());
-
-    memoizeIndex(index);
-  }
-
-  // TODO(indexing): Use a counter rather than the starting timestamp.
   @Override
-  public @Nullable String getNextCollectionGroupToUpdate(Timestamp startingTimestamp) {
+  public @Nullable String getNextCollectionGroupToUpdate(long maxSequenceNumber) {
     hardAssert(started, "IndexManager not started");
-
-    final String[] nextCollectionGroup = {null};
-    db.query(
-            "SELECT collection_group "
-                + "FROM collection_group_update_times "
-                + "WHERE update_time_seconds <= ? AND update_time_nanos <= ?"
-                + "ORDER BY update_time_seconds, update_time_nanos "
-                + "LIMIT 1")
-        .binding(startingTimestamp.getSeconds(), startingTimestamp.getNanoseconds())
-        .firstValue(
-            row -> {
-              nextCollectionGroup[0] = row.getString(0);
-              return null;
-            });
-
-    if (nextCollectionGroup[0] == null) {
-      return null;
-    }
-
-    // Store that this collection group will updated.
-    // TODO(indexing): Store progress with a counter rather than a timestamp. If using a timestamp,
-    // use the read time of the last document read in the loop.
-    setCollectionGroupUpdateTime(nextCollectionGroup[0], Timestamp.now());
-
-    return nextCollectionGroup[0];
+    FieldIndex nextIndex = nextIndexToUpdate.peek();
+    return nextIndex != null && nextIndex.getIndexState().getSequenceNumber() < maxSequenceNumber
+        ? nextIndex.getCollectionGroup()
+        : null;
   }
 
   @Override
   public void updateIndexEntries(Collection<Document> documents) {
     hardAssert(started, "IndexManager not started");
-
-    Map<Integer, FieldIndex> updatedFieldIndexes = new HashMap<>();
-
     for (Document document : documents) {
       Collection<FieldIndex> fieldIndexes = getFieldIndexes(document.getKey().getCollectionGroup());
       for (FieldIndex fieldIndex : fieldIndexes) {
-        boolean modified = writeEntries(document, fieldIndex);
-        if (modified) {
-          // TODO(indexing): This would be much simpler with a sequence counter since we would
-          // always update the index to the next sequence value.
-          FieldIndex latestIndex =
-              updatedFieldIndexes.get(fieldIndex.getIndexId()) != null
-                  ? updatedFieldIndexes.get(fieldIndex.getIndexId())
-                  : fieldIndex;
-          FieldIndex updatedIndex = getPostUpdateIndex(latestIndex, document.getReadTime());
-          updatedFieldIndexes.put(fieldIndex.getIndexId(), updatedIndex);
-        }
+        writeEntries(document, fieldIndex);
       }
     }
+  }
 
-    // TODO(indexing): Use RemoteDocumentCache's readTime version rather than the document version.
-    // This will require plumbing out the RDC's readTime into the IndexBackfiller.
-    for (FieldIndex updatedFieldIndex : updatedFieldIndexes.values()) {
-      updateFieldIndex(updatedFieldIndex);
-    }
+  @Override
+  public long getHighestSequenceNumber() {
+    hardAssert(started, "IndexManager not started");
+    return memoizedMaxSequenceNumber;
   }
 
   @Override
@@ -283,52 +247,42 @@ final class SQLiteIndexManager implements IndexManager {
       existingIndexes = new HashMap<>();
       memoizedIndexes.put(fieldIndex.getCollectionGroup(), existingIndexes);
     }
-    existingIndexes.put(fieldIndex.getIndexId(), fieldIndex);
-    memoizedMaxId = Math.max(memoizedMaxId, fieldIndex.getIndexId());
-  }
 
-  /**
-   * Returns a field index with the later read time.
-   *
-   * <p>This method should only be called on field indexes that had index entries written.
-   */
-  private FieldIndex getPostUpdateIndex(FieldIndex baseIndex, SnapshotVersion newReadTime) {
-    if (baseIndex.getUpdateTime().compareTo(newReadTime) > 0) {
-      return baseIndex;
-    } else {
-      return FieldIndex.create(
-          baseIndex.getIndexId(),
-          baseIndex.getCollectionGroup(),
-          baseIndex.getSegments(),
-          newReadTime);
+    FieldIndex existingIndex = existingIndexes.get(fieldIndex.getIndexId());
+    if (existingIndex != null) {
+      nextIndexToUpdate.remove(existingIndex);
     }
+
+    existingIndexes.put(fieldIndex.getIndexId(), fieldIndex);
+    nextIndexToUpdate.add(fieldIndex);
+    memoizedMaxIndexId = Math.max(memoizedMaxIndexId, fieldIndex.getIndexId());
+    memoizedMaxSequenceNumber =
+        Math.max(memoizedMaxSequenceNumber, fieldIndex.getIndexState().getSequenceNumber());
   }
 
   /**
    * If applicable, writes index entries for the given document. Returns whether any index entry was
    * written.
    */
-  private boolean writeEntries(Document document, FieldIndex fieldIndex) {
+  private void writeEntries(Document document, FieldIndex fieldIndex) {
     @Nullable byte[] directionalValue = encodeDirectionalElements(fieldIndex, document);
     if (directionalValue == null) {
-      return false;
+      return;
     }
 
     @Nullable FieldIndex.Segment arraySegment = fieldIndex.getArraySegment();
     if (arraySegment != null) {
       Value value = document.getField(arraySegment.getFieldPath());
       if (!isArray(value)) {
-        return false;
+        return;
       }
 
       for (Value arrayValue : value.getArrayValue().getValuesList()) {
         addSingleEntry(
             document, fieldIndex.getIndexId(), encodeSingleElement(arrayValue), directionalValue);
       }
-      return true;
     } else {
       addSingleEntry(document, fieldIndex.getIndexId(), /* arrayValue= */ null, directionalValue);
-      return true;
     }
   }
 
@@ -350,17 +304,8 @@ final class SQLiteIndexManager implements IndexManager {
    * @param fieldIndexes A list of field indexes to apply.
    */
   private void addIndexEntry(Document document, Collection<FieldIndex> fieldIndexes) {
-    List<FieldIndex> updatedIndexes = new ArrayList<>();
-
     for (FieldIndex fieldIndex : fieldIndexes) {
-      boolean modified = writeEntries(document, fieldIndex);
-      if (modified) {
-        updatedIndexes.add(getPostUpdateIndex(fieldIndex, document.getVersion()));
-      }
-    }
-
-    for (FieldIndex updatedIndex : updatedIndexes) {
-      updateFieldIndex(updatedIndex);
+      writeEntries(document, fieldIndex);
     }
   }
 
@@ -663,14 +608,27 @@ final class SQLiteIndexManager implements IndexManager {
     return serializer.encodeFieldIndexSegments(fieldIndex.getSegments()).toByteArray();
   }
 
-  @VisibleForTesting
-  void setCollectionGroupUpdateTime(String collectionGroup, Timestamp updateTime) {
-    db.execute(
-        "INSERT OR REPLACE INTO collection_group_update_times "
-            + "(collection_group, update_time_seconds, update_time_nanos) "
-            + "VALUES (?, ?, ?)",
-        collectionGroup,
-        updateTime.getSeconds(),
-        updateTime.getNanoseconds());
+  @Override
+  public void updateCollectionGroup(
+      String collectionGroup, long sequenceNumber, SnapshotVersion readTime) {
+    hardAssert(started, "IndexManager not started");
+
+    for (FieldIndex fieldIndex : getFieldIndexes(collectionGroup)) {
+      FieldIndex updatedIndex =
+          FieldIndex.create(
+              fieldIndex.getIndexId(),
+              fieldIndex.getCollectionGroup(),
+              fieldIndex.getSegments(),
+              FieldIndex.IndexState.create(sequenceNumber, readTime));
+      db.execute(
+          "REPLACE INTO index_state (index_id, uid,  sequence_number, "
+              + "read_time_seconds, read_time_nanos) VALUES(?, ?, ?, ?, ?)",
+          collectionGroup,
+          user.getUid(),
+          sequenceNumber,
+          readTime.getTimestamp().getSeconds(),
+          readTime.getTimestamp().getNanoseconds());
+      memoizeIndex(updatedIndex);
+    }
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteIndexManager.java
@@ -624,7 +624,7 @@ final class SQLiteIndexManager implements IndexManager {
       db.execute(
           "REPLACE INTO index_state (index_id, uid,  sequence_number, "
               + "read_time_seconds, read_time_nanos) VALUES(?, ?, ?, ?, ?)",
-          collectionGroup,
+          fieldIndex.getIndexId(),
           uid,
           memoizedMaxSequenceNumber,
           readTime.getTimestamp().getSeconds(),

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -217,6 +217,17 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
     return matchingDocuments[0];
   }
 
+  @Override
+  public SnapshotVersion getLatestReadTime() {
+    SnapshotVersion latestReadTime =
+        db.query(
+                "SELECT read_time_seconds, read_time_nanos "
+                    + "FROM remote_documents ORDER BY read_time_seconds DESC, read_time_nanos DESC "
+                    + "LIMIT 1")
+            .firstValue(row -> new SnapshotVersion(new Timestamp(row.getLong(0), row.getInt(1))));
+    return latestReadTime != null ? latestReadTime : SnapshotVersion.NONE;
+  }
+
   private String pathForKey(DocumentKey key) {
     return EncodedPath.encode(key.getPath());
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -193,7 +193,6 @@ class SQLiteSchema {
     if (fromVersion < INDEXING_SUPPORT_VERSION && toVersion >= INDEXING_SUPPORT_VERSION) {
       Preconditions.checkState(Persistence.INDEXING_SUPPORT_ENABLED);
       createFieldIndex();
-      createCollectionGroupsTable();
     }
   }
 
@@ -365,45 +364,39 @@ class SQLiteSchema {
    */
   private void createFieldIndex() {
     ifTablesDontExist(
-        new String[] {"index_configuration", "index_entries"},
+        new String[] {"index_configuration", "index_state", "collection_state", "index_entries"},
         () -> {
-          // TODO(indexing): Do we need to store a different update time per user? We need to ensure
-          // that we index mutations entries for all users.
+          // Global configuration for all existing indices
           db.execSQL(
               "CREATE TABLE index_configuration ("
                   + "index_id INTEGER, "
                   + "collection_group TEXT, "
                   + "index_proto BLOB, " // V1 Admin index proto
-                  + "active INTEGER, " // whether index is active
-                  + "update_time_seconds INTEGER, " // time of last document update added to index
-                  + "update_time_nanos INTEGER, "
                   + "PRIMARY KEY (index_id))");
 
-          // The index entries table only has a single primary index. `array_value` should be set
-          // for all queries.
+          // Per index per user state to track the backfill state for each index
+          db.execSQL(
+              "CREATE TABLE index_state ("
+                  + "uid TEXT, "
+                  + "index_id INTEGER, " // Name of the collection group.
+                  + "sequence_number INTEGER, " // Specifies the order of updates
+                  + "read_time_seconds INTEGER, " // Time of last index backfill update
+                  + "read_time_nanos INTEGER, "
+                  + "PRIMARY KEY (uid, index_id))");
+
+          // The index entries stores the encoded entries for all fields. The table only has a
+          // single primary index. `array_value` should be set for all queries.
           db.execSQL(
               "CREATE TABLE index_entries ("
+                  + "uid TEXT, " // user id
                   + "index_id INTEGER, " // The index_id of the field index creating this entry
                   + "array_value BLOB, " // index values for ArrayContains/ArrayContainsAny
                   + "directional_value BLOB, " // index values for equality and inequalities
-                  + "uid TEXT, " // user id or null if there are no pending mutations
                   + "document_name TEXT, "
-                  + "PRIMARY KEY (index_id, array_value, directional_value, uid, document_name))");
-        });
-  }
+                  + "PRIMARY KEY (uid, index_id, array_value, directional_value, document_name))");
 
-  // TODO(indexing): Consolidate this table with the `collection_parents` table and figure out
-  // GC strategy.
-  private void createCollectionGroupsTable() {
-    ifTablesDontExist(
-        new String[] {"collection_group_update_times"},
-        () -> {
           db.execSQL(
-              "CREATE TABLE collection_group_update_times ("
-                  + "collection_group TEXT, " // Name of the collection group.
-                  + "update_time_seconds INTEGER," // Time of last index backfill update
-                  + "update_time_nanos INTEGER,"
-                  + "PRIMARY KEY (collection_group))");
+              "CREATE INDEX read_time ON remote_documents(read_time_seconds, read_time_nanos)");
         });
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -364,9 +364,9 @@ class SQLiteSchema {
    */
   private void createFieldIndex() {
     ifTablesDontExist(
-        new String[] {"index_configuration", "index_state", "collection_state", "index_entries"},
+        new String[] {"index_configuration", "index_state", "index_entries"},
         () -> {
-          // Global configuration for all existing indices
+          // Global configuration for all existing field indexes
           db.execSQL(
               "CREATE TABLE index_configuration ("
                   + "index_id INTEGER, "
@@ -378,14 +378,14 @@ class SQLiteSchema {
           db.execSQL(
               "CREATE TABLE index_state ("
                   + "uid TEXT, "
-                  + "index_id INTEGER, " // Name of the collection group.
+                  + "index_id INTEGER, "
                   + "sequence_number INTEGER, " // Specifies the order of updates
-                  + "read_time_seconds INTEGER, " // Time of last index backfill update
+                  + "read_time_seconds INTEGER, " // Read time of last processed document
                   + "read_time_nanos INTEGER, "
                   + "PRIMARY KEY (uid, index_id))");
 
-          // The index entries stores the encoded entries for all fields. The table only has a
-          // single primary index. `array_value` should be set for all queries.
+          // The index entry table stores the encoded entries for all fields.
+          // The table only has a single primary index. `array_value` should be set for all queries.
           db.execSQL(
               "CREATE TABLE index_entries ("
                   + "uid TEXT, " // user id

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
@@ -81,9 +81,29 @@ public abstract class FieldIndex {
     }
   }
 
+  /** Stores the "high water mark" that indicates how updated the Index is for the current user. */
+  @AutoValue
+  public abstract static class IndexState {
+    public static IndexState DEFAULT = create(0, SnapshotVersion.NONE);
+
+    public static IndexState create(long sequenceNumber, SnapshotVersion readTime) {
+      return new AutoValue_FieldIndex_IndexState(sequenceNumber, readTime);
+    }
+
+    /**
+     * Returns a number that indicates when the index was last updated (relative to other indexes).
+     */
+    public abstract long getSequenceNumber();
+
+    /**
+     * Returns the latest read time version that has been indexed by Firestore for this field index.
+     */
+    public abstract SnapshotVersion getReadTime();
+  }
+
   public static FieldIndex create(
-      int indexId, String collectionGroup, List<Segment> segments, SnapshotVersion updateTime) {
-    return new AutoValue_FieldIndex(indexId, collectionGroup, segments, updateTime);
+      int indexId, String collectionGroup, List<Segment> segments, IndexState indexState) {
+    return new AutoValue_FieldIndex(indexId, collectionGroup, segments, indexState);
   }
 
   /**
@@ -98,8 +118,8 @@ public abstract class FieldIndex {
   /** Returns all field segments for this index. */
   public abstract List<Segment> getSegments();
 
-  /** Returns when this index was last updated. */
-  public abstract SnapshotVersion getUpdateTime();
+  /** Returns how up-to-date the index is for the current user. */
+  public abstract IndexState getIndexState();
 
   /** Returns all directional (ascending/descending) segments for this index. */
   public List<Segment> getDirectionalSegments() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
@@ -35,6 +35,16 @@ import java.util.List;
 @AutoValue
 public abstract class FieldIndex {
 
+  /** An ID for an index that has not yet been added to persistence. */
+  public static final int UNKNOWN_ID = -1;
+
+  /** The initial sequence number for each index. Gets updated during index backfill. */
+  public static final int INITIAL_SEQUENCE_NUMBER = 0;
+
+  /** The state of an index that has not yet been backfilled. */
+  public static IndexState INITIAL_STATE =
+      IndexState.create(INITIAL_SEQUENCE_NUMBER, SnapshotVersion.NONE);
+
   /** Compares indexes by collection group and segments. Ignores update time and index ID. */
   public static final Comparator<FieldIndex> SEMANTIC_COMPARATOR =
       (left, right) -> {
@@ -84,8 +94,6 @@ public abstract class FieldIndex {
   /** Stores the "high water mark" that indicates how updated the Index is for the current user. */
   @AutoValue
   public abstract static class IndexState {
-    public static IndexState DEFAULT = create(0, SnapshotVersion.NONE);
-
     public static IndexState create(long sequenceNumber, SnapshotVersion readTime) {
       return new AutoValue_FieldIndex_IndexState(sequenceNumber, readTime);
     }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/CountingQueryEngine.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/CountingQueryEngine.java
@@ -156,6 +156,11 @@ class CountingQueryEngine implements QueryEngine {
         documentsReadByQuery[0] += result.size();
         return result;
       }
+
+      @Override
+      public SnapshotVersion getLatestReadTime() {
+        return subject.getLatestReadTime();
+      }
     };
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
@@ -251,7 +251,7 @@ public class IndexBackfillerTest {
         fieldIndex(
             collectionGroup,
             FieldIndex.UNKNOWN_ID,
-            FieldIndex.INITIAL_STATE,
+            FieldIndex.IndexState.create(0, version),
             fieldName,
             FieldIndex.Segment.Kind.ASCENDING);
     indexManager.addFieldIndex(fieldIndex);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
@@ -195,8 +195,7 @@ public class IndexBackfillerTest {
     IndexBackfiller.Results results = backfiller.backfill();
     assertEquals(2, results.getDocumentsProcessed());
 
-    // Check that index entries are written in order of the collection group update times by
-    // verifying the collection group update times have been updated in the correct order.
+    // Check that coll1 was backfilled and that coll2 is next
     collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll2", collectionGroup);
   }
@@ -251,8 +250,8 @@ public class IndexBackfillerTest {
     FieldIndex fieldIndex =
         fieldIndex(
             collectionGroup,
-            -1,
-            FieldIndex.IndexState.create(0, version),
+            FieldIndex.UNKNOWN_ID,
+            FieldIndex.INITIAL_STATE,
             fieldName,
             FieldIndex.Segment.Kind.ASCENDING);
     indexManager.addFieldIndex(fieldIndex);
@@ -262,7 +261,7 @@ public class IndexBackfillerTest {
     FieldIndex fieldIndex =
         fieldIndex(
             collectionGroup,
-            -1,
+            FieldIndex.UNKNOWN_ID,
             FieldIndex.IndexState.create(sequenceNumber, SnapshotVersion.NONE),
             fieldName,
             FieldIndex.Segment.Kind.ASCENDING);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
@@ -189,7 +189,7 @@ public class IndexBackfillerTest {
     addDoc("coll1/docB", "foo", version(20));
     addDoc("coll2/docA", "foo", version(30));
 
-    String collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    String collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll1", collectionGroup);
 
     IndexBackfiller.Results results = backfiller.backfill();
@@ -197,7 +197,7 @@ public class IndexBackfillerTest {
 
     // Check that index entries are written in order of the collection group update times by
     // verifying the collection group update times have been updated in the correct order.
-    collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll2", collectionGroup);
   }
 
@@ -216,7 +216,7 @@ public class IndexBackfillerTest {
     addDoc("coll3/doc", "foo", version(30));
 
     // Check that coll3 is the next collection ID the backfiller should update
-    assertEquals("coll3", indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE));
+    assertEquals("coll3", indexManager.getNextCollectionGroupToUpdate());
 
     IndexBackfiller.Results results = backfiller.backfill();
     assertEquals(1, results.getDocumentsProcessed());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
@@ -15,32 +15,29 @@
 package com.google.firebase.firestore.local;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.firebase.firestore.local.SQLiteIndexManagerTest.getCollectionGroupsOrderByUpdateTime;
 import static com.google.firebase.firestore.testutil.TestUtil.doc;
 import static com.google.firebase.firestore.testutil.TestUtil.fieldIndex;
-import static com.google.firebase.firestore.testutil.TestUtil.key;
 import static com.google.firebase.firestore.testutil.TestUtil.map;
 import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
 import static com.google.firebase.firestore.testutil.TestUtil.query;
 import static com.google.firebase.firestore.testutil.TestUtil.version;
 import static junit.framework.TestCase.assertEquals;
 
-import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.core.Target;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.MutableDocument;
 import com.google.firebase.firestore.model.SnapshotVersion;
+import com.google.firebase.firestore.testutil.TestUtil;
 import com.google.firebase.firestore.util.AsyncQueue;
+import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -95,26 +92,24 @@ public class IndexBackfillerTest {
     persistence.shutdown();
   }
 
-  // TODO(indexing): Re-enable this test once we have counters implemented.
   @Test
-  @Ignore
   public void testBackfillWritesLatestReadTimeToFieldIndexOnCompletion() {
     addFieldIndex("coll1", "foo");
     addFieldIndex("coll2", "bar");
-    addDoc("coll1/docA", "foo", version(10, 0));
-    addDoc("coll2/docA", "bar", version(20, 0));
+    addDoc("coll1/docA", "foo", version(10));
+    addDoc("coll2/docA", "bar", version(20));
 
     IndexBackfiller.Results results = backfiller.backfill();
     assertEquals(2, results.getDocumentsProcessed());
 
     FieldIndex fieldIndex1 = indexManager.getFieldIndexes("coll1").iterator().next();
     FieldIndex fieldIndex2 = indexManager.getFieldIndexes("coll2").iterator().next();
-    assertEquals(version(10, 0), fieldIndex1.getUpdateTime());
-    assertEquals(version(20, 0), fieldIndex2.getUpdateTime());
+    assertEquals(version(10), fieldIndex1.getIndexState().getReadTime());
+    assertEquals(version(20), fieldIndex2.getIndexState().getReadTime());
 
     addDoc("coll1/docB", "foo", version(50, 10));
-    addDoc("coll1/docC", "foo", version(50, 0));
-    addDoc("coll2/docB", "bar", version(60, 0));
+    addDoc("coll1/docC", "foo", version(50));
+    addDoc("coll2/docB", "bar", version(60));
     addDoc("coll2/docC", "bar", version(60, 10));
 
     results = backfiller.backfill();
@@ -122,43 +117,41 @@ public class IndexBackfillerTest {
 
     fieldIndex1 = indexManager.getFieldIndexes("coll1").iterator().next();
     fieldIndex2 = indexManager.getFieldIndexes("coll2").iterator().next();
-    assertEquals(version(50, 10), fieldIndex1.getUpdateTime());
-    assertEquals(version(60, 10), fieldIndex2.getUpdateTime());
+    assertEquals(version(50, 10), fieldIndex1.getIndexState().getReadTime());
+    assertEquals(version(60, 10), fieldIndex2.getIndexState().getReadTime());
   }
 
   @Test
-  @Ignore("Flaky")
-  // TODO(indexing): This test is flaky. Fix.
   public void testBackfillFetchesDocumentsAfterEarliestReadTime() {
-    addFieldIndex("coll1", "foo", version(10, 0));
-    addFieldIndex("coll1", "boo", version(20, 0));
-    addFieldIndex("coll1", "moo", version(30, 0));
+    addFieldIndex("coll1", "foo", version(10));
 
     // Documents before earliest read time should not be fetched.
-    addDoc("coll1/docA", "foo", version(9, 0));
+    addDoc("coll1/docA", "foo", version(9));
     IndexBackfiller.Results results = backfiller.backfill();
     assertEquals(0, results.getDocumentsProcessed());
 
+    // Read time of index should not change.
+    Iterator<FieldIndex> it = indexManager.getFieldIndexes("coll1").iterator();
+    assertEquals(version(10), it.next().getIndexState().getReadTime());
+
     // Documents that are after the earliest read time but before field index read time are fetched.
-    addDoc("coll1/docB", "boo", version(19, 0));
+    addDoc("coll1/docB", "boo", version(19));
     results = backfiller.backfill();
     assertEquals(1, results.getDocumentsProcessed());
 
-    // Field indexes should still hold the latest read time.
-    Iterator<FieldIndex> it = indexManager.getFieldIndexes("coll1").iterator();
-    assertEquals(version(10, 0), it.next().getUpdateTime());
-    assertEquals(version(20, 0), it.next().getUpdateTime());
-    assertEquals(version(30, 0), it.next().getUpdateTime());
+    // Field indexes should now hold the latest read time
+    it = indexManager.getFieldIndexes("coll1").iterator();
+    assertEquals(version(19), it.next().getIndexState().getReadTime());
   }
 
   @Test
   public void testBackfillWritesIndexEntries() {
     addFieldIndex("coll1", "foo");
     addFieldIndex("coll2", "bar");
-    addDoc("coll1/docA", "foo", version(10, 0));
-    addDoc("coll1/docB", "boo", version(10, 0));
-    addDoc("coll2/docA", "bar", version(10, 0));
-    addDoc("coll2/docB", "car", version(10, 0));
+    addDoc("coll1/docA", "foo", version(10));
+    addDoc("coll1/docB", "boo", version(10));
+    addDoc("coll2/docA", "bar", version(10));
+    addDoc("coll2/docB", "car", version(10));
 
     IndexBackfiller.Results results = backfiller.backfill();
     assertEquals(4, results.getDocumentsProcessed());
@@ -170,75 +163,65 @@ public class IndexBackfillerTest {
 
     addFieldIndex("coll1", "foo");
     Target target = query("coll1").orderBy(orderBy("foo")).toTarget();
-    addDoc("coll1/docA", "foo", version(5, 0));
-    addDoc("coll1/docB", "foo", version(3, 0));
-    addDoc("coll1/docC", "foo", version(10, 0));
+    addDoc("coll1/docA", "foo", version(5));
+    addDoc("coll1/docB", "foo", version(3));
+    addDoc("coll1/docC", "foo", version(10));
 
     IndexBackfiller.Results results = backfiller.backfill();
     assertEquals(2, results.getDocumentsProcessed());
 
-    FieldIndex persistedIndex = indexManager.getFieldIndex(target);
-    Set<DocumentKey> keys = indexManager.getDocumentsMatchingTarget(persistedIndex, target);
-    assertThat(keys).contains(key("coll1/docA"));
-    assertThat(keys).contains(key("coll1/docB"));
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB");
 
     results = backfiller.backfill();
     assertEquals(1, results.getDocumentsProcessed());
 
-    keys = indexManager.getDocumentsMatchingTarget(persistedIndex, query("coll1").toTarget());
-    assertThat(keys).contains(key("coll1/docA"));
-    assertThat(keys).contains(key("coll1/docB"));
-    assertThat(keys).contains(key("coll1/docC"));
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB", "coll1/docC");
   }
 
   @Test
-  @Ignore("Flaky")
-  // TODO(indexing): This test is flaky. Fix.
   public void testBackfillUpdatesCollectionGroups() {
+    backfiller.setMaxDocumentsToProcess(2);
+
     addFieldIndex("coll1", "foo");
     addFieldIndex("coll2", "foo");
-    addFieldIndex("coll3", "foo");
-    addCollectionGroup("coll1", new Timestamp(30, 0));
-    addCollectionGroup("coll2", new Timestamp(30, 30));
-    addCollectionGroup("coll3", new Timestamp(10, 0));
-    addDoc("coll1/docA", "foo", version(10, 0));
-    addDoc("coll2/docA", "foo", version(10, 0));
-    addDoc("coll3/docA", "foo", version(10, 0));
+
+    addDoc("coll1/docA", "foo", version(10));
+    addDoc("coll1/docB", "foo", version(20));
+    addDoc("coll2/docA", "foo", version(30));
+
+    String collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    assertEquals("coll1", collectionGroup);
 
     IndexBackfiller.Results results = backfiller.backfill();
-    assertEquals(3, results.getDocumentsProcessed());
+    assertEquals(2, results.getDocumentsProcessed());
 
     // Check that index entries are written in order of the collection group update times by
     // verifying the collection group update times have been updated in the correct order.
-    List<String> collectionGroups = getCollectionGroupsOrderByUpdateTime(persistence);
-    assertEquals(3, collectionGroups.size());
-    assertEquals("coll3", collectionGroups.get(0));
-    assertEquals("coll1", collectionGroups.get(1));
-    assertEquals("coll2", collectionGroups.get(2));
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    assertEquals("coll2", collectionGroup);
   }
 
   @Test
-  @Ignore("Flaky")
-  // TODO(indexing): This test is flaky. Fix.
   public void testBackfillPrioritizesNewCollectionGroups() {
+    backfiller.setMaxDocumentsToProcess(1);
+
     // In this test case, `coll3` is a new collection group that hasn't been indexed, so it should
     // be processed ahead of the other collection groups.
-    addFieldIndex("coll1", "foo");
-    addFieldIndex("coll2", "foo");
-    addCollectionGroup("coll1", new Timestamp(1, 0));
-    addCollectionGroup("coll2", new Timestamp(2, 0));
-    addFieldIndex("coll3", "foo");
+    addFieldIndex("coll1", "foo", /* sequenceNumber= */ 1);
+    addFieldIndex("coll2", "foo", /* sequenceNumber= */ 2);
+    addFieldIndex("coll3", "foo", /* sequenceNumber= */ 0);
+
+    addDoc("coll1/doc", "foo", version(10));
+    addDoc("coll2/doc", "foo", version(20));
+    addDoc("coll3/doc", "foo", version(30));
+
+    // Check that coll3 is the next collection ID the backfiller should update
+    assertEquals("coll3", indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE));
 
     IndexBackfiller.Results results = backfiller.backfill();
-    assertEquals(0, results.getDocumentsProcessed());
+    assertEquals(1, results.getDocumentsProcessed());
 
-    // Check that index entries are written in order of the collection group update times by
-    // verifying the collection group update times have been updated in the correct order.
-    List<String> collectionGroups = getCollectionGroupsOrderByUpdateTime(persistence);
-    assertEquals(3, collectionGroups.size());
-    assertEquals("coll3", collectionGroups.get(0));
-    assertEquals("coll1", collectionGroups.get(1));
-    assertEquals("coll2", collectionGroups.get(2));
+    verifyQueryResults("coll3", "coll3/doc");
   }
 
   @Test
@@ -246,22 +229,16 @@ public class IndexBackfillerTest {
     backfiller.setMaxDocumentsToProcess(3);
     addFieldIndex("coll1", "foo");
     addFieldIndex("coll2", "foo");
-    addCollectionGroup("coll1", new Timestamp(1, 0));
-    addDoc("coll1/docA", "foo", version(10, 0));
-    addDoc("coll1/docB", "foo", version(10, 0));
-    addDoc("coll2/docA", "foo", version(10, 0));
-    addDoc("coll2/docB", "foo", version(10, 0));
+    addDoc("coll1/docA", "foo", version(10));
+    addDoc("coll1/docB", "foo", version(20));
+    addDoc("coll2/docA", "foo", version(30));
+    addDoc("coll2/docA", "foo", version(40));
 
     IndexBackfiller.Results results = backfiller.backfill();
     assertEquals(3, results.getDocumentsProcessed());
 
-    // Check that collection groups are updated even if the backfiller hits the write cap. Since
-    // `coll1` was already in the table, `coll2` should be processed first, and thus appear first
-    // in the ordering.
-    List<String> collectionGroups = getCollectionGroupsOrderByUpdateTime(persistence);
-    assertEquals(2, collectionGroups.size());
-    assertEquals("coll2", collectionGroups.get(0));
-    assertEquals("coll1", collectionGroups.get(1));
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB");
+    verifyQueryResults("coll2", "coll2/docA");
   }
 
   private void addFieldIndex(String collectionGroup, String fieldName) {
@@ -270,14 +247,34 @@ public class IndexBackfillerTest {
     indexManager.addFieldIndex(fieldIndex);
   }
 
-  private void addFieldIndex(String collectionGroup, String fieldName, SnapshotVersion readTime) {
+  private void addFieldIndex(String collectionGroup, String fieldName, SnapshotVersion version) {
     FieldIndex fieldIndex =
-        fieldIndex(collectionGroup, -1, readTime, fieldName, FieldIndex.Segment.Kind.ASCENDING);
+        fieldIndex(
+            collectionGroup,
+            -1,
+            FieldIndex.IndexState.create(0, version),
+            fieldName,
+            FieldIndex.Segment.Kind.ASCENDING);
     indexManager.addFieldIndex(fieldIndex);
   }
 
-  private void addCollectionGroup(String collectionGroup, Timestamp updateTime) {
-    indexManager.setCollectionGroupUpdateTime(collectionGroup, updateTime);
+  private void addFieldIndex(String collectionGroup, String fieldName, long sequenceNumber) {
+    FieldIndex fieldIndex =
+        fieldIndex(
+            collectionGroup,
+            -1,
+            FieldIndex.IndexState.create(sequenceNumber, SnapshotVersion.NONE),
+            fieldName,
+            FieldIndex.Segment.Kind.ASCENDING);
+    indexManager.addFieldIndex(fieldIndex);
+  }
+
+  private void verifyQueryResults(String collectionGroup, String... expectedKeys) {
+    Target target = query(collectionGroup).orderBy(orderBy("foo")).toTarget();
+    FieldIndex persistedIndex = indexManager.getFieldIndex(target);
+    Set<DocumentKey> actualKeys = indexManager.getDocumentsMatchingTarget(persistedIndex, target);
+    assertThat(actualKeys)
+        .containsExactlyElementsIn(Arrays.stream(expectedKeys).map(TestUtil::key).toArray());
   }
 
   /** Creates a document and adds it to the RemoteDocumentCache. */

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexingEnabledSQLiteLocalStoreTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexingEnabledSQLiteLocalStoreTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.firestore.testutil.TestUtil.fieldIndex;
 
 import com.google.firebase.firestore.model.FieldIndex;
-import com.google.firebase.firestore.model.FieldIndex.IndexState;
 import com.google.firebase.firestore.model.FieldIndex.Segment.Kind;
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,10 +45,10 @@ public class IndexingEnabledSQLiteLocalStoreTest extends SQLiteLocalStoreTest {
 
   @Test
   public void testConfiguresIndexes() {
-    FieldIndex indexA = fieldIndex("coll", 0, IndexState.DEFAULT, "a", Kind.ASCENDING);
-    FieldIndex indexB = fieldIndex("coll", 1, IndexState.DEFAULT, "b", Kind.DESCENDING);
+    FieldIndex indexA = fieldIndex("coll", 0, FieldIndex.INITIAL_STATE, "a", Kind.ASCENDING);
+    FieldIndex indexB = fieldIndex("coll", 1, FieldIndex.INITIAL_STATE, "b", Kind.DESCENDING);
     FieldIndex indexC =
-        fieldIndex("coll", 2, IndexState.DEFAULT, "c1", Kind.ASCENDING, "c2", Kind.CONTAINS);
+        fieldIndex("coll", 2, FieldIndex.INITIAL_STATE, "c1", Kind.ASCENDING, "c2", Kind.CONTAINS);
 
     configureFieldIndexes(Arrays.asList(indexA, indexB));
     Collection<FieldIndex> fieldIndexes = getFieldIndexes();

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexingEnabledSQLiteLocalStoreTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexingEnabledSQLiteLocalStoreTest.java
@@ -18,7 +18,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.firestore.testutil.TestUtil.fieldIndex;
 
 import com.google.firebase.firestore.model.FieldIndex;
-import com.google.firebase.firestore.model.SnapshotVersion;
+import com.google.firebase.firestore.model.FieldIndex.IndexState;
+import com.google.firebase.firestore.model.FieldIndex.Segment.Kind;
 import java.util.Arrays;
 import java.util.Collection;
 import org.junit.BeforeClass;
@@ -45,19 +46,10 @@ public class IndexingEnabledSQLiteLocalStoreTest extends SQLiteLocalStoreTest {
 
   @Test
   public void testConfiguresIndexes() {
-    FieldIndex indexA =
-        fieldIndex("coll", 0, SnapshotVersion.NONE, "a", FieldIndex.Segment.Kind.ASCENDING);
-    FieldIndex indexB =
-        fieldIndex("coll", 1, SnapshotVersion.NONE, "b", FieldIndex.Segment.Kind.DESCENDING);
+    FieldIndex indexA = fieldIndex("coll", 0, IndexState.DEFAULT, "a", Kind.ASCENDING);
+    FieldIndex indexB = fieldIndex("coll", 1, IndexState.DEFAULT, "b", Kind.DESCENDING);
     FieldIndex indexC =
-        fieldIndex(
-            "coll",
-            2,
-            SnapshotVersion.NONE,
-            "c1",
-            FieldIndex.Segment.Kind.ASCENDING,
-            "c2",
-            FieldIndex.Segment.Kind.CONTAINS);
+        fieldIndex("coll", 2, IndexState.DEFAULT, "c1", Kind.ASCENDING, "c2", Kind.CONTAINS);
 
     configureFieldIndexes(Arrays.asList(indexA, indexB));
     Collection<FieldIndex> fieldIndexes = getFieldIndexes();

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
@@ -212,6 +212,24 @@ abstract class RemoteDocumentCacheTestCase {
     assertEquals(expected, values(results));
   }
 
+  @Test
+  public void testLatestReadTime() {
+    SnapshotVersion latestReadTime = remoteDocumentCache.getLatestReadTime();
+    assertEquals(SnapshotVersion.NONE, latestReadTime);
+
+    addTestDocumentAtPath("coll/a", /* updateTime= */ 0, /* readTime= */ 1);
+    latestReadTime = remoteDocumentCache.getLatestReadTime();
+    assertEquals(version(1), latestReadTime);
+
+    addTestDocumentAtPath("coll/b", /* updateTime= */ 0, /* readTime= */ 3);
+    latestReadTime = remoteDocumentCache.getLatestReadTime();
+    assertEquals(version(3), latestReadTime);
+
+    addTestDocumentAtPath("coll/c", /* updateTime= */ 0, /* readTime= */ 2);
+    latestReadTime = remoteDocumentCache.getLatestReadTime();
+    assertEquals(version(3), latestReadTime);
+  }
+
   private MutableDocument addTestDocumentAtPath(String path) {
     return addTestDocumentAtPath(path, 42, 42);
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
@@ -584,16 +584,16 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   @Test
   public void testGetFieldIndexes() {
     indexManager.addFieldIndex(
-        fieldIndex("coll1", 1, IndexState.DEFAULT, "value", Kind.ASCENDING));
+        fieldIndex("coll1", 1, FieldIndex.INITIAL_STATE, "value", Kind.ASCENDING));
     indexManager.addFieldIndex(
-        fieldIndex("coll2", 2, IndexState.DEFAULT, "value", Kind.CONTAINS));
+        fieldIndex("coll2", 2, FieldIndex.INITIAL_STATE, "value", Kind.CONTAINS));
 
     Collection<FieldIndex> indexes = indexManager.getFieldIndexes("coll1");
     assertEquals(indexes.size(), 1);
     Iterator<FieldIndex> it = indexes.iterator();
     assertEquals(it.next().getCollectionGroup(), "coll1");
     indexManager.addFieldIndex(
-        fieldIndex("coll1", 3, IndexState.DEFAULT, "newValue", Kind.CONTAINS));
+        fieldIndex("coll1", 3, FieldIndex.INITIAL_STATE, "newValue", Kind.CONTAINS));
 
     indexes = indexManager.getFieldIndexes("coll1");
     assertEquals(indexes.size(), 2);
@@ -622,8 +622,8 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
     indexManager.start();
 
     // Add two indexes and mark one as updated.
-    indexManager.addFieldIndex(fieldIndex("coll1", 1, IndexState.DEFAULT));
-    indexManager.addFieldIndex(fieldIndex("coll2", 2, IndexState.DEFAULT));
+    indexManager.addFieldIndex(fieldIndex("coll1", 1, FieldIndex.INITIAL_STATE));
+    indexManager.addFieldIndex(fieldIndex("coll2", 2, FieldIndex.INITIAL_STATE));
     indexManager.updateCollectionGroup("coll1", version(1));
 
     verifySequenceNumber(indexManager, "coll1", 1);
@@ -635,7 +635,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
     indexManager.start();
 
     // Add a new index and mark it as updated.
-    indexManager.addFieldIndex(fieldIndex("coll3", 2, IndexState.DEFAULT));
+    indexManager.addFieldIndex(fieldIndex("coll3", 2, FieldIndex.INITIAL_STATE));
     indexManager.updateCollectionGroup("coll3", version(2));
 
     verifySequenceNumber(indexManager, "coll1", 0);
@@ -651,8 +651,16 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
     verifySequenceNumber(indexManager, "coll3", 0);
   }
 
-  private void verifySequenceNumber(IndexManager indexManager, String collectionGroup, int expectedSequnceNumber) {
-    assertEquals(expectedSequnceNumber, indexManager.getFieldIndexes(collectionGroup).iterator().next().getIndexState().getSequenceNumber());
+  private void verifySequenceNumber(
+      IndexManager indexManager, String collectionGroup, int expectedSequnceNumber) {
+    assertEquals(
+        expectedSequnceNumber,
+        indexManager
+            .getFieldIndexes(collectionGroup)
+            .iterator()
+            .next()
+            .getIndexState()
+            .getSequenceNumber());
   }
 
   private void addDoc(String key, Map<String, Object> data) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
@@ -15,6 +15,8 @@
 package com.google.firebase.firestore.local;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.firebase.firestore.model.FieldIndex.IndexState;
+import static com.google.firebase.firestore.model.FieldIndex.Segment.Kind;
 import static com.google.firebase.firestore.testutil.TestUtil.bound;
 import static com.google.firebase.firestore.testutil.TestUtil.doc;
 import static com.google.firebase.firestore.testutil.TestUtil.fieldIndex;
@@ -29,13 +31,11 @@ import static com.google.firebase.firestore.testutil.TestUtil.wrap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.core.Target;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.MutableDocument;
-import com.google.firebase.firestore.model.SnapshotVersion;
 import com.google.firebase.firestore.model.Values;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,14 +68,14 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   }
 
   private void setUpSingleValueFilter() {
-    indexManager.addFieldIndex(fieldIndex("coll", "count", FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "count", Kind.ASCENDING));
     addDoc("coll/doc1", map("count", 1));
     addDoc("coll/doc2", map("count", 2));
     addDoc("coll/doc3", map("count", 3));
   }
 
   private void setUpArrayValueFilter() {
-    indexManager.addFieldIndex(fieldIndex("coll", "values", FieldIndex.Segment.Kind.CONTAINS));
+    indexManager.addFieldIndex(fieldIndex("coll", "values", Kind.CONTAINS));
     addDoc("coll/doc1", map("values", Arrays.asList(1, 2, 3)));
     addDoc("coll/doc2", map("values", Arrays.asList(4, 5, 6)));
     addDoc("coll/doc3", map("values", Arrays.asList(7, 8, 9)));
@@ -91,7 +91,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
 
   @Test
   public void addsDocuments() {
-    indexManager.addFieldIndex(fieldIndex("coll", "exists", FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "exists", Kind.ASCENDING));
     addDoc("coll/doc1", map("exists", 1));
     addDoc("coll/doc2", map());
   }
@@ -105,7 +105,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
 
   @Test
   public void testNestedFieldEqualityFilter() {
-    indexManager.addFieldIndex(fieldIndex("coll", "a.b", FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "a.b", Kind.ASCENDING));
     addDoc("coll/doc1", map("a", map("b", 1)));
     addDoc("coll/doc2", map("a", map("b", 2)));
     Query query = query("coll").filter(filter("a.b", "==", 2));
@@ -251,7 +251,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
 
   @Test
   public void testEqualityFilterWithNonMatchingType() {
-    indexManager.addFieldIndex(fieldIndex("coll", "value", FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "value", Kind.ASCENDING));
     addDoc("coll/boolean", map("value", true));
     addDoc("coll/string", map("value", "true"));
     addDoc("coll/number", map("value", 1));
@@ -261,7 +261,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
 
   @Test
   public void testCollectionGroup() {
-    indexManager.addFieldIndex(fieldIndex("coll1", "value", FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll1", "value", Kind.ASCENDING));
     addDoc("coll1/doc1", map("value", true));
     addDoc("coll2/doc2/coll1/doc1", map("value", true));
     addDoc("coll2/doc2", map("value", true));
@@ -271,7 +271,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
 
   @Test
   public void testLimitFilter() {
-    indexManager.addFieldIndex(fieldIndex("coll", "value", FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "value", Kind.ASCENDING));
     addDoc("coll/doc1", map("value", 1));
     addDoc("coll/doc2", map("value", 1));
     addDoc("coll/doc3", map("value", 1));
@@ -281,13 +281,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
 
   @Test
   public void testLimitAppliesOrdering() {
-    indexManager.addFieldIndex(
-        fieldIndex(
-            "coll",
-            "value",
-            FieldIndex.Segment.Kind.CONTAINS,
-            "value",
-            FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "value", Kind.CONTAINS, "value", Kind.ASCENDING));
     addDoc("coll/doc1", map("value", Arrays.asList(1, "foo")));
     addDoc("coll/doc2", map("value", Arrays.asList(3, "foo")));
     addDoc("coll/doc3", map("value", Arrays.asList(2, "foo")));
@@ -303,60 +297,25 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   public void testAdvancedQueries() {
     // This test compares local query results with those received from the Java Server SDK.
 
-    indexManager.addFieldIndex(fieldIndex("coll", "null", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "int", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "float", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "string", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "multi", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "array", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "array", FieldIndex.Segment.Kind.DESCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "array", FieldIndex.Segment.Kind.CONTAINS));
-    indexManager.addFieldIndex(fieldIndex("coll", "map", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "map.field", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "prefix", FieldIndex.Segment.Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "null", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "int", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "float", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "string", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "multi", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "array", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "array", Kind.DESCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "array", Kind.CONTAINS));
+    indexManager.addFieldIndex(fieldIndex("coll", "map", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "map.field", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "prefix", Kind.ASCENDING));
     indexManager.addFieldIndex(
-        fieldIndex(
-            "coll",
-            "prefix",
-            FieldIndex.Segment.Kind.ASCENDING,
-            "suffix",
-            FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(fieldIndex("coll", "a", FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(
-        fieldIndex(
-            "coll",
-            "a",
-            FieldIndex.Segment.Kind.ASCENDING,
-            "b",
-            FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(
-        fieldIndex(
-            "coll",
-            "a",
-            FieldIndex.Segment.Kind.DESCENDING,
-            "b",
-            FieldIndex.Segment.Kind.ASCENDING));
-    indexManager.addFieldIndex(
-        fieldIndex(
-            "coll",
-            "a",
-            FieldIndex.Segment.Kind.ASCENDING,
-            "b",
-            FieldIndex.Segment.Kind.DESCENDING));
-    indexManager.addFieldIndex(
-        fieldIndex(
-            "coll",
-            "a",
-            FieldIndex.Segment.Kind.DESCENDING,
-            "b",
-            FieldIndex.Segment.Kind.DESCENDING));
-    indexManager.addFieldIndex(
-        fieldIndex(
-            "coll",
-            "b",
-            FieldIndex.Segment.Kind.ASCENDING,
-            "a",
-            FieldIndex.Segment.Kind.ASCENDING));
+        fieldIndex("coll", "prefix", Kind.ASCENDING, "suffix", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "a", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "a", Kind.ASCENDING, "b", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "a", Kind.DESCENDING, "b", Kind.ASCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "a", Kind.ASCENDING, "b", Kind.DESCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "a", Kind.DESCENDING, "b", Kind.DESCENDING));
+    indexManager.addFieldIndex(fieldIndex("coll", "b", Kind.ASCENDING, "a", Kind.ASCENDING));
 
     List<Map<String, Object>> data =
         new ArrayList<Map<String, Object>>() {
@@ -596,45 +555,59 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   @Test
   public void testUpdateTime() {
     indexManager.addFieldIndex(
-        fieldIndex("coll1", -1, version(20), "value", FieldIndex.Segment.Kind.ASCENDING));
+        fieldIndex("coll1", 1, IndexState.create(-1, version(20)), "value", Kind.ASCENDING));
 
     Collection<FieldIndex> indexes = indexManager.getFieldIndexes("coll1");
     assertEquals(indexes.size(), 1);
     FieldIndex index = indexes.iterator().next();
-    assertEquals(index.getUpdateTime(), version(20));
+    assertEquals(index.getIndexState().getReadTime(), version(20));
   }
 
   @Test
-  public void testCollectionGroupUpdateTimesCanBeUpdated() {
-    SQLiteIndexManager sqLiteIndexManager = (SQLiteIndexManager) indexManager;
-    sqLiteIndexManager.setCollectionGroupUpdateTime("coll1", new Timestamp(30, 0));
-    sqLiteIndexManager.setCollectionGroupUpdateTime("coll2", new Timestamp(30, 50));
-    List<String> orderedCollectionGroups =
-        getCollectionGroupsOrderByUpdateTime((SQLitePersistence) getPersistence());
-    List<String> expected = Arrays.asList("coll1", "coll2");
-    assertEquals(expected, orderedCollectionGroups);
+  public void testCollectionGroupSequenceNumbersCanBeUpdated() {
+    indexManager.addFieldIndex(fieldIndex("coll1"));
+    indexManager.addFieldIndex(fieldIndex("coll2"));
 
-    sqLiteIndexManager.setCollectionGroupUpdateTime("coll1", new Timestamp(50, 0));
-    orderedCollectionGroups =
-        getCollectionGroupsOrderByUpdateTime((SQLitePersistence) getPersistence());
-    expected = Arrays.asList("coll2", "coll1");
-    assertEquals(expected, orderedCollectionGroups);
+    indexManager.updateCollectionGroup("coll1", 3, version(0));
+    indexManager.updateCollectionGroup("coll2", 5, version(0));
+    String collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    assertEquals("coll1", collectionGroup);
+
+    indexManager.updateCollectionGroup("coll2", 4, version(0));
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    assertEquals("coll1", collectionGroup);
+
+    indexManager.updateCollectionGroup("coll2", 2, version(0));
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    assertEquals("coll2", collectionGroup);
+  }
+
+  @Test
+  public void testGetNextCollectionGroupIgnoresCurrentSequenceNumber() {
+    indexManager.addFieldIndex(fieldIndex("coll1"));
+
+    indexManager.updateCollectionGroup("coll1", 1, version(1));
+    String collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    assertEquals("coll1", collectionGroup);
+
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate(1);
+    assertNull(collectionGroup);
   }
 
   @Test
   public void testGetFieldIndexes() {
     SQLiteIndexManager sqLiteIndexManager = (SQLiteIndexManager) indexManager;
     sqLiteIndexManager.addFieldIndex(
-        fieldIndex("coll1", 1, version(30), "value", FieldIndex.Segment.Kind.ASCENDING));
+        fieldIndex("coll1", 1, IndexState.DEFAULT, "value", Kind.ASCENDING));
     sqLiteIndexManager.addFieldIndex(
-        fieldIndex("coll2", 2, SnapshotVersion.NONE, "value", FieldIndex.Segment.Kind.CONTAINS));
+        fieldIndex("coll2", 2, IndexState.DEFAULT, "value", Kind.CONTAINS));
 
     Collection<FieldIndex> indexes = sqLiteIndexManager.getFieldIndexes("coll1");
     assertEquals(indexes.size(), 1);
     Iterator<FieldIndex> it = indexes.iterator();
     assertEquals(it.next().getCollectionGroup(), "coll1");
     sqLiteIndexManager.addFieldIndex(
-        fieldIndex("coll1", 3, version(20), "newValue", FieldIndex.Segment.Kind.CONTAINS));
+        fieldIndex("coll1", 3, IndexState.DEFAULT, "newValue", Kind.CONTAINS));
 
     indexes = sqLiteIndexManager.getFieldIndexes("coll1");
     assertEquals(indexes.size(), 2);
@@ -647,14 +620,15 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   public void testAddFieldIndexWritesToCollectionGroup() {
     SQLiteIndexManager sqLiteIndexManager = (SQLiteIndexManager) indexManager;
     sqLiteIndexManager.addFieldIndex(
-        fieldIndex("coll1", 1, version(30), "value", FieldIndex.Segment.Kind.ASCENDING));
+        fieldIndex("coll1", 1, IndexState.create(1, version(30)), "value", Kind.ASCENDING));
     sqLiteIndexManager.addFieldIndex(
-        fieldIndex("coll2", 2, SnapshotVersion.NONE, "value", FieldIndex.Segment.Kind.CONTAINS));
-    List<String> collectionGroups =
-        getCollectionGroupsOrderByUpdateTime((SQLitePersistence) getPersistence());
-    assertEquals(2, collectionGroups.size());
-    assertEquals("coll1", collectionGroups.get(0));
-    assertEquals("coll2", collectionGroups.get(1));
+        fieldIndex("coll2", 2, IndexState.create(2, version(0)), "value", Kind.CONTAINS));
+    String collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    assertEquals("coll1", collectionGroup);
+
+    indexManager.deleteFieldIndex(indexManager.getFieldIndexes("coll1").iterator().next());
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    assertEquals("coll2", collectionGroup);
   }
 
   private void addDoc(String key, Map<String, Object> data) {
@@ -668,19 +642,5 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
     Iterable<DocumentKey> results = indexManager.getDocumentsMatchingTarget(fieldIndex, target);
     List<DocumentKey> keys = Arrays.stream(documents).map(s -> key(s)).collect(Collectors.toList());
     assertWithMessage("Result for %s", query).that(results).containsExactlyElementsIn(keys);
-  }
-
-  public static List<String> getCollectionGroupsOrderByUpdateTime(SQLitePersistence persistence) {
-    List<String> orderedCollectionGroups = new ArrayList<>();
-    persistence
-        .query(
-            "SELECT collection_group "
-                + "FROM collection_group_update_times "
-                + "ORDER BY update_time_seconds, update_time_nanos")
-        .forEach(
-            row -> {
-              orderedCollectionGroups.add(row.getString(0));
-            });
-    return orderedCollectionGroups;
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
@@ -564,34 +564,20 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   }
 
   @Test
-  public void testCollectionGroupSequenceNumbersCanBeUpdated() {
+  public void testNextCollectionGroupAdvancesWhenCollectionIsUpdated() {
     indexManager.addFieldIndex(fieldIndex("coll1"));
     indexManager.addFieldIndex(fieldIndex("coll2"));
 
-    indexManager.updateCollectionGroup("coll1", 3, version(0));
-    indexManager.updateCollectionGroup("coll2", 5, version(0));
-    String collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    String collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll1", collectionGroup);
 
-    indexManager.updateCollectionGroup("coll2", 4, version(0));
-    collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
-    assertEquals("coll1", collectionGroup);
-
-    indexManager.updateCollectionGroup("coll2", 2, version(0));
-    collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    indexManager.updateCollectionGroup("coll1", version(0));
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll2", collectionGroup);
-  }
 
-  @Test
-  public void testGetNextCollectionGroupIgnoresCurrentSequenceNumber() {
-    indexManager.addFieldIndex(fieldIndex("coll1"));
-
-    indexManager.updateCollectionGroup("coll1", 1, version(1));
-    String collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    indexManager.updateCollectionGroup("coll2", version(0));
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll1", collectionGroup);
-
-    collectionGroup = indexManager.getNextCollectionGroupToUpdate(1);
-    assertNull(collectionGroup);
   }
 
   @Test
@@ -623,11 +609,11 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
         fieldIndex("coll1", 1, IndexState.create(1, version(30)), "value", Kind.ASCENDING));
     sqLiteIndexManager.addFieldIndex(
         fieldIndex("coll2", 2, IndexState.create(2, version(0)), "value", Kind.CONTAINS));
-    String collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    String collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll1", collectionGroup);
 
     indexManager.deleteFieldIndex(indexManager.getFieldIndexes("coll1").iterator().next());
-    collectionGroup = indexManager.getNextCollectionGroupToUpdate(Long.MAX_VALUE);
+    collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll2", collectionGroup);
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteIndexManagerTest.java
@@ -603,7 +603,7 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
   }
 
   @Test
-  public void testAddFieldIndexWritesToCollectionGroup() {
+  public void testDeleteFieldIndexRemovesEntryFromCollectionGroup() {
     indexManager.addFieldIndex(
         fieldIndex("coll1", 1, IndexState.create(1, version(30)), "value", Kind.ASCENDING));
     indexManager.addFieldIndex(
@@ -624,10 +624,11 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
     // Add two indexes and mark one as updated.
     indexManager.addFieldIndex(fieldIndex("coll1", 1, FieldIndex.INITIAL_STATE));
     indexManager.addFieldIndex(fieldIndex("coll2", 2, FieldIndex.INITIAL_STATE));
-    indexManager.updateCollectionGroup("coll1", version(1));
 
-    verifySequenceNumber(indexManager, "coll1", 1);
-    verifySequenceNumber(indexManager, "coll2", 0);
+    indexManager.updateCollectionGroup("coll2", version(1));
+
+    verifySequenceNumber(indexManager, "coll1", 0);
+    verifySequenceNumber(indexManager, "coll2", 1);
 
     // New user signs it. The user should see all existing field indices.
     // Sequence numbers are set to 0.
@@ -646,8 +647,8 @@ public class SQLiteIndexManagerTest extends IndexManagerTestCase {
     indexManager = persistence.getIndexManager(User.UNAUTHENTICATED);
     indexManager.start();
 
-    verifySequenceNumber(indexManager, "coll1", 1);
-    verifySequenceNumber(indexManager, "coll2", 0);
+    verifySequenceNumber(indexManager, "coll1", 0);
+    verifySequenceNumber(indexManager, "coll2", 1);
     verifySequenceNumber(indexManager, "coll3", 0);
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -630,7 +630,7 @@ public class SQLiteSchemaTest {
 
       assertTableExists("index_configuration");
       assertTableExists("index_entries");
-      assertTableExists("collection_group_update_times");
+      assertTableExists("index_state");
     } finally {
       Persistence.INDEXING_SUPPORT_ENABLED = indexingEnabled;
     }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
@@ -40,17 +40,17 @@ public class FieldIndexTest {
 
   @Test
   public void comparatorIgnoresIndexId() {
-    FieldIndex indexOriginal = fieldIndex("collA", 1, IndexState.DEFAULT);
-    FieldIndex indexSame = fieldIndex("collA", 1, IndexState.DEFAULT);
-    FieldIndex indexDifferent = fieldIndex("collA", 2, IndexState.DEFAULT);
+    FieldIndex indexOriginal = fieldIndex("collA", 1, FieldIndex.INITIAL_STATE);
+    FieldIndex indexSame = fieldIndex("collA", 1, FieldIndex.INITIAL_STATE);
+    FieldIndex indexDifferent = fieldIndex("collA", 2, FieldIndex.INITIAL_STATE);
     assertEquals(0, SEMANTIC_COMPARATOR.compare(indexOriginal, indexSame));
     assertEquals(0, SEMANTIC_COMPARATOR.compare(indexOriginal, indexDifferent));
   }
 
   @Test
   public void comparatorIgnoresIndexState() {
-    FieldIndex indexOriginal = fieldIndex("collA", 1, FieldIndex.IndexState.DEFAULT);
-    FieldIndex indexSame = fieldIndex("collA", 1, IndexState.DEFAULT);
+    FieldIndex indexOriginal = fieldIndex("collA", 1, FieldIndex.INITIAL_STATE);
+    FieldIndex indexSame = fieldIndex("collA", 1, FieldIndex.INITIAL_STATE);
     FieldIndex indexDifferent = fieldIndex("collA", 1, IndexState.create(1, version(2)));
     assertEquals(0, SEMANTIC_COMPARATOR.compare(indexOriginal, indexSame));
     assertEquals(0, SEMANTIC_COMPARATOR.compare(indexOriginal, indexDifferent));

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.model;
 
+import static com.google.firebase.firestore.model.FieldIndex.IndexState;
 import static com.google.firebase.firestore.model.FieldIndex.SEMANTIC_COMPARATOR;
 import static com.google.firebase.firestore.testutil.TestUtil.fieldIndex;
 import static com.google.firebase.firestore.testutil.TestUtil.version;
@@ -39,18 +40,18 @@ public class FieldIndexTest {
 
   @Test
   public void comparatorIgnoresIndexId() {
-    FieldIndex indexOriginal = fieldIndex("collA", 1, SnapshotVersion.NONE);
-    FieldIndex indexSame = fieldIndex("collA", 1, SnapshotVersion.NONE);
-    FieldIndex indexDifferent = fieldIndex("collA", 2, SnapshotVersion.NONE);
+    FieldIndex indexOriginal = fieldIndex("collA", 1, IndexState.DEFAULT);
+    FieldIndex indexSame = fieldIndex("collA", 1, IndexState.DEFAULT);
+    FieldIndex indexDifferent = fieldIndex("collA", 2, IndexState.DEFAULT);
     assertEquals(0, SEMANTIC_COMPARATOR.compare(indexOriginal, indexSame));
     assertEquals(0, SEMANTIC_COMPARATOR.compare(indexOriginal, indexDifferent));
   }
 
   @Test
-  public void comparatorIgnoreUpdateTime() {
-    FieldIndex indexOriginal = fieldIndex("collA", 1, version(1));
-    FieldIndex indexSame = fieldIndex("collA", 1, version(1));
-    FieldIndex indexDifferent = fieldIndex("collA", 1, version(2));
+  public void comparatorIgnoresIndexState() {
+    FieldIndex indexOriginal = fieldIndex("collA", 1, FieldIndex.IndexState.DEFAULT);
+    FieldIndex indexSame = fieldIndex("collA", 1, IndexState.DEFAULT);
+    FieldIndex indexDifferent = fieldIndex("collA", 1, IndexState.create(1, version(2)));
     assertEquals(0, SEMANTIC_COMPARATOR.compare(indexOriginal, indexSame));
     assertEquals(0, SEMANTIC_COMPARATOR.compare(indexOriginal, indexDifferent));
   }

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -55,6 +55,7 @@ import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.DocumentSet;
 import com.google.firebase.firestore.model.FieldIndex;
+import com.google.firebase.firestore.model.FieldIndex.IndexState;
 import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.model.MutableDocument;
 import com.google.firebase.firestore.model.ObjectValue;
@@ -593,7 +594,7 @@ public class TestUtil {
   public static FieldIndex fieldIndex(
       String collectionGroup,
       int indexId,
-      SnapshotVersion readTime,
+      IndexState indexState,
       String field,
       FieldIndex.Segment.Kind kind,
       Object... fieldAndKinds) {
@@ -604,21 +605,22 @@ public class TestUtil {
           FieldIndex.Segment.create(
               field((String) fieldAndKinds[i]), (FieldIndex.Segment.Kind) fieldAndKinds[i + 1]));
     }
-    return FieldIndex.create(indexId, collectionGroup, segments, readTime);
+    return FieldIndex.create(indexId, collectionGroup, segments, indexState);
   }
 
   public static FieldIndex fieldIndex(
       String collectionGroup, String field, FieldIndex.Segment.Kind kind, Object... fieldAndKind) {
-    return fieldIndex(collectionGroup, -1, SnapshotVersion.NONE, field, kind, fieldAndKind);
+    FieldIndex fieldIndex =
+        fieldIndex(collectionGroup, -1, IndexState.DEFAULT, field, kind, fieldAndKind);
+    return fieldIndex;
   }
 
-  public static FieldIndex fieldIndex(
-      String collectionGroup, int indexId, SnapshotVersion readTime) {
-    return FieldIndex.create(indexId, collectionGroup, Collections.emptyList(), readTime);
+  public static FieldIndex fieldIndex(String collectionGroup, int indexId, IndexState indexState) {
+    return FieldIndex.create(indexId, collectionGroup, Collections.emptyList(), indexState);
   }
 
   public static FieldIndex fieldIndex(String collectionGroup) {
-    return fieldIndex(collectionGroup, -1, SnapshotVersion.NONE);
+    return fieldIndex(collectionGroup, -1, IndexState.DEFAULT);
   }
 
   private static Map<String, Object> fromJsonString(String json) {

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -611,7 +611,7 @@ public class TestUtil {
   public static FieldIndex fieldIndex(
       String collectionGroup, String field, FieldIndex.Segment.Kind kind, Object... fieldAndKind) {
     FieldIndex fieldIndex =
-        fieldIndex(collectionGroup, -1, IndexState.DEFAULT, field, kind, fieldAndKind);
+        fieldIndex(collectionGroup, -1, FieldIndex.INITIAL_STATE, field, kind, fieldAndKind);
     return fieldIndex;
   }
 
@@ -620,7 +620,7 @@ public class TestUtil {
   }
 
   public static FieldIndex fieldIndex(String collectionGroup) {
-    return fieldIndex(collectionGroup, -1, IndexState.DEFAULT);
+    return fieldIndex(collectionGroup, -1, FieldIndex.INITIAL_STATE);
   }
 
   private static Map<String, Object> fromJsonString(String json) {


### PR DESCRIPTION
This PR moves the "how updated is the index?" state from the index table to a per-user table and adds a sequence number. This allows the backfiller to process all index entries independently for each user.