### PR TITLE
Remove unnecessary dependencies from App Distribution stub SDK

### DIFF
--- a/firebase-appdistribution-stub/firebase-appdistribution-stub.gradle
+++ b/firebase-appdistribution-stub/firebase-appdistribution-stub.gradle
@@ -39,8 +39,6 @@ android {
 
 dependencies {
     implementation 'org.jetbrains:annotations:15.0'
-    implementation project(':firebase-components')
-    implementation project(':firebase-common')
     implementation 'com.google.android.gms:play-services-tasks:17.0.0'
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
The stub does not have any dependencies on core Firebase classes, so removing these.