### PR TITLE
Set DevelopmentPlatform info for Flutter apps

### DIFF
--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashlyticsNdkRegistrar.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashlyticsNdkRegistrar.java
@@ -14,8 +14,6 @@
 
 package com.google.firebase.crashlytics.ndk;
 
-import static com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider.UNITY_PLATFORM;
-
 import android.content.Context;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentContainer;
@@ -43,8 +41,7 @@ public class CrashlyticsNdkRegistrar implements ComponentRegistrar {
     Context context = container.get(Context.class);
     // The signal handler is installed immediately for non-Unity apps. For Unity apps, it will
     // be installed when the Firebase Unity SDK explicitly calls installSignalHandler().
-    boolean installHandlerDuringPrepSession =
-        !UNITY_PLATFORM.equals(new DevelopmentPlatformProvider(context).getDevelopmentPlatform());
+    boolean installHandlerDuringPrepSession = !DevelopmentPlatformProvider.isUnity(context);
     return FirebaseCrashlyticsNdk.create(context, installHandlerDuringPrepSession);
   }
 }

--- a/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashpadController.java
+++ b/firebase-crashlytics-ndk/src/main/java/com/google/firebase/crashlytics/ndk/CrashpadController.java
@@ -118,8 +118,8 @@ public class CrashpadController {
             appData.versionName(),
             appData.installUuid(),
             appData.deliveryMechanism(),
-            appData.developmentPlatform(),
-            appData.developmentPlatformVersion());
+            appData.developmentPlatformProvider().getDevelopmentPlatform(),
+            appData.developmentPlatformProvider().getDevelopmentPlatformVersion());
     writeSessionJsonFile(fileStore, sessionId, json, APP_METADATA_FILE);
   }
 

--- a/firebase-crashlytics/src/androidTest/assets/flutter_assets/NOTICES.Z
+++ b/firebase-crashlytics/src/androidTest/assets/flutter_assets/NOTICES.Z
@@ -1,0 +1,1 @@
+matt says hi

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsNativeComponentDeferredProxyTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsNativeComponentDeferredProxyTest.java
@@ -15,6 +15,7 @@
 package com.google.firebase.crashlytics.internal;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 
 import androidx.annotation.NonNull;
 import androidx.test.runner.AndroidJUnit4;
@@ -57,7 +58,7 @@ public class CrashlyticsNativeComponentDeferredProxyTest {
 
     StaticSessionData.AppData appData =
         StaticSessionData.AppData.create(
-            "appId", "123", "1.2.3", "install_id", 0, "unity", "unityVersion");
+            "appId", "123", "1.2.3", "install_id", 0, mock(DevelopmentPlatformProvider.class));
     StaticSessionData.OsData osData = StaticSessionData.OsData.create("release", "codeName", false);
     StaticSessionData.DeviceData deviceData =
         StaticSessionData.DeviceData.create(

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/DevelopmentPlatformProviderTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/DevelopmentPlatformProviderTest.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.crashlytics.internal;
 
-import static com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider.UNITY_PLATFORM;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -27,10 +26,14 @@ import android.os.Bundle;
 
 public class DevelopmentPlatformProviderTest extends CrashlyticsTestCase {
   private static final String PACKAGE_NAME = "package.name";
+  private static final String UNITY_PLATFORM = "Unity";
   private static final String UNITY_VERSION = "2.0.0";
+  private static final String FLUTTER_PLATFORM = "Flutter";
 
   public void testDevelopmentPlatformInfo_withUnity_returnsPlatformAndVersion() throws Exception {
     Context context = createMockContext(/*withUnityResource=*/ true);
+
+    assertTrue(DevelopmentPlatformProvider.isUnity(context));
 
     DevelopmentPlatformProvider provider = new DevelopmentPlatformProvider(context);
 
@@ -38,8 +41,20 @@ public class DevelopmentPlatformProviderTest extends CrashlyticsTestCase {
     assertEquals(UNITY_VERSION, provider.getDevelopmentPlatformVersion());
   }
 
+  public void testDevelopmentPlatformInfo_withFlutter_returnsPlatformAndNoVersion() {
+    Context context = getContext(); // has asset in DevelopmentPlatformProvider.FLUTTER_ASSETS_PATH
+
+    DevelopmentPlatformProvider provider = new DevelopmentPlatformProvider(context);
+
+    assertEquals(FLUTTER_PLATFORM, provider.getDevelopmentPlatform());
+    assertNull(provider.getDevelopmentPlatformVersion());
+    assertFalse(DevelopmentPlatformProvider.isUnity(context));
+  }
+
   public void testDevelopmentPlatformInfo_unknownPlatform_returnsNull() throws Exception {
     Context context = createMockContext(/*withUnityResource=*/ false);
+
+    assertFalse(DevelopmentPlatformProvider.isUnity(context));
 
     DevelopmentPlatformProvider provider = new DevelopmentPlatformProvider(context);
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -34,6 +34,7 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
+import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.NativeSessionFileProvider;
 import com.google.firebase.crashlytics.internal.analytics.AnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.log.LogFileManager;
@@ -142,8 +143,7 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
               "packageName",
               "versionCode",
               "versionName",
-              /*developmentPlatform=*/ null,
-              /*developmentPlatformVersion=*/ null);
+              mock(DevelopmentPlatformProvider.class));
 
       final CrashlyticsController controller =
           new CrashlyticsController(

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -30,6 +30,7 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
+import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.analytics.UnavailableAnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.breadcrumbs.DisabledBreadcrumbSource;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
@@ -263,8 +264,7 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
             "packageName",
             "versionCode",
             "versionName",
-            "Unity",
-            "1.0");
+            mock(DevelopmentPlatformProvider.class));
   }
 
   private void setupResource(Integer resId, String type, String name, String value) {

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -32,6 +32,7 @@ import com.google.firebase.crashlytics.BuildConfig;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
+import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.analytics.UnavailableAnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.breadcrumbs.BreadcrumbHandler;
 import com.google.firebase.crashlytics.internal.breadcrumbs.BreadcrumbSource;
@@ -343,8 +344,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
             "packageName",
             "versionCode",
             "versionName",
-            "Unity",
-            "1.0");
+            mock(DevelopmentPlatformProvider.class));
 
     crashlyticsCore.onPreExecute(appData, mockSettingsController);
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.crashlytics.internal.common;
 
