### PR TITLE
Adding IF NOT EXISTS to CREATE log_event_dropped

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -84,7 +84,7 @@ final class SchemaManager extends SQLiteOpenHelper {
   private static final String DROP_PAYLOADS_SQL = "DROP TABLE IF EXISTS event_payloads";
 
   private static final String CREATE_LOG_EVENT_DROPPED_TABLE =
-      "CREATE TABLE log_event_dropped "
+      "CREATE TABLE IF NOT EXISTS log_event_dropped "
           + "(log_source VARCHAR(45) NOT NULL,"
           + "reason INTEGER NOT NULL,"
           + "events_dropped_count BIGINT NOT NULL,"

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -84,7 +84,7 @@ final class SchemaManager extends SQLiteOpenHelper {
   private static final String DROP_PAYLOADS_SQL = "DROP TABLE IF EXISTS event_payloads";
 
   private static final String CREATE_LOG_EVENT_DROPPED_TABLE =
-      "CREATE TABLE IF NOT EXISTS log_event_dropped "
+      "CREATE TABLE log_event_dropped "
           + "(log_source VARCHAR(45) NOT NULL,"
           + "reason INTEGER NOT NULL,"
           + "events_dropped_count BIGINT NOT NULL,"
@@ -131,6 +131,7 @@ final class SchemaManager extends SQLiteOpenHelper {
 
   private static final SchemaManager.Migration MIGRATION_TO_V5 =
       db -> {
+        db.execSQL(DROP_LOG_EVENT_DROPPED_SQL);
         db.execSQL(CREATE_LOG_EVENT_DROPPED_TABLE);
         db.execSQL(CREATE_GLOBAL_LOG_EVENT_STATE_TABLE);
         db.execSQL(CREATE_INITIAL_GLOBAL_LOG_EVENT_STATE_VALUE_SQL);


### PR DESCRIPTION
Proposed fix for #3301. 

The `log_event_dropped` table was initially added on `SchemaManager.java` on 
- Firebase Crashlytics `18.2.4`
- datatransport:transport-runtime:`3.1.0`

EDIT: Proposed solution by mkocus is to use `DROP TABLE IF EXISTS` before the `CREATE TABLE` is called.

The `DROP_LOG_EVENT_DROPPED_SQL` is only called during `onDowngrade`, which means if somehow the migration fails half way, there is no way of continuing the migration, thus it's best to call `DROP_LOG_EVENT_DROPPED_SQL` whenever creating the table to ensure this table does not exist before upgrade.