### PR TITLE
Add firebase-app-distribution-stub SDK

### DIFF
--- a/firebase-app-distribution-stub/api.txt
+++ b/firebase-app-distribution-stub/api.txt
@@ -1,76 +1,79 @@
 // Signature format: 2.0
-package com.google.firebase.app.distribution {
+package com.google.firebase.appdistribution {
 
   public abstract class AppDistributionRelease {
     ctor public AppDistributionRelease();
-    method @NonNull public abstract com.google.firebase.app.distribution.BinaryType getBinaryType();
+    method @NonNull public abstract com.google.firebase.appdistribution.BinaryType getBinaryType();
     method @NonNull public abstract String getDisplayVersion();
     method @Nullable public abstract String getReleaseNotes();
     method @NonNull public abstract long getVersionCode();
   }
 
   public enum BinaryType {
-    enum_constant public static final com.google.firebase.app.distribution.BinaryType AAB;
-    enum_constant public static final com.google.firebase.app.distribution.BinaryType APK;
+    enum_constant public static final com.google.firebase.appdistribution.BinaryType AAB;
+    enum_constant public static final com.google.firebase.appdistribution.BinaryType APK;
   }
 
   public class FirebaseAppDistribution {
-    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.app.distribution.AppDistributionRelease> checkForNewRelease();
-    method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getInstance();
+    ctor public FirebaseAppDistribution();
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.appdistribution.AppDistributionRelease> checkForNewRelease();
+    method @NonNull public static com.google.firebase.appdistribution.FirebaseAppDistribution getInstance();
     method public boolean isTesterSignedIn();
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();
     method public void signOutTester();
-    method @NonNull public com.google.firebase.app.distribution.UpdateTask updateApp();
-    method @NonNull public com.google.firebase.app.distribution.UpdateTask updateIfNewReleaseAvailable();
+    method @NonNull public com.google.firebase.appdistribution.UpdateTask updateApp();
+    method @NonNull public com.google.firebase.appdistribution.UpdateTask updateIfNewReleaseAvailable();
   }
 
   public class FirebaseAppDistributionException extends com.google.firebase.FirebaseException {
-    method @NonNull public com.google.firebase.app.distribution.FirebaseAppDistributionException.Status getErrorCode();
-    method @Nullable public com.google.firebase.app.distribution.AppDistributionRelease getRelease();
+    ctor public FirebaseAppDistributionException();
+    method @NonNull public com.google.firebase.appdistribution.FirebaseAppDistributionException.Status getErrorCode();
+    method @Nullable public com.google.firebase.appdistribution.AppDistributionRelease getRelease();
   }
 
   public enum FirebaseAppDistributionException.Status {
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status APP_RUNNING_IN_PRODUCTION;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status AUTHENTICATION_CANCELED;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status AUTHENTICATION_FAILURE;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status DOWNLOAD_FAILURE;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_CANCELED;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_FAILURE;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_FAILURE_SIGNATURE_MISMATCH;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status NETWORK_FAILURE;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status RELEASE_URL_EXPIRED;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status UNKNOWN;
-    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status UPDATE_NOT_AVAILABLE;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status APP_RUNNING_IN_PRODUCTION;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status AUTHENTICATION_CANCELED;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status AUTHENTICATION_FAILURE;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status DOWNLOAD_FAILURE;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status FOREGROUND_ACTIVITY_NOT_AVAILABLE;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status INSTALLATION_CANCELED;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status INSTALLATION_FAILURE;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status INSTALLATION_FAILURE_SIGNATURE_MISMATCH;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status NETWORK_FAILURE;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status RELEASE_URL_EXPIRED;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status UNKNOWN;
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status UPDATE_NOT_AVAILABLE;
   }
 
   public interface OnProgressListener {
-    method public void onProgressUpdate(@NonNull com.google.firebase.app.distribution.UpdateProgress);
+    method public void onProgressUpdate(@NonNull com.google.firebase.appdistribution.UpdateProgress);
   }
 
   public abstract class UpdateProgress {
     ctor public UpdateProgress();
     method @NonNull public abstract long getApkBytesDownloaded();
     method @NonNull public abstract long getApkFileTotalBytes();
-    method @NonNull public abstract com.google.firebase.app.distribution.UpdateStatus getUpdateStatus();
+    method @NonNull public abstract com.google.firebase.appdistribution.UpdateStatus getUpdateStatus();
   }
 
   public enum UpdateStatus {
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOADED;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOADING;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOAD_FAILED;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus INSTALL_CANCELED;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus INSTALL_FAILED;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus NEW_RELEASE_CHECK_FAILED;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus NEW_RELEASE_NOT_AVAILABLE;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus PENDING;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus REDIRECTED_TO_PLAY;
-    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus UPDATE_CANCELED;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus DOWNLOADED;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus DOWNLOADING;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus DOWNLOAD_FAILED;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus INSTALL_CANCELED;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus INSTALL_FAILED;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus NEW_RELEASE_CHECK_FAILED;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus NEW_RELEASE_NOT_AVAILABLE;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus PENDING;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus REDIRECTED_TO_PLAY;
+    enum_constant public static final com.google.firebase.appdistribution.UpdateStatus UPDATE_CANCELED;
   }
 
   public abstract class UpdateTask extends com.google.android.gms.tasks.Task<java.lang.Void> {
     ctor public UpdateTask();
-    method @NonNull public abstract com.google.firebase.app.distribution.UpdateTask addOnProgressListener(@NonNull com.google.firebase.app.distribution.OnProgressListener);
-    method @NonNull public abstract com.google.firebase.app.distribution.UpdateTask addOnProgressListener(@Nullable java.util.concurrent.Executor, @NonNull com.google.firebase.app.distribution.OnProgressListener);
+    method @NonNull public abstract com.google.firebase.appdistribution.UpdateTask addOnProgressListener(@NonNull com.google.firebase.appdistribution.OnProgressListener);
+    method @NonNull public abstract com.google.firebase.appdistribution.UpdateTask addOnProgressListener(@Nullable java.util.concurrent.Executor, @NonNull com.google.firebase.appdistribution.OnProgressListener);
   }
 
 }

--- a/firebase-app-distribution-stub/api.txt
+++ b/firebase-app-distribution-stub/api.txt
@@ -1,0 +1,77 @@
+// Signature format: 2.0
+package com.google.firebase.app.distribution {
+
+  public abstract class AppDistributionRelease {
+    ctor public AppDistributionRelease();
+    method @NonNull public abstract com.google.firebase.app.distribution.BinaryType getBinaryType();
+    method @NonNull public abstract String getDisplayVersion();
+    method @Nullable public abstract String getReleaseNotes();
+    method @NonNull public abstract long getVersionCode();
+  }
+
+  public enum BinaryType {
+    enum_constant public static final com.google.firebase.app.distribution.BinaryType AAB;
+    enum_constant public static final com.google.firebase.app.distribution.BinaryType APK;
+  }
+
+  public class FirebaseAppDistribution {
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.app.distribution.AppDistributionRelease> checkForNewRelease();
+    method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getInstance();
+    method public boolean isTesterSignedIn();
+    method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();
+    method public void signOutTester();
+    method @NonNull public com.google.firebase.app.distribution.UpdateTask updateApp();
+    method @NonNull public com.google.firebase.app.distribution.UpdateTask updateIfNewReleaseAvailable();
+  }
+
+  public class FirebaseAppDistributionException extends com.google.firebase.FirebaseException {
+    method @NonNull public com.google.firebase.app.distribution.FirebaseAppDistributionException.Status getErrorCode();
+    method @Nullable public com.google.firebase.app.distribution.AppDistributionRelease getRelease();
+  }
+
+  public enum FirebaseAppDistributionException.Status {
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status APP_RUNNING_IN_PRODUCTION;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status AUTHENTICATION_CANCELED;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status AUTHENTICATION_FAILURE;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status DOWNLOAD_FAILURE;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_CANCELED;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_FAILURE;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status INSTALLATION_FAILURE_SIGNATURE_MISMATCH;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status NETWORK_FAILURE;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status RELEASE_URL_EXPIRED;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status UNKNOWN;
+    enum_constant public static final com.google.firebase.app.distribution.FirebaseAppDistributionException.Status UPDATE_NOT_AVAILABLE;
+  }
+
+  public interface OnProgressListener {
+    method public void onProgressUpdate(@NonNull com.google.firebase.app.distribution.UpdateProgress);
+  }
+
+  public abstract class UpdateProgress {
+    ctor public UpdateProgress();
+    method @NonNull public abstract long getApkBytesDownloaded();
+    method @NonNull public abstract long getApkFileTotalBytes();
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateStatus getUpdateStatus();
+  }
+
+  public enum UpdateStatus {
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOADED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOADING;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus DOWNLOAD_FAILED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus INSTALL_CANCELED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus INSTALL_FAILED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus NEW_RELEASE_CHECK_FAILED;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus NEW_RELEASE_NOT_AVAILABLE;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus PENDING;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus REDIRECTED_TO_PLAY;
+    enum_constant public static final com.google.firebase.app.distribution.UpdateStatus UPDATE_CANCELED;
+  }
+
+  public abstract class UpdateTask extends com.google.android.gms.tasks.Task<java.lang.Void> {
+    ctor public UpdateTask();
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateTask addOnProgressListener(@NonNull com.google.firebase.app.distribution.OnProgressListener);
+    method @NonNull public abstract com.google.firebase.app.distribution.UpdateTask addOnProgressListener(@Nullable java.util.concurrent.Executor, @NonNull com.google.firebase.app.distribution.OnProgressListener);
+  }
+
+}
+

--- a/firebase-app-distribution-stub/firebase-app-distribution-stub.gradle
+++ b/firebase-app-distribution-stub/firebase-app-distribution-stub.gradle
@@ -43,6 +43,9 @@ dependencies {
     implementation project(':firebase-common')
     implementation 'com.google.android.gms:play-services-tasks:17.0.0'
 
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 }

--- a/firebase-app-distribution-stub/firebase-app-distribution-stub.gradle
+++ b/firebase-app-distribution-stub/firebase-app-distribution-stub.gradle
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id 'firebase-library'
+}
+
+android {
+    compileSdkVersion project.targetSdkVersion
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion project.targetSdkVersion
+        multiDexEnabled true
+        versionName version
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    implementation 'org.jetbrains:annotations:15.0'
+    implementation project(':firebase-components')
+    implementation project(':firebase-common')
+    implementation 'com.google.android.gms:play-services-tasks:17.0.0'
+
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
+    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
+}

