### PR TITLE
issue_3321_seperate_firebaseapp

### DIFF
--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloader.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloader.java
@@ -55,7 +55,7 @@ public class FirebaseModelDownloader {
       FirebaseApp firebaseApp, FirebaseInstallationsApi firebaseInstallationsApi) {
     this.firebaseOptions = firebaseApp.getOptions();
     this.sharedPreferencesUtil = new SharedPreferencesUtil(firebaseApp);
-    this.eventLogger = FirebaseMlLogger.getInstance();
+    this.eventLogger = FirebaseMlLogger.getInstance(firebaseApp);
     this.fileDownloadService = new ModelFileDownloadService(firebaseApp);
     this.modelDownloadService =
         new CustomModelDownloadService(firebaseApp, firebaseInstallationsApi);

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
@@ -97,7 +97,7 @@ public class FirebaseMlLogger {
   @NonNull
   public static FirebaseMlLogger getInstance(FirebaseApp app) {
     Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
-    return (FirebaseMlLogger)FirebaseApp.getInstance(app.getName()).get(FirebaseMlLogger.class);
+    return FirebaseApp.getInstance(app.getName()).get(FirebaseMlLogger.class);
   }
 
   void logModelInfoRetrieverFailure(CustomModel model, ErrorCode errorCode) {

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
@@ -95,7 +95,7 @@ public class FirebaseMlLogger {
 
   @NonNull
   public static FirebaseMlLogger getInstance(@NonNull FirebaseApp app) {
-    return FirebaseApp.getInstance(app.getName()).get(FirebaseMlLogger.class);
+    return app.get(FirebaseMlLogger.class);
   }
 
   void logModelInfoRetrieverFailure(CustomModel model, ErrorCode errorCode) {

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
@@ -95,8 +95,7 @@ public class FirebaseMlLogger {
   }
 
   @NonNull
-  public static FirebaseMlLogger getInstance(FirebaseApp app) {
-    Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
+  public static FirebaseMlLogger getInstance(@NonNull FirebaseApp app) {
     return FirebaseApp.getInstance(app.getName()).get(FirebaseMlLogger.class);
   }
 

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
@@ -23,7 +23,6 @@ import androidx.annotation.VisibleForTesting;
 import androidx.annotation.WorkerThread;
 import com.google.android.datatransport.TransportFactory;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.components.Preconditions;
 import com.google.firebase.ml.modeldownloader.BuildConfig;
 import com.google.firebase.ml.modeldownloader.CustomModel;
 import com.google.firebase.ml.modeldownloader.internal.FirebaseMlLogEvent.DeleteModelLogEvent;

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/FirebaseMlLogger.java
@@ -23,6 +23,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.annotation.WorkerThread;
 import com.google.android.datatransport.TransportFactory;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.components.Preconditions;
 import com.google.firebase.ml.modeldownloader.BuildConfig;
 import com.google.firebase.ml.modeldownloader.CustomModel;
 import com.google.firebase.ml.modeldownloader.internal.FirebaseMlLogEvent.DeleteModelLogEvent;
@@ -91,6 +92,12 @@ public class FirebaseMlLogger {
   @NonNull
   public static FirebaseMlLogger getInstance() {
     return FirebaseApp.getInstance().get(FirebaseMlLogger.class);
+  }
+
+  @NonNull
+  public static FirebaseMlLogger getInstance(FirebaseApp app) {
+    Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
+    return (FirebaseMlLogger)FirebaseApp.getInstance(app.getName()).get(FirebaseMlLogger.class);
   }
 
   void logModelInfoRetrieverFailure(CustomModel model, ErrorCode errorCode) {

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
@@ -85,7 +85,7 @@ public class ModelFileDownloadService {
   public ModelFileDownloadService(@NonNull FirebaseApp firebaseApp) {
     this.context = firebaseApp.getApplicationContext();
     downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-    this.fileManager = ModelFileManager.getInstance();
+    this.fileManager = ModelFileManager.getInstance(firebaseApp);
     this.sharedPreferencesUtil = new SharedPreferencesUtil(firebaseApp);
     this.isInitialLoad = true;
     this.eventLogger = FirebaseMlLogger.getInstance();

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
@@ -66,7 +66,7 @@ public class ModelFileManager {
   @NonNull
   public static ModelFileManager getInstance(FirebaseApp app) {
     Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
-    return (ModelFileManager)FirebaseApp.getInstance(app.getName()).get(ModelFileManager.class);
+    return FirebaseApp.getInstance(app.getName()).get(ModelFileManager.class);
   }
 
   void deleteNonLatestCustomModels() throws FirebaseMlException {

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
@@ -24,6 +24,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.annotation.WorkerThread;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.components.Preconditions;
 import com.google.firebase.ml.modeldownloader.CustomModel;
 import com.google.firebase.ml.modeldownloader.FirebaseMlException;
 import java.io.File;
@@ -60,6 +61,12 @@ public class ModelFileManager {
   @NonNull
   public static ModelFileManager getInstance() {
     return FirebaseApp.getInstance().get(ModelFileManager.class);
+  }
+
+  @NonNull
+  public static ModelFileManager getInstance(FirebaseApp app) {
+    Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
+    return (ModelFileManager)FirebaseApp.getInstance(app.getName()).get(ModelFileManager.class);
   }
 
   void deleteNonLatestCustomModels() throws FirebaseMlException {

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
@@ -64,8 +64,7 @@ public class ModelFileManager {
   }
 
   @NonNull
-  public static ModelFileManager getInstance(FirebaseApp app) {
-    Preconditions.checkArgument(app != null, "Null is not a valid value of FirebaseApp.");
+  public static ModelFileManager getInstance(@NonNull FirebaseApp app) {
     return FirebaseApp.getInstance(app.getName()).get(ModelFileManager.class);
   }
 

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
@@ -24,7 +24,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.annotation.WorkerThread;
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.components.Preconditions;
 import com.google.firebase.ml.modeldownloader.CustomModel;
 import com.google.firebase.ml.modeldownloader.FirebaseMlException;
 import java.io.File;

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
@@ -64,7 +64,7 @@ public class ModelFileManager {
 
   @NonNull
   public static ModelFileManager getInstance(@NonNull FirebaseApp app) {
-    return FirebaseApp.getInstance(app.getName()).get(ModelFileManager.class);
+    return app.get(ModelFileManager.class);
   }
 
   void deleteNonLatestCustomModels() throws FirebaseMlException {


### PR DESCRIPTION
Proposed fix for #3321 by dev-gloomyfox.

TLDR: FirebaseModelDownloader instance creation fails when using a separate FirebaseApp instance. 

The proposed fix will overload the `getInstance` method of both `FirebaseMlLogger.java` & `ModelFileManager.java`. This method will have a parameter of `FirebaseApp`, and will be used in [FirebaseModelDownloader.java#L58](https://github.com/firebase/firebase-android-sdk/blob/master/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseModelDownloader.java#L58) & [ModelFileDownloadService.java#L88](https://github.com/firebase/firebase-android-sdk/blob/master/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java#L88). 

More details is explained by the developer in the said issue.