### PR TITLE
String format with decimal issue in Android 8.1.0

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -51,6 +51,7 @@ import com.google.firebase.perf.v1.PerfMetric;
 import com.google.firebase.perf.v1.PerfMetricOrBuilder;
 import com.google.firebase.perf.v1.TraceMetric;
 import java.lang.ref.WeakReference;
+import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
@@ -619,7 +620,7 @@ public class TransportManager implements AppStateCallback {
         Locale.ENGLISH,
         "trace metric: %s (duration: %.4fms)",
         traceMetric.getName(),
-        durationInUs / 1000.0);
+        new DecimalFormat("#.####").format(durationInUs / 1000.0));
   }
 
   private static String getLogcatMsg(NetworkRequestMetric networkRequestMetric) {
@@ -638,7 +639,7 @@ public class TransportManager implements AppStateCallback {
         "network request trace: %s (responseCode: %s, responseTime: %.4fms)",
         networkRequestMetric.getUrl(),
         responseCode,
-        durationInUs / 1000.0);
+        new DecimalFormat("#.####").format(durationInUs / 1000.0));
   }
 
   private static String getLogcatMsg(GaugeMetric gaugeMetric) {


### PR DESCRIPTION
Speculative fix for issue #3084. NullPointerException is encountered specifically on Android version 8.1.0, this is due to String.format inserted with Double values.

The proposed fix is to use DecimalFormat to format the values before being inserted in String.format