### PR TITLE
Improve error handling around downloading and installing

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/AabUpdater.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/AabUpdater.java
@@ -24,6 +24,7 @@ import android.net.Uri;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import com.google.firebase.app.distribution.Constants.ErrorMessages;
 import com.google.firebase.app.distribution.internal.InstallActivity;
 import com.google.firebase.app.distribution.internal.LogWrapper;
 import com.google.firebase.app.distribution.internal.SignInResultActivity;
@@ -127,8 +128,7 @@ class AabUpdater {
       if (lifecycleNotifier.getCurrentActivity() == null) {
         safeSetTaskException(
             cachedUpdateTask,
-            new FirebaseAppDistributionException(
-                Constants.ErrorMessages.APP_BACKGROUNDED, DOWNLOAD_FAILURE));
+            new FirebaseAppDistributionException(ErrorMessages.APP_BACKGROUNDED, DOWNLOAD_FAILURE));
         return;
       }
     }
@@ -173,7 +173,7 @@ class AabUpdater {
       safeSetTaskException(
           cachedUpdateTask,
           new FirebaseAppDistributionException(
-              Constants.ErrorMessages.UPDATE_CANCELED,
+              ErrorMessages.UPDATE_CANCELED,
               FirebaseAppDistributionException.Status.INSTALLATION_CANCELED,
               ReleaseUtils.convertToAppDistributionRelease(aabReleaseInProgress)));
     }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/AabUpdater.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/AabUpdater.java
