### PR TITLE
Refactor notification tests to be more focused to the classes under test

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
@@ -67,10 +67,10 @@ class ApkUpdater {
       @NonNull FirebaseApp firebaseApp,
       @NonNull ApkInstaller apkInstaller,
       @NonNull FirebaseAppDistributionNotificationsManager appDistributionNotificationsManager) {
-    this.appDistributionNotificationsManager = appDistributionNotificationsManager;
     this.taskExecutor = taskExecutor;
     this.firebaseApp = firebaseApp;
     this.apkInstaller = apkInstaller;
+    this.appDistributionNotificationsManager = appDistributionNotificationsManager;
   }
 
   UpdateTaskImpl updateApk(

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/ApkUpdater.java
@@ -295,8 +295,7 @@ class ApkUpdater {
     }
   }
 
-  @VisibleForTesting
-  void postUpdateProgress(
+  private void postUpdateProgress(
       long totalBytes, long downloadedBytes, UpdateStatus status, boolean showNotification) {
     synchronized (updateTaskLock) {
       cachedUpdateTask.updateProgress(

--- a/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/AppIconSource.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/app/distribution/AppIconSource.java
@@ -1,0 +1,66 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.app.distribution;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.drawable.AdaptiveIconDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Build.VERSION;
+import androidx.core.content.ContextCompat;
+import com.google.firebase.app.distribution.internal.LogWrapper;
+
+class AppIconSource {
+  private static final String TAG = "AppIconSource: ";
+
+  private static final int DEFAULT_ICON = android.R.drawable.sym_def_app_icon;
+
+  /**
+   * Get an icon for the given app context, or a default icon if the app icon is adaptive or does
+   * not exist.
+   *
+   * <p>This is useful for showing an icon in notifications, since adaptive icons cause a crash loop
+   * in the NotificationsManager (b/69969749).
+   *
+   * @return A drawable resource identifier (in the package's resources) of the icon.
+   */
+  int getNonAdaptiveIconOrDefault(Context context) {
+    int iconId = context.getApplicationInfo().icon;
+    if (iconId == 0) {
+      return DEFAULT_ICON;
+    }
+
+    Drawable icon;
+    try {
+      icon = ContextCompat.getDrawable(context, iconId);
+    } catch (Resources.NotFoundException ex) {
+      return DEFAULT_ICON;
+    }
+
+    if (isAdaptiveIcon(icon)) {
+      LogWrapper.getInstance()
+          .e(TAG + "Adaptive icons cannot be used in notifications. Ignoring icon id: " + iconId);
+      return DEFAULT_ICON;
+    }
+
+    return iconId;
+  }
+
+  private boolean isAdaptiveIcon(Drawable icon) {
+    // AdaptiveIcons were introduced in API 26
+    return VERSION.SDK_INT >= Build.VERSION_CODES.O && icon instanceof AdaptiveIconDrawable;
+  }
+}

--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/AppIconSourceTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/AppIconSourceTest.java
@@ -1,0 +1,81 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.app.distribution;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.os.Bundle;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.core.content.pm.ApplicationInfoBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class AppIconSourceTest {
+
+  @Mock Context mockContext;
+
+  AppIconSource appIconSource;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    appIconSource = new AppIconSource();
+  }
+
+  @Test
+  public void getSmallIcon_whenAppIconSet_usesAppIcon() {
+    setupApplicationInfo(R.drawable.test_app_icon);
+    int iconId = appIconSource.getNonAdaptiveIconOrDefault(mockContext);
+    assertThat(iconId).isEqualTo(R.drawable.test_app_icon);
+  }
+
+  @Test
+  public void getSmallIcon_whenAppIconAdaptive_usesDefaultIcon() {
+    setupApplicationInfo(R.mipmap.test_adaptive_icon);
+    // get correct drawable for ContextCompat.getDrawable in isAdaptiveIcon()
+    when(mockContext.getDrawable(R.mipmap.test_adaptive_icon))
+        .thenReturn(
+            ApplicationProvider.getApplicationContext().getDrawable(R.mipmap.test_adaptive_icon));
+
+    int iconId = appIconSource.getNonAdaptiveIconOrDefault(mockContext);
+
+    assertThat(iconId).isEqualTo(android.R.drawable.sym_def_app_icon);
+  }
+
+  @Test
+  public void getSmallIcon_whenAppIconNotPresent_usesDefaultIcon() {
+    setupApplicationInfo(0);
+    int iconId = appIconSource.getNonAdaptiveIconOrDefault(mockContext);
+    assertThat(iconId).isEqualTo(android.R.drawable.sym_def_app_icon);
+  }
+
+  private void setupApplicationInfo(int iconId) {
+    ApplicationInfo applicationInfo =
+        ApplicationInfoBuilder.newBuilder()
+            .setPackageName(ApplicationProvider.getApplicationContext().getPackageName())
+            .build();
+    applicationInfo.metaData = new Bundle();
+    applicationInfo.icon = iconId;
+    when(mockContext.getApplicationInfo()).thenReturn(applicationInfo);
+  }
+}

--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/FirebaseAppDistributionTest.java
@@ -49,13 +49,10 @@ import com.google.firebase.app.distribution.internal.SignInStorage;
 import com.google.firebase.installations.InstallationTokenResult;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
@@ -103,13 +100,10 @@ public class FirebaseAppDistributionTest {
   @Mock private InstallationTokenResult mockInstallationTokenResult;
   @Mock private TesterSignInManager mockTesterSignInManager;
   @Mock private NewReleaseFetcher mockNewReleaseFetcher;
-  @Mock private ApkInstaller mockApkInstaller;
-  private ApkUpdater mockApkUpdater;
+  @Mock private ApkUpdater mockApkUpdater;
   @Mock private AabUpdater mockAabUpdater;
   @Mock private SignInStorage mockSignInStorage;
   @Mock private FirebaseAppDistributionLifecycleNotifier mockLifecycleNotifier;
-
-  Executor testExecutor = Executors.newSingleThreadExecutor();
 
   static class TestActivity extends Activity {}
 
@@ -128,8 +122,6 @@ public class FirebaseAppDistributionTest {
                 .setProjectId(TEST_PROJECT_ID)
                 .setApiKey(TEST_API_KEY)
                 .build());
-
-    this.mockApkUpdater = Mockito.spy(new ApkUpdater(testExecutor, firebaseApp, mockApkInstaller));
 
     firebaseAppDistribution =
         spy(


### PR DESCRIPTION
This should also make `UpdateApkTest` less flaky.