### PR TITLE
Don't use JUnit's MultipleViolationsException.

### DIFF
--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -57,6 +57,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-inline:2.25.0'
 
+    androidTestImplementation project(':integ-testing')
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"

--- a/firebase-installations/src/androidTest/java/com/google/firebase/installations/StrictModeTest.java
+++ b/firebase-installations/src/androidTest/java/com/google/firebase/installations/StrictModeTest.java
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.installations;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions.Builder;
+import com.google.firebase.testing.integ.StrictModeRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class StrictModeTest {
+
+  @Rule public StrictModeRule strictMode = new StrictModeRule();
+
+  @Test
+  @Ignore("enable once strict mode violations are addressed")
+  public void initializingFirebaseInstallations_shouldNotViolateStrictMode() {
+    strictMode.runOnMainThread(
+        () -> {
+          FirebaseApp app =
+              FirebaseApp.initializeApp(
+                  ApplicationProvider.getApplicationContext(),
+                  new Builder()
+                      .setApiKey("api")
+                      .setProjectId("123")
+                      .setApplicationId("appId")
+                      .build(),
+                  "hello");
+          app.get(FirebaseInstallationsApi.class);
+        });
+  }
+}

--- a/integ-testing/src/main/java/com/google/firebase/testing/integ/MultipleViolationsException.java
+++ b/integ-testing/src/main/java/com/google/firebase/testing/integ/MultipleViolationsException.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.testing.integ;
 
 import org.junit.internal.Throwables;

--- a/integ-testing/src/main/java/com/google/firebase/testing/integ/MultipleViolationsException.java
+++ b/integ-testing/src/main/java/com/google/firebase/testing/integ/MultipleViolationsException.java
@@ -1,0 +1,56 @@
+package com.google.firebase.testing.integ;
+
+import org.junit.internal.Throwables;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MultipleViolationsException extends Exception {
+  private final List<Throwable> errors;
+
+  private MultipleViolationsException(List<Throwable> errors) {
+    this.errors = new ArrayList<>(errors);
+  }
+
+  @Override
+  public String getMessage() {
+    StringBuilder sb = new StringBuilder("There were " + errors.size() + " errors:");
+    for (Throwable e : errors) {
+      sb.append(String.format("%n  %s(%s)", e.getClass().getName(), e.getMessage()));
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public void printStackTrace() {
+    for (Throwable e : errors) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public void printStackTrace(PrintStream s) {
+    for (Throwable e : errors) {
+      e.printStackTrace(s);
+    }
+  }
+
+  @Override
+  public void printStackTrace(PrintWriter s) {
+    for (Throwable e : errors) {
+      e.printStackTrace(s);
+    }
+  }
+
+  public static void assertEmpty(List<Throwable> errors) throws Exception {
+    if (errors.isEmpty()) {
+      return;
+    }
+    if (errors.size() == 1) {
+      throw Throwables.rethrowAsException(errors.get(0));
+    }
+    throw new MultipleViolationsException(errors);
+  }
+}

--- a/integ-testing/src/main/java/com/google/firebase/testing/integ/StrictModeRule.java
+++ b/integ-testing/src/main/java/com/google/firebase/testing/integ/StrictModeRule.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
-import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 /**
@@ -133,7 +132,7 @@ public class StrictModeRule implements TestRule {
           runGc();
           StrictMode.setVmPolicy(originalVmPolicy);
         }
-        MultipleFailureException.assertEmpty(new ArrayList<>(violations));
+        MultipleViolationsException.assertEmpty(new ArrayList<>(violations));
       }
     };
   }


### PR DESCRIPTION
It has special meaning in JUnit which results in only the first failure
being printed as test failure.

Also added an example strict mode test to FIS(disabled since there are
violations).