### PR TITLE
Construct FirebaseAppDistribution on startup

### DIFF
--- a/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionRegistrar.java
+++ b/firebase-app-distribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionRegistrar.java
@@ -46,6 +46,9 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
             .add(Dependency.required(FirebaseApp.class))
             .add(Dependency.requiredProvider(FirebaseInstallationsApi.class))
             .factory(this::buildFirebaseAppDistribution)
+            // construct FirebaseAppDistribution instance on startup so we can register for
+            // activity lifecycle callbacks before the API is called
+            .alwaysEager()
             .build(),
         LibraryVersionComponent.create("fire-app-distribution", BuildConfig.VERSION_NAME));
   }


### PR DESCRIPTION
Our SDK depends on Activity Lifecycle callbacks to manage SDK state. While we do plan to refactor some of our Activity Context dependencies, these lifecycle-dependent state changes are likely out of scope for the current refactor.  

This PR constructs FirebaseAppDistribution on app start so that the activity lifecycle callbacks are always registered before the customer uses the API. This will allow us to remove the following caveat from our docs:

```You must initialize the FirebaseAppDistribution instance in the onCreate() method of anActivity```