--- a/firebase-app-distribution-stub/gradle.properties
+++ b/firebase-app-distribution-stub/gradle.properties
@@ -1,0 +1,16 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version=0.0.1
+latestReleasedVersion=0.0.1

--- a/firebase-app-distribution-stub/ktx/api.txt
+++ b/firebase-app-distribution-stub/ktx/api.txt
@@ -1,0 +1,10 @@
+// Signature format: 2.0
+package com.google.firebase.app.distribution.ktx {
+
+  public final class FirebaseAppDistributionKt {
+    ctor public FirebaseAppDistributionKt();
+    method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getAppDistribution(@NonNull com.google.firebase.ktx.Firebase);
+  }
+
+}
+

--- a/firebase-app-distribution-stub/ktx/api.txt
+++ b/firebase-app-distribution-stub/ktx/api.txt
@@ -3,7 +3,7 @@ package com.google.firebase.app.distribution.ktx {
 
   public final class FirebaseAppDistributionKt {
     ctor public FirebaseAppDistributionKt();
-    method @NonNull public static com.google.firebase.app.distribution.FirebaseAppDistribution getAppDistribution(@NonNull com.google.firebase.ktx.Firebase);
+    method @NonNull public static com.google.firebase.appdistribution.FirebaseAppDistribution getAppDistribution(@NonNull com.google.firebase.ktx.Firebase);
   }
 
 }

