### PR TITLE
DRY up the FirebaseAppDistributionTest class with assertTaskFailure

### DIFF
--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/AabUpdaterTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/AabUpdaterTest.java
@@ -14,6 +14,7 @@
 package com.google.firebase.app.distribution;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.app.distribution.TestUtils.assertTaskFailure;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
@@ -172,20 +173,5 @@ public class AabUpdaterTest {
     UpdateTask updateTask2 = aabUpdater.updateAab(TEST_RELEASE_NEWER_AAB_INTERNAL);
 
     assertEquals(updateTask1, updateTask2);
-  }
-
-  private void assertTaskFailure(UpdateTask updateTask, Status status, String messageSubstring) {
-    assertThat(updateTask.isSuccessful()).isFalse();
-    assertThat(updateTask.getException()).isInstanceOf(FirebaseAppDistributionException.class);
-    FirebaseAppDistributionException e =
-        (FirebaseAppDistributionException) updateTask.getException();
-    assertThat(e.getErrorCode()).isEqualTo(status);
-    assertThat(e).hasMessageThat().contains(messageSubstring);
-  }
-
-  private void assertTaskFailure(
-      UpdateTask updateTask, Status status, String messageSubstring, Throwable cause) {
-    assertTaskFailure(updateTask, status, messageSubstring);
-    assertThat(updateTask.getException()).hasCauseThat().isEqualTo(cause);
   }
 }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/FirebaseAppDistributionTest.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.app.distribution;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.app.distribution.Constants.ErrorMessages.AUTHENTICATION_ERROR;
 import static com.google.firebase.app.distribution.Constants.ErrorMessages.JSON_PARSING_ERROR;
 import static com.google.firebase.app.distribution.Constants.ErrorMessages.NETWORK_ERROR;
@@ -25,6 +24,7 @@ import static com.google.firebase.app.distribution.FirebaseAppDistributionExcept
 import static com.google.firebase.app.distribution.FirebaseAppDistributionException.Status.INSTALLATION_CANCELED;
 import static com.google.firebase.app.distribution.FirebaseAppDistributionException.Status.NETWORK_FAILURE;
 import static com.google.firebase.app.distribution.FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE;
+import static com.google.firebase.app.distribution.TestUtils.assertTaskFailure;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -459,13 +459,5 @@ public class FirebaseAppDistributionTest {
     assertTrue(dialog.isShowing());
 
     return dialog;
-  }
-
-  void assertTaskFailure(Task task, Status status, String messageSubstring) {
-    assertThat(task.isSuccessful()).isFalse();
-    assertThat(task.getException()).isInstanceOf(FirebaseAppDistributionException.class);
-    FirebaseAppDistributionException e = (FirebaseAppDistributionException) task.getException();
-    assertThat(e.getErrorCode()).isEqualTo(status);
-    assertThat(e).hasMessageThat().contains(messageSubstring);
   }
 }

--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/TestUtils.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/TestUtils.java
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.app.distribution;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/TestUtils.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/app/distribution/TestUtils.java
@@ -1,0 +1,24 @@
+package com.google.firebase.app.distribution;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.app.distribution.FirebaseAppDistributionException.Status;
+
+final class TestUtils {
+  private TestUtils() {}
+
+  static void assertTaskFailure(Task task, Status status, String messageSubstring) {
+    assertThat(task.isSuccessful()).isFalse();
+    assertThat(task.getException()).isInstanceOf(FirebaseAppDistributionException.class);
+    FirebaseAppDistributionException e = (FirebaseAppDistributionException) task.getException();
+    assertThat(e.getErrorCode()).isEqualTo(status);
+    assertThat(e).hasMessageThat().contains(messageSubstring);
+  }
+
+  static void assertTaskFailure(
+      UpdateTask updateTask, Status status, String messageSubstring, Throwable cause) {
+    assertTaskFailure(updateTask, status, messageSubstring);
+    assertThat(updateTask.getException()).hasCauseThat().isEqualTo(cause);
+  }
+}


### PR DESCRIPTION
Refactors tests using the assertTaskFailure method

Creates a shared TestUtils class