### PR TITLE
Replace getForegroundActivity with applyToForegroundActivity[Task]

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/AabUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/AabUpdater.java
@@ -16,7 +16,6 @@ package com.google.firebase.appdistribution;
 
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.DOWNLOAD_FAILURE;
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.NETWORK_FAILURE;
-import static com.google.firebase.appdistribution.TaskUtils.combineWithResultOf;
 import static com.google.firebase.appdistribution.TaskUtils.runAsyncInTask;
 import static com.google.firebase.appdistribution.TaskUtils.safeSetTaskException;
 
@@ -97,10 +96,10 @@ class AabUpdater {
 
       // On a background thread, fetch the redirect URL and open it in the Play app
       runAsyncInTask(executor, () -> fetchDownloadRedirectUrl(newRelease.getDownloadUrl()))
-          .onSuccessTask(combineWithResultOf(() -> lifecycleNotifier.getForegroundActivity()))
-          .addOnSuccessListener(
-              urlAndActivity ->
-                  openRedirectUrlInPlay(urlAndActivity.first(), urlAndActivity.second()))
+          .onSuccessTask(
+              redirectUrl ->
+                  lifecycleNotifier.getForegroundActivity(
+                      activity -> openRedirectUrlInPlay(redirectUrl, activity)))
           .addOnFailureListener(this::setUpdateTaskCompletionError);
 
       return cachedUpdateTask;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/AabUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/AabUpdater.java
@@ -98,7 +98,7 @@ class AabUpdater {
       runAsyncInTask(executor, () -> fetchDownloadRedirectUrl(newRelease.getDownloadUrl()))
           .onSuccessTask(
               redirectUrl ->
-                  lifecycleNotifier.getForegroundActivity(
+                  lifecycleNotifier.applyToForegroundActivity(
                       activity -> openRedirectUrlInPlay(redirectUrl, activity)))
           .addOnFailureListener(this::setUpdateTaskCompletionError);
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
@@ -113,8 +113,8 @@ class ApkUpdater {
 
   private void installApk(File file, boolean showDownloadNotificationManager) {
     lifeCycleNotifier
-        .getForegroundActivity()
-        .onSuccessTask(taskExecutor, activity -> apkInstaller.installApk(file.getPath(), activity))
+        .applyToForegroundActivityTask(
+            activity -> apkInstaller.installApk(file.getPath(), activity))
         .addOnSuccessListener(
             taskExecutor,
             unused -> {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -142,8 +142,7 @@ public class FirebaseAppDistribution {
     }
 
     lifecycleNotifier
-        .getForegroundActivity()
-        .onSuccessTask(this::showSignInConfirmationDialog)
+        .applyToForegroundActivityTask(this::showSignInConfirmationDialog)
         // TODO(rachelprince): Revisit this comment once changes to checkForNewRelease are reviewed
         // Even though checkForNewRelease() calls signInTester(), we explicitly call signInTester
         // here both for code clarifty, and because we plan to remove the signInTester() call
@@ -173,9 +172,8 @@ public class FirebaseAppDistribution {
                 setCachedUpdateIfNewReleaseResult();
                 return Tasks.forResult(null);
               }
-              return lifecycleNotifier
-                  .getForegroundActivity()
-                  .onSuccessTask((activity) -> showUpdateAlertDialog(activity, release));
+              return lifecycleNotifier.applyToForegroundActivityTask(
+                  activity -> showUpdateAlertDialog(activity, release));
             })
         .onSuccessTask(
             unused ->

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionLifecycleNotifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionLifecycleNotifier.java
@@ -39,9 +39,6 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
     void consume(Activity activity);
   }
 
-  /** A {@link SuccessContinuation} that takes an activity and returns a new {@link Task}. */
-  interface ActivityContinuation<T> extends SuccessContinuation<Activity, T> {}
-
   private static FirebaseAppDistributionLifecycleNotifier instance;
   private final Object lock = new Object();
 
@@ -121,7 +118,7 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
    * Apply a function to a foreground activity, when one is available, returning a {@link Task} that
    * will complete with the result of the Task returned by that function.
    */
-  <T> Task<T> applyToForegroundActivityTask(ActivityContinuation<T> continuation) {
+  <T> Task<T> applyToForegroundActivityTask(SuccessContinuation<Activity, T> continuation) {
     return getForegroundActivity()
         .onSuccessTask(
             // Use direct executor to ensure the consumer is called while Activity is in foreground

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TaskUtils.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TaskUtils.java
@@ -14,11 +14,9 @@
 
 package com.google.firebase.appdistribution;
 
-import com.google.android.gms.tasks.SuccessContinuation;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
-import com.google.auto.value.AutoValue;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
 import com.google.firebase.appdistribution.internal.LogWrapper;
 import java.util.concurrent.Executor;
@@ -32,11 +30,6 @@ class TaskUtils {
    */
   interface Operation<TResult> {
     TResult run() throws FirebaseAppDistributionException;
-  }
-
-  /** A functional interface to wrap a function that produces a {@link Task}. */
-  interface TaskSource<TResult> {
-    Task<TResult> get();
   }
 
   /**
@@ -90,58 +83,6 @@ class TaskUtils {
           : Tasks.forException(FirebaseAppDistributionException.wrap(e));
     }
     return task;
-  }
-
-  /**
-   * An @{link AutoValue} class to hold the result of two Tasks, combined using {@link
-   * #combineWithResultOf}.
-   *
-   * @param <T1> The result type of the first task
-   * @param <T2> The result type of the second task
-   */
-  @AutoValue
-  abstract static class CombinedTaskResults<T1, T2> {
-    abstract T1 first();
-
-    abstract T2 second();
-
-    static <T1, T2> CombinedTaskResults<T1, T2> create(T1 first, T2 second) {
-      return new AutoValue_TaskUtils_CombinedTaskResults(first, second);
-    }
-  }
-
-  /**
-   * Returns a {@link SuccessContinuation} to be chained off of a {@link Task}, that will run
-   * another task in sequence and combine both results together.
-   *
-   * <p>This is useful when you want to run two tasks and use the results of each, but those tasks
-   * need to be run sequentially. If they can be run in parallel, use {@link Tasks#whenAll} or one
-   * of its variations.
-   *
-   * <p>Usage:
-   *
-   * <pre>{@code
-   * runFirstAsyncTask()
-   *   .onSuccessTask(combineWithResultOf(executor, () -> startSecondAsyncTask())
-   *   .addOnSuccessListener(
-   *       results ->
-   *           doSomethingWithBothResults(results.result1(), results.result2()));
-   * }</pre>
-   *
-   * @param secondTaskSource A {@link TaskSource} providing the next task to run
-   * @param <T1> The result type of the first task
-   * @param <T2> The result type of the second task
-   * @return A {@link SuccessContinuation} that will return a new task with result type {@link
-   *     CombinedTaskResults}, combining the results of both tasks
-   */
-  static <T1, T2> SuccessContinuation<T1, CombinedTaskResults<T1, T2>> combineWithResultOf(
-      TaskSource<T2> secondTaskSource) {
-    return firstResult ->
-        secondTaskSource
-            .get()
-            .onSuccessTask(
-                secondResult ->
-                    Tasks.forResult(CombinedTaskResults.create(firstResult, secondResult)));
   }
 
   static void safeSetTaskException(TaskCompletionSource taskCompletionSource, Exception e) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
@@ -148,8 +148,8 @@ class TesterSignInManager {
     }
   }
 
-  private Task<Activity> getForegroundActivityAndOpenSignInFlow(String fid) {
-    return lifecycleNotifier.getForegroundActivity(
+  private Task<Void> getForegroundActivityAndOpenSignInFlow(String fid) {
+    return lifecycleNotifier.applyToForegroundActivity(
         activity -> {
           // Launch the intent outside of the synchronized block because we don't need to wait
           // for the lock, and we don't want to risk the activity leaving the foreground in

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
@@ -15,7 +15,6 @@
 package com.google.firebase.appdistribution;
 
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.AUTHENTICATION_CANCELED;
-import static com.google.firebase.appdistribution.TaskUtils.combineWithResultOf;
 import static com.google.firebase.appdistribution.TaskUtils.safeSetTaskException;
 import static com.google.firebase.appdistribution.TaskUtils.safeSetTaskResult;
 
@@ -141,26 +140,28 @@ class TesterSignInManager {
           .getId()
           .addOnFailureListener(
               handleTaskFailure(ErrorMessages.AUTHENTICATION_ERROR, Status.AUTHENTICATION_FAILURE))
-          .onSuccessTask(combineWithResultOf(() -> lifecycleNotifier.getForegroundActivity()))
-          .addOnSuccessListener(
-              fidAndActivity -> {
-                // Launch the intent outside of the synchronized block because we don't need to wait
-                // for the lock, and we don't want to risk the activity leaving the foreground in
-                // the meantime.
-                openSignInFlowInBrowser(fidAndActivity.first(), fidAndActivity.second());
-                // This synchronized block is required by the @GuardedBy annotation, but is not
-                // practically required in this case because the only reads of this variable are on
-                // the main thread, which this callback is also running on.
-                synchronized (signInTaskLock) {
-                  hasBeenSentToBrowserForCurrentTask = true;
-                }
-              })
-          // No failures expected here, since getForegroundActivity() will wait indefinitely for a
-          // foreground activity, but catch any unexpected failures to be safe.
+          .onSuccessTask(this::getForegroundActivityAndOpenSignInFlow)
+          // Catch any unexpected failures to be safe.
           .addOnFailureListener(handleTaskFailure(ErrorMessages.UNKNOWN_ERROR, Status.UNKNOWN));
 
       return signInTaskCompletionSource.getTask();
     }
+  }
+
+  private Task<Activity> getForegroundActivityAndOpenSignInFlow(String fid) {
+    return lifecycleNotifier.getForegroundActivity(
+        activity -> {
+          // Launch the intent outside of the synchronized block because we don't need to wait
+          // for the lock, and we don't want to risk the activity leaving the foreground in
+          // the meantime.
+          openSignInFlowInBrowser(fid, activity);
+          // This synchronized block is required by the @GuardedBy annotation, but is not
+          // practically required in this case because the only reads of this variable are on
+          // the main thread, which this callback is also running on.
+          synchronized (signInTaskLock) {
+            hasBeenSentToBrowserForCurrentTask = true;
+          }
+        });
   }
 
   private OnFailureListener handleTaskFailure(String message, Status status) {

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/AabUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/AabUpdaterTest.java
@@ -16,14 +16,15 @@ package com.google.firebase.appdistribution;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.appdistribution.TestUtils.assertTaskFailure;
 import static com.google.firebase.appdistribution.TestUtils.awaitAsyncOperations;
+import static com.google.firebase.appdistribution.TestUtils.getForegroundActivityAnswer;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
 
 import android.app.Activity;
 import android.net.Uri;
-import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appdistribution.Constants.ErrorMessages;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
@@ -88,7 +89,9 @@ public class AabUpdaterTest {
     aabUpdater =
         Mockito.spy(
             new AabUpdater(mockLifecycleNotifier, mockHttpsUrlConnectionFactory, testExecutor));
-    when(mockLifecycleNotifier.getForegroundActivity()).thenReturn(Tasks.forResult(activity));
+
+    when(mockLifecycleNotifier.getForegroundActivity(any()))
+        .thenAnswer(getForegroundActivityAnswer(activity));
   }
 
   @Test

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/AabUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/AabUpdaterTest.java
@@ -14,9 +14,9 @@
 package com.google.firebase.appdistribution;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.appdistribution.TestUtils.applyToForegroundActivityAnswer;
 import static com.google.firebase.appdistribution.TestUtils.assertTaskFailure;
 import static com.google.firebase.appdistribution.TestUtils.awaitAsyncOperations;
-import static com.google.firebase.appdistribution.TestUtils.getForegroundActivityAnswer;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -90,8 +90,8 @@ public class AabUpdaterTest {
         Mockito.spy(
             new AabUpdater(mockLifecycleNotifier, mockHttpsUrlConnectionFactory, testExecutor));
 
-    when(mockLifecycleNotifier.getForegroundActivity(any()))
-        .thenAnswer(getForegroundActivityAnswer(activity));
+    when(mockLifecycleNotifier.applyToForegroundActivity(any()))
+        .thenAnswer(applyToForegroundActivityAnswer(activity));
   }
 
   @Test

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionLifecycleNotifierTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionLifecycleNotifierTest.java
@@ -1,0 +1,99 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import android.app.Activity;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class FirebaseAppDistributionLifecycleNotifierTest {
+  private TestActivity activity;
+  private FirebaseAppDistributionLifecycleNotifier lifecycleNotifier;
+
+  static class TestActivity extends Activity {}
+
+  @Before
+  public void setup() {
+    activity = Robolectric.buildActivity(TestActivity.class).create().get();
+    lifecycleNotifier = new FirebaseAppDistributionLifecycleNotifier();
+  }
+
+  @Test
+  public void getForegroundActivity_whenActivityResumes_succeeds() {
+    Task<Activity> task = lifecycleNotifier.getForegroundActivity();
+    assertThat(task.isComplete()).isFalse();
+
+    // Simulate an activity resuming
+    lifecycleNotifier.onActivityResumed(activity);
+
+    assertThat(task.isComplete()).isTrue();
+    assertThat(task.isSuccessful()).isTrue();
+    assertThat(task.getResult()).isEqualTo(activity);
+  }
+
+  @Test
+  public void getForegroundActivity_withCurrentActivity_succeeds() {
+    // Resume an activity so there is a current foreground activity already when
+    // getForegroundActivity is called
+    lifecycleNotifier.onActivityResumed(activity);
+
+    Task<Activity> task = lifecycleNotifier.getForegroundActivity();
+
+    assertThat(task.isComplete()).isTrue();
+    assertThat(task.isSuccessful()).isTrue();
+    assertThat(task.getResult()).isEqualTo(activity);
+  }
+
+  @Test
+  public void getForegroundActivity_withConsumer_succeedsAndCallsConsumer()
+      throws FirebaseAppDistributionException {
+    ActivityConsumer consumer = spy(ActivityConsumer.class);
+    Task<Activity> task = lifecycleNotifier.getForegroundActivity(consumer);
+
+    // Simulate an activity resuming
+    lifecycleNotifier.onActivityResumed(activity);
+
+    assertThat(task.isComplete()).isTrue();
+    assertThat(task.isSuccessful()).isTrue();
+    assertThat(task.getResult()).isEqualTo(activity);
+    verify(consumer).consume(activity);
+  }
+
+  @Test
+  public void getForegroundActivity_withConsumerAndCurrentActivity_succeedsAndCallsConsumer()
+      throws FirebaseAppDistributionException {
+    // Resume an activity so there is a current foreground activity already when
+    // getForegroundActivity is called
+    lifecycleNotifier.onActivityResumed(activity);
+
+    ActivityConsumer consumer = spy(ActivityConsumer.class);
+    Task<Activity> task = lifecycleNotifier.getForegroundActivity(consumer);
+
+    assertThat(task.isComplete()).isTrue();
+    assertThat(task.isSuccessful()).isTrue();
+    assertThat(task.getResult()).isEqualTo(activity);
+    verify(consumer).consume(activity);
+  }
+}

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionLifecycleNotifierTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionLifecycleNotifierTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.verify;
 
 import android.app.Activity;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
+import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityFunction;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,7 +69,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
   @Test
   public void getForegroundActivity_withConsumer_succeedsAndCallsConsumer()
       throws FirebaseAppDistributionException {
-    ActivityConsumer consumer = spy(ActivityConsumer.class);
+    ActivityFunction consumer = spy(ActivityFunction.class);
     Task<Activity> task = lifecycleNotifier.getForegroundActivity(consumer);
 
     // Simulate an activity resuming
@@ -78,7 +78,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     assertThat(task.isComplete()).isTrue();
     assertThat(task.isSuccessful()).isTrue();
     assertThat(task.getResult()).isEqualTo(activity);
-    verify(consumer).consume(activity);
+    verify(consumer).apply(activity);
   }
 
   @Test
@@ -88,12 +88,12 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     // getForegroundActivity is called
     lifecycleNotifier.onActivityResumed(activity);
 
-    ActivityConsumer consumer = spy(ActivityConsumer.class);
+    ActivityFunction consumer = spy(ActivityFunction.class);
     Task<Activity> task = lifecycleNotifier.getForegroundActivity(consumer);
 
     assertThat(task.isComplete()).isTrue();
     assertThat(task.isSuccessful()).isTrue();
     assertThat(task.getResult()).isEqualTo(activity);
-    verify(consumer).consume(activity);
+    verify(consumer).apply(activity);
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionLifecycleNotifierTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionLifecycleNotifierTest.java
@@ -22,11 +22,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
+import com.google.android.gms.tasks.SuccessContinuation;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
 import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
-import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityContinuation;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -95,7 +95,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     // applyToForegroundActivityTask is called
     lifecycleNotifier.onActivityResumed(activity);
 
-    ActivityContinuation<String> continuation = spy(ActivityContinuation.class);
+    SuccessContinuation<Activity, String> continuation = spy(SuccessContinuation.class);
     when(continuation.then(activity)).thenReturn(Tasks.forResult("result"));
     Task<String> task = lifecycleNotifier.applyToForegroundActivityTask(continuation);
 
@@ -107,7 +107,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
   @Test
   public void applyToForegroundActivityTask_noCurrentActivity_succeedsAndCallsConsumer()
       throws Exception {
-    ActivityContinuation<String> continuation = spy(ActivityContinuation.class);
+    SuccessContinuation<Activity, String> continuation = spy(SuccessContinuation.class);
     when(continuation.then(activity)).thenReturn(Tasks.forResult("result"));
     Task<String> task = lifecycleNotifier.applyToForegroundActivityTask(continuation);
 
@@ -121,7 +121,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
 
   @Test
   public void applyToForegroundActivityTask_continuationThrows_fails() throws Exception {
-    ActivityContinuation<String> continuation = spy(ActivityContinuation.class);
+    SuccessContinuation<Activity, String> continuation = spy(SuccessContinuation.class);
     FirebaseAppDistributionException continuationException =
         new FirebaseAppDistributionException(
             "exception in continuation task", Status.AUTHENTICATION_CANCELED);
@@ -137,7 +137,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
   @Test
   public void applyToForegroundActivityTask_continuationThrowsUnknownException_wrapsException()
       throws Exception {
-    ActivityContinuation<String> continuation = spy(ActivityContinuation.class);
+    SuccessContinuation<Activity, String> continuation = spy(SuccessContinuation.class);
     RuntimeException continuationException = new RuntimeException("exception in continuation");
     when(continuation.then(activity)).thenThrow(continuationException);
     Task<String> task = lifecycleNotifier.applyToForegroundActivityTask(continuation);
@@ -151,7 +151,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
   @Test
   public void applyToForegroundActivityTask_continuationTaskFails_failsWithSameException()
       throws Exception {
-    ActivityContinuation<String> continuation = spy(ActivityContinuation.class);
+    SuccessContinuation<Activity, String> continuation = spy(SuccessContinuation.class);
     RuntimeException continuationException = new RuntimeException("exception in continuation");
     when(continuation.then(activity)).thenReturn(Tasks.forException(continuationException));
     Task<String> task = lifecycleNotifier.applyToForegroundActivityTask(continuation);

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/FirebaseAppDistributionTest.java
@@ -24,12 +24,14 @@ import static com.google.firebase.appdistribution.FirebaseAppDistributionExcepti
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.INSTALLATION_CANCELED;
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.NETWORK_FAILURE;
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE;
+import static com.google.firebase.appdistribution.TestUtils.applyToForegroundActivityTaskAnswer;
 import static com.google.firebase.appdistribution.TestUtils.assertTaskFailure;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -167,7 +169,8 @@ public class FirebaseAppDistributionTest {
     shadowPackageManager.installPackage(packageInfo);
 
     activity = spy(Robolectric.buildActivity(TestActivity.class).create().get());
-    when(mockLifecycleNotifier.getForegroundActivity()).thenReturn(Tasks.forResult(activity));
+    when(mockLifecycleNotifier.applyToForegroundActivityTask(any()))
+        .thenAnswer(applyToForegroundActivityTaskAnswer(activity));
     when(mockSignInStorage.getSignInStatus()).thenReturn(true);
   }
 

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TestUtils.java
@@ -18,10 +18,14 @@ import static android.os.Looper.getMainLooper;
 import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
+import android.app.Activity;
 import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
+import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.mockito.stubbing.Answer;
 
 final class TestUtils {
   private TestUtils() {}
@@ -49,5 +53,16 @@ final class TestUtils {
     // Idle the main looper, which is also running these tests, so any Task or lifecycle callbacks
     // can be handled. See http://robolectric.org/blog/2019/06/04/paused-looper/ for more info.
     shadowOf(getMainLooper()).idle();
+  }
+
+  static Answer<Task<Activity>> getForegroundActivityAnswer(Activity activity) {
+    return invocationOnMock -> {
+      ActivityConsumer consumer = (ActivityConsumer) invocationOnMock.getArgument(0);
+      if (consumer == null) {
+        return Tasks.forException(new IllegalStateException("ActivityConsumer was null"));
+      }
+      consumer.consume(activity);
+      return Tasks.forResult(activity);
+    };
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TestUtils.java
@@ -19,11 +19,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
+import com.google.android.gms.tasks.SuccessContinuation;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
 import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
-import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityContinuation;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.mockito.stubbing.Answer;
@@ -69,10 +69,10 @@ final class TestUtils {
 
   static <T> Answer<Task<T>> applyToForegroundActivityTaskAnswer(Activity activity) {
     return invocationOnMock -> {
-      ActivityContinuation<T> continuation =
-          (ActivityContinuation<T>) invocationOnMock.getArgument(0);
+      SuccessContinuation<Activity, T> continuation =
+          (SuccessContinuation<Activity, T>) invocationOnMock.getArgument(0);
       if (continuation == null) {
-        return Tasks.forException(new IllegalStateException("ActivityContinuation was null"));
+        return Tasks.forException(new IllegalStateException("Success was null"));
       }
       return continuation.then(activity);
     };

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TestUtils.java
@@ -22,7 +22,7 @@ import android.app.Activity;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
-import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
+import com.google.firebase.appdistribution.FirebaseAppDistributionLifecycleNotifier.ActivityFunction;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.mockito.stubbing.Answer;
@@ -57,11 +57,11 @@ final class TestUtils {
 
   static Answer<Task<Activity>> getForegroundActivityAnswer(Activity activity) {
     return invocationOnMock -> {
-      ActivityConsumer consumer = (ActivityConsumer) invocationOnMock.getArgument(0);
+      ActivityFunction consumer = (ActivityFunction) invocationOnMock.getArgument(0);
       if (consumer == null) {
         return Tasks.forException(new IllegalStateException("ActivityConsumer was null"));
       }
-      consumer.consume(activity);
+      consumer.apply(activity);
       return Tasks.forResult(activity);
     };
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TesterSignInManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TesterSignInManagerTest.java
@@ -16,8 +16,8 @@ package com.google.firebase.appdistribution;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.AUTHENTICATION_CANCELED;
+import static com.google.firebase.appdistribution.TestUtils.applyToForegroundActivityAnswer;
 import static com.google.firebase.appdistribution.TestUtils.assertTaskFailure;
-import static com.google.firebase.appdistribution.TestUtils.getForegroundActivityAnswer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -130,8 +130,8 @@ public class TesterSignInManagerTest {
     activity = Robolectric.buildActivity(TestActivity.class).create().get();
     shadowActivity = shadowOf(activity);
 
-    when(mockLifecycleNotifier.getForegroundActivity(any()))
-        .thenAnswer(getForegroundActivityAnswer(activity));
+    when(mockLifecycleNotifier.applyToForegroundActivity(any()))
+        .thenAnswer(applyToForegroundActivityAnswer(activity));
 
     testerSignInManager =
         new TesterSignInManager(
@@ -155,8 +155,8 @@ public class TesterSignInManagerTest {
   @Test
   public void signInTester_whenUnexpectedFailureInTask_failsWithUnknownError() {
     Exception unexpectedException = new Exception("unexpected exception");
-    // Raise an unexpected exception in our handler passed to getForegroundActivity
-    when(mockLifecycleNotifier.getForegroundActivity(any()))
+    // Raise an unexpected exception in our handler passed to applyToForegroundActivity
+    when(mockLifecycleNotifier.applyToForegroundActivity(any()))
         .thenAnswer(unused -> Tasks.forException(unexpectedException));
 
     Task signInTask = testerSignInManager.signInTester();

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TesterSignInManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TesterSignInManagerTest.java
@@ -17,9 +17,11 @@ package com.google.firebase.appdistribution;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.AUTHENTICATION_CANCELED;
 import static com.google.firebase.appdistribution.TestUtils.assertTaskFailure;
+import static com.google.firebase.appdistribution.TestUtils.getForegroundActivityAnswer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -127,7 +129,9 @@ public class TesterSignInManagerTest {
 
     activity = Robolectric.buildActivity(TestActivity.class).create().get();
     shadowActivity = shadowOf(activity);
-    when(mockLifecycleNotifier.getForegroundActivity()).thenReturn(Tasks.forResult(activity));
+
+    when(mockLifecycleNotifier.getForegroundActivity(any()))
+        .thenAnswer(getForegroundActivityAnswer(activity));
 
     testerSignInManager =
         new TesterSignInManager(
@@ -151,10 +155,9 @@ public class TesterSignInManagerTest {
   @Test
   public void signInTester_whenUnexpectedFailureInTask_failsWithUnknownError() {
     Exception unexpectedException = new Exception("unexpected exception");
-    // We never expect getForegroundActivity to fail, only hang, so this represents an unexpected
-    // failure during sign in
-    when(mockLifecycleNotifier.getForegroundActivity())
-        .thenReturn(Tasks.forException(unexpectedException));
+    // Raise an unexpected exception in our handler passed to getForegroundActivity
+    when(mockLifecycleNotifier.getForegroundActivity(any()))
+        .thenAnswer(unused -> Tasks.forException(unexpectedException));
 
     Task signInTask = testerSignInManager.signInTester();
 


### PR DESCRIPTION
This allows the handler to be run _immediately_ after the foreground activity is resumed. When relying on a Task handler, you're actually enqueueing the handler to either the main thread queue or our own executor's queue, and there's no guarantee that the activity is still in the foreground when it's called. While a race condition should be rare, it's better to avoid it if possible.

An alternative would be to pass in a "direct executor" that runs the listener in the same thread that sets the result, but this approach enforces that approach so the caller doesn't have to remember to do that.