### PR TITLE
Change device model for testlab

### DIFF
--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -20,7 +20,7 @@ plugins {
 firebaseLibrary {
     testLab {
         enabled = true
-        device 'model=flame,version=30'
+        device 'model=redfin,version=30'
     }
 }
 


### PR DESCRIPTION
Flame (Pixel 4) does not support API 30 any longer (1), so we need to use Redfin

(1) According to `gcloud firebase test android models list`