### PR TITLE
Check for default FirebaseApp before logging to Scion.

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/MessagingAnalytics.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/MessagingAnalytics.java
@@ -238,6 +238,13 @@ public class MessagingAnalytics {
    */
   @VisibleForTesting
   static void logToScion(String event, Bundle extras) {
+    try {
+      FirebaseApp.getInstance();
+    } catch (IllegalStateException e) {
+      Log.e(TAG, "Default FirebaseApp has not been initialized. Skip logging event to GA.");
+      return;
+    }
+
     if (extras == null) {
       extras = new Bundle();
     }

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/MessagingAnalyticsRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/MessagingAnalyticsRoboTest.java
@@ -868,6 +868,15 @@ public class MessagingAnalyticsRoboTest {
   }
 
   @Test
+  public void testLogToScion_noDefaultFirebaseApp_doesNotThrow() {
+    FirebaseApp.clearInstancesForTest();
+
+    MessagingAnalytics.logToScion("test_event", null);
+
+    // no exception thrown means we are handling the IllegalStateException gracefully.
+  }
+
+  @Test
   public void testLogToScion_invalidMessageTime_doesNotThrow() {
     Bundle extras = new Bundle();
     extras.putString(AnalyticsKeys.MESSAGE_TIMESTAMP, "invalid_message_time");


### PR DESCRIPTION
* Added getting the default FirebaseApp instance before logging to Scion and not continuing if it throws IllegalStateException because it hasn't been initialized. This prevents throwing IllegalStateException when trying to log to Scion if the default FirebaseApp has not been initialized.