### PR TITLE
Use immutable Documents in MemoryRemoteDocumentCache

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
@@ -21,6 +21,7 @@ import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.bundle.BundledQuery;
 import com.google.firebase.firestore.core.Query.LimitType;
 import com.google.firebase.firestore.core.Target;
+import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.FieldPath;
@@ -48,7 +49,7 @@ public final class LocalSerializer {
   }
 
   /** Encodes a MaybeDocument model to the equivalent protocol buffer for local storage. */
-  com.google.firebase.firestore.proto.MaybeDocument encodeMaybeDocument(MutableDocument document) {
+  com.google.firebase.firestore.proto.MaybeDocument encodeMaybeDocument(Document document) {
     com.google.firebase.firestore.proto.MaybeDocument.Builder builder =
         com.google.firebase.firestore.proto.MaybeDocument.newBuilder();
 
@@ -88,7 +89,7 @@ public final class LocalSerializer {
    * Encodes a Document for local storage. This differs from the v1 RPC serializer for Documents in
    * that it preserves the updateTime, which is considered an output only value by the server.
    */
-  private com.google.firestore.v1.Document encodeDocument(MutableDocument document) {
+  private com.google.firestore.v1.Document encodeDocument(Document document) {
     com.google.firestore.v1.Document.Builder builder =
         com.google.firestore.v1.Document.newBuilder();
     builder.setName(rpcSerializer.encodeKey(document.getKey()));
@@ -110,8 +111,7 @@ public final class LocalSerializer {
   }
 
   /** Encodes a NoDocument value to the equivalent proto. */
-  private com.google.firebase.firestore.proto.NoDocument encodeNoDocument(
-      MutableDocument document) {
+  private com.google.firebase.firestore.proto.NoDocument encodeNoDocument(Document document) {
     com.google.firebase.firestore.proto.NoDocument.Builder builder =
         com.google.firebase.firestore.proto.NoDocument.newBuilder();
     builder.setName(rpcSerializer.encodeKey(document.getKey()));
@@ -130,7 +130,7 @@ public final class LocalSerializer {
 
   /** Encodes a UnknownDocument value to the equivalent proto. */
   private com.google.firebase.firestore.proto.UnknownDocument encodeUnknownDocument(
-      MutableDocument document) {
+      Document document) {
     com.google.firebase.firestore.proto.UnknownDocument.Builder builder =
         com.google.firebase.firestore.proto.UnknownDocument.newBuilder();
     builder.setName(rpcSerializer.encodeKey(document.getKey()));

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryLruReferenceDelegate.java
@@ -18,6 +18,7 @@ import static com.google.firebase.firestore.util.Assert.hardAssert;
 
 import android.util.SparseArray;
 import com.google.firebase.firestore.core.ListenSequence;
+import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.MutableDocument;
 import com.google.firebase.firestore.util.Consumer;
@@ -117,7 +118,7 @@ class MemoryLruReferenceDelegate implements ReferenceDelegate, LruDelegate {
   public int removeOrphanedDocuments(long upperBound) {
     int count = 0;
     MemoryRemoteDocumentCache cache = persistence.getRemoteDocumentCache();
-    for (MutableDocument doc : cache.getDocuments()) {
+    for (Document doc : cache.getDocuments()) {
       DocumentKey key = doc.getKey();
       if (!isPinned(key, upperBound)) {
         cache.remove(key);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Document.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/Document.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.model;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.firestore.v1.Value;
 import java.util.Comparator;
@@ -22,7 +23,7 @@ import java.util.Comparator;
  * Represents a document in Firestore with a key, version, data and whether the data has local
  * mutations applied to it.
  */
-public interface Document {
+public interface Document extends Cloneable {
   /** A document comparator that returns document by key and key only. */
   Comparator<Document> KEY_COMPARATOR = (left, right) -> left.getKey().compareTo(right.getKey());
 
@@ -73,4 +74,7 @@ public interface Document {
    * Whether this document has a local mutation applied that has not yet been acknowledged by Watch.
    */
   boolean hasPendingWrites();
+
+  @NonNull
+  MutableDocument clone();
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/MutableDocument.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/MutableDocument.java
@@ -26,7 +26,7 @@ import com.google.firestore.v1.Value;
  * one of these states even after all mutations have been applied, {@link #isValidDocument} returns
  * false and the document should be removed from all views.
  */
-public final class MutableDocument implements Document, Cloneable {
+public final class MutableDocument implements Document {
 
   private enum DocumentType {
     /**


### PR DESCRIPTION
This is a small refactor that makes it possible to ensure via compile-time checks that we never return a Document directly from the RemoteDocumentCache. Instead, we must call `clone()`.