### PR TITLE
Fix flaky PerfSessionTest due to async access to SharedPrefs

### DIFF
--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/PerfSessionTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/PerfSessionTest.java
@@ -30,6 +30,7 @@ import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.ImmutableBundle;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.SessionVerbosity;
+import com.google.testing.timing.FakeDirectExecutorService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +55,9 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
     ConfigResolver.clearInstance();
 
     appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit().clear().commit();
-    ConfigResolver.getInstance().setApplicationContext(appContext);
+    ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setApplicationContext(appContext);
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
   }
 
   @Test


### PR DESCRIPTION
`shouldCollectGaugesAndEvents_perfMonDisabledAtRuntime_sessionNotVerbose` occasionally fails when it tries to programmatically set the config. This is likely due to the [ConfigResolver](https://github.com/firebase/firebase-android-sdk/blob/486da83a45ba9658c413c19aed3026e0f6e8ced4/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java#L187) trying to setValue before the [shared preferences is ready](https://github.com/firebase/firebase-android-sdk/blob/486da83a45ba9658c413c19aed3026e0f6e8ced4/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java#L247).

This just forces the test to use a single threaded [FakeDirectExecutorService](https://github.com/firebase/firebase-android-sdk/blob/ac3276ce7d5f5181b1c419731495eb88a98537af/firebase-perf/src/test/java/com/google/testing/timing/FakeDirectExecutorService.java) for the DeviceCacheManager