### PR TITLE
Remove support for multiple sdk instances in Firebase App Distribution

### DIFF
--- a/firebase-app-distribution/api.txt
+++ b/firebase-app-distribution/api.txt
@@ -17,7 +17,6 @@ package com.google.firebase.app.distribution {
   public class FirebaseAppDistribution {
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.app.distribution.AppDistributionRelease> checkForNewRelease();
     method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getInstance();
-    method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getInstance(@NonNull com.google.firebase.FirebaseApp);
     method public boolean isTesterSignedIn();
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();
     method public void signOutTester();

--- a/firebase-app-distribution/ktx/api.txt
+++ b/firebase-app-distribution/ktx/api.txt
@@ -3,7 +3,6 @@ package com.google.firebase.app.distribution.ktx {
 
   public final class FirebaseAppDistributionKt {
     ctor public FirebaseAppDistributionKt();
-    method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution appDistribution(@NonNull com.google.firebase.ktx.Firebase, @NonNull com.google.firebase.FirebaseApp app);
     method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getAppDistribution(@NonNull com.google.firebase.ktx.Firebase);
   }
 

--- a/firebase-app-distribution/ktx/src/androidTest/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistributionTests.kt
+++ b/firebase-app-distribution/ktx/src/androidTest/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistributionTests.kt
@@ -70,12 +70,6 @@ class FirebaseAppDistributionTests : BaseTestCase() {
     fun appDistribution_default_callsDefaultGetInstance() {
         Truth.assertThat(Firebase.appDistribution).isSameInstanceAs(FirebaseAppDistribution.getInstance())
     }
-
-    @Test
-    fun appDistribution_withFirebaseApp_callsGetInstanceWithApp() {
-        val app = Firebase.app(EXISTING_APP)
-        Truth.assertThat(Firebase.appDistribution(app)).isSameInstanceAs(FirebaseAppDistribution.getInstance(app))
-    }
 }
 
 internal const val LIBRARY_NAME: String = "fire-app-distribution-ktx"

--- a/firebase-app-distribution/ktx/src/main/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistribution.kt
+++ b/firebase-app-distribution/ktx/src/main/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistribution.kt
@@ -27,10 +27,6 @@ import com.google.firebase.platforminfo.LibraryVersionComponent
 val Firebase.appDistribution: FirebaseAppDistribution
     get() = FirebaseAppDistribution.getInstance()
 
-/** Returns the [FirebaseAppDistribution] instance of a given [FirebaseApp]. */
-fun Firebase.appDistribution(app: FirebaseApp): FirebaseAppDistribution =
-        FirebaseAppDistribution.getInstance(app)
-
 internal const val LIBRARY_NAME: String = "fire-app-distribution-ktx"
 
 /** @suppress */

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/FirebaseAppDistribution.java
@@ -26,7 +26,6 @@ import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import com.google.android.gms.common.internal.Preconditions;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
@@ -113,19 +112,7 @@ public class FirebaseAppDistribution {
   /** @return a FirebaseAppDistribution instance */
   @NonNull
   public static FirebaseAppDistribution getInstance() {
-    return getInstance(FirebaseApp.getInstance());
-  }
-
-  /**
-   * Returns the {@link FirebaseAppDistribution} initialized with a custom {@link FirebaseApp}.
-   *
-   * @param app a custom {@link FirebaseApp}
-   * @return a {@link FirebaseAppDistribution} instance
-   */
-  @NonNull
-  public static FirebaseAppDistribution getInstance(@NonNull FirebaseApp app) {
-    Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
-    return app.get(FirebaseAppDistribution.class);
+    return FirebaseApp.getInstance().get(FirebaseAppDistribution.class);
   }
 
   /**


### PR DESCRIPTION
Remove support for multiple instances of the sdk. Only support the default Firebase app