--- a/firebase-app-distribution-stub/ktx/gradle.properties
+++ b/firebase-app-distribution-stub/ktx/gradle.properties
@@ -1,0 +1,1 @@
+android.enableUnitTestBinaryResources=true

--- a/firebase-app-distribution-stub/ktx/ktx.gradle
+++ b/firebase-app-distribution-stub/ktx/ktx.gradle
@@ -1,0 +1,62 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+    id 'firebase-library'
+    id 'kotlin-android'
+}
+
+firebaseLibrary {
+    releaseWith project(':firebase-app-distribution-stub')
+    testLab.enabled = true
+    publishJavadoc = true
+    publishSources = true
+}
+
+android {
+    compileSdkVersion project.targetSdkVersion
+    defaultConfig {
+        minSdkVersion 16
+        multiDexEnabled true
+        targetSdkVersion project.targetSdkVersion
+        versionName version
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+        test.java {
+            srcDir 'src/test/kotlin'
+        }
+        androidTest.java.srcDirs += 'src/androidTest/kotlin'
+    }
+    testOptions.unitTests.includeAndroidResources = true
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+
+    implementation project(':firebase-common:ktx')
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation project(':firebase-app-distribution-stub')
+
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:core:1.2.0'
+}

--- a/firebase-app-distribution-stub/ktx/ktx.gradle
+++ b/firebase-app-distribution-stub/ktx/ktx.gradle
@@ -46,6 +46,8 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 
+    implementation project(':firebase-common')
+    implementation project(':firebase-components')
     implementation project(':firebase-common:ktx')
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation project(':firebase-app-distribution-stub')

