### PR TITLE
Cancel task if activity is destroyed while sign in task is rotating

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -344,6 +344,12 @@ public class FirebaseAppDistribution {
       // SignInResult is internal to the SDK and is destroyed after creation
       return;
     }
+    if (signInDialog != null && signInDialog.isShowing()) {
+      setCachedUpdateIfNewReleaseCompletionError(
+          new FirebaseAppDistributionException(
+              ErrorMessages.AUTHENTICATION_CANCELED, AUTHENTICATION_CANCELED));
+    }
+
     if (updateDialog != null && updateDialog.isShowing()) {
       setCachedUpdateIfNewReleaseCompletionError(
           new FirebaseAppDistributionException(

--- a/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-app-distribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -452,7 +452,7 @@ public class FirebaseAppDistributionTest {
   }
 
   @Test
-  public void taskCancelledOnScreenRotation() {
+  public void taskCancelledOnScreenRotation_whenUpdateDialogShowing() {
     AppDistributionReleaseInternal newRelease = TEST_RELEASE_NEWER_AAB_INTERNAL.build();
     when(mockNewReleaseFetcher.checkForNewRelease()).thenReturn(Tasks.forResult(newRelease));
 
@@ -462,6 +462,18 @@ public class FirebaseAppDistributionTest {
     firebaseAppDistribution.onActivityDestroyed(activity);
 
     assertTaskFailure(updateTask, INSTALLATION_CANCELED, UPDATE_CANCELED);
+  }
+
+  @Test
+  public void taskCancelledOnScreenRotation_whenSignInDialogShowing() {
+    when(mockSignInStorage.getSignInStatus()).thenReturn(false);
+
+    UpdateTask updateTask = firebaseAppDistribution.updateIfNewReleaseAvailable();
+
+    // Mimic activity dying
+    firebaseAppDistribution.onActivityDestroyed(activity);
+
+    assertTaskFailure(updateTask, AUTHENTICATION_CANCELED, ErrorMessages.AUTHENTICATION_CANCELED);
   }
 
   @Test


### PR DESCRIPTION
Follows logic pattern established by: https://github.com/firebase/firebase-android-sdk/pull/3057/files

When an app rotates, the activity is destroyed. We close any open dialogs to prevent hanging references to the destroyed activity, and cancel the task.  If we wanted to avoid cancelling the task, we'd need to pull work to would need to store the state of the dialog / task, close it, and then reopen it .