### PR TITLE
Move jcenter() to the end on repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ buildscript {
     ext.kotlinVersion = '1.3.72'
     repositories {
         google()
-        jcenter()
         mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -70,7 +69,6 @@ if(JavaVersion.current() != JavaVersion.VERSION_11){
 configure(subprojects) {
     repositories {
         google()
-        jcenter()
         mavenLocal()
         maven {
             url 'https://storage.googleapis.com/android-ci/mvn/'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
         maven {
             url 'https://storage.googleapis.com/android-ci/mvn/'
         }
+        jcenter()
     }
 
     dependencies {
@@ -73,6 +74,7 @@ configure(subprojects) {
         maven {
             url 'https://storage.googleapis.com/android-ci/mvn/'
         }
+        jcenter()
     }
 
     apply plugin: "org.jlleitschuh.gradle.ktlint"


### PR DESCRIPTION
Fireperf has some flaky E2E tests due to failures in downloading dependencies from jcenter(), which was deprecated and unstable. This PR will let Fireperf to download dependencies from mavenCentral() at the first place.

Note: Currently, it is hard to remove jcenter() for all Firebase products as many tests/products still depend on it. Firebase core team will remove jcenter() for all products.