### PR TITLE
call DROP_GLOBAL_LOG_EVENT_STATE_SQL before inserting during migration

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManager.java
@@ -132,6 +132,7 @@ final class SchemaManager extends SQLiteOpenHelper {
   private static final SchemaManager.Migration MIGRATION_TO_V5 =
       db -> {
         db.execSQL(DROP_LOG_EVENT_DROPPED_SQL);
+        db.execSQL(DROP_GLOBAL_LOG_EVENT_STATE_SQL);
         db.execSQL(CREATE_LOG_EVENT_DROPPED_TABLE);
         db.execSQL(CREATE_GLOBAL_LOG_EVENT_STATE_TABLE);
         db.execSQL(CREATE_INITIAL_GLOBAL_LOG_EVENT_STATE_VALUE_SQL);


### PR DESCRIPTION
Proposed fix for #3459 by [danyalberton](https://github.com/danyalberton).

The DROP_GLOBAL_LOG_EVENT_STATE_SQL is only called during onDowngrade, which means if somehow the migration fails half way, there is no way of continuing the migration, thus it's best to call DROP_GLOBAL_LOG_EVENT_STATE_SQL whenever creating the table to ensure this table does not exist before upgrade.