### PR TITLE
Backfill Mutations

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -275,7 +275,7 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
     assertCallback("writeMutations");
 
     LocalDocumentsResult result = localStore.writeLocally(mutations);
-    addUserCallback(result.getLargestBatchId(), userTask);
+    addUserCallback(result.getBatchId(), userTask);
 
     emitNewSnapsAndNotifyLocalStore(result.getDocuments(), /*remoteEvent=*/ null);
     remoteStore.fillWritePipeline();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -32,9 +32,9 @@ import com.google.firebase.firestore.bundle.BundleLoader;
 import com.google.firebase.firestore.bundle.BundleMetadata;
 import com.google.firebase.firestore.bundle.BundleReader;
 import com.google.firebase.firestore.core.ViewSnapshot.SyncState;
+import com.google.firebase.firestore.local.LocalDocumentsResult;
 import com.google.firebase.firestore.local.LocalStore;
 import com.google.firebase.firestore.local.LocalViewChanges;
-import com.google.firebase.firestore.local.LocalWriteResult;
 import com.google.firebase.firestore.local.QueryPurpose;
 import com.google.firebase.firestore.local.QueryResult;
 import com.google.firebase.firestore.local.ReferenceSet;
@@ -274,10 +274,10 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
   public void writeMutations(List<Mutation> mutations, TaskCompletionSource<Void> userTask) {
     assertCallback("writeMutations");
 
-    LocalWriteResult result = localStore.writeLocally(mutations);
-    addUserCallback(result.getBatchId(), userTask);
+    LocalDocumentsResult result = localStore.writeLocally(mutations);
+    addUserCallback(result.getLargestBatchId(), userTask);
 
-    emitNewSnapsAndNotifyLocalStore(result.getChanges(), /*remoteEvent=*/ null);
+    emitNewSnapsAndNotifyLocalStore(result.getDocuments(), /*remoteEvent=*/ null);
     remoteStore.fillWritePipeline();
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
@@ -158,14 +158,12 @@ public class IndexBackfiller {
     return IndexOffset.create(
         maxOffset.getReadTime(),
         maxOffset.getDocumentKey(),
-        Math.max(lookupResult.getLargestBatchId(), existingOffset.getLargestBatchId()));
+        Math.max(lookupResult.getBatchId(), existingOffset.getLargestBatchId()));
   }
 
   /** Returns the lowest offset for the provided index group. */
   private IndexOffset getExistingOffset(Collection<FieldIndex> fieldIndexes) {
-    if (fieldIndexes.isEmpty()) {
-      return IndexOffset.NONE;
-    }
+    hardAssert(!fieldIndexes.isEmpty(), "Updating collection without indexes");
 
     Iterator<FieldIndex> it = fieldIndexes.iterator();
     IndexOffset minOffset = it.next().getIndexState().getOffset();

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
@@ -107,7 +107,7 @@ public class IndexBackfiller {
   public int backfill() {
     hardAssert(localDocumentsView != null, "setLocalDocumentsView() not called");
     hardAssert(indexManager != null, "setIndexManager() not called");
-    return persistence.runTransaction("Backfill Indexes", this::writeIndexEntries);
+    return persistence.runTransaction("Backfill Indexes", () -> this.writeIndexEntries());
   }
 
   /** Writes index entries until the cap is reached. Returns the number of documents processed. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/IndexBackfiller.java
@@ -44,7 +44,6 @@ public class IndexBackfiller {
 
   private final Scheduler scheduler;
   private final Persistence persistence;
-  private final RemoteDocumentCache remoteDocumentCache;
   private LocalDocumentsView localDocumentsView;
   private IndexManager indexManager;
   private int maxDocumentsToProcess = MAX_DOCUMENTS_TO_PROCESS;
@@ -52,7 +51,6 @@ public class IndexBackfiller {
   public IndexBackfiller(Persistence persistence, AsyncQueue asyncQueue) {
     this.persistence = persistence;
     this.scheduler = new Scheduler(asyncQueue);
-    this.remoteDocumentCache = persistence.getRemoteDocumentCache();
   }
 
   public void setLocalDocumentsView(LocalDocumentsView localDocumentsView) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsResult.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsResult.java
@@ -18,22 +18,21 @@ import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 
-/** The result of a write to the local store. */
-public final class LocalWriteResult {
-  private final int batchId;
+/** The result of a applying local mutations. */
+public final class LocalDocumentsResult {
+  private final int largestBatchId;
+  private final ImmutableSortedMap<DocumentKey, Document> documents;
 
-  private final ImmutableSortedMap<DocumentKey, Document> changes;
-
-  LocalWriteResult(int batchId, ImmutableSortedMap<DocumentKey, Document> changes) {
-    this.batchId = batchId;
-    this.changes = changes;
+  LocalDocumentsResult(int largestBatchId, ImmutableSortedMap<DocumentKey, Document> documents) {
+    this.largestBatchId = largestBatchId;
+    this.documents = documents;
   }
 
-  public int getBatchId() {
-    return batchId;
+  public int getLargestBatchId() {
+    return largestBatchId;
   }
 
-  public ImmutableSortedMap<DocumentKey, Document> getChanges() {
-    return changes;
+  public ImmutableSortedMap<DocumentKey, Document> getDocuments() {
+    return documents;
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsResult.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsResult.java
@@ -18,18 +18,23 @@ import com.google.firebase.database.collection.ImmutableSortedMap;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 
-/** The result of a applying local mutations. */
+/**
+ * Represents a set of document along with their mutation batch ID.
+ *
+ * <p>This class is used when applying mutations to the local store and to propagate document
+ * updates to the indexing table.
+ */
 public final class LocalDocumentsResult {
-  private final int largestBatchId;
+  private final int batchId;
   private final ImmutableSortedMap<DocumentKey, Document> documents;
 
-  LocalDocumentsResult(int largestBatchId, ImmutableSortedMap<DocumentKey, Document> documents) {
-    this.largestBatchId = largestBatchId;
+  LocalDocumentsResult(int batchId, ImmutableSortedMap<DocumentKey, Document> documents) {
+    this.batchId = batchId;
     this.documents = documents;
   }
 
-  public int getLargestBatchId() {
-    return largestBatchId;
+  public int getBatchId() {
+    return batchId;
   }
 
   public ImmutableSortedMap<DocumentKey, Document> getDocuments() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -114,14 +114,14 @@ class LocalDocumentsView {
    */
   ImmutableSortedMap<DocumentKey, Document> getLocalViewOfDocuments(
       Map<DocumentKey, MutableDocument> docs, Set<DocumentKey> existenceStateChanged) {
-    return computeView(docs, Collections.emptyMap(), existenceStateChanged);
+    return computeViews(docs, Collections.emptyMap(), existenceStateChanged);
   }
 
   /**
    * Computes the local view for doc, applying overlays from both {@code memoizedOverlays} and the
    * overlay cache.
    */
-  private ImmutableSortedMap<DocumentKey, Document> computeView(
+  private ImmutableSortedMap<DocumentKey, Document> computeViews(
       Map<DocumentKey, MutableDocument> docs,
       Map<DocumentKey, Overlay> memoizedOverlays,
       Set<DocumentKey> existenceStateChanged) {
@@ -286,7 +286,7 @@ class LocalDocumentsView {
     }
 
     ImmutableSortedMap<DocumentKey, Document> localDocs =
-        computeView(docs, overlays, Collections.emptySet());
+        computeViews(docs, overlays, Collections.emptySet());
     return new LocalDocumentsResult(largestBatchId, localDocs);
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -17,6 +17,7 @@ package com.google.firebase.firestore.local;
 import static com.google.firebase.firestore.model.DocumentCollections.emptyDocumentMap;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.Timestamp;
 import com.google.firebase.database.collection.ImmutableSortedMap;
@@ -31,6 +32,7 @@ import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.model.mutation.MutationBatch;
 import com.google.firebase.firestore.model.mutation.Overlay;
 import com.google.firebase.firestore.model.mutation.PatchMutation;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -84,15 +86,10 @@ class LocalDocumentsView {
    */
   Document getDocument(DocumentKey key) {
     Overlay overlay = documentOverlayCache.getOverlay(key);
-    // Only read from remote document cache if overlay is a patch.
-    MutableDocument document =
-        (overlay == null || overlay.getMutation() instanceof PatchMutation)
-            ? remoteDocumentCache.get(key)
-            : MutableDocument.newInvalidDocument(key);
+    MutableDocument document = createBaseDocument(key, overlay);
     if (overlay != null) {
       overlay.getMutation().applyToLocalView(document, null, Timestamp.now());
     }
-
     return document;
   }
 
@@ -117,21 +114,35 @@ class LocalDocumentsView {
    */
   ImmutableSortedMap<DocumentKey, Document> getLocalViewOfDocuments(
       Map<DocumentKey, MutableDocument> docs, Set<DocumentKey> existenceStateChanged) {
+    return computeView(docs, Collections.emptyMap(), existenceStateChanged);
+  }
+
+  /**
+   * Computes the local view for doc, applying overlays from both {@code memoizedOverlays} and the
+   * overlay cache.
+   */
+  private ImmutableSortedMap<DocumentKey, Document> computeView(
+      Map<DocumentKey, MutableDocument> docs,
+      Map<DocumentKey, Overlay> memoizedOverlays,
+      Set<DocumentKey> existenceStateChanged) {
     ImmutableSortedMap<DocumentKey, Document> results = emptyDocumentMap();
     Map<DocumentKey, MutableDocument> recalculateDocuments = new HashMap<>();
-    for (Map.Entry<DocumentKey, MutableDocument> entry : docs.entrySet()) {
-      Overlay overlay = documentOverlayCache.getOverlay(entry.getKey());
+    for (MutableDocument doc : docs.values()) {
+      Overlay overlay =
+          memoizedOverlays.containsKey(doc.getKey())
+              ? memoizedOverlays.get(doc.getKey())
+              : documentOverlayCache.getOverlay(doc.getKey());
       // Recalculate an overlay if the document's existence state is changed due to a remote
       // event *and* the overlay is a PatchMutation. This is because document existence state
       // can change if some patch mutation's preconditions are met.
       // NOTE: we recalculate when `overlay` is null as well, because there might be a patch
       // mutation whose precondition does not match before the change (hence overlay==null),
       // but would now match.
-      if (existenceStateChanged.contains(entry.getKey())
+      if (existenceStateChanged.contains(doc.getKey())
           && (overlay == null || overlay.getMutation() instanceof PatchMutation)) {
-        recalculateDocuments.put(entry.getKey(), docs.get(entry.getKey()));
+        recalculateDocuments.put(doc.getKey(), doc);
       } else if (overlay != null) {
-        overlay.getMutation().applyToLocalView(entry.getValue(), null, Timestamp.now());
+        overlay.getMutation().applyToLocalView(doc, null, Timestamp.now());
       }
     }
 
@@ -190,14 +201,6 @@ class LocalDocumentsView {
     recalculateAndSaveOverlays(docs);
   }
 
-  /** Gets the local view of the next {@code count} documents based on their read time. */
-  ImmutableSortedMap<DocumentKey, Document> getDocuments(
-      String collectionGroup, IndexOffset offset, int count) {
-    Map<DocumentKey, MutableDocument> docs =
-        remoteDocumentCache.getAll(collectionGroup, offset, count);
-    return getLocalViewOfDocuments(docs, new HashSet<>());
-  }
-
   /**
    * Performs a query against the local view of all documents.
    *
@@ -250,7 +253,43 @@ class LocalDocumentsView {
     return results;
   }
 
-  /** Queries the remote documents and overlays by doing a full collection scan. */
+  /**
+   * Given a collection group, returns the next documents that follow the provided offset, along
+   * with an updated batch ID.
+   *
+   * <p>The documents returned by this method are ordered by remote version from the provided
+   * offset. If there are no more remote documents after the provided offset, documents with
+   * mutations in order of batch id from the offset are returned. Since all documents in a batch are
+   * returned together, the total number of documents returned can exceed {@code count}.
+   *
+   * @param collectionGroup The collection group for the documents.
+   * @param offset The offset to index into.
+   * @param count The number of documents to return
+   * @return A LocalDocumentsRResult with the documents that follow the provided offset and the last
+   *     processed batch id.
+   */
+  LocalDocumentsResult getNextDocuments(String collectionGroup, IndexOffset offset, int count) {
+    Map<DocumentKey, MutableDocument> docs =
+        remoteDocumentCache.getAll(collectionGroup, offset, count);
+    Map<DocumentKey, Overlay> overlays =
+        count - docs.size() > 0
+            ? documentOverlayCache.getOverlays(
+                collectionGroup, offset.getLargestBatchId(), count - docs.size())
+            : Collections.emptyMap();
+
+    int largestBatchId = -1;
+    for (Overlay overlay : overlays.values()) {
+      if (!docs.containsKey(overlay.getKey())) {
+        docs.put(overlay.getKey(), createBaseDocument(overlay.getKey(), overlay));
+      }
+      largestBatchId = Math.max(largestBatchId, overlay.getLargestBatchId());
+    }
+
+    ImmutableSortedMap<DocumentKey, Document> localDocs =
+        computeView(docs, overlays, Collections.emptySet());
+    return new LocalDocumentsResult(largestBatchId, localDocs);
+  }
+
   private ImmutableSortedMap<DocumentKey, Document> getDocumentsMatchingCollectionQuery(
       Query query, IndexOffset offset) {
     Map<DocumentKey, MutableDocument> remoteDocuments =
@@ -280,5 +319,12 @@ class LocalDocumentsView {
     }
 
     return results;
+  }
+
+  /** Returns a base document that can be used to apply `overlay`. */
+  private MutableDocument createBaseDocument(DocumentKey key, @Nullable Overlay overlay) {
+    return (overlay == null || overlay.getMutation() instanceof PatchMutation)
+        ? remoteDocumentCache.get(key)
+        : MutableDocument.newInvalidDocument(key);
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -236,7 +236,7 @@ public final class LocalStore implements BundleCallback {
   }
 
   /** Accepts locally generated Mutations and commits them to storage. */
-  public LocalWriteResult writeLocally(List<Mutation> mutations) {
+  public LocalDocumentsResult writeLocally(List<Mutation> mutations) {
     Timestamp localWriteTime = Timestamp.now();
 
     // TODO: Call queryEngine.handleDocumentChange() appropriately.
@@ -277,7 +277,7 @@ public final class LocalStore implements BundleCallback {
               mutationQueue.addMutationBatch(localWriteTime, baseMutations, mutations);
           Map<DocumentKey, Mutation> overlays = batch.applyToLocalDocumentSet(documents);
           documentOverlayCache.saveOverlays(batch.getBatchId(), overlays);
-          return new LocalWriteResult(batch.getBatchId(), documents);
+          return new LocalDocumentsResult(batch.getBatchId(), documents);
         });
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java
@@ -37,12 +37,9 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
   private ImmutableSortedMap<DocumentKey, Document> docs;
   /** Manages the collection group index. */
   private IndexManager indexManager;
-  /** The latest read time of any document in the cache. */
-  private SnapshotVersion latestReadTime;
 
   MemoryRemoteDocumentCache() {
     docs = emptyDocumentMap();
-    latestReadTime = SnapshotVersion.NONE;
   }
 
   @Override
@@ -57,7 +54,6 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
         !readTime.equals(SnapshotVersion.NONE),
         "Cannot add document to the RemoteDocumentCache with a read time of zero");
     docs = docs.insert(document.getKey(), document.mutableCopy().withReadTime(readTime));
-    latestReadTime = readTime.compareTo(latestReadTime) > 0 ? readTime : latestReadTime;
 
     indexManager.addToCollectionParentIndex(document.getKey().getCollectionPath());
   }
@@ -130,11 +126,6 @@ final class MemoryRemoteDocumentCache implements RemoteDocumentCache {
     }
 
     return result;
-  }
-
-  @Override
-  public SnapshotVersion getLatestReadTime() {
-    return latestReadTime;
   }
 
   Iterable<Document> getDocuments() {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryEngine.java
@@ -162,7 +162,8 @@ public class QueryEngine {
     return appendRemainingResults(
         previousResults,
         query,
-        IndexOffset.create(lastLimboFreeSnapshotVersion, FieldIndex.INITIAL_LARGEST_BATCH_ID));
+        IndexOffset.createSuccessor(
+            lastLimboFreeSnapshotVersion, FieldIndex.INITIAL_LARGEST_BATCH_ID));
   }
 
   /** Applies the query filter and sorting to the provided documents. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/QueryEngine.java
@@ -160,7 +160,9 @@ public class QueryEngine {
     }
 
     return appendRemainingResults(
-        previousResults, query, IndexOffset.create(lastLimboFreeSnapshotVersion));
+        previousResults,
+        query,
+        IndexOffset.create(lastLimboFreeSnapshotVersion, FieldIndex.INITIAL_LARGEST_BATCH_ID));
   }
 
   /** Applies the query filter and sorting to the provided documents. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java
@@ -84,7 +84,4 @@ interface RemoteDocumentCache {
    * @return A newly created map with the set of documents in the collection.
    */
   Map<DocumentKey, MutableDocument> getAll(ResourcePath collection, IndexOffset offset);
-
-  /** Returns the latest read time of any document in the cache. */
-  SnapshotVersion getLatestReadTime();
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCache.java
@@ -255,17 +255,6 @@ final class SQLiteRemoteDocumentCache implements RemoteDocumentCache {
     return getAll(Collections.singletonList(collection), offset, Integer.MAX_VALUE);
   }
 
-  @Override
-  public SnapshotVersion getLatestReadTime() {
-    SnapshotVersion latestReadTime =
-        db.query(
-                "SELECT read_time_seconds, read_time_nanos "
-                    + "FROM remote_documents ORDER BY read_time_seconds DESC, read_time_nanos DESC "
-                    + "LIMIT 1")
-            .firstValue(row -> new SnapshotVersion(new Timestamp(row.getLong(0), row.getInt(1))));
-    return latestReadTime != null ? latestReadTime : SnapshotVersion.NONE;
-  }
-
   private MutableDocument decodeMaybeDocument(
       byte[] bytes, int readTimeSeconds, int readTimeNanos) {
     try {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
@@ -141,7 +141,7 @@ public abstract class FieldIndex {
     /**
      * Creates an offset that matches all documents with a read time higher than {@code readTime}.
      */
-    public static IndexOffset create(SnapshotVersion readTime) {
+    public static IndexOffset create(SnapshotVersion readTime, int largestBatchId) {
       // We want to create an offset that matches all documents with a read time greater than
       // the provided read time. To do so, we technically need to create an offset for
       // `(readTime, MAX_DOCUMENT_KEY)`. While we could use Unicode codepoints to generate
@@ -154,7 +154,7 @@ public abstract class FieldIndex {
               successorNanos == 1e9
                   ? new Timestamp(successorSeconds + 1, 0)
                   : new Timestamp(successorSeconds, successorNanos));
-      return create(successor, DocumentKey.empty(), INITIAL_LARGEST_BATCH_ID);
+      return create(successor, DocumentKey.empty(), largestBatchId);
     }
 
     /** Creates a new offset based on the provided document. */

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/FieldIndex.java
@@ -141,7 +141,7 @@ public abstract class FieldIndex {
     /**
      * Creates an offset that matches all documents with a read time higher than {@code readTime}.
      */
-    public static IndexOffset create(SnapshotVersion readTime, int largestBatchId) {
+    public static IndexOffset createSuccessor(SnapshotVersion readTime, int largestBatchId) {
       // We want to create an offset that matches all documents with a read time greater than
       // the provided read time. To do so, we technically need to create an offset for
       // `(readTime, MAX_DOCUMENT_KEY)`. While we could use Unicode codepoints to generate

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -316,7 +316,12 @@ public class Util {
    */
   public static <T extends Comparable<T>> void diffCollections(
       SortedSet<T> before, SortedSet<T> after, Consumer<T> onAdd, Consumer<T> onRemove) {
-    diffCollections(before.iterator(), after.iterator(), before.comparator(), onAdd, onRemove);
+    diffCollections(
+        before.iterator(),
+        after.iterator(),
+        before.comparator() != null ? before.comparator() : (l, r) -> l.compareTo(r),
+        onAdd,
+        onRemove);
   }
 
   private static <T> void diffCollections(

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/CountingQueryEngine.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/CountingQueryEngine.java
@@ -156,11 +156,6 @@ class CountingQueryEngine extends QueryEngine {
         documentsReadByCollection[0] += result.size();
         return result;
       }
-
-      @Override
-      public SnapshotVersion getLatestReadTime() {
-        return subject.getLatestReadTime();
-      }
     };
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
@@ -15,25 +15,36 @@
 package com.google.firebase.firestore.local;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.firestore.testutil.TestUtil.deleteMutation;
 import static com.google.firebase.firestore.testutil.TestUtil.doc;
 import static com.google.firebase.firestore.testutil.TestUtil.fieldIndex;
+import static com.google.firebase.firestore.testutil.TestUtil.filter;
+import static com.google.firebase.firestore.testutil.TestUtil.key;
 import static com.google.firebase.firestore.testutil.TestUtil.map;
 import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
+import static com.google.firebase.firestore.testutil.TestUtil.patchMutation;
 import static com.google.firebase.firestore.testutil.TestUtil.query;
+import static com.google.firebase.firestore.testutil.TestUtil.setMutation;
 import static com.google.firebase.firestore.testutil.TestUtil.version;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.core.Target;
+import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.FieldIndex.IndexOffset;
 import com.google.firebase.firestore.model.MutableDocument;
 import com.google.firebase.firestore.model.SnapshotVersion;
+import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.testutil.TestUtil;
 import com.google.firebase.firestore.util.AsyncQueue;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -64,24 +75,27 @@ public class IndexBackfillerTest {
 
   @Rule public TestName name = new TestName();
 
-  private SQLitePersistence persistence;
-  private SQLiteIndexManager indexManager;
+  private Persistence persistence;
+  private IndexManager indexManager;
+  private RemoteDocumentCache remoteDocumentCache;
+  private DocumentOverlayCache documentOverlayCache;
   private IndexBackfiller backfiller;
 
   @Before
   public void setUp() {
     persistence = PersistenceTestHelpers.createSQLitePersistence();
-    indexManager = (SQLiteIndexManager) persistence.getIndexManager(User.UNAUTHENTICATED);
+    remoteDocumentCache = persistence.getRemoteDocumentCache();
+    documentOverlayCache = persistence.getDocumentOverlay(User.UNAUTHENTICATED);
+    indexManager = persistence.getIndexManager(User.UNAUTHENTICATED);
     indexManager.start();
 
     RemoteDocumentCache remoteDocumentCache = persistence.getRemoteDocumentCache();
     remoteDocumentCache.setIndexManager(indexManager);
-
     LocalDocumentsView localDocumentsView =
         new LocalDocumentsView(
             remoteDocumentCache,
             persistence.getMutationQueue(User.UNAUTHENTICATED, indexManager),
-            persistence.getDocumentOverlay(User.UNAUTHENTICATED),
+            documentOverlayCache,
             indexManager);
     backfiller = new IndexBackfiller(persistence, new AsyncQueue());
     backfiller.setIndexManager(indexManager);
@@ -97,8 +111,8 @@ public class IndexBackfillerTest {
   public void testBackfillWritesLatestReadTimeToFieldIndexOnCompletion() {
     addFieldIndex("coll1", "foo");
     addFieldIndex("coll2", "bar");
-    addDoc("coll1/docA", "foo", version(10));
-    addDoc("coll2/docA", "bar", version(20));
+    addDoc("coll1/docA", version(10), "foo", 1);
+    addDoc("coll2/docA", version(20), "bar", 1);
 
     int documentsProcessed = backfiller.backfill();
     assertEquals(2, documentsProcessed);
@@ -108,10 +122,10 @@ public class IndexBackfillerTest {
     assertEquals(version(10), fieldIndex1.getIndexState().getOffset().getReadTime());
     assertEquals(version(20), fieldIndex2.getIndexState().getOffset().getReadTime());
 
-    addDoc("coll1/docB", "foo", version(50, 10));
-    addDoc("coll1/docC", "foo", version(50));
-    addDoc("coll2/docB", "bar", version(60));
-    addDoc("coll2/docC", "bar", version(60, 10));
+    addDoc("coll1/docB", version(50, 10), "foo", 1);
+    addDoc("coll1/docC", version(50), "foo", 1);
+    addDoc("coll2/docB", version(60), "bar", 1);
+    addDoc("coll2/docC", version(60, 10), "bar", 1);
 
     documentsProcessed = backfiller.backfill();
     assertEquals(4, documentsProcessed);
@@ -124,20 +138,21 @@ public class IndexBackfillerTest {
 
   @Test
   public void testBackfillFetchesDocumentsAfterEarliestReadTime() {
-    addDoc("latest/doc", "foo", version(10));
     addFieldIndex("coll1", "foo", version(10));
 
-    // Documents before earliest read time should not be fetched.
-    addDoc("coll1/docA", "foo", version(9));
+    // Documents before read time should not be fetched.
+    addDoc("coll1/docA", version(9), "foo", 1);
     int documentsProcessed = backfiller.backfill();
     assertEquals(0, documentsProcessed);
 
     // Read time should be the highest read time from the cache.
     Iterator<FieldIndex> it = indexManager.getFieldIndexes("coll1").iterator();
-    assertEquals(IndexOffset.create(version(10)), it.next().getIndexState().getOffset());
+    assertEquals(
+        IndexOffset.create(version(10), DocumentKey.empty(), -1),
+        it.next().getIndexState().getOffset());
 
     // Documents that are after the earliest read time but before field index read time are fetched.
-    addDoc("coll1/docB", "boo", version(19));
+    addDoc("coll1/docB", version(19), "boo", 1);
     documentsProcessed = backfiller.backfill();
     assertEquals(1, documentsProcessed);
 
@@ -150,10 +165,10 @@ public class IndexBackfillerTest {
   public void testBackfillWritesIndexEntries() {
     addFieldIndex("coll1", "foo");
     addFieldIndex("coll2", "bar");
-    addDoc("coll1/docA", "foo", version(10));
-    addDoc("coll1/docB", "boo", version(10));
-    addDoc("coll2/docA", "bar", version(10));
-    addDoc("coll2/docB", "car", version(10));
+    addDoc("coll1/docA", version(10), "foo", 1);
+    addDoc("coll1/docB", version(10), "boo", 1);
+    addDoc("coll2/docA", version(10), "bar", 1);
+    addDoc("coll2/docB", version(10), "car", 1);
 
     int documentsProcessed = backfiller.backfill();
     assertEquals(4, documentsProcessed);
@@ -165,9 +180,9 @@ public class IndexBackfillerTest {
 
     addFieldIndex("coll1", "foo");
     Target target = query("coll1").orderBy(orderBy("foo")).toTarget();
-    addDoc("coll1/docA", "foo", version(5));
-    addDoc("coll1/docB", "foo", version(3));
-    addDoc("coll1/docC", "foo", version(10));
+    addDoc("coll1/docA", version(5), "foo", 1);
+    addDoc("coll1/docB", version(3), "foo", 1);
+    addDoc("coll1/docC", version(10), "foo", 1);
 
     int documentsProcessed = backfiller.backfill();
     assertEquals(2, documentsProcessed);
@@ -186,9 +201,9 @@ public class IndexBackfillerTest {
 
     addFieldIndex("coll1", "foo");
     Target target = query("coll1").orderBy(orderBy("foo")).toTarget();
-    addDoc("coll1/docA", "foo", version(1));
-    addDoc("coll1/docB", "foo", version(1));
-    addDoc("coll1/docC", "foo", version(1));
+    addDoc("coll1/docA", version(1), "foo", 1);
+    addDoc("coll1/docB", version(1), "foo", 1);
+    addDoc("coll1/docC", version(1), "foo", 1);
 
     int documentsProcessed = backfiller.backfill();
     assertEquals(2, documentsProcessed);
@@ -208,9 +223,9 @@ public class IndexBackfillerTest {
     addFieldIndex("coll1", "foo");
     addFieldIndex("coll2", "foo");
 
-    addDoc("coll1/docA", "foo", version(10));
-    addDoc("coll1/docB", "foo", version(20));
-    addDoc("coll2/docA", "foo", version(30));
+    addDoc("coll1/docA", version(10), "foo", 1);
+    addDoc("coll1/docB", version(20), "foo", 1);
+    addDoc("coll2/docA", version(30), "foo", 1);
 
     String collectionGroup = indexManager.getNextCollectionGroupToUpdate();
     assertEquals("coll1", collectionGroup);
@@ -233,9 +248,9 @@ public class IndexBackfillerTest {
     addFieldIndex("coll2", "foo", /* sequenceNumber= */ 2);
     addFieldIndex("coll3", "foo", /* sequenceNumber= */ 0);
 
-    addDoc("coll1/doc", "foo", version(10));
-    addDoc("coll2/doc", "foo", version(20));
-    addDoc("coll3/doc", "foo", version(30));
+    addDoc("coll1/doc", version(10), "foo", 1);
+    addDoc("coll2/doc", version(20), "foo", 1);
+    addDoc("coll3/doc", version(30), "foo", 1);
 
     // Check that coll3 is the next collection ID the backfiller should update
     assertEquals("coll3", indexManager.getNextCollectionGroupToUpdate());
@@ -251,10 +266,10 @@ public class IndexBackfillerTest {
     backfiller.setMaxDocumentsToProcess(3);
     addFieldIndex("coll1", "foo");
     addFieldIndex("coll2", "foo");
-    addDoc("coll1/docA", "foo", version(10));
-    addDoc("coll1/docB", "foo", version(20));
-    addDoc("coll2/docA", "foo", version(30));
-    addDoc("coll2/docA", "foo", version(40));
+    addDoc("coll1/docA", version(10), "foo", 1);
+    addDoc("coll1/docB", version(20), "foo", 1);
+    addDoc("coll2/docA", version(30), "foo", 1);
+    addDoc("coll2/docA", version(40), "foo", 1);
 
     int documentsProcessed = backfiller.backfill();
     assertEquals(3, documentsProcessed);
@@ -266,16 +281,195 @@ public class IndexBackfillerTest {
   @Test
   public void testBackfillUsesLatestReadTimeForEmptyCollections() {
     addFieldIndex("coll", "foo", version(1));
-    addDoc("readtime/doc", "foo", version(2));
+    addDoc("readtime/doc", version(1), "foo", 1);
 
     int documentsProcessed = backfiller.backfill();
     assertEquals(0, documentsProcessed);
 
-    addDoc("coll/ignored", "foo", version(2));
-    addDoc("coll/added", "foo", version(3));
+    addDoc("coll/ignored", version(2), "foo", 1);
+    addDoc("coll/added", version(3), "foo", 1);
 
     documentsProcessed = backfiller.backfill();
+    assertEquals(2, documentsProcessed);
+  }
+
+  @Test
+  public void testBackfillHandlesLocalMutationsAfterRemoteDocs() {
+    backfiller.setMaxDocumentsToProcess(2);
+    addFieldIndex("coll1", "foo");
+
+    addDoc("coll1/docA", version(10), "foo", 1);
+    addDoc("coll1/docB", version(20), "foo", 1);
+    addDoc("coll1/docC", version(30), "foo", 1);
+    addSetMutationsToOverlay(1, "coll1/docD");
+
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(2, documentsProcessed);
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB");
+
+    documentsProcessed = backfiller.backfill();
+    assertEquals(2, documentsProcessed);
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB", "coll1/docC", "coll1/docD");
+  }
+
+  @Test
+  public void testBackfillMutationsUpToDocumentLimitAndUpdatesBatchIdOnIndex() {
+    backfiller.setMaxDocumentsToProcess(2);
+    addFieldIndex("coll1", "foo");
+    addDoc("coll1/docA", version(10), "foo", 1);
+    addSetMutationsToOverlay(2, "coll1/docB");
+    addSetMutationsToOverlay(3, "coll1/docC");
+    addSetMutationsToOverlay(4, "coll1/docD");
+
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(2, documentsProcessed);
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB");
+    FieldIndex fieldIndex = indexManager.getFieldIndexes("coll1").iterator().next();
+    assertEquals(2, fieldIndex.getIndexState().getOffset().getLargestBatchId());
+
+    documentsProcessed = backfiller.backfill();
+    assertEquals(2, documentsProcessed);
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB", "coll1/docC", "coll1/docD");
+    fieldIndex = indexManager.getFieldIndexes("coll1").iterator().next();
+    assertEquals(4, fieldIndex.getIndexState().getOffset().getLargestBatchId());
+  }
+
+  @Test
+  public void testBackfillMutationFinishesMutationBatchEvenIfItExceedsLimit() {
+    backfiller.setMaxDocumentsToProcess(2);
+    addFieldIndex("coll1", "foo");
+    addDoc("coll1/docA", version(10), "foo", 1);
+    addSetMutationsToOverlay(2, "coll1/docB", "coll1/docC", "coll1/docD");
+    addSetMutationsToOverlay(3, "coll1/docE");
+
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(4, documentsProcessed);
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB", "coll1/docC", "coll1/docD");
+  }
+
+  @Test
+  public void testBackfillMutationsFromHighWaterMark() {
+    backfiller.setMaxDocumentsToProcess(2);
+    addFieldIndex("coll1", "foo");
+    addDoc("coll1/docA", version(10), "foo", 1);
+    addSetMutationsToOverlay(3, "coll1/docB");
+
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(2, documentsProcessed);
+    verifyQueryResults("coll1", "coll1/docA", "coll1/docB");
+
+    addSetMutationsToOverlay(1, "coll1/docC");
+    addSetMutationsToOverlay(2, "coll1/docD");
+    documentsProcessed = backfiller.backfill();
+    assertEquals(0, documentsProcessed);
+  }
+
+  @Test
+  public void testBackfillUpdatesExistingDocToNewValue() {
+    backfiller.setMaxDocumentsToProcess(1);
+    addFieldIndex("coll1", "foo");
+    FieldIndex fieldIndex = indexManager.getFieldIndexes("coll1").iterator().next();
+
+    addDoc("coll1/docA", version(10), "foo", 1);
+    int documentsProcessed = backfiller.backfill();
     assertEquals(1, documentsProcessed);
+    Target target = query("coll1").filter(filter("foo", "==", 2)).toTarget();
+    Set<DocumentKey> matching = indexManager.getDocumentsMatchingTarget(fieldIndex, target);
+    assertEquals(0, matching.size());
+
+    // Update doc to new remote version with new value.
+    addDoc("coll1/docA", version(40), "foo", 2);
+    documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+    matching = indexManager.getDocumentsMatchingTarget(fieldIndex, target);
+    assertEquals(1, matching.size());
+  }
+
+  @Test
+  public void testBackfillUpdatesDocsThatNoLongerMatch() {
+    backfiller.setMaxDocumentsToProcess(1);
+    addFieldIndex("coll1", "foo");
+    FieldIndex fieldIndex = indexManager.getFieldIndexes("coll1").iterator().next();
+
+    addDoc("coll1/docA", version(10), "foo", 1);
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+    Target target = query("coll1").filter(filter("foo", ">", 0)).toTarget();
+    Set<DocumentKey> matching = indexManager.getDocumentsMatchingTarget(fieldIndex, target);
+    assertEquals(1, matching.size());
+
+    // Update doc to new remote version with new value that doesn't match field index.
+    addDoc("coll1/docA", version(40), "foo", -1);
+    documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+    matching = indexManager.getDocumentsMatchingTarget(fieldIndex, target);
+    assertTrue(matching.isEmpty());
+  }
+
+  @Test
+  public void testBackfillUpdatesToLatestReadTimeInCollection() {
+    // check that offset is set to rdc latest read time if no docs match current coll
+    addFieldIndex("coll1", "foo");
+    addDoc("coll1/doc", version(5), "foo", 1);
+
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+
+    // Offset should be set to latest read time in the cache if no documents were indexed.
+    Iterator<FieldIndex> it = indexManager.getFieldIndexes("coll1").iterator();
+    assertEquals(version(5), it.next().getIndexState().getOffset().getReadTime());
+  }
+
+  @Test
+  public void testBackfillDoesNotProcessSameDocumentTwice() {
+    addFieldIndex("coll", "foo");
+    addDoc("coll/doc", version(5), "foo", 1);
+    addSetMutationsToOverlay(1, "coll/doc");
+
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+
+    FieldIndex fieldIndex = indexManager.getFieldIndexes("coll").iterator().next();
+    assertEquals(version(5), fieldIndex.getIndexState().getOffset().getReadTime());
+    assertEquals(1, fieldIndex.getIndexState().getOffset().getLargestBatchId());
+  }
+
+  @Test
+  public void testBackfillAppliesOverlayToRemoteDoc() {
+    addFieldIndex("coll", "foo");
+    addDoc("coll/doc", version(5), "boo", 1);
+
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+
+    Mutation patch = patchMutation("coll/doc", map("foo", 1));
+    addMutationToOverlay("coll/doc", patch);
+    documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+
+    FieldIndex fieldIndex = indexManager.getFieldIndexes("coll").iterator().next();
+    Target target = query("coll").filter(filter("foo", "==", 1)).toTarget();
+    Set<DocumentKey> matching = indexManager.getDocumentsMatchingTarget(fieldIndex, target);
+    assertEquals(1, matching.size());
+  }
+
+  @Test
+  public void testBackfillAppliesDeleteMutationOnRemoteDoc() {
+    addFieldIndex("coll", "foo");
+    addDoc("coll/doc", version(5), "foo", 1);
+
+    int documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+
+    Mutation delete = deleteMutation("coll/doc");
+    addMutationToOverlay("coll/doc", delete);
+    documentsProcessed = backfiller.backfill();
+    assertEquals(1, documentsProcessed);
+
+    FieldIndex fieldIndex = indexManager.getFieldIndexes("coll").iterator().next();
+    Target target = query("coll").filter(filter("foo", "==", 2)).toTarget();
+    Set<DocumentKey> matching = indexManager.getDocumentsMatchingTarget(fieldIndex, target);
+    assertTrue(matching.isEmpty());
   }
 
   private void addFieldIndex(String collectionGroup, String fieldName) {
@@ -315,8 +509,21 @@ public class IndexBackfillerTest {
   }
 
   /** Creates a document and adds it to the RemoteDocumentCache. */
-  private void addDoc(String path, String field, SnapshotVersion readTime) {
-    MutableDocument doc = doc(path, 10, map(field, 2));
-    persistence.getRemoteDocumentCache().add(doc, readTime);
+  private void addDoc(String path, SnapshotVersion readTime, String field, int value) {
+    MutableDocument doc = doc(path, 10, map(field, value));
+    remoteDocumentCache.add(doc, readTime);
+  }
+
+  /** Adds a set mutation to a batch with the specified id for every specified document path. */
+  private void addSetMutationsToOverlay(int batchId, String... paths) {
+    Map<DocumentKey, Mutation> map = new HashMap<>();
+    for (String path : paths) {
+      map.put(key(path), setMutation(path, map("foo", "bar")));
+    }
+    documentOverlayCache.saveOverlays(batchId, map);
+  }
+
+  private void addMutationToOverlay(String path, Mutation mutation) {
+    documentOverlayCache.saveOverlays(5, Collections.singletonMap(key(path), mutation));
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/IndexBackfillerTest.java
@@ -31,7 +31,6 @@ import static junit.framework.TestCase.assertTrue;
 
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.core.Target;
-import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.FieldIndex;
 import com.google.firebase.firestore.model.FieldIndex.IndexOffset;

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -144,7 +144,7 @@ public abstract class LocalStoreTestCase {
     LocalDocumentsResult result = localStore.writeLocally(mutations);
     batches.add(
         new MutationBatch(
-            result.getLargestBatchId(), Timestamp.now(), Collections.emptyList(), mutations));
+            result.getBatchId(), Timestamp.now(), Collections.emptyList(), mutations));
     lastChanges = result.getDocuments();
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -136,16 +136,16 @@ public abstract class LocalStoreTestCase {
     localStorePersistence.shutdown();
   }
 
-  private void writeMutation(Mutation mutation) {
+  protected void writeMutation(Mutation mutation) {
     writeMutations(asList(mutation));
   }
 
   private void writeMutations(List<Mutation> mutations) {
-    LocalWriteResult result = localStore.writeLocally(mutations);
+    LocalDocumentsResult result = localStore.writeLocally(mutations);
     batches.add(
         new MutationBatch(
-            result.getBatchId(), Timestamp.now(), Collections.emptyList(), mutations));
-    lastChanges = result.getChanges();
+            result.getLargestBatchId(), Timestamp.now(), Collections.emptyList(), mutations));
+    lastChanges = result.getDocuments();
   }
 
   protected void applyRemoteEvent(RemoteEvent event) {
@@ -327,7 +327,7 @@ public abstract class LocalStoreTestCase {
    * Asserts the expected numbers of mutations read by the OverlayQueue since the last call to
    * `resetPersistenceStats()`.
    */
-  private void assertOverlaysRead(int byKey, int byCollection) {
+  protected void assertOverlaysRead(int byKey, int byCollection) {
     assertEquals("Overlays read (by key)", byKey, queryEngine.getOverlaysReadByKey());
     assertEquals(
         "Overlays read (by collection)", byCollection, queryEngine.getOverlaysReadByCollection());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
@@ -207,7 +207,7 @@ abstract class RemoteDocumentCacheTestCase {
 
     ResourcePath collection = path("b");
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll(collection, IndexOffset.create(version(12)));
+        remoteDocumentCache.getAll(collection, IndexOffset.create(version(12), -1));
     assertThat(results.values()).containsExactly(doc("b/new", 3, DOC_DATA));
   }
 
@@ -219,7 +219,7 @@ abstract class RemoteDocumentCacheTestCase {
 
     ResourcePath collection = path("b");
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll(collection, IndexOffset.create(version(1, 2)));
+        remoteDocumentCache.getAll(collection, IndexOffset.create(version(1, 2), -1));
     assertThat(results.values()).containsExactly(doc("b/new", 1, DOC_DATA));
   }
 
@@ -243,26 +243,8 @@ abstract class RemoteDocumentCacheTestCase {
 
     ResourcePath collection = path("b");
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll(collection, IndexOffset.create(version(1)));
+        remoteDocumentCache.getAll(collection, IndexOffset.create(version(1), -1));
     assertThat(results.values()).containsExactly(doc("b/old", 1, DOC_DATA));
-  }
-
-  @Test
-  public void testLatestReadTime() {
-    SnapshotVersion latestReadTime = remoteDocumentCache.getLatestReadTime();
-    assertEquals(SnapshotVersion.NONE, latestReadTime);
-
-    addTestDocumentAtPath("coll/a", /* updateTime= */ 0, /* readTime= */ 1);
-    latestReadTime = remoteDocumentCache.getLatestReadTime();
-    assertEquals(version(1), latestReadTime);
-
-    addTestDocumentAtPath("coll/b", /* updateTime= */ 0, /* readTime= */ 3);
-    latestReadTime = remoteDocumentCache.getLatestReadTime();
-    assertEquals(version(3), latestReadTime);
-
-    addTestDocumentAtPath("coll/c", /* updateTime= */ 0, /* readTime= */ 2);
-    latestReadTime = remoteDocumentCache.getLatestReadTime();
-    assertEquals(version(3), latestReadTime);
   }
 
   protected MutableDocument addTestDocumentAtPath(String path) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/RemoteDocumentCacheTestCase.java
@@ -207,7 +207,7 @@ abstract class RemoteDocumentCacheTestCase {
 
     ResourcePath collection = path("b");
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll(collection, IndexOffset.create(version(12), -1));
+        remoteDocumentCache.getAll(collection, IndexOffset.createSuccessor(version(12), -1));
     assertThat(results.values()).containsExactly(doc("b/new", 3, DOC_DATA));
   }
 
@@ -219,7 +219,7 @@ abstract class RemoteDocumentCacheTestCase {
 
     ResourcePath collection = path("b");
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll(collection, IndexOffset.create(version(1, 2), -1));
+        remoteDocumentCache.getAll(collection, IndexOffset.createSuccessor(version(1, 2), -1));
     assertThat(results.values()).containsExactly(doc("b/new", 1, DOC_DATA));
   }
 
@@ -243,7 +243,7 @@ abstract class RemoteDocumentCacheTestCase {
 
     ResourcePath collection = path("b");
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll(collection, IndexOffset.create(version(1), -1));
+        remoteDocumentCache.getAll(collection, IndexOffset.createSuccessor(version(1), -1));
     assertThat(results.values()).containsExactly(doc("b/old", 1, DOC_DATA));
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteOverlayMigrationManagerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteOverlayMigrationManagerTest.java
@@ -74,7 +74,7 @@ public class SQLiteOverlayMigrationManagerTest {
   }
 
   private void writeMutations(List<Mutation> mutations) {
-    LocalWriteResult result = localStore.writeLocally(mutations);
+    localStore.writeLocally(mutations);
   }
 
   /** Asserts that the given local store contains the given document. */

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCacheTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCacheTest.java
@@ -65,14 +65,14 @@ public final class SQLiteRemoteDocumentCacheTest extends RemoteDocumentCacheTest
     addTestDocumentAtPath("a/3", /* updateTime= */ 3, /*  readTime= = */ 13);
 
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll("a", FieldIndex.IndexOffset.create(version(11), -1), 2);
+        remoteDocumentCache.getAll("a", FieldIndex.IndexOffset.createSuccessor(version(11), -1), 2);
     assertThat(results.keySet()).containsExactly(key("b/2/a/2"), key("a/3"));
   }
 
   @Test
   public void testNextDocumentsFromNonExistingCollectionGroup() {
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll("a", FieldIndex.IndexOffset.create(version(11), -1), 2);
+        remoteDocumentCache.getAll("a", FieldIndex.IndexOffset.createSuccessor(version(11), -1), 2);
     assertThat(results).isEmpty();
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCacheTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteRemoteDocumentCacheTest.java
@@ -65,14 +65,14 @@ public final class SQLiteRemoteDocumentCacheTest extends RemoteDocumentCacheTest
     addTestDocumentAtPath("a/3", /* updateTime= */ 3, /*  readTime= = */ 13);
 
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll("a", FieldIndex.IndexOffset.create(version(11)), 2);
+        remoteDocumentCache.getAll("a", FieldIndex.IndexOffset.create(version(11), -1), 2);
     assertThat(results.keySet()).containsExactly(key("b/2/a/2"), key("a/3"));
   }
 
   @Test
   public void testNextDocumentsFromNonExistingCollectionGroup() {
     Map<DocumentKey, MutableDocument> results =
-        remoteDocumentCache.getAll("a", FieldIndex.IndexOffset.create(version(11)), 2);
+        remoteDocumentCache.getAll("a", FieldIndex.IndexOffset.create(version(11), -1), 2);
     assertThat(results).isEmpty();
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -450,7 +450,7 @@ public class SQLiteSchemaTest {
 
     // Queries that filter by read time only return documents that were written after the index-free
     // migration.
-    results = remoteDocumentCache.getAll(path("coll"), IndexOffset.create(version(2), -1));
+    results = remoteDocumentCache.getAll(path("coll"), IndexOffset.createSuccessor(version(2), -1));
     assertResultsContain(results, "coll/new");
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/SQLiteSchemaTest.java
@@ -450,7 +450,7 @@ public class SQLiteSchemaTest {
 
     // Queries that filter by read time only return documents that were written after the index-free
     // migration.
-    results = remoteDocumentCache.getAll(path("coll"), IndexOffset.create(version(2)));
+    results = remoteDocumentCache.getAll(path("coll"), IndexOffset.create(version(2), -1));
     assertResultsContain(results, "coll/new");
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
@@ -96,9 +96,9 @@ public class FieldIndexTest {
   public void indexOffsetComparator() {
     IndexOffset docAOffset = IndexOffset.create(version(1), key("foo/a"), -1);
     IndexOffset docBOffset = IndexOffset.create(version(1), key("foo/b"), -1);
-    IndexOffset version1Offset = IndexOffset.create(version(1));
+    IndexOffset version1Offset = IndexOffset.create(version(1), -1);
     IndexOffset docCOffset = IndexOffset.create(version(2), key("foo/c"), -1);
-    IndexOffset version2Offset = IndexOffset.create(version(2));
+    IndexOffset version2Offset = IndexOffset.create(version(2), -1);
 
     assertEquals(-1, docAOffset.compareTo(docBOffset));
     assertEquals(-1, docAOffset.compareTo(version1Offset));
@@ -109,7 +109,7 @@ public class FieldIndexTest {
 
   @Test
   public void indexOffsetAdvancesSeconds() {
-    IndexOffset actualSuccessor = IndexOffset.create(version(1, (int) 1e9 - 1));
+    IndexOffset actualSuccessor = IndexOffset.create(version(1, (int) 1e9 - 1), -1);
     IndexOffset expectedSuccessor = IndexOffset.create(version(2, 0), DocumentKey.empty(), -1);
     assertEquals(expectedSuccessor, actualSuccessor);
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
@@ -96,9 +96,9 @@ public class FieldIndexTest {
   public void indexOffsetComparator() {
     IndexOffset docAOffset = IndexOffset.create(version(1), key("foo/a"), -1);
     IndexOffset docBOffset = IndexOffset.create(version(1), key("foo/b"), -1);
-    IndexOffset version1Offset = IndexOffset.create(version(1), -1);
+    IndexOffset version1Offset = IndexOffset.createSuccessor(version(1), -1);
     IndexOffset docCOffset = IndexOffset.create(version(2), key("foo/c"), -1);
-    IndexOffset version2Offset = IndexOffset.create(version(2), -1);
+    IndexOffset version2Offset = IndexOffset.createSuccessor(version(2), -1);
 
     assertEquals(-1, docAOffset.compareTo(docBOffset));
     assertEquals(-1, docAOffset.compareTo(version1Offset));
@@ -109,7 +109,7 @@ public class FieldIndexTest {
 
   @Test
   public void indexOffsetAdvancesSeconds() {
-    IndexOffset actualSuccessor = IndexOffset.create(version(1, (int) 1e9 - 1), -1);
+    IndexOffset actualSuccessor = IndexOffset.createSuccessor(version(1, (int) 1e9 - 1), -1);
     IndexOffset expectedSuccessor = IndexOffset.create(version(2, 0), DocumentKey.empty(), -1);
     assertEquals(expectedSuccessor, actualSuccessor);
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/FieldIndexTest.java
@@ -78,7 +78,7 @@ public class FieldIndexTest {
   }
 
   @Test
-  public void comparatorIncludesSegmentsLength() {
+  public void comparatorIncludesSegmentLength() {
     FieldIndex indexOriginal = fieldIndex("collA", "a", FieldIndex.Segment.Kind.ASCENDING);
     FieldIndex indexSame = fieldIndex("collA", "a", FieldIndex.Segment.Kind.ASCENDING);
     FieldIndex indexDifferent =

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/TestUtil.java
@@ -631,9 +631,9 @@ public class TestUtil {
   }
 
   public static FieldIndex fieldIndex(
-      String collectionGroup, String field, FieldIndex.Segment.Kind kind, Object... fieldAndKind) {
+      String collectionGroup, String field, FieldIndex.Segment.Kind kind, Object... fieldsAndKind) {
     FieldIndex fieldIndex =
-        fieldIndex(collectionGroup, -1, FieldIndex.INITIAL_STATE, field, kind, fieldAndKind);
+        fieldIndex(collectionGroup, -1, FieldIndex.INITIAL_STATE, field, kind, fieldsAndKind);
     return fieldIndex;
   }
 


### PR DESCRIPTION
This is another version of https://github.com/firebase/firebase-android-sdk/pull/3202

It's a bit simpler:
- It moves all IndexOffset logic to IndexBackfiller
- It re-uses more code in the LocalDocumentsView
- It removes the latest read time from the offset, as we can just keep the offset at the current read time

I also added a new LocalStoreTestCase that verifies our query processing.