### PR TITLE
Adding clear task flag to fix update app bug

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/internal/InstallActivity.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/internal/InstallActivity.java
@@ -144,8 +144,7 @@ public class InstallActivity extends AppCompatActivity {
 
     // These flags open the installation activity in a new task and to prevent earlier installation
     // tasks from causing future ones to fail we use the clear task flag
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
     LogWrapper.getInstance().v("Kicking off install as new activity");
     startActivity(intent);
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/internal/InstallActivity.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/internal/InstallActivity.java
@@ -143,6 +143,7 @@ public class InstallActivity extends AppCompatActivity {
     }
 
     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
     LogWrapper.getInstance().v("Kicking off install as new activity");
     startActivity(intent);
   }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/internal/InstallActivity.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/internal/InstallActivity.java
@@ -142,6 +142,8 @@ public class InstallActivity extends AppCompatActivity {
       intent.setDataAndType(Uri.fromFile(apkFile), APK_MIME_TYPE);
     }
 
+    // These flags open the installation activity in a new task and to prevent earlier installation
+    // tasks from causing future ones to fail we use the clear task flag
     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
     LogWrapper.getInstance().v("Kicking off install as new activity");


### PR DESCRIPTION
The bug in question would occur when a user would update the app and not close the app after updating and opening it using the system dialog that occurs after an update. When they would try to update again the update would fail and the task would hang.