### PR TITLE
Fixing BadTokenException while showing FIAM

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -349,6 +349,10 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
         new FiamImageLoader.Callback() {
           @Override
           public void onSuccess() {
+            if (activity.isFinishing()) {
+              Logging.logi("Activity is finishing or does not have valid window token. Cannot show FIAM.");
+              return;
+            }
             // Setup dismiss on touch outside
             if (!bindingWrapper.getConfig().backgroundEnabled()) {
               bindingWrapper


### PR DESCRIPTION
This is a possible fix as the BadTokenException usually happens when we try to add/show new views with a finishing activity context.