### PR TITLE
Update Python dependencies before running trigger_workflow script.

### DIFF
--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -71,4 +71,5 @@ jobs:
 
       - name: Trigger firebase-cpp-sdk update
         run: |
+          pip install -r scripts/gha/requirements.txt
           python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w update-dependencies.yml -p updateAndroid 1 -p updateiOS 0 -p comment "[Triggered]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) by [firebase-android-sdk $(date '+%b %d') release]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/${{ github.sha }})." -s 10 -A


### PR DESCRIPTION
Updated version of the script requires the Python "requests" module, which needs to be explicitly installed.
