### PR TITLE
MemoryDocumentOverlayCache: add a comment about getOverlays()

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryDocumentOverlayCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryDocumentOverlayCache.java
@@ -117,6 +117,9 @@ public class MemoryDocumentOverlayCache implements DocumentOverlayCache {
   @Override
   public Map<DocumentKey, Overlay> getOverlays(
       String collectionGroup, int sinceBatchId, int count) {
+    // NOTE: This method is only used by the backfiller, which will not run for memory persistence;
+    // therefore, this method is being implemented only so that the test suite for
+    // `LevelDbDocumentOverlayCache` can be re-used by the test suite for this class.
     SortedMap<Integer, Map<DocumentKey, Overlay>> batchIdToOverlays = new TreeMap<>();
 
     for (Overlay overlay : overlays.values()) {


### PR DESCRIPTION
Add a comment to the `MemoryDocumentOverlayCache.getOverlays()` overload for collection groups about the method not actually being used in production but being implemented only to satisfy unit tests.

This comment was ported from a comment in https://github.com/firebase/firebase-ios-sdk/pull/9330.