### PR TITLE
`Query.get` should wait for backend connection

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 - [fixed] Fixed a crash that prevented the RTDB SDK from reconnecting to the
   backend if a token refresh attempt was unsuccesful.
+- [fixed] `Query.get` no longer throws "Client is offline" exception when local
+  value is not available, waits for connection instead.
 
 # 20.0.2
 - [fixed] The SDK can now continue to issue writes for apps that send an

--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -2,7 +2,7 @@
 - [fixed] Fixed a crash that prevented the RTDB SDK from reconnecting to the
   backend if a token refresh attempt was unsuccesful.
 - [fixed] `Query.get` no longer throws "Client is offline" exception when local
-  value is not available, waits for connection instead.
+  value is not available. Instead, it waits for a backend connection.
 
 # 20.0.2
 - [fixed] The SDK can now continue to issue writes for apps that send an

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/QueryTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/QueryTest.java
@@ -4569,7 +4569,7 @@ public class QueryTest {
     THREAD_POOL_EXECUTOR.execute(
         () -> {
           try {
-            Thread.sleep(3000L);
+            Thread.sleep(200L);
           } catch (InterruptedException e) {
             fail("Exception while pausing for get.");
           } finally {

--- a/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
@@ -428,22 +428,6 @@ public class PersistentConnectionImpl implements Connection.Delegate, Persistent
             });
     outstandingGets.put(readId, outstandingGet);
 
-    if (!connected()) {
-      executorService.schedule(
-          () -> {
-            if (!outstandingGet.markSent()) {
-              return;
-            }
-            if (logger.logsDebug()) {
-              logger.debug("get " + readId + " timed out waiting for connection");
-            }
-            outstandingGets.remove(readId);
-            source.setException(new Exception("Client is offline"));
-          },
-          GET_CONNECT_TIMEOUT,
-          TimeUnit.MILLISECONDS);
-    }
-
     if (canSendReads()) {
       sendGet(readId);
     }

--- a/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
@@ -275,7 +275,6 @@ public class PersistentConnectionImpl implements Connection.Delegate, Persistent
   private static final long SUCCESSFUL_CONNECTION_ESTABLISHED_DELAY = 30 * 1000;
 
   private static final long IDLE_TIMEOUT = 60 * 1000;
-  private static final long GET_CONNECT_TIMEOUT = 3 * 1000;
 
   /**
    * If auth or appcheck fails repeatedly, we'll assume something is wrong and log a warning / back

--- a/firebase-database/src/main/java/com/google/firebase/database/core/Repo.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/Repo.java
@@ -537,7 +537,7 @@ public class Repo implements PersistentConnection.Delegate {
                     ((DefaultRunLoop) ctx.getRunLoop()).getExecutorService(),
                     (@NonNull Task<Object> task) -> {
                       // We do not need to synchronize with the persisted set result callback
-                      // because the run on the same run loop. If the delayed callback above runs
+                      // because they run on the same run loop. If the delayed callback above runs
                       // before this one, this task is a no-op.
                       if (!task.isSuccessful()) {
                         if (!persisted.exists()) {


### PR DESCRIPTION
Addresses [b/221106730](http://b/221106730). Existing behavior is to throw a "Client is offline" exception when no local value is available. The reason we did this was so that we could fallback to disk cache when the server is unresponsive. 

However, if there is no local persisted value available, which could be the case when an app is just starting up, get will just give up. For consistency with our other operations, get should await a database connection in this case.

Since we want to "try" the server when a persisted value is available, and "await" the server when a persisted value is not available, we have to check for the persisted value before sending any requests to the server.