### PR TITLE
Improve testIgnoresTargetMappingAfterExistenceFilterMismatch

### DIFF
--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -1155,7 +1155,7 @@ public abstract class LocalStoreTestCase {
 
     // Create an existence filter mismatch and verify that the last limbo free snapshot version
     // is deleted
-    applyRemoteEvent(existenceFilterEvent(targetId, 2, 20));
+    applyRemoteEvent(existenceFilterEvent(targetId, keySet(key("foo/a")), 2, 20));
     cachedTargetData = localStore.getTargetData(query.toTarget());
     Assert.assertEquals(version(0), cachedTargetData.getLastLimboFreeSnapshotVersion());
     Assert.assertEquals(ByteString.EMPTY, cachedTargetData.getResumeToken());

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -428,12 +428,12 @@ public class TestUtil {
   }
 
   public static RemoteEvent existenceFilterEvent(
-      int targetId, ImmutableSortedSet<DocumentKey> synced_keys, int remote_count, int version) {
+      int targetId, ImmutableSortedSet<DocumentKey> syncedKeys, int remoteCount, int version) {
     TargetData targetData = TestUtil.targetData(targetId, QueryPurpose.LISTEN, "foo");
     TestTargetMetadataProvider testTargetMetadataProvider = new TestTargetMetadataProvider();
-    testTargetMetadataProvider.setSyncedKeys(targetData, synced_keys);
+    testTargetMetadataProvider.setSyncedKeys(targetData, syncedKeys);
 
-    ExistenceFilter existenceFilter = new ExistenceFilter(remote_count);
+    ExistenceFilter existenceFilter = new ExistenceFilter(remoteCount);
     WatchChangeAggregator aggregator = new WatchChangeAggregator(testTargetMetadataProvider);
 
     WatchChange.ExistenceFilterWatchChange existenceFilterWatchChange =

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -427,12 +427,13 @@ public class TestUtil {
     return addedRemoteEvent(singletonList(doc), updatedInTargets, removedFromTargets, null);
   }
 
-  public static RemoteEvent existenceFilterEvent(int targetId, int count, int version) {
+  public static RemoteEvent existenceFilterEvent(
+      int targetId, ImmutableSortedSet<DocumentKey> synced_keys, int remote_count, int version) {
     TargetData targetData = TestUtil.targetData(targetId, QueryPurpose.LISTEN, "foo");
     TestTargetMetadataProvider testTargetMetadataProvider = new TestTargetMetadataProvider();
-    testTargetMetadataProvider.setSyncedKeys(targetData, DocumentKey.emptyKeySet());
+    testTargetMetadataProvider.setSyncedKeys(targetData, synced_keys);
 
-    ExistenceFilter existenceFilter = new ExistenceFilter(count);
+    ExistenceFilter existenceFilter = new ExistenceFilter(remote_count);
     WatchChangeAggregator aggregator = new WatchChangeAggregator(testTargetMetadataProvider);
 
     WatchChange.ExistenceFilterWatchChange existenceFilterWatchChange =


### PR DESCRIPTION
This makes the test match reality more as the target has synced keys when it hits the existence filter mismatch.