### PR TITLE
Update LocalStoreTestCase to validate overlays

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -76,11 +76,6 @@ class LocalDocumentsView {
     return documentOverlayCache;
   }
 
-  @VisibleForTesting
-  IndexManager getIndexManager() {
-    return indexManager;
-  }
-
   /**
    * Returns the the local view of the document identified by {@code key}.
    *

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/CountingQueryEngine.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/CountingQueryEngine.java
@@ -93,17 +93,16 @@ class CountingQueryEngine extends QueryEngine {
   }
 
   /**
-   * Returns the number of mutations returned by the OVelrayCaches's
-   * `getAllMutationBatchesAffectingQuery()` API (since the last call to `resetCounts()`)
+   * Returns the number of mutations returned by the OverlayCache's `getOverlays()` API (since the
+   * last call to `resetCounts()`)
    */
   int getOverlaysReadByCollection() {
     return overlaysReadByCollection[0];
   }
 
   /**
-   * Returns the number of mutations returned by the MutationQueue's
-   * `getAllMutationBatchesAffectingDocumentKey()` and
-   * `getAllMutationBatchesAffectingDocumentKeys()` APIs (since the last call to `resetCounts()`)
+   * Returns the number of mutations returned by the OverlayCache's `getOverlay()` API (since the
+   * last call to `resetCounts()`)
    */
   int getOverlaysReadByKey() {
     return overlaysReadByKey[0];
@@ -170,7 +169,7 @@ class CountingQueryEngine extends QueryEngine {
       @Nullable
       @Override
       public Overlay getOverlay(DocumentKey key) {
-        overlaysReadByKey[0] += 1;
+        ++overlaysReadByKey[0];
         return subject.getOverlay(key);
       }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/CountingQueryEngine.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/CountingQueryEngine.java
@@ -59,7 +59,7 @@ class CountingQueryEngine extends QueryEngine {
             wrapRemoteDocumentCache(localDocuments.getRemoteDocumentCache()),
             localDocuments.getMutationQueue(),
             wrapOverlayCache(localDocuments.getDocumentOverlayCache()),
-            localDocuments.getIndexManager());
+            indexManager);
     queryEngine.initialize(wrappedView, indexManager);
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalStoreTestCase.java
@@ -324,13 +324,13 @@ public abstract class LocalStoreTestCase {
   }
 
   /**
-   * Asserts the expected numbers of mutations read by the MutationQueue since the last call to
+   * Asserts the expected numbers of mutations read by the OverlayQueue since the last call to
    * `resetPersistenceStats()`.
    */
-  private void assertMutationsRead(int byKey, int byCollection) {
+  private void assertOverlaysRead(int byKey, int byCollection) {
+    assertEquals("Overlays read (by key)", byKey, queryEngine.getOverlaysReadByKey());
     assertEquals(
-        "Mutations read (by collection)", byCollection, queryEngine.getMutationsReadByCollection());
-    assertEquals("Mutations read (by key)", byKey, queryEngine.getMutationsReadByKey());
+        "Overlays read (by collection)", byCollection, queryEngine.getOverlaysReadByCollection());
   }
 
   /**
@@ -975,8 +975,7 @@ public abstract class LocalStoreTestCase {
 
     localStore.executeQuery(query, /* usePreviousResults= */ true);
     assertRemoteDocumentsRead(/* byKey= */ 0, /* byCollection= */ 2);
-    // No mutations are read because only overlay is needed.
-    assertMutationsRead(/* byKey= */ 0, /* byCollection= */ 0);
+    assertOverlaysRead(/* byKey= */ 0, /* byCollection= */ 1);
   }
 
   @Test


### PR DESCRIPTION
This updates the LocalStore tests to be able to verify how many overlays were processed. This will be used in the Mutation Backfill PR.