### PR TITLE
Update `performance-gradle` to `perf-plugin`

### DIFF
--- a/ci/fireci/fireciplugins/fireperf.py
+++ b/ci/fireci/fireciplugins/fireperf.py
@@ -42,7 +42,7 @@ def fireperf_e2e_test(target_environment, plugin_repo_dir):
 
   _logger.info('Building fireperf plugin ...')
   with chdir(plugin_repo_dir):
-    build_plugin_task = ':firebase-performance:performance-gradle:publishToMavenLocal'
+    build_plugin_task = ':firebase-performance:perf-plugin:publishToMavenLocal'
     gradle.run(build_plugin_task, gradle.P('publishMode', 'SNAPSHOT'))
 
   version = _find_fireperf_plugin_version()


### PR DESCRIPTION
I recently updated the folder structure of fireperf plugin in the gradle repo and this needs to be updated.