-import static com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider.UNITY_PLATFORM;
 import static com.google.firebase.crashlytics.internal.common.CrashlyticsReportDataCapture.GENERATOR;
 import static com.google.firebase.crashlytics.internal.common.CrashlyticsReportDataCapture.GENERATOR_TYPE;
 import static org.junit.Assert.assertArrayEquals;
@@ -51,6 +50,7 @@ import org.mockito.MockitoAnnotations;
 
 @RunWith(AndroidJUnit4.class)
 public class CrashlyticsReportDataCaptureTest {
+  private static final String UNITY_PLATFORM = "Unity";
 
   private Context context = getContext();
   private IdManager idManager;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/AppData.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/AppData.java
@@ -17,7 +17,6 @@ package com.google.firebase.crashlytics.internal.common;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import androidx.annotation.Nullable;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 
 /** Carries static information about the app. */
@@ -31,8 +30,7 @@ public class AppData {
   public final String versionCode;
   public final String versionName;
 
-  @Nullable public final String developmentPlatform;
-  @Nullable public final String developmentPlatformVersion;
+  public final DevelopmentPlatformProvider developmentPlatformProvider;
 
   public static AppData create(
       Context context,
@@ -56,8 +54,7 @@ public class AppData {
         packageName,
         versionCode,
         versionName,
-        developmentPlatformProvider.getDevelopmentPlatform(),
-        developmentPlatformProvider.getDevelopmentPlatformVersion());
+        developmentPlatformProvider);
   }
 
   public AppData(
@@ -67,15 +64,13 @@ public class AppData {
       String packageName,
       String versionCode,
       String versionName,
-      @Nullable String developmentPlatform,
-      @Nullable String developmentPlatformVersion) {
+      DevelopmentPlatformProvider developmentPlatformProvider) {
     this.googleAppId = googleAppId;
     this.buildId = buildId;
     this.installerPackageName = installerPackageName;
     this.packageName = packageName;
     this.versionCode = versionCode;
     this.versionName = versionName;
-    this.developmentPlatform = developmentPlatform;
-    this.developmentPlatformVersion = developmentPlatformVersion;
+    this.developmentPlatformProvider = developmentPlatformProvider;
   }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -696,8 +696,7 @@ class CrashlyticsController {
         appData.versionName,
         idManager.getCrashlyticsInstallId(),
         DeliveryMechanism.determineFrom(appData.installerPackageName).getId(),
-        appData.developmentPlatform,
-        appData.developmentPlatformVersion);
+        appData.developmentPlatformProvider);
   }
 
   private static StaticSessionData.OsData createOsData(Context context) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
@@ -153,8 +153,9 @@ public class CrashlyticsReportDataCapture {
             .setVersion(appData.versionCode)
             .setDisplayVersion(appData.versionName)
             .setInstallationUuid(idManager.getCrashlyticsInstallId())
-            .setDevelopmentPlatform(appData.developmentPlatform)
-            .setDevelopmentPlatformVersion(appData.developmentPlatformVersion);
+            .setDevelopmentPlatform(appData.developmentPlatformProvider.getDevelopmentPlatform())
+            .setDevelopmentPlatformVersion(
+                appData.developmentPlatformProvider.getDevelopmentPlatformVersion());
     return builder.build();
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/StaticSessionData.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/StaticSessionData.java
@@ -14,8 +14,8 @@
 
 package com.google.firebase.crashlytics.internal.model;
 
-import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
+import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 
 @AutoValue
 public abstract class StaticSessionData {
@@ -44,11 +44,7 @@ public abstract class StaticSessionData {
 
     public abstract int deliveryMechanism();
 
-    @Nullable
-    public abstract String developmentPlatform();
-
-    @Nullable
-    public abstract String developmentPlatformVersion();
+    public abstract DevelopmentPlatformProvider developmentPlatformProvider();
 
     public static AppData create(
         String appIdentifier,
@@ -56,16 +52,14 @@ public abstract class StaticSessionData {
         String versionName,
         String installUuid,
         int deliveryMechanism,
-        @Nullable String developmentPlatform,
-        @Nullable String developmentPlatformVersion) {
+        DevelopmentPlatformProvider developmentPlatformProvider) {
       return new AutoValue_StaticSessionData_AppData(
           appIdentifier,
           versionCode,
           versionName,
           installUuid,
           deliveryMechanism,
-          developmentPlatform,
-          developmentPlatformVersion);
+          developmentPlatformProvider);
     }
   }
 

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
@@ -30,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
+import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.analytics.AnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.log.LogFileManager;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
@@ -143,8 +144,7 @@ public class CrashlyticsControllerRobolectricTest {
             "packageName",
             "versionCode",
             "versionName",
-            /*developmentPlatform=*/ null,
-            /*developmentPlatformVersion=*/ null);
+            mock(DevelopmentPlatformProvider.class));
 
     final CrashlyticsController controller =
         new CrashlyticsController(


### PR DESCRIPTION
Set DevelopmentPlatform info for Flutter apps

Also made DevelopmentPlatform delay the initialization when possible to avoid an additional file operation during start up.