### PR TITLE
Adding null checks for instantiating InstrHttpInputStream/InstrHttpOutputStream

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/network/InstrURLConnectionBase.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/network/InstrURLConnectionBase.java
@@ -140,7 +140,13 @@ class InstrURLConnectionBase {
 
     try {
       final InputStream inputStream = httpUrlConnection.getInputStream();
-      return new InstrHttpInputStream(inputStream, networkMetricBuilder, timer);
+      // Make sure we don't pass in a null into InstrHttpInputStream, since InstrHttpInputStream is
+      // not null-safe.
+      if (inputStream != null) {
+        return new InstrHttpInputStream(inputStream, networkMetricBuilder, timer);
+      }
+      // Only reached when inputStream is null
+      return inputStream;
     } catch (final IOException e) {
       networkMetricBuilder.setTimeToResponseCompletedMicros(timer.getDurationMicros());
       NetworkRequestMetricBuilderUtil.logError(networkMetricBuilder);
@@ -156,8 +162,14 @@ class InstrURLConnectionBase {
 
   public OutputStream getOutputStream() throws IOException {
     try {
-      return new InstrHttpOutputStream(
-          httpUrlConnection.getOutputStream(), networkMetricBuilder, timer);
+      final OutputStream outputStream = httpUrlConnection.getOutputStream();
+      // Make sure we don't pass in a null into InstrHttpOutputStream, since InstrHttpOutputStream
+      // is not null-safe.
+      if (outputStream != null) {
+        return new InstrHttpOutputStream(outputStream, networkMetricBuilder, timer);
+      }
+      // Only reached when outputStream is null
+      return outputStream;
     } catch (final IOException e) {
       networkMetricBuilder.setTimeToResponseCompletedMicros(timer.getDurationMicros());
       NetworkRequestMetricBuilderUtil.logError(networkMetricBuilder);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrURLConnectionBaseTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/network/InstrURLConnectionBaseTest.java
@@ -108,6 +108,15 @@ public class InstrURLConnectionBaseTest extends FirebasePerformanceTestBase {
   }
 
   @Test
+  public void testGetInputStreamWithNullInputStreamReturnsNull() throws IOException {
+    HttpURLConnection urlConnection = mockHttpUrlConnection();
+    when(urlConnection.getInputStream()).thenReturn(null);
+    assertThat(
+            new InstrURLConnectionBase(urlConnection, timer, networkMetricBuilder).getInputStream())
+        .isNull();
+  }
+
+  @Test
   public void testGetOutputStreamThrowsIOException() throws IOException {
     HttpURLConnection urlConnection = mockHttpUrlConnection();
     doThrow(IOException.class).when(urlConnection).getOutputStream();
@@ -120,6 +129,16 @@ public class InstrURLConnectionBaseTest extends FirebasePerformanceTestBase {
         .log(networkArgumentCaptor.capture(), ArgumentMatchers.any(ApplicationProcessState.class));
     NetworkRequestMetric metric = networkArgumentCaptor.getValue();
     assertThat(metric.getTimeToResponseCompletedUs()).isEqualTo(2000);
+  }
+
+  @Test
+  public void testGetOutputStreamWithNullOuputStreamReturnsNull() throws IOException {
+    HttpURLConnection urlConnection = mockHttpUrlConnection();
+    when(urlConnection.getOutputStream()).thenReturn(null);
+    assertThat(
+            new InstrURLConnectionBase(urlConnection, timer, networkMetricBuilder)
+                .getOutputStream())
+        .isNull();
   }
 
   @Test


### PR DESCRIPTION
This should remove the possibility of a null being passed to InstrHttpInputStream/InstrHttpOutputStream.

Fixes #3406