### PR TITLE
[test-infra] Fix release tagging implementation

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/GitClient.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/GitClient.java
@@ -15,6 +15,7 @@
 package com.google.firebase.gradle.bomgenerator.tagging;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
@@ -38,7 +39,8 @@ public class GitClient {
 
     this.newTags = new ArrayList<>();
     this.handler = this.deriveGitCommandOutputHandlerFromLogger(logger);
-    this.configureSshCommand();
+    this.showVersion();
+    this.configureRemoteRepo("FirebasePrivate/firebase-android-sdk");
   }
 
   public void tagReleaseVersion() {
@@ -60,8 +62,10 @@ public class GitClient {
       return;
     }
 
+    List<String> copy = new ArrayList<>(newTags);
+    Collections.reverse(copy); // GitHub list tags in the reverse chronological order
     StringJoiner joiner = new StringJoiner(" ");
-    newTags.forEach(joiner::add);
+    copy.stream().map(x -> "refs/tags/" + x).forEach(joiner::add);
     String tags = joiner.toString();
 
     logger.accept("Tags to be pushed: " + tags);
@@ -86,20 +90,12 @@ public class GitClient {
     executor.execute(command, handler);
   }
 
-  private void configureSshCommand() {
-    if (!this.onProw()) {
-      return;
-    }
-    // TODO(yifany):
-    //   - Change to use environment variables according to the Git doc:
-    //       https://git-scm.com/docs/git-config#Documentation/git-config.txt-coresshCommand
-    //   - Call of `git config core.sshCommand` in prow/config.yaml will become redundant as well
-    String ssh =
-        "ssh -i /etc/github-ssh-key/github-ssh"
-            + " -o IdentitiesOnly=yes"
-            + " -o UserKnownHostsFile=/dev/null"
-            + " -o StrictHostKeyChecking=no";
-    String command = String.format("git config core.sshCommand \"%s\"", ssh);
+  private void showVersion() {
+    executor.execute("git --version", handler);
+  }
+
+  private void configureRemoteRepo(String repo) {
+    String command = String.format("git remote add origin git@github.com:%s.git", repo);
     executor.execute(command, handler);
   }
 }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/ShellExecutor.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/ShellExecutor.java
@@ -38,7 +38,7 @@ public class ShellExecutor {
     this.execute(command, consumer, consumer);
   }
 
-  public void execute(String command, Consumer<List<String>> stderrConsumer, Consumer<List<String>> stdoutConsumer) {
+  public void execute(String command, Consumer<List<String>> err, Consumer<List<String>> out) {
     try {
       logger.accept("[shell] Executing: \"" + command + "\" at: " + cwd.getAbsolutePath());
       Process p = runtime.exec(command, null, cwd);
@@ -46,8 +46,8 @@ public class ShellExecutor {
       logger.accept("[shell] Command: \"" + command + "\" returned with code: " + code);
       BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream()));
       BufferedReader stderr = new BufferedReader(new InputStreamReader(p.getErrorStream()));
-      stdoutConsumer.accept(CharStreams.readLines(stdout));
-      stderrConsumer.accept(CharStreams.readLines(stderr));
+      out.accept(CharStreams.readLines(stdout));
+      err.accept(CharStreams.readLines(stderr));
     } catch (IOException e) {
       throw new GradleException("Failed when executing command: " + command, e);
     } catch (InterruptedException e) {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/ShellExecutor.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/ShellExecutor.java
@@ -40,8 +40,10 @@ public class ShellExecutor {
       Process p = runtime.exec(command, null, cwd);
       int code = p.waitFor();
       logger.accept("[shell] Command: \"" + command + "\" returned with code: " + code);
-      BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
-      consumer.accept(CharStreams.readLines(reader));
+      BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream()));
+      BufferedReader stderr = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+      consumer.accept(CharStreams.readLines(stdout));
+      consumer.accept(CharStreams.readLines(stderr));
     } catch (IOException e) {
       throw new GradleException("Failed when executing command: " + command, e);
     } catch (InterruptedException e) {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/ShellExecutor.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/ShellExecutor.java
@@ -35,6 +35,10 @@ public class ShellExecutor {
   }
 
   public void execute(String command, Consumer<List<String>> consumer) {
+    this.execute(command, consumer, consumer);
+  }
+
+  public void execute(String command, Consumer<List<String>> stderrConsumer, Consumer<List<String>> stdoutConsumer) {
     try {
       logger.accept("[shell] Executing: \"" + command + "\" at: " + cwd.getAbsolutePath());
       Process p = runtime.exec(command, null, cwd);
@@ -42,8 +46,8 @@ public class ShellExecutor {
       logger.accept("[shell] Command: \"" + command + "\" returned with code: " + code);
       BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream()));
       BufferedReader stderr = new BufferedReader(new InputStreamReader(p.getErrorStream()));
-      consumer.accept(CharStreams.readLines(stdout));
-      consumer.accept(CharStreams.readLines(stderr));
+      stdoutConsumer.accept(CharStreams.readLines(stdout));
+      stderrConsumer.accept(CharStreams.readLines(stderr));
     } catch (IOException e) {
       throw new GradleException("Failed when executing command: " + command, e);
     } catch (InterruptedException e) {

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/bomgenerator/tagging/GitClientTest.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/bomgenerator/tagging/GitClientTest.kt
@@ -31,12 +31,13 @@ class GitClientTest {
     private val branch = AtomicReference<String>()
     private val commit = AtomicReference<String>()
 
-    private val executor = ShellExecutor(testGitDirectory.root, System.out::println)
+    private lateinit var executor: ShellExecutor
     private val handler: (List<String>) -> Unit = { it.forEach(System.out::println) }
 
     @Before
     fun setup() {
         testGitDirectory.newFile("hello.txt").writeText("hello git!")
+        executor = ShellExecutor(testGitDirectory.root, System.out::println)
 
         executor.execute("git init", handler)
         executor.execute("git config user.email 'GitClientTest@example.com'", handler)

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/bomgenerator/tagging/GitClientTest.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/bomgenerator/tagging/GitClientTest.kt
@@ -31,11 +31,12 @@ class GitClientTest {
     private val branch = AtomicReference<String>()
     private val commit = AtomicReference<String>()
 
+    private val executor = ShellExecutor(testGitDirectory.root, System.out::println)
+    private val handler: (List<String>) -> Unit = { it.forEach(System.out::println) }
+
     @Before
     fun setup() {
         testGitDirectory.newFile("hello.txt").writeText("hello git!")
-        val executor = ShellExecutor(testGitDirectory.root, System.out::println)
-        val handler: (List<String>) -> Unit = { it.forEach(System.out::println) }
 
         executor.execute("git init", handler)
         executor.execute("git config user.email 'GitClientTest@example.com'", handler)
@@ -50,30 +51,27 @@ class GitClientTest {
 
     @Test
     fun `tag M release version succeeds on local file system`() {
-        val executor = ShellExecutor(testGitDirectory.root, System.out::println)
         val git = GitClient(branch.get(), commit.get(), executor, System.out::println)
         git.tagReleaseVersion()
-        executor.execute("git tag --points-at HEAD", null) {
+        executor.execute("git tag --points-at HEAD", handler) {
             Assert.assertTrue(it.stream().anyMatch { x -> x.contains(branch.get()) })
         }
     }
 
     @Test
     fun `tag bom version succeeds on local file system`() {
-        val executor = ShellExecutor(testGitDirectory.root, System.out::println)
         val git = GitClient(branch.get(), commit.get(), executor, System.out::println)
         git.tagBomVersion("1.2.3")
-        executor.execute("git tag --points-at HEAD", null) {
+        executor.execute("git tag --points-at HEAD", handler) {
             Assert.assertTrue(it.stream().anyMatch { x -> x.contains("bom@1.2.3") })
         }
     }
 
     @Test
     fun `tag product version succeeds on local file system`() {
-        val executor = ShellExecutor(testGitDirectory.root, System.out::println)
         val git = GitClient(branch.get(), commit.get(), executor, System.out::println)
         git.tagProductVersion("firebase-database", "1.2.3")
-        executor.execute("git tag --points-at HEAD", null) {
+        executor.execute("git tag --points-at HEAD", handler) {
             Assert.assertTrue(it.stream().anyMatch { x -> x.contains("firebase-database@1.2.3") })
         }
     }

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/bomgenerator/tagging/GitClientTest.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/bomgenerator/tagging/GitClientTest.kt
@@ -44,8 +44,8 @@ class GitClientTest {
         executor.execute("git commit -m 'init_commit'", handler)
         executor.execute("git status", handler)
 
-        executor.execute("git rev-parse --abbrev-ref HEAD") { branch.set(it[0]) }
-        executor.execute("git rev-parse HEAD") { commit.set(it[0]) }
+        executor.execute("git rev-parse --abbrev-ref HEAD", handler) { branch.set(it[0]) }
+        executor.execute("git rev-parse HEAD", handler) { commit.set(it[0]) }
     }
 
     @Test
@@ -53,7 +53,7 @@ class GitClientTest {
         val executor = ShellExecutor(testGitDirectory.root, System.out::println)
         val git = GitClient(branch.get(), commit.get(), executor, System.out::println)
         git.tagReleaseVersion()
-        executor.execute("git tag --points-at HEAD") {
+        executor.execute("git tag --points-at HEAD", null) {
             Assert.assertTrue(it.stream().anyMatch { x -> x.contains(branch.get()) })
         }
     }
@@ -63,7 +63,7 @@ class GitClientTest {
         val executor = ShellExecutor(testGitDirectory.root, System.out::println)
         val git = GitClient(branch.get(), commit.get(), executor, System.out::println)
         git.tagBomVersion("1.2.3")
-        executor.execute("git tag --points-at HEAD") {
+        executor.execute("git tag --points-at HEAD", null) {
             Assert.assertTrue(it.stream().anyMatch { x -> x.contains("bom@1.2.3") })
         }
     }
@@ -73,7 +73,7 @@ class GitClientTest {
         val executor = ShellExecutor(testGitDirectory.root, System.out::println)
         val git = GitClient(branch.get(), commit.get(), executor, System.out::println)
         git.tagProductVersion("firebase-database", "1.2.3")
-        executor.execute("git tag --points-at HEAD") {
+        executor.execute("git tag --points-at HEAD", null) {
             Assert.assertTrue(it.stream().anyMatch { x -> x.contains("firebase-database@1.2.3") })
         }
     }


### PR DESCRIPTION
Verified in the fake release `MFake`: https://github.com/FirebasePrivate/firebase-android-sdk/pull/412.

The tag `MFake` was successfully created and uploaded to `FirebasePrivate/firebase-android-sdk`. 

https://prow-gob.gcpnode.com/view/gcs/fireescape/pr-logs/pull/FirebasePrivate_firebase-android-sdk/412/make-bom/1469548790112325632/#1:build-log.txt%3A207