### PR TITLE
Add mutation batch id to index backfill

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
@@ -20,6 +20,7 @@ import static com.google.firebase.firestore.util.Util.nullSafeCompare;
 import com.google.auto.value.AutoValue;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.util.Util;
+import java.util.Comparator;
 
 /** Represents an index entry saved by the SDK in its local storage. */
 @AutoValue
@@ -53,4 +54,9 @@ public abstract class IndexEntry implements Comparable<IndexEntry> {
 
     return nullSafeCompare(getArrayValue(), other.getArrayValue(), Util::compareByteArrays);
   }
+
+  public static final Comparator<IndexEntry> SEMANTIC_COMPARATOR =
+      (left, right) -> {
+        return left.compareTo(right);
+      };
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/DocumentOverlayCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/DocumentOverlayCache.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.local;
 
+import android.util.Pair;
 import androidx.annotation.Nullable;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.ResourcePath;
@@ -54,4 +55,14 @@ public interface DocumentOverlayCache {
    *     change past `sinceBatchId` are returned.
    */
   Map<DocumentKey, Mutation> getOverlays(ResourcePath collection, int sinceBatchId);
+
+  /**
+   * Returns a mapping of overlays containing the largest batch id for each overlay mutation.
+   *
+   * @param collection The collection path to get the overlays for.
+   * @param sinceBatchId The minimum batch ID to filter by (exclusive). Only overlays that contain a
+   *     change past `sinceBatchId` are returned.
+   */
+  Map<DocumentKey, Pair<Integer, Mutation>> getOverlaysWithBatchId(
+      ResourcePath collection, int sinceBatchId);
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteSchema.java
@@ -284,7 +284,7 @@ class SQLiteSchema {
     mutationDeleter.bindString(1, uid);
     mutationDeleter.bindLong(2, batchId);
     int deleted = mutationDeleter.executeUpdateDelete();
-    hardAssert(deleted != 0, "Mutatiohn batch (%s, %d) did not exist", uid, batchId);
+    hardAssert(deleted != 0, "Mutation batch (%s, %d) did not exist", uid, batchId);
 
     // Delete all index entries for this batch
     db.execSQL(
@@ -385,6 +385,7 @@ class SQLiteSchema {
                   + "read_time_seconds INTEGER, " // Read time of last processed document
                   + "read_time_nanos INTEGER, "
                   + "document_key TEXT, " // Key of the last processed document
+                  + "largest_batch_id INTEGER, " // Largest mutation batch id that was processed
                   + "PRIMARY KEY (index_id, uid))");
 
           // The index entry table stores the encoded entries for all fields.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -34,7 +34,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
-import java.util.SortedSet;
 
 /** A utility class for Firestore */
 public class Util {
@@ -296,25 +295,6 @@ public class Util {
     Collections.sort(afterEntries, comparator);
 
     diffCollections(beforeEntries.iterator(), afterEntries.iterator(), comparator, onAdd, onRemove);
-  }
-
-  /**
-   * Compares two sorted sets for equality using their natural ordering. The method computes the
-   * intersection and invokes `onAdd` for every element that is in `after` but not `before`.
-   * `onRemove` is invoked for every element in `before` but missing from `after`.
-   *
-   * <p>The method creates a copy of both `before` and `after` and runs in O(n log n), where n is
-   * the size of the two lists.
-   *
-   * @param before The elements that exist in the original set.
-   * @param after The elements to diff against the original set.
-   * @param onAdd A function to invoke for every element that is part of `after` but not `before`.
-   * @param onRemove A function to invoke for every element that is part of `before` but not
-   *     `after`.
-   */
-  public static <T extends Comparable<T>> void diffCollections(
-      SortedSet<T> before, SortedSet<T> after, Consumer<T> onAdd, Consumer<T> onRemove) {
-    diffCollections(before.iterator(), after.iterator(), before.comparator(), onAdd, onRemove);
   }
 
   private static <T> void diffCollections(


### PR DESCRIPTION
This PR adds mutation batch id support to the index backfiller. All documents in the same mutation batch are processed, even if it goes over the limit (the alternative is to add an offset for mutations, but batches are limited to 500 writes).

Still todo:
- Current implementation performs a collection group query with documents + overlay, but local mutations are not written to the collection_groups table that support collection group queries. This means that the current implementation only supports local mutations that already have a remote document in the same collection.