### PR TITLE
Fireperf: fix screen trace in multi-activity apps

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -324,7 +324,9 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
      */
     try {
       frameMetricsAggregator.remove(activity);
-    } catch (IllegalArgumentException ignored) {}
+    } catch (IllegalArgumentException ignored) {
+      logger.debug("View not hardware accelerated. Unable to collect screen trace.");
+    }
     SparseIntArray[] arr = frameMetricsAggregator.reset();
     if (arr != null) {
       SparseIntArray frameTimes = arr[FrameMetricsAggregator.TOTAL_INDEX];

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -285,9 +285,12 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   @Override
   public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
 
-  /** Stops screen trace in onPause because of b/210055697 */
   @Override
-  public void onActivityPaused(Activity activity) {
+  public void onActivityPaused(Activity activity) {}
+
+  /** Stops screen trace right after onPause because of b/210055697 */
+  @Override
+  public void onActivityPostPaused(@NonNull Activity activity) {
     if (isScreenTraceSupported(activity)) {
       sendScreenTrace(activity);
     }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
@@ -367,7 +367,7 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
       monitor.onActivityStarted(activity);
       assertThat(monitor.getActivity2ScreenTrace()).hasSize(1);
       currentTime = endTime;
-      monitor.onActivityStopped(activity);
+      monitor.onPostPausedStopped(activity);
       Assert.assertEquals(0, monitor.getActivity2ScreenTrace().size());
     }
   }
@@ -419,7 +419,7 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
     monitor.onActivityStarted(activityWithNonHardwareAcceleratedView);
     assertThat(monitor.getActivity2ScreenTrace()).hasSize(1);
     currentTime = 200;
-    monitor.onActivityStopped(activityWithNonHardwareAcceleratedView);
+    monitor.onActivityPostPaused(activityWithNonHardwareAcceleratedView);
     assertThat(monitor.getActivity2ScreenTrace()).isEmpty();
 
     // Case #2: developer has disabled Performance Monitoring during runtime.
@@ -429,7 +429,7 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
     monitor.onActivityStarted(activityWithNonHardwareAcceleratedView);
     assertThat(monitor.getActivity2ScreenTrace()).isEmpty();
     // Confirm that this doesn't throw an exception.
-    monitor.onActivityStopped(activityWithNonHardwareAcceleratedView);
+    monitor.onActivityPostPaused(activityWithNonHardwareAcceleratedView);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
@@ -367,7 +367,7 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
       monitor.onActivityStarted(activity);
       assertThat(monitor.getActivity2ScreenTrace()).hasSize(1);
       currentTime = endTime;
-      monitor.onPostPausedStopped(activity);
+      monitor.onActivityPostPaused(activity);
       Assert.assertEquals(0, monitor.getActivity2ScreenTrace().size());
     }
   }


### PR DESCRIPTION
b/210055697

### Cause:
In multi-activity apps, when Activity 1 starts Activity 2, `FrameMetricsAggregator` does not work when `frameMetricsAggregator.add(activity2)` is called before `reset()` of activity1. That is the current behaviour because we use `onStart` and `onStop`. The order of these lifecycle callbacks are well defined in the activity lifecycle documentation, "[Coordinating activities](https://developer.android.com/guide/components/activities/activity-lifecycle#coordinating-activities)" section. 

### Fix:
Move the "stopping of screen traces" from `onActivityStopped` to `onActivityPostPaused`. According to the same [documentation](https://developer.android.com/guide/components/activities/activity-lifecycle#coordinating-activities), the order of these callbacks are well defined, and it is **guaranteed that activity 1's `onPause` will happen before activity 2's `onStart`**. 

The reason `onActivityPostPaused` is picked over `onActivityPaused` is because **`onActivityPaused` is called [at the beginning](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:fragment/fragment/src/main/java/androidx/fragment/app/FragmentActivity.java;l=322) of `onPause`**, and **`onPause` [then calls each fragment's](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:fragment/fragment/src/main/java/androidx/fragment/app/FragmentActivity.java;l=324) `onPause`**. If `reset()` is called in `onActivityPaused`, then the last fragment in the activity won't have a chance to read its frame metrics. 

### Consequence:
Fragment screen traces **must use `onPause`** instead of `onStop` because `frameMetricsAggregator.reset()` is moved from `onStop` to `onPause`. 