### PR TITLE
Remove base mutations

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalSerializer.java
@@ -153,9 +153,6 @@ public final class LocalSerializer {
 
     result.setBatchId(batch.getBatchId());
     result.setLocalWriteTime(rpcSerializer.encodeTimestamp(batch.getLocalWriteTime()));
-    for (Mutation mutation : batch.getBaseMutations()) {
-      result.addBaseWrites(rpcSerializer.encodeMutation(mutation));
-    }
     for (Mutation mutation : batch.getMutations()) {
       result.addWrites(rpcSerializer.encodeMutation(mutation));
     }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalSerializerTest.java
@@ -273,19 +273,9 @@ public final class LocalSerializerTest {
         new MutationBatch(
             42, writeTime, Collections.singletonList(baseWrite), asList(set, patch, del));
 
-    Write baseWriteProto =
-        Write.newBuilder()
-            .setUpdate(
-                com.google.firestore.v1.Document.newBuilder()
-                    .setName("projects/p/databases/d/documents/foo/bar")
-                    .putFields("a", Value.newBuilder().setStringValue("b").build()))
-            .setUpdateMask(DocumentMask.newBuilder().addFieldPaths("a"))
-            .build();
-
     com.google.firebase.firestore.proto.WriteBatch batchProto =
         com.google.firebase.firestore.proto.WriteBatch.newBuilder()
             .setBatchId(42)
-            .addBaseWrites(baseWriteProto)
             .addAllWrites(asList(setProto, patchProto, deleteProto))
             .setLocalWriteTime(writeTimeProto)
             .build();
@@ -295,7 +285,6 @@ public final class LocalSerializerTest {
     assertEquals(model.getBatchId(), decoded.getBatchId());
     assertEquals(model.getLocalWriteTime(), decoded.getLocalWriteTime());
     assertEquals(model.getMutations(), decoded.getMutations());
-    assertEquals(model.getBaseMutations(), decoded.getBaseMutations());
     assertEquals(model.getKeys(), decoded.getKeys());
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -1349,8 +1349,8 @@ public abstract class LocalStoreTestCase {
     assertContains(doc("foo/bar", 0, map("sum", 1)).setHasLocalMutations());
 
     applyRemoteEvent(addedRemoteEvent(doc("foo/bar", 1, map("sum", 1337)), asList(2), emptyList()));
-    assertChanged(doc("foo/bar", 1, map("sum", 1)).setHasLocalMutations());
-    assertContains(doc("foo/bar", 1, map("sum", 1)).setHasLocalMutations());
+    assertChanged(doc("foo/bar", 1, map("sum", 1338)).setHasLocalMutations());
+    assertContains(doc("foo/bar", 1, map("sum", 1338)).setHasLocalMutations());
   }
 
   @Test
@@ -1363,12 +1363,9 @@ public abstract class LocalStoreTestCase {
     assertChanged(deletedDoc("foo/bar", 0));
     assertNotContains("foo/bar");
 
-    // Note: This test reflects the current behavior, but it may be preferable to replay the
-    // mutation once we receive the first value from the remote event.
-
     applyRemoteEvent(addedRemoteEvent(doc("foo/bar", 1, map("sum", 1337)), asList(2), emptyList()));
-    assertChanged(doc("foo/bar", 1, map("sum", 1)).setHasLocalMutations());
-    assertContains(doc("foo/bar", 1, map("sum", 1)).setHasLocalMutations());
+    assertChanged(doc("foo/bar", 1, map("sum", 1338)).setHasLocalMutations());
+    assertContains(doc("foo/bar", 1, map("sum", 1338)).setHasLocalMutations());
   }
 
   @Test
@@ -1445,8 +1442,8 @@ public abstract class LocalStoreTestCase {
     assertContains(doc("foo/bar", 0, map("sum", 1)).setHasLocalMutations());
 
     bundleDocuments(doc("foo/bar", 1, map("sum", 1337)));
-    assertChanged(doc("foo/bar", 1, map("sum", 1)).setHasLocalMutations());
-    assertContains(doc("foo/bar", 1, map("sum", 1)).setHasLocalMutations());
+    assertChanged(doc("foo/bar", 1, map("sum", 1338)).setHasLocalMutations());
+    assertContains(doc("foo/bar", 1, map("sum", 1338)).setHasLocalMutations());
 
     assertQueryDocumentMapping(/* targetId= */ 4, key("foo/bar"));
   }
@@ -1464,8 +1461,8 @@ public abstract class LocalStoreTestCase {
     assertNotContains("foo/bar");
 
     bundleDocuments(doc("foo/bar", 1, map("sum", 1337)));
-    assertChanged(doc("foo/bar", 1, map("sum", 1)).setHasLocalMutations());
-    assertContains(doc("foo/bar", 1, map("sum", 1)).setHasLocalMutations());
+    assertChanged(doc("foo/bar", 1, map("sum", 1338)).setHasLocalMutations());
+    assertContains(doc("foo/bar", 1, map("sum", 1338)).setHasLocalMutations());
 
     assertQueryDocumentMapping(/* targetId= */ 4, key("foo/bar"));
   }


### PR DESCRIPTION
Some tests need to be updated, they have document existence change, hence mutation queue is re-applied. IMO I think it is the right thing to do.