### PR TITLE
[DO NOT SUBMIT] Overlay performance tests

### DIFF
--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -168,6 +168,7 @@ dependencies {
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'com.github.javafaker:javafaker:1.0.2'
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation ("org.robolectric:robolectric:$robolectricVersion") {
@@ -178,6 +179,7 @@ dependencies {
     testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
 
     androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.github.javafaker:javafaker:1.0.2'
     androidTestImplementation("com.google.truth:truth:$googleTruthVersion"){
         exclude group: "org.codehaus.mojo", module: "animal-sniffer-annotations"
     }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/performance/PerformanceTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/performance/PerformanceTest.java
@@ -1,0 +1,119 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore.performance;
+
+import static com.google.firebase.firestore.FieldValue.arrayUnion;
+import static com.google.firebase.firestore.FieldValue.increment;
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testFirestore;
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.waitFor;
+import static com.google.firebase.firestore.testutil.TestUtil.map;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.github.javafaker.Faker;
+import com.github.javafaker.service.RandomService;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QuerySnapshot;
+import com.google.firebase.firestore.Source;
+import com.google.firebase.firestore.local.Persistence;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+// TODO: Add the skipped tests from typescript.
+@RunWith(AndroidJUnit4.class)
+public class PerformanceTest {
+  Map<String, List<DocumentReference>> docs = new HashMap<>();
+  FirebaseFirestore db = null;
+
+  @Before
+  public void setUp() {
+    Persistence.OVERLAY_SUPPORT_ENABLED = true;
+    // Persistence.OVERLAY_SUPPORT_ENABLED = false;
+    int mutationPerDoc = 3;
+    System.out.println(
+        "PERF: Testing with overlay support: " + Persistence.OVERLAY_SUPPORT_ENABLED);
+    System.out.println("PERF: Testing with mutation per doc: " + mutationPerDoc * 3);
+    Faker faker = new Faker(new Locale("zh-CN"));
+    RandomService randomService = new RandomService();
+    db = testFirestore();
+    for (int i = 0; i < 100; ++i) {
+      String coll = randomService.hex(20);
+      docs.put(coll, new ArrayList<>());
+      for (int j = 0; j < 100; ++j) {
+        Object doc =
+            map(
+                "name", faker.pokemon().name(),
+                "location", faker.pokemon().location(),
+                "bool", randomService.nextBoolean(),
+                "double", randomService.nextDouble(),
+                "color", faker.color().name());
+        DocumentReference ref = waitFor(db.collection(coll).add(doc));
+        docs.get(coll).add(ref);
+      }
+    }
+
+    waitFor(db.disableNetwork());
+
+    long milli = System.currentTimeMillis();
+    for (Map.Entry<String, List<DocumentReference>> entry : docs.entrySet()) {
+      for (DocumentReference ref : entry.getValue()) {
+        Object doc =
+            map(
+                "name", faker.pokemon().name(),
+                "location", faker.pokemon().location(),
+                "bool", randomService.nextBoolean(),
+                "double", randomService.nextDouble(),
+                "color", faker.color().name());
+        ref.set(doc);
+        for (int i = 0; i < mutationPerDoc; i++) {
+          ref.update(map("bool", faker.app().version()));
+          ref.update(map("double", increment(randomService.nextInt(-10, 10))));
+          ref.update(map("color", arrayUnion(faker.color().name())));
+        }
+      }
+    }
+
+    waitFor(db.getAsyncQueue().enqueue(() -> {}));
+
+    long durationInMilli = System.currentTimeMillis() - milli;
+
+    System.out.println("PERF: Setup mutation takes " + durationInMilli + " milliseconds");
+  }
+
+  @Test
+  public void testQueries() {
+    Faker faker = new Faker(new Locale("zh-CN"));
+    RandomService randomService = new RandomService();
+    long milli = System.currentTimeMillis();
+    for (Map.Entry<String, List<DocumentReference>> entry : docs.entrySet()) {
+      CollectionReference coll = db.collection(entry.getKey());
+      QuerySnapshot snap =
+          waitFor(coll.whereEqualTo("name", faker.pokemon().name()).get(Source.CACHE));
+      snap = waitFor(coll.whereLessThan("double", randomService.nextDouble()).get(Source.CACHE));
+      snap = waitFor(coll.whereArrayContains("color", faker.color().name()).get(Source.CACHE));
+      // System.out.println("PERF: Collection query take " + (System.currentTimeMillis() - milli) +
+      // " milliseconds");
+    }
+    long durationInMilli = System.currentTimeMillis() - milli;
+    System.out.println("PERF: Queries take " + durationInMilli + " milliseconds");
+  }
+}

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -38,7 +38,6 @@ import com.google.firebase.firestore.MetadataChanges;
 import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.core.DatabaseInfo;
-import com.google.firebase.firestore.local.Persistence;
 import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.testutil.provider.FirestoreProvider;
 import com.google.firebase.firestore.util.AsyncQueue;
@@ -97,7 +96,7 @@ public class IntegrationTestUtil {
   private static final Map<FirebaseFirestore, Boolean> firestoreStatus = new HashMap<>();
 
   /** Default amount of time to wait for a given operation to complete, used by waitFor() helper. */
-  private static final long OPERATION_WAIT_TIMEOUT_MS = 30000;
+  private static final long OPERATION_WAIT_TIMEOUT_MS = 300000;
 
   /**
    * Firestore databases can be subject to a ~30s "cold start" delay if they have not been used
@@ -256,8 +255,8 @@ public class IntegrationTestUtil {
     Logger.setLogLevel(logLevel);
 
     // TODO(Overlay): Remove below once this is ready to ship.
-    Persistence.OVERLAY_SUPPORT_ENABLED = true;
-    Persistence.INDEXING_SUPPORT_ENABLED = true;
+    // Persistence.OVERLAY_SUPPORT_ENABLED = true;
+    // Persistence.INDEXING_SUPPORT_ENABLED = true;
 
     Context context = ApplicationProvider.getApplicationContext();
     DatabaseId databaseId = DatabaseId.forDatabase(projectId, DatabaseId.DEFAULT_DATABASE_ID);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -529,7 +529,7 @@ public class FirebaseFirestore {
   }
 
   @VisibleForTesting
-  AsyncQueue getAsyncQueue() {
+  public AsyncQueue getAsyncQueue() {
     return asyncQueue;
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/FirestoreClient.java
@@ -329,6 +329,10 @@ public final class FirestoreClient {
     return asyncQueue.enqueue(() -> localStore.configureFieldIndexes(fieldIndices));
   }
 
+  public AsyncQueue getAsyncQueue() {
+    return asyncQueue;
+  }
+
   public void removeSnapshotsInSyncListener(EventListener<Void> listener) {
     // Checks for shutdown but does not raise error, allowing remove after shutdown to be a no-op.
     if (isTerminated()) {


### PR DESCRIPTION
_All data are from the average of three runs._

As expected, with overlay the query performance stays constant as the number of local mutations grows; while without overlay, the query performance grows linearly as the number of local mutations grows.

**Without Overlay**

Write 10,000 mutations, each document has 1 mutation: 11614ms
Run 100 queries: **3932ms**

Write 40,000 mutations, each document has 4 mutations: 57618ms
Run 100 queries: **7987ms**

Write 70,000 mutations, each document has 7 mutations: 108599ms
Run 100 queries: **11798ms**

Write 100,000 mutations, each document has 10 mutations: 168217ms
Run 100 queries: **15406ms**


**With Overlay**

Write 10,000 mutations, each document has 1 mutation: 15327ms
Run 100 queries: **4493ms**

Write 40,000 mutations, each document has 4 mutations: 67575ms
Run 100 queries: **4278ms**

Write 70,000 mutations, each document has 7 mutations: 123661ms
Run 100 queries: **4767ms**

Write 100,000 mutations, each document has 10 mutations: 185487ms
Run 100 queries: **4699ms**