### PR TITLE
Stop image download by canceling a Future.

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/DisplayNotification.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/DisplayNotification.java
@@ -32,7 +32,7 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.messaging.Constants.MessageNotificationKeys;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -46,12 +46,12 @@ class DisplayNotification {
 
   private static final int IMAGE_DOWNLOAD_TIMEOUT_SECONDS = 5;
 
-  private final Executor networkIoExecutor;
+  private final ExecutorService networkIoExecutor;
   private final Context context;
   private final NotificationParams params;
 
   public DisplayNotification(
-      Context context, NotificationParams params, Executor networkIoExecutor) {
+      Context context, NotificationParams params, ExecutorService networkIoExecutor) {
     this.networkIoExecutor = networkIoExecutor;
     this.context = context;
     this.params = params;

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/DisplayNotificationChannelRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/DisplayNotificationChannelRoboTest.java
@@ -30,7 +30,7 @@ import android.os.Bundle;
 import androidx.test.core.app.ApplicationProvider;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +54,7 @@ public final class DisplayNotificationChannelRoboTest {
   Context context = ApplicationProvider.getApplicationContext();
 
   NotificationManager notificationManager;
-  Executor executor;
+  ExecutorService executor;
 
   @Before
   public void setup() throws Exception {
@@ -204,7 +204,7 @@ public final class DisplayNotificationChannelRoboTest {
   }
 
   private static DisplayNotification createDisplayNotification(
-      Context context, Bundle message, Executor executor) {
+      Context context, Bundle message, ExecutorService executor) {
     return new DisplayNotification(context, new NotificationParams(message), executor);
   }
 

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/DisplayNotificationRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/DisplayNotificationRoboTest.java
@@ -54,7 +54,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.json.JSONArray;
 import org.junit.Before;
@@ -127,7 +127,7 @@ public class DisplayNotificationRoboTest {
   private ActivityManager activityManager;
   private KeyguardManager keyguardManager;
   private NotificationManager notificationManager;
-  private Executor executor;
+  private ExecutorService executor;
 
   @Before
   public void setUp() throws IOException {

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/ImageDownloadRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/ImageDownloadRoboTest.java
@@ -26,7 +26,7 @@ import com.google.firebase.messaging.testing.TestImageServer;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -46,7 +46,7 @@ public class ImageDownloadRoboTest {
 
   @Rule public TestImageServer testImageServer = new TestImageServer();
 
-  private Executor executor;
+  private ExecutorService executor;
 
   @Before
   public void setUp() throws IOException {


### PR DESCRIPTION
- Switched to stopping an image download by canceling a Future to interrupt the download thread instead of trying to close the InputStream directly since the underlying library does not appear to be thread safe and can throw a variety of Exceptions when close is called on a different thread (https://github.com/firebase/firebase-android-sdk/issues/1830 for a previous issue).