### PR TITLE
Replace fixed sized thread pool with single thread exectuor in checkfornewrelease

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/CheckForNewReleaseClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/CheckForNewReleaseClient.java
@@ -37,7 +37,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 class CheckForNewReleaseClient {
-  private static final int NEW_RELEASE_THREAD_POOL_SIZE = 4;
   private static final String TAG = "CheckForNewReleaseClient:";
 
   private final FirebaseApp firebaseApp;
@@ -56,8 +55,7 @@ class CheckForNewReleaseClient {
     this.firebaseApp = firebaseApp;
     this.firebaseAppDistributionTesterApiClient = firebaseAppDistributionTesterApiClient;
     this.firebaseInstallationsApi = firebaseInstallationsApi;
-    // TODO: verify if this is best way to use executorservice here
-    this.checkForNewReleaseExecutor = Executors.newFixedThreadPool(NEW_RELEASE_THREAD_POOL_SIZE);
+    this.checkForNewReleaseExecutor = Executors.newSingleThreadExecutor();
     this.releaseIdentifierStorage =
         new ReleaseIdentifierStorage(firebaseApp.getApplicationContext());
   }


### PR DESCRIPTION
We only call one task from this background thread, so we don't need a multi-thread threadpool.

The two tasks that are kicked off in parallel in this class (firebaseinstalltion.getId() and firebaseinstallation.getToken) are handled by a threadpool in the FirebaseInstallations class