### PR TITLE
Fix API text files for App Distribution

### DIFF
--- a/firebase-app-distribution/api.txt
+++ b/firebase-app-distribution/api.txt
@@ -1,14 +1,192 @@
 // Signature format: 2.0
 package com.google.firebase.app.distribution {
-  public class FirebaseAppDistribution{
+
+  public abstract class AppDistributionRelease {
+    ctor public AppDistributionRelease();
+    method @NonNull public static com.google.firebase.app.distribution.AppDistributionRelease.Builder builder();
+    method @NonNull public abstract com.google.firebase.app.distribution.BinaryType getBinaryType();
+    method @NonNull public abstract String getDisplayVersion();
+    method @Nullable public abstract String getReleaseNotes();
+    method @NonNull public abstract long getVersionCode();
+  }
+
+  public abstract static class AppDistributionRelease.Builder {
+    ctor public AppDistributionRelease.Builder();
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionRelease build();
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionRelease.Builder setBinaryType(@NonNull com.google.firebase.app.distribution.BinaryType);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionRelease.Builder setDisplayVersion(@NonNull String);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionRelease.Builder setReleaseNotes(@Nullable String);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionRelease.Builder setVersionCode(@NonNull long);
+  }
+
+  public abstract class AppDistributionReleaseInternal {
+    ctor public AppDistributionReleaseInternal();
+    method @NonNull public static com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder builder();
+    method @Nullable public abstract String getApkHash();
+    method @NonNull public abstract com.google.firebase.app.distribution.BinaryType getBinaryType();
+    method @NonNull public abstract String getBuildVersion();
+    method @Nullable public abstract String getCodeHash();
+    method @NonNull public abstract String getDisplayVersion();
+    method @Nullable public abstract String getDownloadUrl();
+    method @Nullable public abstract String getIasArtifactId();
+    method @Nullable public abstract String getReleaseNotes();
+  }
+
+  public abstract static class AppDistributionReleaseInternal.Builder {
+    ctor public AppDistributionReleaseInternal.Builder();
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal build();
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder setApkHash(@NonNull String);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder setBinaryType(@NonNull com.google.firebase.app.distribution.BinaryType);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder setBuildVersion(@NonNull String);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder setCodeHash(@NonNull String);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder setDisplayVersion(@NonNull String);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder setDownloadUrl(@NonNull String);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder setIasArtifactId(@NonNull String);
+    method @NonNull public abstract com.google.firebase.app.distribution.AppDistributionReleaseInternal.Builder setReleaseNotes(@Nullable String);
+  }
+
+  public enum BinaryType {
+    enum_constant public static final com.google.firebase.app.distribution.BinaryType AAB;
+    enum_constant public static final com.google.firebase.app.distribution.BinaryType APK;
+  }
+
+  public class FirebaseAppDistribution {
+    ctor public FirebaseAppDistribution(@NonNull com.google.firebase.FirebaseApp, @NonNull com.google.firebase.installations.FirebaseInstallationsApi, @NonNull com.google.firebase.app.distribution.SignInStorage, @NonNull com.google.firebase.app.distribution.FirebaseAppDistributionLifecycleNotifier);
+    ctor public FirebaseAppDistribution(@NonNull com.google.firebase.FirebaseApp, @NonNull com.google.firebase.installations.FirebaseInstallationsApi);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.app.distribution.AppDistributionRelease> checkForNewRelease();
     method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getInstance();
     method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getInstance(@NonNull com.google.firebase.FirebaseApp);
-    method @NonNull public com.google.firebase.app.distribution.UpdateTask updateIfNewReleaseAvailable();
+    method public boolean isTesterSignedIn();
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();
-    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.app.distribution.AppDistributionRelease> checkForNewRelease();
+    method public void signOutTester();
     method @NonNull public com.google.firebase.app.distribution.UpdateTask updateApp();
-    method public java.lang.Boolean istesterSignedIn()
-    method public java.lang.Void signOutTester();
+    method @NonNull public com.google.firebase.app.distribution.UpdateTask updateIfNewReleaseAvailable();
+  }
+
+  public class FirebaseAppDistributionException extends com.google.firebase.FirebaseException {
+    ctor public FirebaseAppDistributionException(@NonNull String, @NonNull com.google.firebase.app.distribution.FirebaseAppDistributionException.Status);
+    ctor public FirebaseAppDistributionException(@NonNull String, @NonNull com.google.firebase.app.distribution.FirebaseAppDistributionException.Status, @Nullable com.google.firebase.app.distribution.AppDistributionRelease);
+    ctor public FirebaseAppDistributionException(@NonNull String, @NonNull com.google.firebase.app.distribution.FirebaseAppDistributionException.Status, @NonNull Throwable);
+    ctor public FirebaseAppDistributionException(@NonNull String, @NonNull com.google.firebase.app.distribution.FirebaseAppDistributionException.Status, @Nullable com.google.firebase.app.distribution.AppDistributionRelease, @NonNull Throwable);
+    method @NonNull public com.google.firebase.app.distribution.FirebaseAppDistributionException.Status getErrorCode();
+    method @Nullable public com.google.firebase.app.distribution.AppDistributionRelease getRelease();
+  }
+
+  public enum FirebaseAppDistributionException.Status {
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status APP_RUNNING_IN_PRODUCTION;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status AUTHENTICATION_CANCELED;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status AUTHENTICATION_FAILURE;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status DOWNLOAD_FAILURE;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_CANCELED;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_FAILURE;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_FAILURE_SIGNATURE_MISMATCH;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status NETWORK_FAILURE;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status RELEASE_URL_EXPIRED;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status UNKNOWN;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status UPDATE_NOT_AVAILABLE;
+  }
+
+  public class FirebaseAppDistributionFileProvider extends androidx.core.content.FileProvider {
+    ctor public FirebaseAppDistributionFileProvider();
+  }
+
+  public class FirebaseAppDistributionLifecycleNotifier implements android.app.Application.ActivityLifecycleCallbacks {
+    method public void addOnActivityCreatedListener(@NonNull com.google.firebase.app.distribution.FirebaseAppDistributionLifecycleNotifier.OnActivityCreatedListener);
+    method public void addOnActivityDestroyedListener(@NonNull com.google.firebase.app.distribution.FirebaseAppDistributionLifecycleNotifier.OnActivityDestroyedListener);
+    method public void addOnActivityStartedListener(@NonNull com.google.firebase.app.distribution.FirebaseAppDistributionLifecycleNotifier.OnActivityStartedListener);
+    method public android.app.Activity getCurrentActivity();
+    method public static com.google.firebase.app.distribution.FirebaseAppDistributionLifecycleNotifier getInstance();
+    method public void onActivityCreated(@NonNull android.app.Activity, @Nullable android.os.Bundle);
+    method public void onActivityDestroyed(@NonNull android.app.Activity);
+    method public void onActivityPaused(@NonNull android.app.Activity);
+    method public void onActivityResumed(@NonNull android.app.Activity);
+    method public void onActivitySaveInstanceState(@NonNull android.app.Activity, @NonNull android.os.Bundle);
+    method public void onActivityStarted(@NonNull android.app.Activity);
+    method public void onActivityStopped(@NonNull android.app.Activity);
+  }
+
+  public static interface FirebaseAppDistributionLifecycleNotifier.OnActivityCreatedListener {
+    method public void onCreated(android.app.Activity);
+  }
+
+  public static interface FirebaseAppDistributionLifecycleNotifier.OnActivityDestroyedListener {
+    method public void onDestroyed(android.app.Activity);
+  }
+
+  public static interface FirebaseAppDistributionLifecycleNotifier.OnActivityPausedListener {
+    method public void onPaused(android.app.Activity);
+  }
+
+  public static interface FirebaseAppDistributionLifecycleNotifier.OnActivityStartedListener {
+    method public void onStarted(android.app.Activity);
+  }
+
+  public class InstallActivity extends androidx.appcompat.app.AppCompatActivity {
+    ctor public InstallActivity();
+    method public void onResume();
+  }
+
+  public class LogWrapper {
+    method public void d(@NonNull String);
+    method public void e(@NonNull String);
+    method public void e(@NonNull String, @NonNull Throwable);
+    method @NonNull public static com.google.firebase.app.distribution.LogWrapper getInstance();
+    method public void i(@NonNull String);
+    method public void v(@NonNull String);
+    method public void w(@NonNull String);
+  }
+
+  public interface OnProgressListener {
+    method public void onProgressUpdate(@NonNull com.google.firebase.app.distribution.UpdateProgress);
+  }
+
+  public final class ReleaseIdentificationUtils {
+    ctor public ReleaseIdentificationUtils();
+    method @Nullable public static String calculateApkHash(@NonNull java.io.File);
+    method @Nullable public static String extractInternalAppSharingArtifactId(@NonNull android.content.Context);
+  }
+
+  public class SignInResultActivity extends androidx.appcompat.app.AppCompatActivity {
+    ctor public SignInResultActivity();
+    method public void onCreate(@NonNull android.os.Bundle);
+  }
+
+  public class SignInStorage {
+  }
+
+  public abstract class UpdateProgress {
+    ctor public UpdateProgress();
+    method @NonNull public static com.google.firebase.app.distribution.UpdateProgress.Builder builder();
+    method @NonNull public abstract long getApkBytesDownloaded();
+    method @NonNull public abstract long getApkFileTotalBytes();
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateStatus getUpdateStatus();
+  }
+
+  public abstract static class UpdateProgress.Builder {
+    ctor public UpdateProgress.Builder();
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateProgress build();
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateProgress.Builder setApkBytesDownloaded(@NonNull long);
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateProgress.Builder setApkFileTotalBytes(@NonNull long);
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateProgress.Builder setUpdateStatus(@Nullable com.google.firebase.app.distribution.UpdateStatus);
+  }
+
+  public enum UpdateStatus {
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOADED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOADING;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOAD_FAILED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus INSTALL_CANCELED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus INSTALL_FAILED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus NEW_RELEASE_CHECK_FAILED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus NEW_RELEASE_NOT_AVAILABLE;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus PENDING;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus REDIRECTED_TO_PLAY;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus UPDATE_CANCELED;
+  }
+
+  public abstract class UpdateTask extends com.google.android.gms.tasks.Task<java.lang.Void> {
+    ctor public UpdateTask();
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateTask addOnProgressListener(@NonNull com.google.firebase.app.distribution.OnProgressListener);
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateTask addOnProgressListener(@Nullable java.util.concurrent.Executor, @NonNull com.google.firebase.app.distribution.OnProgressListener);
   }
 
 }

--- a/firebase-app-distribution/ktx/api.txt
+++ b/firebase-app-distribution/ktx/api.txt
@@ -3,8 +3,9 @@ package com.google.firebase.app.distribution.ktx {
 
   public final class FirebaseAppDistributionKt {
     ctor public FirebaseAppDistributionKt();
-    method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getAppDistribution(@NonNull com.google.firebase.ktx.Firebase);
     method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution appDistribution(@NonNull com.google.firebase.ktx.Firebase, @NonNull com.google.firebase.FirebaseApp app);
+    method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getAppDistribution(@NonNull com.google.firebase.ktx.Firebase);
   }
 
 }
+


### PR DESCRIPTION
Based off #3213 . Fixes both the java and kotlin api text files by running

`/gradlew :firebase-app-distribution:generateApiTxtFile` and 
`/gradlew :firebase-app-distribution:ktx:generateApiTxtFile`