### PR TITLE
Fix Crashlytics user id serialization bug

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/MetaDataStore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/MetaDataStore.java
@@ -40,7 +40,7 @@ class MetaDataStore {
 
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-  private static final String USERDATA_FILENAME = "user";
+  private static final String USERDATA_FILENAME = "user-data";
   private static final String KEYDATA_FILENAME = "keys";
   private static final String INTERNAL_KEYDATA_FILENAME = "internal-keys";
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
@@ -54,7 +54,7 @@ public class CrashlyticsReportPersistence {
   private static final int MAX_OPEN_SESSIONS = 8;
 
   private static final String REPORT_FILE_NAME = "report";
-  private static final String USER_FILE_NAME = "user";
+  private static final String USER_ID_FILE_NAME = "user-id";
   // We use the lastModified timestamp of this file to quickly store and access the startTime in ms
   // of a session.
   private static final String SESSION_START_TIMESTAMP_FILE_NAME = "start-time";
@@ -142,7 +142,7 @@ public class CrashlyticsReportPersistence {
 
   public void persistUserIdForSession(@NonNull String userId, @NonNull String sessionId) {
     try {
-      writeTextFile(fileStore.getSessionFile(sessionId, USER_FILE_NAME), userId);
+      writeTextFile(fileStore.getSessionFile(sessionId, USER_ID_FILE_NAME), userId);
     } catch (IOException e) {
       // Session directory is not guaranteed to exist
       Logger.getLogger().w("Could not persist user ID for session " + sessionId, e);
@@ -322,7 +322,7 @@ public class CrashlyticsReportPersistence {
     }
 
     String userId = null;
-    final File userIdFile = fileStore.getSessionFile(sessionId, USER_FILE_NAME);
+    final File userIdFile = fileStore.getSessionFile(sessionId, USER_ID_FILE_NAME);
     if (userIdFile.isFile()) {
       try {
         userId = readTextFile(userIdFile);


### PR DESCRIPTION
This fixes a bug caught in post-commit validation of PR #3143. The
bug never shipped.

Before the earlier refactor, the user id was serialized in two different
files on disk: one as a raw id and the other in JSON. In the refactor,
this was inadvertedly consolidated to one file path. The result is that
when generating a Crashlytics report, the SDK expects a plain text user id
in the file, and instead sends up the entire JSON blob as the user id.

A follow-on refactor is already underway which will elliminate the need
for the redundant file. Until that change is ready, we'll return to
using distinct file paths for the two files.