### PR TITLE
Guard mutable fields with synchronization blocks or methods

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/FirebaseAppDistribution.java
@@ -186,7 +186,7 @@ public class FirebaseAppDistribution {
    * sign in UI
    */
   @NonNull
-  public Task<AppDistributionRelease> checkForNewRelease() {
+  public synchronized Task<AppDistributionRelease> checkForNewRelease() {
     if (cachedCheckForNewReleaseTask != null && !cachedCheckForNewReleaseTask.isComplete()) {
       LogWrapper.getInstance().v("Response in progress");
       return cachedCheckForNewReleaseTask;

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/FirebaseAppDistribution.java
@@ -23,6 +23,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.tasks.Task;
@@ -35,24 +36,28 @@ import com.google.firebase.app.distribution.internal.FirebaseAppDistributionLife
 import com.google.firebase.installations.FirebaseInstallationsApi;
 
 public class FirebaseAppDistribution {
+  private static final int UNKNOWN_RELEASE_FILE_SIZE = -1;
 
   private final FirebaseApp firebaseApp;
   private final TesterSignInClient testerSignInClient;
   private final CheckForNewReleaseClient checkForNewReleaseClient;
   private final UpdateAppClient updateAppClient;
   private final FirebaseAppDistributionLifecycleNotifier lifecycleNotifier;
-  private static final int UNKNOWN_RELEASE_FILE_SIZE = -1;
+  private final SignInStorage signInStorage;
 
-  @GuardedBy("updateTaskLock")
+  private final Object updateIfNewReleaseTaskLock = new Object();
+
+  @GuardedBy("updateIfNewReleaseTaskLock")
   private UpdateTaskImpl cachedUpdateIfNewReleaseTask;
 
-  private final Object updateTaskLock = new Object();
-  private Task<AppDistributionRelease> cachedCheckForNewReleaseTask;
+  private final Object cachedNewReleaseLock = new Object();
 
+  @GuardedBy("cachedNewReleaseLock")
   private AppDistributionReleaseInternal cachedNewRelease;
+
+  private Task<AppDistributionRelease> cachedCheckForNewReleaseTask;
   private AlertDialog updateDialog;
   private boolean updateDialogShown;
-  private final SignInStorage signInStorage;
 
   /** Constructor for FirebaseAppDistribution */
   @VisibleForTesting
@@ -126,8 +131,8 @@ public class FirebaseAppDistribution {
    * to complete the download and installation.
    */
   @NonNull
-  public synchronized UpdateTask updateIfNewReleaseAvailable() {
-    synchronized (updateTaskLock) {
+  public UpdateTask updateIfNewReleaseAvailable() {
+    synchronized (updateIfNewReleaseTaskLock) {
       if (cachedUpdateIfNewReleaseTask != null && !cachedUpdateIfNewReleaseTask.isComplete()) {
         return cachedUpdateIfNewReleaseTask;
       }
@@ -163,7 +168,8 @@ public class FirebaseAppDistribution {
                       Constants.ErrorMessages.NETWORK_ERROR,
                       FirebaseAppDistributionException.Status.NETWORK_FAILURE));
             });
-    synchronized (updateTaskLock) {
+
+    synchronized (updateIfNewReleaseTaskLock) {
       return cachedUpdateIfNewReleaseTask;
     }
   }
@@ -180,7 +186,7 @@ public class FirebaseAppDistribution {
    * sign in UI
    */
   @NonNull
-  public synchronized Task<AppDistributionRelease> checkForNewRelease() {
+  public Task<AppDistributionRelease> checkForNewRelease() {
     if (cachedCheckForNewReleaseTask != null && !cachedCheckForNewReleaseTask.isComplete()) {
       LogWrapper.getInstance().v("Response in progress");
       return cachedCheckForNewReleaseTask;
@@ -218,7 +224,7 @@ public class FirebaseAppDistribution {
    * new release is cached from checkForNewRelease
    */
   @NonNull
-  public synchronized UpdateTask updateApp() {
+  public UpdateTask updateApp() {
     return updateApp(false);
   }
 
@@ -226,7 +232,7 @@ public class FirebaseAppDistribution {
    * Overloaded updateApp with boolean input showDownloadInNotificationsManager. Set to true for
    * basic configuration and false for advanced configuration.
    */
-  private synchronized UpdateTask updateApp(boolean showDownloadInNotificationManager) {
+  private UpdateTask updateApp(boolean showDownloadInNotificationManager) {
     if (!isTesterSignedIn()) {
       UpdateTaskImpl updateTask = new UpdateTaskImpl();
       updateTask.setException(
@@ -235,7 +241,9 @@ public class FirebaseAppDistribution {
       return updateTask;
     }
 
-    return this.updateAppClient.updateApp(cachedNewRelease, showDownloadInNotificationManager);
+    synchronized (cachedNewReleaseLock) {
+      return this.updateAppClient.updateApp(cachedNewRelease, showDownloadInNotificationManager);
+    }
   }
 
   /** Returns true if the App Distribution tester is signed in */
@@ -245,7 +253,7 @@ public class FirebaseAppDistribution {
 
   /** Signs out the App Distribution tester */
   public void signOutTester() {
-    this.cachedNewRelease = null;
+    setCachedNewRelease(null);
     this.signInStorage.setSignInStatus(false);
   }
 
@@ -263,13 +271,17 @@ public class FirebaseAppDistribution {
   }
 
   @VisibleForTesting
-  void setCachedNewRelease(AppDistributionReleaseInternal newRelease) {
-    this.cachedNewRelease = newRelease;
+  void setCachedNewRelease(@Nullable AppDistributionReleaseInternal newRelease) {
+    synchronized (cachedNewReleaseLock) {
+      this.cachedNewRelease = newRelease;
+    }
   }
 
   @VisibleForTesting
   AppDistributionReleaseInternal getCachedNewRelease() {
-    return this.cachedNewRelease;
+    synchronized (cachedNewReleaseLock) {
+      return this.cachedNewRelease;
+    }
   }
 
   private UpdateTaskImpl showUpdateAlertDialog(AppDistributionRelease newRelease) {
@@ -302,7 +314,7 @@ public class FirebaseAppDistribution {
         AlertDialog.BUTTON_POSITIVE,
         context.getString(R.string.update_yes_button),
         (dialogInterface, i) -> {
-          synchronized (updateTaskLock) {
+          synchronized (updateIfNewReleaseTaskLock) {
             // show download progress in notification manager
             updateApp(true)
                 .addOnProgressListener(this::postProgressToCachedUpdateIfNewReleaseTask)
@@ -316,7 +328,7 @@ public class FirebaseAppDistribution {
         context.getString(R.string.update_no_button),
         (dialogInterface, i) -> {
           dialogInterface.dismiss();
-          synchronized (updateTaskLock) {
+          synchronized (updateIfNewReleaseTaskLock) {
             postProgressToCachedUpdateIfNewReleaseTask(
                 UpdateProgress.builder()
                     .setApkFileTotalBytes(UNKNOWN_RELEASE_FILE_SIZE)
@@ -331,16 +343,16 @@ public class FirebaseAppDistribution {
 
     updateDialog.show();
     updateDialogShown = true;
-    synchronized (updateTaskLock) {
+    synchronized (updateIfNewReleaseTaskLock) {
       return cachedUpdateIfNewReleaseTask;
     }
   }
 
   private void setCachedUpdateIfNewReleaseCompletionError(FirebaseAppDistributionException e) {
-    synchronized (updateTaskLock) {
+    synchronized (updateIfNewReleaseTaskLock) {
       safeSetTaskException(cachedUpdateIfNewReleaseTask, e);
-      dismissUpdateDialog();
     }
+    dismissUpdateDialog();
   }
 
   private void setCachedUpdateIfNewReleaseCompletionError(
@@ -353,16 +365,16 @@ public class FirebaseAppDistribution {
   }
 
   private void postProgressToCachedUpdateIfNewReleaseTask(UpdateProgress progress) {
-    synchronized (updateTaskLock) {
+    synchronized (updateIfNewReleaseTaskLock) {
       cachedUpdateIfNewReleaseTask.updateProgress(progress);
     }
   }
 
   private void setCachedUpdateIfNewReleaseResult() {
-    synchronized (updateTaskLock) {
+    synchronized (updateIfNewReleaseTaskLock) {
       safeSetTaskResult(cachedUpdateIfNewReleaseTask);
-      dismissUpdateDialog();
     }
+    dismissUpdateDialog();
   }
 
   private void dismissUpdateDialog() {

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/InstallApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/InstallApkClient.java
@@ -81,7 +81,7 @@ class InstallApkClient {
     }
   }
 
-  synchronized Task<Void> installApk(String path) {
+  Task<Void> installApk(String path) {
     synchronized (installTaskLock) {
       Activity currentActivity = lifeCycleNotifier.getCurrentActivity();
       // This ensures that we save the state of the install if the app is backgrounded during

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/InstallApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/InstallApkClient.java
@@ -81,7 +81,7 @@ class InstallApkClient {
     }
   }
 
-  Task<Void> installApk(String path) {
+  synchronized Task<Void> installApk(String path) {
     synchronized (installTaskLock) {
       Activity currentActivity = lifeCycleNotifier.getCurrentActivity();
       // This ensures that we save the state of the install if the app is backgrounded during

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/TesterSignInClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/TesterSignInClient.java
@@ -124,30 +124,26 @@ class TesterSignInClient {
       return Tasks.forResult(null);
     }
 
-    if (this.isCurrentlySigningIn()) {
-      LogWrapper.getInstance()
-          .v(TAG + "Detected In-Progress sign in task. Returning the same task.");
-      synchronized (signInTaskLock) {
+    synchronized (signInTaskLock) {
+      if (this.isCurrentlySigningIn()) {
+        LogWrapper.getInstance()
+            .v(TAG + "Detected In-Progress sign in task. Returning the same task.");
         return signInTaskCompletionSource.getTask();
       }
-    }
-    Activity currentActivity = lifecycleNotifier.getCurrentActivity();
-    if (currentActivity == null) {
-      LogWrapper.getInstance().e(TAG + "No foreground activity found.");
-      return Tasks.forException(
-          new FirebaseAppDistributionException(
-              ErrorMessages.APP_BACKGROUNDED,
-              FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE));
-    }
+      Activity currentActivity = lifecycleNotifier.getCurrentActivity();
+      if (currentActivity == null) {
+        LogWrapper.getInstance().e(TAG + "No foreground activity found.");
+        return Tasks.forException(
+            new FirebaseAppDistributionException(
+                ErrorMessages.APP_BACKGROUNDED,
+                FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE));
+      }
 
-    synchronized (signInTaskLock) {
       signInTaskCompletionSource = new TaskCompletionSource<>();
-    }
 
-    alertDialog = getSignInAlertDialog(currentActivity);
-    alertDialog.show();
+      alertDialog = getSignInAlertDialog(currentActivity);
+      alertDialog.show();
 
-    synchronized (signInTaskLock) {
       return signInTaskCompletionSource.getTask();
     }
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/UpdateApkClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/UpdateApkClient.java
@@ -74,7 +74,7 @@ class UpdateApkClient {
     this.installApkClient = installApkClient;
   }
 
-  public synchronized UpdateTaskImpl updateApk(
+  public UpdateTaskImpl updateApk(
       @NonNull AppDistributionReleaseInternal newRelease, boolean showDownloadNotificationManager) {
     synchronized (updateTaskLock) {
       if (cachedUpdateTask != null && !cachedUpdateTask.isComplete()) {


### PR DESCRIPTION
Makes our synchronization patterns more consistent by:

- guarding mutable fields with either a synchronization block or method
- if the object is written asynchronously by our codebase, we use a synchronized block to prevent memory inconsistencies after the calling method returns. 
-avoiding the use of synchronized blocks within synchronized methods, because this increases the chances of deadlock