### PR TITLE
Prefer arrayValue when sorting FieldIndex

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
@@ -48,9 +48,9 @@ public abstract class IndexEntry implements Comparable<IndexEntry> {
     cmp = getDocumentKey().compareTo(other.getDocumentKey());
     if (cmp != 0) return cmp;
 
-    cmp = compareByteArrays(getDirectionalValue(), other.getDirectionalValue());
+    cmp = nullSafeCompare(getArrayValue(), other.getArrayValue(), Util::compareByteArrays);
     if (cmp != 0) return cmp;
 
-    return nullSafeCompare(getArrayValue(), other.getArrayValue(), Util::compareByteArrays);
+    return compareByteArrays(getDirectionalValue(), other.getDirectionalValue());
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/index/IndexEntry.java
@@ -15,11 +15,9 @@
 package com.google.firebase.firestore.index;
 
 import static com.google.firebase.firestore.util.Util.compareByteArrays;
-import static com.google.firebase.firestore.util.Util.nullSafeCompare;
 
 import com.google.auto.value.AutoValue;
 import com.google.firebase.firestore.model.DocumentKey;
-import com.google.firebase.firestore.util.Util;
 
 /** Represents an index entry saved by the SDK in its local storage. */
 @AutoValue
@@ -48,7 +46,7 @@ public abstract class IndexEntry implements Comparable<IndexEntry> {
     cmp = getDocumentKey().compareTo(other.getDocumentKey());
     if (cmp != 0) return cmp;
 
-    cmp = nullSafeCompare(getArrayValue(), other.getArrayValue(), Util::compareByteArrays);
+    cmp = compareByteArrays(getArrayValue(), other.getArrayValue());
     if (cmp != 0) return cmp;
 
     return compareByteArrays(getDirectionalValue(), other.getDirectionalValue());

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Util.java
@@ -214,18 +214,6 @@ public class Util {
             });
   }
 
-  public static <T> int nullSafeCompare(
-      @Nullable T left, @Nullable T right, Comparator<T> comparator) {
-    if (left != null && right != null) {
-      return comparator.compare(left, right);
-    }
-    return left == null ? (right == null ? 0 : -1) : 1;
-  }
-
-  public static <T extends Comparable<T>> int nullSafeCompare(@Nullable T left, @Nullable T right) {
-    return nullSafeCompare(left, right, Comparable::compareTo);
-  }
-
   public static int compareByteArrays(byte[] left, byte[] right) {
     int size = Math.min(left.length, right.length);
     for (int i = 0; i < size; i++) {


### PR DESCRIPTION
The schema is `index_id, uid, array_value, directional_value, document_key`. Our internal order should match this.