@@ -50,7 +50,10 @@ class AabUpdater {
   private final Object updateAabLock = new Object();
 
   AabUpdater() {
-    this(FirebaseAppDistributionLifecycleNotifier.getInstance(), new HttpsUrlConnectionFactory(), Executors.newSingleThreadExecutor());
+    this(
+        FirebaseAppDistributionLifecycleNotifier.getInstance(),
+        new HttpsUrlConnectionFactory(),
+        Executors.newSingleThreadExecutor());
   }
 
   AabUpdater(
@@ -134,32 +137,31 @@ class AabUpdater {
     }
 
     // The 302 redirect is obtained here to open the play store directly and avoid opening chrome
-    executor
-        .execute( // Execute the network calls on a background thread
-            () -> {
-              String redirectUrl;
-              try {
-                redirectUrl = fetchDownloadRedirectUrl(downloadUrl);
-              } catch (FirebaseAppDistributionException e) {
-                setUpdateTaskCompletionError(e);
-                return;
-              }
+    executor.execute( // Execute the network calls on a background thread
+        () -> {
+          String redirectUrl;
+          try {
+            redirectUrl = fetchDownloadRedirectUrl(downloadUrl);
+          } catch (FirebaseAppDistributionException e) {
+            setUpdateTaskCompletionError(e);
+            return;
+          }
 
-              Intent updateIntent = new Intent(Intent.ACTION_VIEW);
-              updateIntent.setData(Uri.parse(redirectUrl));
-              updateIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-              LogWrapper.getInstance().v(TAG + "Redirecting to play");
+          Intent updateIntent = new Intent(Intent.ACTION_VIEW);
+          updateIntent.setData(Uri.parse(redirectUrl));
+          updateIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          LogWrapper.getInstance().v(TAG + "Redirecting to play");
 
-              synchronized (updateAabLock) {
-                lifecycleNotifier.getCurrentActivity().startActivity(updateIntent);
-                cachedUpdateTask.updateProgress(
-                    UpdateProgress.builder()
-                        .setApkBytesDownloaded(-1)
-                        .setApkFileTotalBytes(-1)
-                        .setUpdateStatus(UpdateStatus.REDIRECTED_TO_PLAY)
-                        .build());
-              }
-            });
+          synchronized (updateAabLock) {
+            lifecycleNotifier.getCurrentActivity().startActivity(updateIntent);
+            cachedUpdateTask.updateProgress(
+                UpdateProgress.builder()
+                    .setApkBytesDownloaded(-1)
+                    .setApkFileTotalBytes(-1)
+                    .setUpdateStatus(UpdateStatus.REDIRECTED_TO_PLAY)
+                    .build());
+          }
+        });
   }
 
   private void setUpdateTaskCompletionError(FirebaseAppDistributionException e) {

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
@@ -61,7 +61,12 @@ class ApkUpdater {
   private final Object updateTaskLock = new Object();
 
   public ApkUpdater(@NonNull FirebaseApp firebaseApp, @NonNull ApkInstaller apkInstaller) {
-    this(Executors.newSingleThreadExecutor(), firebaseApp, apkInstaller, new FirebaseAppDistributionNotificationsManager(firebaseApp.getApplicationContext()), new HttpsUrlConnectionFactory());
+    this(
+        Executors.newSingleThreadExecutor(),
+        firebaseApp,
+        apkInstaller,
+        new FirebaseAppDistributionNotificationsManager(firebaseApp.getApplicationContext()),
+        new HttpsUrlConnectionFactory());
   }
 
   @VisibleForTesting

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
@@ -94,8 +94,7 @@ class ApkUpdater {
     }
 
     downloadApk(newRelease, showNotification)
-        .addOnSuccessListener(
-            taskExecutor, file -> installApk(file, showNotification))
+        .addOnSuccessListener(taskExecutor, file -> installApk(file, showNotification))
         .addOnFailureListener(
             taskExecutor,
             e -> {
@@ -179,14 +178,12 @@ class ApkUpdater {
     String fileName = getApkFileName();
     LogWrapper.getInstance().v(TAG + "Attempting to download APK to disk");
 
-    long bytesDownloaded =
-        downloadToDisk(connection, responseLength, fileName, showNotification);
+    long bytesDownloaded = downloadToDisk(connection, responseLength, fileName, showNotification);
 
     File apkFile = firebaseApp.getApplicationContext().getFileStreamPath(fileName);
     validateJarFile(apkFile, responseLength, showNotification, bytesDownloaded);
 
-    postUpdateProgress(
-        responseLength, bytesDownloaded, UpdateStatus.DOWNLOADED, showNotification);
+    postUpdateProgress(responseLength, bytesDownloaded, UpdateStatus.DOWNLOADED, showNotification);
     safeSetTaskResult(downloadTaskCompletionSource, apkFile);
   }
 
@@ -195,10 +192,7 @@ class ApkUpdater {
   }
 
   private long downloadToDisk(
-      HttpsURLConnection connection,
-      long totalSize,
-      String fileName,
-      boolean showNotification)
+      HttpsURLConnection connection, long totalSize, String fileName, boolean showNotification)
       throws FirebaseAppDistributionException {
     Context context = firebaseApp.getApplicationContext();
     context.deleteFile(fileName);
@@ -227,10 +221,7 @@ class ApkUpdater {
       }
     } catch (IOException e) {
       postUpdateProgress(
-          totalSize,
-          bytesDownloaded,
-          UpdateStatus.DOWNLOAD_FAILED,
-          showNotification);
+          totalSize, bytesDownloaded, UpdateStatus.DOWNLOAD_FAILED, showNotification);
       throw new FirebaseAppDistributionException("Failed to download APK", DOWNLOAD_FAILURE, e);
     }
     return bytesDownloaded;
@@ -243,10 +234,7 @@ class ApkUpdater {
       new JarFile(apkFile).close();
     } catch (IOException e) {
       postUpdateProgress(
-          totalSize,
-          bytesDownloaded,
-          UpdateStatus.DOWNLOAD_FAILED,
-          showNotification);
+          totalSize, bytesDownloaded, UpdateStatus.DOWNLOAD_FAILED, showNotification);
       throw new FirebaseAppDistributionException(
           "Downloaded APK was not a valid JAR file", DOWNLOAD_FAILURE, e);
     }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
@@ -67,6 +67,10 @@ class ApkUpdater {
       @NonNull FirebaseApp firebaseApp,
       @NonNull ApkInstaller apkInstaller,
       @NonNull FirebaseAppDistributionNotificationsManager appDistributionNotificationsManager) {
+<<<<<<< HEAD
+=======
+    this.appDistributionNotificationsManager = appDistributionNotificationsManager;
+>>>>>>> a7b82c4c (Refactor tests around notifications to be more focused to the classes under test)
     this.taskExecutor = taskExecutor;
     this.firebaseApp = firebaseApp;
     this.apkInstaller = apkInstaller;

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
@@ -14,23 +14,27 @@
 
 package com.google.firebase.app.distribution;
 
+import static com.google.firebase.app.distribution.FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE;
 import static com.google.firebase.app.distribution.FirebaseAppDistributionException.Status.NETWORK_FAILURE;
 import static com.google.firebase.app.distribution.TaskUtils.safeSetTaskException;
 import static com.google.firebase.app.distribution.TaskUtils.safeSetTaskResult;
 
 import android.content.Context;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.app.distribution.Constants.ErrorMessages;
+import com.google.firebase.app.distribution.FirebaseAppDistributionException.Status;
 import com.google.firebase.app.distribution.internal.LogWrapper;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.jar.JarFile;
@@ -38,15 +42,18 @@ import javax.net.ssl.HttpsURLConnection;
 
 /** Class that handles updateApp functionality for APKs in {@link FirebaseAppDistribution}. */
 class ApkUpdater {
+
   private static final int UPDATE_INTERVAL_MS = 250;
   private static final String TAG = "UpdateApkClient:";
-  private static final String REQUEST_METHOD = "GET";
+  private static final String REQUEST_METHOD_GET = "GET";
+  private static final String DEFAULT_APK_FILE_NAME = "downloaded_release.apk";
 
   private TaskCompletionSource<File> downloadTaskCompletionSource;
   private final Executor taskExecutor; // Executor to run task listeners on a background thread
   private final FirebaseApp firebaseApp;
   private final ApkInstaller apkInstaller;
   private final FirebaseAppDistributionNotificationsManager appDistributionNotificationsManager;
+  private final HttpsUrlConnectionFactory httpsUrlConnectionFactory;
 
   @GuardedBy("updateTaskLock")
   private UpdateTaskImpl cachedUpdateTask;
@@ -54,11 +61,7 @@ class ApkUpdater {
   private final Object updateTaskLock = new Object();
 
   public ApkUpdater(@NonNull FirebaseApp firebaseApp, @NonNull ApkInstaller apkInstaller) {
-    this(
-        Executors.newSingleThreadExecutor(),
-        firebaseApp,
-        apkInstaller,
-        new FirebaseAppDistributionNotificationsManager(firebaseApp.getApplicationContext()));
+    this(Executors.newSingleThreadExecutor(), firebaseApp, apkInstaller, new FirebaseAppDistributionNotificationsManager(firebaseApp.getApplicationContext()), new HttpsUrlConnectionFactory());
   }
 
   @VisibleForTesting
@@ -66,15 +69,13 @@ class ApkUpdater {
       @NonNull Executor taskExecutor,
       @NonNull FirebaseApp firebaseApp,
       @NonNull ApkInstaller apkInstaller,
-      @NonNull FirebaseAppDistributionNotificationsManager appDistributionNotificationsManager) {
-<<<<<<< HEAD
-=======
-    this.appDistributionNotificationsManager = appDistributionNotificationsManager;
->>>>>>> a7b82c4c (Refactor tests around notifications to be more focused to the classes under test)
+      @NonNull FirebaseAppDistributionNotificationsManager appDistributionNotificationsManager,
+      @NonNull HttpsUrlConnectionFactory httpsUrlConnectionFactory) {
     this.taskExecutor = taskExecutor;
     this.firebaseApp = firebaseApp;
     this.apkInstaller = apkInstaller;
     this.appDistributionNotificationsManager = appDistributionNotificationsManager;
+    this.httpsUrlConnectionFactory = httpsUrlConnectionFactory;
   }
 
   UpdateTaskImpl updateApk(
@@ -88,50 +89,41 @@ class ApkUpdater {
     }
 
     downloadApk(newRelease, showNotification)
-        // Using onSuccess task to ensure that all install errors get cascaded to the Failure
-        // listener down below
         .addOnSuccessListener(
-            taskExecutor,
-            file ->
-                apkInstaller
-                    .installApk(file.getPath())
-                    .addOnFailureListener(
-                        taskExecutor,
-                        e -> {
-                          LogWrapper.getInstance().e(TAG + "Newest release failed to install.", e);
-                          postUpdateProgress(
-                              file.length(),
-                              file.length(),
-                              UpdateStatus.INSTALL_FAILED,
-                              showNotification);
-                          setUpdateTaskCompletionErrorWithDefault(
-                              e,
-                              new FirebaseAppDistributionException(
-                                  Constants.ErrorMessages.APK_INSTALLATION_FAILED,
-                                  FirebaseAppDistributionException.Status.INSTALLATION_FAILURE));
-                        })
-                    .addOnSuccessListener(
-                        taskExecutor,
-                        unused -> {
-                          synchronized (updateTaskLock) {
-                            safeSetTaskResult(cachedUpdateTask);
-                          }
-                        }))
+            taskExecutor, file -> installApk(file, showNotification))
         .addOnFailureListener(
             taskExecutor,
             e -> {
-              LogWrapper.getInstance()
-                  .e(TAG + "Download or Installation failure for newest release.", e);
               setUpdateTaskCompletionErrorWithDefault(
-                  e,
-                  new FirebaseAppDistributionException(
-                      Constants.ErrorMessages.NETWORK_ERROR,
-                      FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
+                  e, "Failed to download APK", Status.DOWNLOAD_FAILURE);
             });
 
     synchronized (updateTaskLock) {
       return cachedUpdateTask;
     }
+  }
+
+  private void installApk(File file, boolean showDownloadNotificationManager) {
+    apkInstaller
+        .installApk(file.getPath())
+        .addOnSuccessListener(
+            taskExecutor,
+            unused -> {
+              synchronized (updateTaskLock) {
+                safeSetTaskResult(cachedUpdateTask);
+              }
+            })
+        .addOnFailureListener(
+            taskExecutor,
+            e -> {
+              postUpdateProgress(
+                  file.length(),
+                  file.length(),
+                  UpdateStatus.INSTALL_FAILED,
+                  showDownloadNotificationManager);
+              setUpdateTaskCompletionErrorWithDefault(
+                  e, ErrorMessages.APK_INSTALLATION_FAILED, Status.INSTALLATION_FAILURE);
+            });
   }
 
   @VisibleForTesting
@@ -145,65 +137,80 @@ class ApkUpdater {
 
     downloadTaskCompletionSource = new TaskCompletionSource<>();
 
-    makeApkDownloadRequest(newRelease, showNotification);
-    return downloadTaskCompletionSource.getTask();
-  }
-
-  private void makeApkDownloadRequest(
-      @NonNull AppDistributionReleaseInternal newRelease, boolean showNotification) {
     taskExecutor.execute(
         () -> {
           try {
-            HttpsURLConnection connection = openHttpsUrlConnection(newRelease.getDownloadUrl());
-            connection.setRequestMethod(REQUEST_METHOD);
-            if (connection.getInputStream() == null) {
-              setDownloadTaskCompletionError(
-                  new FirebaseAppDistributionException(
-                      Constants.ErrorMessages.NETWORK_ERROR,
-                      FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
-            } else {
-              long responseLength = connection.getContentLength();
-              postUpdateProgress(responseLength, 0, UpdateStatus.PENDING, showNotification);
-              String fileName = getApplicationName() + ".apk";
-              LogWrapper.getInstance().v(TAG + "Attempting to download to disk");
-
-              downloadToDisk(
-                  connection.getInputStream(), responseLength, fileName, showNotification);
-            }
-          } catch (IOException | FirebaseAppDistributionException e) {
-            setDownloadTaskCompletionErrorWithDefault(
-                e,
-                new FirebaseAppDistributionException(
-                    Constants.ErrorMessages.NETWORK_ERROR,
-                    FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
+            makeApkDownloadRequest(newRelease, showNotification);
+          } catch (FirebaseAppDistributionException e) {
+            safeSetTaskException(downloadTaskCompletionSource, e);
           }
         });
+    return downloadTaskCompletionSource.getTask();
   }
 
-  private void downloadToDisk(
-      InputStream input, long totalSize, String fileName, boolean showNotification) {
+  // TODO(lkellogg): The happy path in this method is not exercised by any tests right now
+  private void makeApkDownloadRequest(
+      @NonNull AppDistributionReleaseInternal newRelease, boolean showNotification)
+      throws FirebaseAppDistributionException {
+    String downloadUrl = newRelease.getDownloadUrl();
+    HttpsURLConnection connection;
+    int responseCode;
+    try {
+      connection = httpsUrlConnectionFactory.openConnection(downloadUrl);
+      connection.setRequestMethod(REQUEST_METHOD_GET);
+      responseCode = connection.getResponseCode();
+    } catch (IOException e) {
+      throw new FirebaseAppDistributionException(
+          "Failed to open connection to: " + downloadUrl, NETWORK_FAILURE, e);
+    }
 
-    File apkFile = getApkFileForApp(fileName);
-    apkFile.delete();
+    if (!isResponseSuccess(responseCode)) {
+      throw new FirebaseAppDistributionException(
+          "Failed to download APK. Response code: " + responseCode, DOWNLOAD_FAILURE);
+    }
+
+    long responseLength = connection.getContentLength();
+    postUpdateProgress(responseLength, 0, UpdateStatus.PENDING, showNotification);
+    String fileName = getApkFileName();
+    LogWrapper.getInstance().v(TAG + "Attempting to download APK to disk");
+
+    long bytesDownloaded =
+        downloadToDisk(connection, responseLength, fileName, showNotification);
+
+    File apkFile = firebaseApp.getApplicationContext().getFileStreamPath(fileName);
+    validateJarFile(apkFile, responseLength, showNotification, bytesDownloaded);
+
+    postUpdateProgress(
+        responseLength, bytesDownloaded, UpdateStatus.DOWNLOADED, showNotification);
+    safeSetTaskResult(downloadTaskCompletionSource, apkFile);
+  }
+
+  private static boolean isResponseSuccess(int responseCode) {
+    return responseCode >= 200 && responseCode < 300;
+  }
+
+  private long downloadToDisk(
+      HttpsURLConnection connection,
+      long totalSize,
+      String fileName,
+      boolean showNotification)
+      throws FirebaseAppDistributionException {
+    Context context = firebaseApp.getApplicationContext();
+    context.deleteFile(fileName);
+    int fileCreationMode =
+        VERSION.SDK_INT >= VERSION_CODES.N ? Context.MODE_PRIVATE : Context.MODE_WORLD_READABLE;
     long bytesDownloaded = 0;
     try (BufferedOutputStream outputStream =
-        new BufferedOutputStream(
-            firebaseApp
-                .getApplicationContext()
-                .openFileOutput(
-                    fileName,
-                    android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N
-                        ? Context.MODE_PRIVATE
-                        : Context.MODE_WORLD_READABLE))) {
-
+            new BufferedOutputStream(context.openFileOutput(fileName, fileCreationMode));
+        InputStream inputStream = connection.getInputStream()) {
       byte[] data = new byte[8 * 1024];
-      int readSize = input.read(data);
+      int readSize = inputStream.read(data);
       long lastMsUpdated = 0;
 
       while (readSize != -1) {
         outputStream.write(data, 0, readSize);
         bytesDownloaded += readSize;
-        readSize = input.read(data);
+        readSize = inputStream.read(data);
 
         // update progress logic for onProgressListener
         long currentTimeMs = System.currentTimeMillis();
@@ -213,74 +220,46 @@ class ApkUpdater {
               totalSize, bytesDownloaded, UpdateStatus.DOWNLOADING, showNotification);
         }
       }
-
     } catch (IOException e) {
       postUpdateProgress(
-          totalSize, bytesDownloaded, UpdateStatus.DOWNLOAD_FAILED, showNotification);
-      setDownloadTaskCompletionError(
-          new FirebaseAppDistributionException(
-              Constants.ErrorMessages.NETWORK_ERROR,
-              FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
+          totalSize,
+          bytesDownloaded,
+          UpdateStatus.DOWNLOAD_FAILED,
+          showNotification);
+      throw new FirebaseAppDistributionException("Failed to download APK", DOWNLOAD_FAILURE, e);
     }
+    return bytesDownloaded;
+  }
 
+  private void validateJarFile(
+      File apkFile, long totalSize, boolean showNotification, long bytesDownloaded)
+      throws FirebaseAppDistributionException {
     try {
-      // check that file is actual JAR
       new JarFile(apkFile).close();
-
-    } catch (Exception e) {
+    } catch (IOException e) {
       postUpdateProgress(
-          totalSize, bytesDownloaded, UpdateStatus.DOWNLOAD_FAILED, showNotification);
-      setDownloadTaskCompletionError(
-          new FirebaseAppDistributionException(
-              Constants.ErrorMessages.NETWORK_ERROR,
-              FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE));
+          totalSize,
+          bytesDownloaded,
+          UpdateStatus.DOWNLOAD_FAILED,
+          showNotification);
+      throw new FirebaseAppDistributionException(
+          "Downloaded APK was not a valid JAR file", DOWNLOAD_FAILURE, e);
     }
-
-    // completion
-    postUpdateProgress(totalSize, totalSize, UpdateStatus.DOWNLOADED, showNotification);
-
-    safeSetTaskResult(downloadTaskCompletionSource, apkFile);
   }
 
-  private File getApkFileForApp(String fileName) {
-    return new File(firebaseApp.getApplicationContext().getFilesDir(), fileName);
-  }
-
-  private String getApplicationName() {
+  private String getApkFileName() {
     try {
       Context context = firebaseApp.getApplicationContext();
-      return context.getApplicationInfo().loadLabel(context.getPackageManager()).toString();
+      String applicationName =
+          context.getApplicationInfo().loadLabel(context.getPackageManager()).toString();
+      return applicationName + ".apk";
     } catch (Exception e) {
-      LogWrapper.getInstance().v(TAG + "Unable to retrieve app name");
-      return "";
-    }
-  }
-
-  HttpsURLConnection openHttpsUrlConnection(String downloadUrl)
-      throws FirebaseAppDistributionException {
-    HttpsURLConnection httpsURLConnection;
-
-    try {
-      URL url = new URL(downloadUrl);
-      httpsURLConnection = (HttpsURLConnection) url.openConnection();
-    } catch (IOException e) {
-      throw new FirebaseAppDistributionException(
-          Constants.ErrorMessages.NETWORK_ERROR, NETWORK_FAILURE, e);
-    }
-    return httpsURLConnection;
-  }
-
-  private void setDownloadTaskCompletionError(FirebaseAppDistributionException e) {
-    LogWrapper.getInstance().e(TAG + "Download failed to complete ", e);
-    safeSetTaskException(downloadTaskCompletionSource, e);
-  }
-
-  private void setDownloadTaskCompletionErrorWithDefault(
-      Exception e, FirebaseAppDistributionException defaultFirebaseException) {
-    if (e instanceof FirebaseAppDistributionException) {
-      setDownloadTaskCompletionError((FirebaseAppDistributionException) e);
-    } else {
-      setDownloadTaskCompletionError(defaultFirebaseException);
+      LogWrapper.getInstance()
+          .w(
+              TAG
+                  + "Unable to retrieve app name. Using generic file name for APK: "
+                  + DEFAULT_APK_FILE_NAME);
+      return DEFAULT_APK_FILE_NAME;
     }
   }
 
@@ -290,12 +269,11 @@ class ApkUpdater {
     }
   }
 
-  private void setUpdateTaskCompletionErrorWithDefault(
-      Exception e, FirebaseAppDistributionException defaultFirebaseException) {
+  private void setUpdateTaskCompletionErrorWithDefault(Exception e, String message, Status status) {
     if (e instanceof FirebaseAppDistributionException) {
       setUpdateTaskCompletionError((FirebaseAppDistributionException) e);
     } else {
-      setUpdateTaskCompletionError(defaultFirebaseException);
+      setUpdateTaskCompletionError(new FirebaseAppDistributionException(message, status, e));
     }
   }
 

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/FirebaseAppDistributionTesterApiClient.java
@@ -39,7 +39,7 @@ class FirebaseAppDistributionTesterApiClient {
 
   private static final String RELEASE_ENDPOINT_URL_FORMAT =
       "https://firebaseapptesters.googleapis.com/v1alpha/devices/-/testerApps/%s/installations/%s/releases";
-  private static final String REQUEST_METHOD = "GET";
+  private static final String REQUEST_METHOD_GET = "GET";
   private static final String API_KEY_HEADER = "x-goog-api-key";
   private static final String INSTALLATION_AUTH_HEADER = "X-Goog-Firebase-Installations-Auth";
   private static final String X_ANDROID_PACKAGE_HEADER_KEY = "X-Android-Package";
@@ -185,7 +185,7 @@ class FirebaseAppDistributionTesterApiClient {
           ErrorMessages.NETWORK_ERROR, Status.NETWORK_FAILURE, e);
     }
     try {
-      httpsURLConnection.setRequestMethod(REQUEST_METHOD);
+      httpsURLConnection.setRequestMethod(REQUEST_METHOD_GET);
     } catch (ProtocolException e) {
       throw new FirebaseAppDistributionException(ErrorMessages.UNKNOWN_ERROR, Status.UNKNOWN, e);
     }

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/HttpsUrlConnectionFactory.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/HttpsUrlConnectionFactory.java
@@ -1,0 +1,25 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.app.distribution;
+
+import java.io.IOException;
+import java.net.URL;
+import javax.net.ssl.HttpsURLConnection;
+
+class HttpsUrlConnectionFactory {
+  HttpsURLConnection openConnection(String url) throws IOException {
+    return (HttpsURLConnection) new URL(url).openConnection();
+  }
+}

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/internal/InstallActivity.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/internal/InstallActivity.java
@@ -78,7 +78,10 @@ public class InstallActivity extends AppCompatActivity {
         return Settings.Secure.getInt(getContentResolver(), Settings.Secure.INSTALL_NON_MARKET_APPS)
             == 1;
       } catch (Settings.SettingNotFoundException e) {
-        LogWrapper.getInstance().e(TAG + "Unable to determine if unknown sources is enabled.", e);
+        LogWrapper.getInstance()
+            .e(
+                TAG + "Unable to determine if unknown sources is enabled. Assuming it's enabled.",
+                e);
         return true;
       }
     }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/AabUpdaterTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/AabUpdaterTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.app.distribution;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -28,8 +27,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -84,7 +81,9 @@ public class AabUpdaterTest {
     when(mockHttpsUrlConnection.getHeaderField("Location")).thenReturn(REDIRECT_TO_PLAY);
     when(mockHttpsUrlConnectionFactory.openConnection(TEST_URL)).thenReturn(mockHttpsUrlConnection);
 
-    aabUpdater = Mockito.spy(new AabUpdater(mockLifecycleNotifier, mockHttpsUrlConnectionFactory, testExecutor));
+    aabUpdater =
+        Mockito.spy(
+            new AabUpdater(mockLifecycleNotifier, mockHttpsUrlConnectionFactory, testExecutor));
     when(mockLifecycleNotifier.getCurrentActivity()).thenReturn(activity);
   }
 
@@ -97,7 +96,8 @@ public class AabUpdaterTest {
     UpdateTask updateTask = aabUpdater.updateAab(TEST_RELEASE_NEWER_AAB_INTERNAL);
     testExecutor.awaitTermination(1, TimeUnit.SECONDS);
 
-    assertTaskFailure(updateTask, Status.NETWORK_FAILURE, "Failed to open connection", caughtException);
+    assertTaskFailure(
+        updateTask, Status.NETWORK_FAILURE, "Failed to open connection", caughtException);
   }
 
   @Test
@@ -184,7 +184,8 @@ public class AabUpdaterTest {
     assertThat(e).hasMessageThat().contains(messageSubstring);
   }
 
-  private void assertTaskFailure(UpdateTask updateTask, Status status, String messageSubstring, Throwable cause) {
+  private void assertTaskFailure(
+      UpdateTask updateTask, Status status, String messageSubstring, Throwable cause) {
     assertTaskFailure(updateTask, status, messageSubstring);
     assertThat(updateTask.getException()).hasCauseThat().isEqualTo(cause);
   }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/ApkUpdaterTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/ApkUpdaterTest.java
@@ -98,9 +98,10 @@ public class ApkUpdaterTest {
     when(mockHttpsUrlConnectionFactory.openConnection(TEST_URL)).thenReturn(mockHttpsUrlConnection);
     when(mockHttpsUrlConnection.getResponseCode()).thenReturn(200);
 
-    this.apkUpdater =
+    apkUpdater =
         Mockito.spy(
-            new ApkUpdater(testExecutor, firebaseApp, mockApkInstaller, mockNotificationsManager, mockHttpsUrlConnectionFactory));
+            new ApkUpdater(
+                testExecutor, firebaseApp, mockApkInstaller, mockNotificationsManager, mockHttpsUrlConnectionFactory));
   }
 
   @Test
@@ -111,7 +112,8 @@ public class ApkUpdaterTest {
     UpdateTaskImpl updateTask = apkUpdater.updateApk(TEST_RELEASE, false);
     testExecutor.awaitTermination(1, TimeUnit.SECONDS);
 
-    assertTaskFailure(updateTask, Status.NETWORK_FAILURE, "Failed to open connection", caughtException);
+    assertTaskFailure(
+        updateTask, Status.NETWORK_FAILURE, "Failed to open connection", caughtException);
   }
 
   @Test
@@ -132,7 +134,8 @@ public class ApkUpdaterTest {
     UpdateTaskImpl updateTask = apkUpdater.updateApk(TEST_RELEASE, false);
     testExecutor.awaitTermination(1, TimeUnit.SECONDS);
 
-    assertTaskFailure(updateTask, Status.DOWNLOAD_FAILURE, "Failed to download APK", caughtException);
+    assertTaskFailure(
+        updateTask, Status.DOWNLOAD_FAILURE, "Failed to download APK", caughtException);
   }
 
   @Test
@@ -232,7 +235,8 @@ public class ApkUpdaterTest {
     assertThat(e).hasMessageThat().contains(messageSubstring);
   }
 
-  private void assertTaskFailure(UpdateTask updateTask, Status status, String messageSubstring, Throwable cause) {
+  private void assertTaskFailure(
+      UpdateTask updateTask, Status status, String messageSubstring, Throwable cause) {
     assertTaskFailure(updateTask, status, messageSubstring);
     assertThat(updateTask.getException()).hasCauseThat().isEqualTo(cause);
   }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/NewReleaseFetcherTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/NewReleaseFetcherTest.java
@@ -348,8 +348,7 @@ public class NewReleaseFetcherTest {
 
   @Test
   public void extractApkHash_ifKeyInCachedApkHashes_doesNotRecalculateZipHash() {
-
-    try (MockedStatic mockedReleaseIdentificationUtils =
+    try (MockedStatic<ReleaseIdentificationUtils> mockedReleaseIdentificationUtils =
         mockStatic(ReleaseIdentificationUtils.class)) {
       PackageInfo packageInfo =
           shadowPackageManager.getInternalMutablePackageInfo(


### PR DESCRIPTION
- Makes error messages and statuses more relevant and specific
- Catches some additional error cases and removes some unnecessary ones
- Replaces all instances of [log-and-(re)throw](http://go/java-practices/exceptions#log_rethrow), instead setting exception causes
- Injects `HttpsUrlConnectionFactory` to avoid mocking package private class methods
- Replaces `Thread.sleep` in tests with `ExecutorServiceawaitTermination()` to speed up tests
- Adds a couple TODO's I will follow up on