### PR TITLE
Remove AccessHelper.clearPersistence()

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AccessHelper.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AccessHelper.java
@@ -15,7 +15,6 @@
 package com.google.firebase.firestore;
 
 import android.content.Context;
-import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.firestore.auth.CredentialsProvider;
 import com.google.firebase.firestore.auth.User;
@@ -49,9 +48,5 @@ public final class AccessHelper {
 
   public static AsyncQueue getAsyncQueue(FirebaseFirestore firestore) {
     return firestore.getAsyncQueue();
-  }
-
-  public static Task<Void> clearPersistence(FirebaseFirestore firestore) {
-    return firestore.clearPersistence();
   }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -1071,7 +1071,7 @@ public class FirestoreTest {
     waitFor(docRef.set(map("foo", "bar")));
     waitFor(firestore.terminate());
     IntegrationTestUtil.removeFirestore(firestore);
-    waitFor(AccessHelper.clearPersistence(firestore));
+    waitFor(firestore.clearPersistence());
 
     // We restart the app with the same name and options to check that the previous instance's
     // persistent storage is actually cleared after the restart. Calling testFirestore() without the
@@ -1088,7 +1088,7 @@ public class FirestoreTest {
     FirebaseFirestore firestore = testFirestore();
     waitFor(firestore.enableNetwork());
 
-    Task<Void> transactionTask = AccessHelper.clearPersistence(firestore);
+    Task<Void> transactionTask = firestore.clearPersistence();
     waitForException(transactionTask);
     assertFalse(transactionTask.isSuccessful());
     Exception e = transactionTask.getException();

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -271,7 +271,7 @@ public class IntegrationTestUtil {
             asyncQueue,
             /*firebaseApp=*/ null,
             /*instanceRegistry=*/ (dbId) -> {});
-    waitFor(AccessHelper.clearPersistence(firestore));
+    waitFor(firestore.clearPersistence());
     firestore.setFirestoreSettings(settings);
     firestoreStatus.put(firestore, true);
 


### PR DESCRIPTION
Not needed anymore since it was added to the public API