### PR TITLE
issue_3265_disk_read_violation

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiter.java
@@ -203,6 +203,6 @@ public class DataCollectionArbiter {
     } else {
       prefsEditor.remove(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED);
     }
-    prefsEditor.commit();
+    prefsEditor.apply();
   }
 }


### PR DESCRIPTION
Proposed fix by DanielNovak for #3265.

TLDR: DiskReadViolation warning is being triggered when setting `setCrashlyticsCollectionEnabled`

The developer found that the issue is caused by `DataCollectionArbitrer.java` where it's using `commit()` instead of `apply()`.

Relevant code:
```
private static void storeDataCollectionValueInSharedPreferences(SharedPreferences sharedPreferences, Boolean enabled) {
        Editor prefsEditor = sharedPreferences.edit();
        if (enabled != null) {
            prefsEditor.putBoolean("firebase_crashlytics_collection_enabled", enabled);
        } else {
            prefsEditor.remove("firebase_crashlytics_collection_enabled");
        }

        prefsEditor.commit();
    }
```

The key difference of `commit` vs `apply` is that apply is asynchronous. Stack Overflow link [here](https://stackoverflow.com/a/5960732/14129564).

Based on the conversation in SO, changing `commit` to `apply` is safe. We can base it on the Android [documentations](https://developer.android.com/reference/android/content/SharedPreferences.Editor#apply()).

> As SharedPreferences instances are singletons within a process, it's safe to replace any instance of commit() with apply() if you were already ignoring the return value.

In this case since we don't use the value for anything else, perhaps this is safe to replace.