--- a/firebase-app-distribution-stub/ktx/src/androidTest/AndroidManifest.xml
+++ b/firebase-app-distribution-stub/ktx/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.google.firebase.app.distribution.ktx">
+  <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
+  <!--<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="23" />-->
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <application>
+    <uses-library android:name="android.test.runner" />
+  </application>
+
+  <instrumentation
+    android:name="androidx.test.runner.AndroidJUnitRunner"
+    android:targetPackage="3com.google.firebase.app.distribution.ktx" />
+</manifest>

--- a/firebase-app-distribution-stub/ktx/src/androidTest/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistributionTests.kt
+++ b/firebase-app-distribution-stub/ktx/src/androidTest/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistributionTests.kt
@@ -19,7 +19,7 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.google.common.truth.Truth
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
-import com.google.firebase.app.distribution.FirebaseAppDistribution
+import com.google.firebase.appdistribution.FirebaseAppDistribution
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.ktx.app
 import com.google.firebase.ktx.initialize

--- a/firebase-app-distribution-stub/ktx/src/androidTest/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistributionTests.kt
+++ b/firebase-app-distribution-stub/ktx/src/androidTest/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistributionTests.kt
@@ -1,0 +1,84 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.app.distribution.ktx
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import com.google.common.truth.Truth
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.app.distribution.FirebaseAppDistribution
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.ktx.app
+import com.google.firebase.ktx.initialize
+import com.google.firebase.platforminfo.UserAgentPublisher
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+const val APP_ID = "APP_ID"
+const val API_KEY = "API_KEY"
+
+const val EXISTING_APP = "existing"
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+abstract class BaseTestCase {
+    @Before
+    fun setUp() {
+        Firebase.initialize(
+                ApplicationProvider.getApplicationContext(),
+                FirebaseOptions.Builder()
+                        .setApplicationId(APP_ID)
+                        .setApiKey(API_KEY)
+                        .setProjectId("123")
+                        .build()
+        )
+
+        Firebase.initialize(
+                ApplicationProvider.getApplicationContext(),
+                FirebaseOptions.Builder()
+                        .setApplicationId(APP_ID)
+                        .setApiKey(API_KEY)
+                        .setProjectId("123")
+                        .build(),
+                EXISTING_APP
+        )
+    }
+
+    @After
+    fun cleanUp() {
+        FirebaseApp.clearInstancesForTest()
+    }
+}
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class FirebaseAppDistributionTests : BaseTestCase() {
+    @Test
+    fun appDistribution_default_callsDefaultGetInstance() {
+        Truth.assertThat(Firebase.appDistribution).isSameInstanceAs(FirebaseAppDistribution.getInstance())
+    }
+}
+
+internal const val LIBRARY_NAME: String = "fire-app-distribution-ktx"
+
+@RunWith(AndroidJUnit4ClassRunner::class)
+class LibraryVersionTest : BaseTestCase() {
+    @Test
+    fun libraryRegistrationAtRuntime() {
+        val publisher = Firebase.app.get(UserAgentPublisher::class.java)
+        Truth.assertThat(publisher.userAgent).contains(LIBRARY_NAME)
+    }
+}

--- a/firebase-app-distribution-stub/ktx/src/androidTest/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistributionTests.kt
+++ b/firebase-app-distribution-stub/ktx/src/androidTest/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistributionTests.kt
@@ -14,71 +14,17 @@
 
 package com.google.firebase.app.distribution.ktx
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import com.google.common.truth.Truth
-import com.google.firebase.FirebaseApp
-import com.google.firebase.FirebaseOptions
 import com.google.firebase.appdistribution.FirebaseAppDistribution
 import com.google.firebase.ktx.Firebase
-import com.google.firebase.ktx.app
-import com.google.firebase.ktx.initialize
-import com.google.firebase.platforminfo.UserAgentPublisher
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-const val APP_ID = "APP_ID"
-const val API_KEY = "API_KEY"
-
-const val EXISTING_APP = "existing"
-
 @RunWith(AndroidJUnit4ClassRunner::class)
