### PR TITLE
Make indexing public

### DIFF
--- a/firebase-common/src/main/java/com/google/firebase/annotations/PreviewApi.java
+++ b/firebase-common/src/main/java/com/google/firebase/annotations/PreviewApi.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.annotations;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
@@ -12,5 +26,4 @@ import java.lang.annotation.Target;
  */
 @KeepForSdk
 @Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
-public @interface PreviewApi {
-}
+public @interface PreviewApi {}

--- a/firebase-common/src/main/java/com/google/firebase/annotations/PreviewApi.java
+++ b/firebase-common/src/main/java/com/google/firebase/annotations/PreviewApi.java
@@ -1,0 +1,16 @@
+package com.google.firebase.annotations;
+
+import com.google.android.gms.common.annotation.KeepForSdk;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that this object (class, method, etc) is experimental and that both its signature and
+ * implementation are subject to change. Any API marked with this annotation provides no guarantee
+ * of API stability or backward-compatibility.
+ */
+@KeepForSdk
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface PreviewApi {
+}

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -2,10 +2,12 @@ Android changes are not released automatically. Ensure that changes are released
 by opting into a release at 
 [go/firebase-android-release](http:go/firebase-android-release) (Googlers only).
 
-# 24.0.2
-- [fixed] Fixed an AppCheck issue that caused Firestore listeners to stop
-  working and receive a "Permission Denied" error. This issue only occurred for
-  AppCheck users that set their expiration time to under an hour.
+# Unreleased
+- [feature] Added experimental support for indexed query execution. Indexes can
+  be enabled by invoking `FirebaseFirestore.setIndexConfiguration()` with the
+  JSON index definition exported by the Firestore CLI. Queries against the
+  cache are executed use an index once the asynchronous operation to generate
+  the index completes.
 - [fixed] Fixed a potential problem during Firestore's shutdown that prevented 
   the shutdown from proceeding if a network connection was opened right before.
 - [changed] Queries are now send to the backend before the SDK starts local 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/FirebaseFirestore.java
@@ -27,6 +27,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.PreviewApi;
 import com.google.firebase.appcheck.interop.InternalAppCheckTokenProvider;
 import com.google.firebase.auth.internal.InternalAuthProvider;
 import com.google.firebase.emulators.EmulatedServiceSettings;
@@ -304,8 +305,8 @@ public class FirebaseFirestore {
    * @return A task that resolves once all indices are successfully configured.
    * @throws IllegalArgumentException if the JSON format is invalid
    */
-  @VisibleForTesting
-  Task<Void> setIndexConfiguration(String json) {
+  @PreviewApi
+  public Task<Void> setIndexConfiguration(String json) {
     ensureClientConfigured();
     Preconditions.checkState(
         settings.isPersistenceEnabled(), "Cannot enable indexes when persistence is disabled");


### PR DESCRIPTION
This exposed the `setIndexConfiguration` API. For now, we will only expose `setIndexConfiguration(String)` and not `setIndexConfiguration(InputStream)` as we still have to determine what thread the stream should be read on.