### PR TITLE
Don't deadlock during shutdown()

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -4,8 +4,10 @@ by opting into a release at
 
 # 24.0.2
 - [fixed] Fixed an AppCheck issue that caused Firestore listeners to stop
-working and receive a "Permission Denied" error. This issue only occurred for
-AppCheck users that set their expiration time to under an hour.
+  working and receive a "Permission Denied" error. This issue only occurred for
+  AppCheck users that set their expiration time to under an hour.
+- [fixed] Fixed a potential problem during Firestore's shutdown that prevented 
+  the shutdown from proceeding if a network connection was opened right before.
 
 # 24.0.1
 - [changed] Improved performance for databases that contain many document

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/GrpcCallProvider.java
@@ -15,7 +15,6 @@
 package com.google.firebase.firestore.remote;
 
 import android.content.Context;
-import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.security.ProviderInstaller;
@@ -63,19 +62,6 @@ public class GrpcCallProvider {
   private final Context context;
   private final DatabaseInfo databaseInfo;
   private final CallCredentials firestoreHeaders;
-
-  /**
-   * Helper function to globally override the channel that RPCs use. Useful for testing when you
-   * want to bypass SSL certificate checking.
-   *
-   * @param channelBuilderSupplier The supplier for a channel builder that is used to create gRPC
-   *     channels.
-   */
-  @VisibleForTesting
-  public static void overrideChannelBuilder(
-      Supplier<ManagedChannelBuilder<?>> channelBuilderSupplier) {
-    overrideChannelBuilderSupplier = channelBuilderSupplier;
-  }
 
   GrpcCallProvider(
       AsyncQueue asyncQueue,
@@ -142,7 +128,7 @@ public class GrpcCallProvider {
   void shutdown() {
     // Handling shutdown synchronously to avoid re-enqueuing on the AsyncQueue after shutdown has
     // started.
-    ManagedChannel channel = null;
+    ManagedChannel channel;
     try {
       channel = Tasks.await(channelTask);
     } catch (ExecutionException e) {


### PR DESCRIPTION
This should fix/improve our flaky Android and Unity CI.