-abstract class BaseTestCase {
-    @Before
-    fun setUp() {
-        Firebase.initialize(
-                ApplicationProvider.getApplicationContext(),
-                FirebaseOptions.Builder()
-                        .setApplicationId(APP_ID)
-                        .setApiKey(API_KEY)
-                        .setProjectId("123")
-                        .build()
-        )
-
-        Firebase.initialize(
-                ApplicationProvider.getApplicationContext(),
-                FirebaseOptions.Builder()
-                        .setApplicationId(APP_ID)
-                        .setApiKey(API_KEY)
-                        .setProjectId("123")
-                        .build(),
-                EXISTING_APP
-        )
-    }
-
-    @After
-    fun cleanUp() {
-        FirebaseApp.clearInstancesForTest()
-    }
-}
-
-@RunWith(AndroidJUnit4ClassRunner::class)
-class FirebaseAppDistributionTests : BaseTestCase() {
+class FirebaseAppDistributionTests {
     @Test
-    fun appDistribution_default_callsDefaultGetInstance() {
-        Truth.assertThat(Firebase.appDistribution).isSameInstanceAs(FirebaseAppDistribution.getInstance())
-    }
-}
-
-internal const val LIBRARY_NAME: String = "fire-app-distribution-ktx"
-
-@RunWith(AndroidJUnit4ClassRunner::class)
-class LibraryVersionTest : BaseTestCase() {
-    @Test
-    fun libraryRegistrationAtRuntime() {
-        val publisher = Firebase.app.get(UserAgentPublisher::class.java)
-        Truth.assertThat(publisher.userAgent).contains(LIBRARY_NAME)
+    fun appDistribution_default_returnsInstanceOfFirebaseAppDistribution() {
+        Truth.assertThat(Firebase.appDistribution).isInstanceOf(FirebaseAppDistribution::class.java)
     }
 }

--- a/firebase-app-distribution-stub/ktx/src/main/AndroidManifest.xml
+++ b/firebase-app-distribution-stub/ktx/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<!-- Copyright 2021 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.app.distribution.ktx">
+    <uses-sdk android:minSdkVersion="16"/>
+
+    <application>
+    </application>
+</manifest>

--- a/firebase-app-distribution-stub/ktx/src/main/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistribution.kt
+++ b/firebase-app-distribution-stub/ktx/src/main/kotlin/com/google/firebase/app/distribution/ktx/FirebaseAppDistribution.kt
@@ -1,0 +1,22 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.app.distribution.ktx
+
+import com.google.firebase.appdistribution.FirebaseAppDistribution
+import com.google.firebase.ktx.Firebase
+
+/** Returns the [FirebaseAppDistribution] instance of the default [FirebaseApp]. */
+val Firebase.appDistribution: FirebaseAppDistribution
+    get() = FirebaseAppDistribution.getInstance()

--- a/firebase-app-distribution-stub/src/main/AndroidManifest.xml
+++ b/firebase-app-distribution-stub/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.app.distribution">
+
+    <application>
+    </application>
+</manifest>

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/AppDistributionRelease.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/AppDistributionRelease.java
@@ -1,0 +1,73 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+
+/**
+ * This class represents the AppDistributionRelease object returned by checkForUpdate() and
+ * updateToLatestRelease()
+ *
+ * <p>It is an immutable value class implemented by AutoValue.
+ *
+ * @see <a
+ *     href="https://github.com/google/auto/tree/master/value">https://github.com/google/auto/tree/master/value</a>
+ */
+@AutoValue
+public abstract class AppDistributionRelease {
+
+  @NonNull
+  static Builder builder() {
+    return new com.google.firebase.appdistribution.AutoValue_AppDistributionRelease.Builder();
+  }
+
+  /** The short bundle version of this build (example 1.0.0) */
+  @NonNull
+  public abstract String getDisplayVersion();
+
+  /** The version code of this build (example: 123) */
+  @NonNull
+  public abstract long getVersionCode();
+
+  /** The release notes for this build */
+  @Nullable
+  public abstract String getReleaseNotes();
+
+  /** The binary type for this build */
+  @NonNull
+  public abstract BinaryType getBinaryType();
+
+  /** Builder for {@link AppDistributionRelease}. */
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    @NonNull
+    abstract Builder setDisplayVersion(@NonNull String value);
+
+    @NonNull
+    abstract Builder setVersionCode(@NonNull long value);
+
+    @NonNull
+    abstract Builder setReleaseNotes(@Nullable String value);
+
+    @NonNull
+    abstract Builder setBinaryType(@NonNull BinaryType value);
+
+    @NonNull
+    abstract AppDistributionRelease build();
+  }
+}

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/BinaryType.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/BinaryType.java
@@ -1,0 +1,21 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+/** Enum of Android App Binary types, used in AppDistributionRelease */
+public enum BinaryType {
+  AAB,
+  APK
+}

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -1,0 +1,172 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import android.app.Activity;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import java.util.concurrent.Executor;
+
+public class FirebaseAppDistribution {
+
+  /** @return a FirebaseAppDistribution instance */
+  @NonNull
+  public static FirebaseAppDistribution getInstance() {
+    return new FirebaseAppDistribution();
+  }
+
+  /**
+   * Updates the app to the newest release, if one is available. Returns the release information or
+   * null if no update is found. Performs the following actions: 1. If tester is not signed in,
+   * presents the tester with a Google sign in UI 2. Checks if a newer release is available. If so,
+   * presents the tester with a confirmation dialog to begin the download. 3. For APKs, downloads
+   * the binary and starts an installation intent. 4. For AABs, directs the tester to the Play app
+   * to complete the download and installation.
+   */
+  @NonNull
+  public UpdateTask updateIfNewReleaseAvailable() {
+    return new CompletedUpdateTask();
+  }
+
+  /** Signs in the App Distribution tester. Presents the tester with a Google sign in UI */
+  @NonNull
+  public Task<Void> signInTester() {
+    return Tasks.forResult(null);
+  }
+
+  /**
+   * Returns an AppDistributionRelease if one is available for the current signed in tester. If no
+   * update is found, returns null. If tester is not signed in, presents the tester with a Google
+   * sign in UI
+   */
+  @NonNull
+  public synchronized Task<AppDistributionRelease> checkForNewRelease() {
+    return Tasks.forResult(null);
+  }
+
+  /**
+   * Updates app to the newest release. If the newest release is an APK, downloads the binary and
+   * starts an installation If the newest release is an AAB, directs the tester to the Play app to
+   * complete the download and installation.
+   *
+   * <p>cancels task with FirebaseAppDistributionException with UPDATE_NOT_AVAILABLE exception if no
+   * new release is cached from checkForNewRelease
+   */
+  @NonNull
+  public UpdateTask updateApp() {
+    return new CompletedUpdateTask();
+  }
+
+  /** Returns true if the App Distribution tester is signed in */
+  public boolean isTesterSignedIn() {
+    return false;
+  }
+
+  /** Signs out the App Distribution tester */
+  public void signOutTester() {}
+
+  private static class CompletedUpdateTask extends UpdateTask {
+    @NonNull
+    @Override
+    public UpdateTask addOnProgressListener(@NonNull OnProgressListener listener) {
+      return this;
+    }
+
+    @NonNull
+    @Override
+    public UpdateTask addOnProgressListener(@Nullable Executor executor,
+        @NonNull OnProgressListener listener) {
+      return this;
+    }
+
+    @Override
+    public boolean isComplete() {
+      return true;
+    }
+
+    @Override
+    public boolean isSuccessful() {
+      return true;
+    }
+
+    @Override
+    public boolean isCanceled() {
+      return false;
+    }
+
+    @Nullable
+    @Override
+    public Void getResult() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public <X extends Throwable> Void getResult(@NonNull Class<X> aClass) throws X {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Exception getException() {
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public Task<Void> addOnSuccessListener(
+        @NonNull OnSuccessListener<? super Void> onSuccessListener) {
+      return this;
+    }
+
+    @NonNull
+    @Override
+    public Task<Void> addOnSuccessListener(@NonNull Executor executor,
+        @NonNull OnSuccessListener<? super Void> onSuccessListener) {
+      return this;
+    }
+
+    @NonNull
+    @Override
+    public Task<Void> addOnSuccessListener(@NonNull Activity activity,
+        @NonNull OnSuccessListener<? super Void> onSuccessListener) {
+      return this;
+    }
+
+    @NonNull
+    @Override
+    public Task<Void> addOnFailureListener(@NonNull OnFailureListener onFailureListener) {
+      return this;
+    }
+
+    @NonNull
+    @Override
+    public Task<Void> addOnFailureListener(@NonNull Executor executor,
+        @NonNull OnFailureListener onFailureListener) {
+      return this;
+    }
+
+    @NonNull
+    @Override
+    public Task<Void> addOnFailureListener(@NonNull Activity activity,
+        @NonNull OnFailureListener onFailureListener) {
+      return this;
+    }
+  }
+}

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -90,8 +90,8 @@ public class FirebaseAppDistribution {
 
     @NonNull
     @Override
-    public UpdateTask addOnProgressListener(@Nullable Executor executor,
-        @NonNull OnProgressListener listener) {
+    public UpdateTask addOnProgressListener(
+        @Nullable Executor executor, @NonNull OnProgressListener listener) {
       return this;
     }
 
@@ -137,15 +137,15 @@ public class FirebaseAppDistribution {
 
     @NonNull
     @Override
-    public Task<Void> addOnSuccessListener(@NonNull Executor executor,
-        @NonNull OnSuccessListener<? super Void> onSuccessListener) {
+    public Task<Void> addOnSuccessListener(
+        @NonNull Executor executor, @NonNull OnSuccessListener<? super Void> onSuccessListener) {
       return this;
     }
 
     @NonNull
     @Override
-    public Task<Void> addOnSuccessListener(@NonNull Activity activity,
-        @NonNull OnSuccessListener<? super Void> onSuccessListener) {
+    public Task<Void> addOnSuccessListener(
+        @NonNull Activity activity, @NonNull OnSuccessListener<? super Void> onSuccessListener) {
       return this;
     }
 
@@ -157,15 +157,15 @@ public class FirebaseAppDistribution {
 
     @NonNull
     @Override
-    public Task<Void> addOnFailureListener(@NonNull Executor executor,
-        @NonNull OnFailureListener onFailureListener) {
+    public Task<Void> addOnFailureListener(
+        @NonNull Executor executor, @NonNull OnFailureListener onFailureListener) {
       return this;
     }
 
     @NonNull
     @Override
-    public Task<Void> addOnFailureListener(@NonNull Activity activity,
-        @NonNull OnFailureListener onFailureListener) {
+    public Task<Void> addOnFailureListener(
+        @NonNull Activity activity, @NonNull OnFailureListener onFailureListener) {
       return this;
     }
   }

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
@@ -1,0 +1,72 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.firebase.FirebaseException;
+
+/** Possible exceptions thrown in FirebaseAppDistribution */
+public class FirebaseAppDistributionException extends FirebaseException {
+  public enum Status {
+    /** Unknown error. */
+    UNKNOWN,
+
+    /** Authentication failed */
+    AUTHENTICATION_FAILURE,
+
+    /** Authentication canceled */
+    AUTHENTICATION_CANCELED,
+
+    /** No Network available to make requests or the request timed out */
+    NETWORK_FAILURE,
+
+    /** Download failed */
+    DOWNLOAD_FAILURE,
+
+    /** Installation failed */
+    INSTALLATION_FAILURE,
+
+    /** Installation canceled */
+    INSTALLATION_CANCELED,
+
+    /** No foreground activity available for a given intent */
+    // TODO(rachelprince): add this to API council review
+    FOREGROUND_ACTIVITY_NOT_AVAILABLE,
+
+    /** Update not available for the current tester and app */
+    UPDATE_NOT_AVAILABLE,
+
+    /** Installation failed due to signature mismatch */
+    INSTALLATION_FAILURE_SIGNATURE_MISMATCH,
+
+    /** App is in production */
+    APP_RUNNING_IN_PRODUCTION,
+
+    /** Download URL for release expired */
+    RELEASE_URL_EXPIRED,
+  }
+
+  /** Get cached release when error was thrown */
+  @Nullable
+  public AppDistributionRelease getRelease() {
+    return null;
+  }
+
+  @NonNull
+  public Status getErrorCode() {
+    return Status.UNKNOWN;
+  }
+}

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/OnProgressListener.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/OnProgressListener.java
@@ -1,0 +1,22 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import androidx.annotation.NonNull;
+
+/** A listener that is called periodically during execution of the {@link UpdateTask}. */
+public interface OnProgressListener {
+  void onProgressUpdate(@NonNull UpdateProgress updateState);
+}

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/UpdateProgress.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/UpdateProgress.java
@@ -1,0 +1,64 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+
+/** Data class to get download progress for APKs and the status of the update. Used in updateApp. */
+@AutoValue
+public abstract class UpdateProgress {
+
+  @NonNull
+  static Builder builder() {
+    return new com.google.firebase.appdistribution.AutoValue_UpdateProgress.Builder();
+  }
+
+  /**
+   * The number of bytes downloaded so far for the APK. Returns -1 if called on an AAB or if no new
+   * release is available.
+   */
+  @NonNull
+  public abstract long getApkBytesDownloaded();
+
+  /**
+   * The file size of the APK file to download in bytes. Returns -1 if called on an AAB or if no new
+   * release is available.
+   */
+  @NonNull
+  public abstract long getApkFileTotalBytes();
+
+  @NonNull
+  /** returns the current state of the update */
+  public abstract UpdateStatus getUpdateStatus();
+
+  /** Builder for {@link UpdateProgress}. */
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    @NonNull
+    abstract Builder setApkBytesDownloaded(@NonNull long value);
+
+    @NonNull
+    abstract Builder setApkFileTotalBytes(@NonNull long value);
+
+    @NonNull
+    abstract Builder setUpdateStatus(@Nullable UpdateStatus value);
+
+    @NonNull
+    abstract UpdateProgress build();
+  }
+}

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/UpdateStatus.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/UpdateStatus.java
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+/** Enum for possible states during Update, used in UpdateProgress. */
+public enum UpdateStatus {
+  /** Update queued but not started */
+  PENDING,
+
+  /** Download in progress */
+  DOWNLOADING,
+
+  /** Download completed */
+  DOWNLOADED,
+
+  /** Download failed */
+  DOWNLOAD_FAILED,
+
+  /** Installation canceled */
+  INSTALL_CANCELED,
+
+  /** Installation failed */
+  INSTALL_FAILED,
+
+  /** AAB flow (directed to Play) */
+  REDIRECTED_TO_PLAY,
+
+  /** Currently on the latest release */
+  NEW_RELEASE_NOT_AVAILABLE,
+
+  /** Release check failed before download started */
+  NEW_RELEASE_CHECK_FAILED,
+
+  /** Customer canceled the update */
+  UPDATE_CANCELED,
+}

--- a/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/UpdateTask.java
+++ b/firebase-app-distribution-stub/src/main/java/com/google/firebase/appdistribution/UpdateTask.java
@@ -1,0 +1,34 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.tasks.Task;
+import java.util.concurrent.Executor;
+
+public abstract class UpdateTask extends Task<Void> {
+  /**
+   * Adds a listener that is called periodically while the UpdateTask executes.
+   *
+   * @return this Task
+   */
+  @NonNull
+  public abstract UpdateTask addOnProgressListener(@NonNull OnProgressListener listener);
+
+  @NonNull
+  public abstract UpdateTask addOnProgressListener(
+      @Nullable Executor executor, @NonNull OnProgressListener listener);
+}

--- a/firebase-app-distribution-stub/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution-stub/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -1,0 +1,71 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.android.gms.tasks.Task;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class FirebaseAppDistributionTest {
+  private FirebaseAppDistribution firebaseAppDistribution;
+
+  @Before
+  public void setup() {
+    firebaseAppDistribution = new FirebaseAppDistribution();
+  }
+
+  @Test
+  public void updateIfNewReleaseAvailable_returnsACompletedTask() {
+    assertThatTaskIsCompletedSuccessfully(firebaseAppDistribution.updateIfNewReleaseAvailable());
+  }
+
+  @Test
+  public void isTesterSignedIn_returnsFalse() {
+    assertThat(firebaseAppDistribution.isTesterSignedIn()).isFalse();
+  }
+
+  @Test
+  public void signInTester_returnsACompletedTask() {
+    assertThatTaskIsCompletedSuccessfully(firebaseAppDistribution.signInTester());
+  }
+
+  @Test
+  public void signOutTester_doesNotThrow() {
+    firebaseAppDistribution.signOutTester();
+  }
+
+  @Test
+  public void checkForNewRelease_returnsACompletedTask() {
+    assertThatTaskIsCompletedSuccessfully(firebaseAppDistribution.checkForNewRelease());
+  }
+
+  @Test
+  public void updateApp_returnsACompletedTask() {
+    assertThatTaskIsCompletedSuccessfully(firebaseAppDistribution.updateApp());
+  }
+
+  private void assertThatTaskIsCompletedSuccessfully(Task task) {
+    assertThat(task.isComplete()).isTrue();
+    assertThat(task.isSuccessful()).isTrue();
+    assertThat(task.isCanceled()).isFalse();
+    assertThat(task.getException()).isNull();
+    assertThat(task.getResult()).isNull();
+  }
+}

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -10,6 +10,8 @@ firebase-abt
 firebase-annotations
 firebase-app-distribution
 firebase-app-distribution:ktx
+firebase-app-distribution-stub
+firebase-app-distribution-stub:ktx
 firebase-common
 firebase-common:data-collection-tests
 firebase-common:ktx


### PR DESCRIPTION
This stubbed-out SDK will be shipped alongside firebase-app-distribution, and will enable customers to selectively compile against the stubbed out version when building for the Play store.

Follow-ups to this will include:

- Adding presubmit checks to make sure that the stub and main SDK have the same version number and api.txt
- Document the release process