### PR TITLE
Fixing sign in cancellation bug

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
@@ -88,7 +88,6 @@ class TesterSignInManager {
 
   @VisibleForTesting
   void onActivityCreated(Activity activity) {
-    LogWrapper.getInstance().e(TAG + "ON ACTIVITY CREATED");
     // We call finish() in the onCreate method of the SignInResultActivity, so we must set the
     // result of the signIn Task in the onActivityCreated callback
     if (activity instanceof SignInResultActivity) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
@@ -148,6 +148,7 @@ class TesterSignInManager {
           .addOnFailureListener(
               handleTaskFailure(
                   FirebaseAppDistributionException.ErrorMessages.UNKNOWN_ERROR, Status.UNKNOWN));
+
       return signInTaskCompletionSource.getTask();
     }
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
@@ -83,22 +83,11 @@ class TesterSignInManager {
     this.lifecycleNotifier = lifecycleNotifier;
 
     lifecycleNotifier.addOnActivityCreatedListener(this::onActivityCreated);
-    lifecycleNotifier.addOnActivityStartedListener(this::onActivityStarted);
+    lifecycleNotifier.addOnActivityResumedListener(this::onActivityResumed);
   }
 
   @VisibleForTesting
-  void onActivityCreated(Activity activity) {
-    // We call finish() in the onCreate method of the SignInResultActivity, so we must set the
-    // result of the signIn Task in the onActivityCreated callback
-    if (activity instanceof SignInResultActivity) {
-      LogWrapper.getInstance().v("Sign in completed");
-      this.setSuccessfulSignInResult();
-      this.signInStorage.setSignInStatus(true);
-    }
-  }
-
-  @VisibleForTesting
-  void onActivityStarted(Activity activity) {
+  void onActivityResumed(Activity activity) {
     if (activity instanceof SignInResultActivity || activity instanceof InstallActivity) {
       // SignInResult and InstallActivity are internal to the SDK and should not be treated as
       // reentering the app
@@ -114,6 +103,18 @@ class TesterSignInManager {
                   AUTHENTICATION_CANCELED));
         }
       }
+    }
+  }
+
+  @VisibleForTesting
+  void onActivityCreated(Activity activity) {
+    LogWrapper.getInstance().e(TAG + "ON ACTIVITY CREATED");
+    // We call finish() in the onCreate method of the SignInResultActivity, so we must set the
+    // result of the signIn Task in the onActivityCreated callback
+    if (activity instanceof SignInResultActivity) {
+      LogWrapper.getInstance().v("Sign in completed");
+      this.setSuccessfulSignInResult();
+      this.signInStorage.setSignInStatus(true);
     }
   }
 
@@ -147,7 +148,7 @@ class TesterSignInManager {
           .addOnFailureListener(
               handleTaskFailure(
                   FirebaseAppDistributionException.ErrorMessages.UNKNOWN_ERROR, Status.UNKNOWN));
-
+      LogWrapper.getInstance().e("DONE WITH SIGN IN");
       return signInTaskCompletionSource.getTask();
     }
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
@@ -87,6 +87,18 @@ class TesterSignInManager {
   }
 
   @VisibleForTesting
+  void onActivityCreated(Activity activity) {
+    LogWrapper.getInstance().e(TAG + "ON ACTIVITY CREATED");
+    // We call finish() in the onCreate method of the SignInResultActivity, so we must set the
+    // result of the signIn Task in the onActivityCreated callback
+    if (activity instanceof SignInResultActivity) {
+      LogWrapper.getInstance().v("Sign in completed");
+      this.setSuccessfulSignInResult();
+      this.signInStorage.setSignInStatus(true);
+    }
+  }
+
+  @VisibleForTesting
   void onActivityResumed(Activity activity) {
     if (activity instanceof SignInResultActivity || activity instanceof InstallActivity) {
       // SignInResult and InstallActivity are internal to the SDK and should not be treated as
@@ -103,18 +115,6 @@ class TesterSignInManager {
                   AUTHENTICATION_CANCELED));
         }
       }
-    }
-  }
-
-  @VisibleForTesting
-  void onActivityCreated(Activity activity) {
-    LogWrapper.getInstance().e(TAG + "ON ACTIVITY CREATED");
-    // We call finish() in the onCreate method of the SignInResultActivity, so we must set the
-    // result of the signIn Task in the onActivityCreated callback
-    if (activity instanceof SignInResultActivity) {
-      LogWrapper.getInstance().v("Sign in completed");
-      this.setSuccessfulSignInResult();
-      this.signInStorage.setSignInStatus(true);
     }
   }
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/TesterSignInManager.java
@@ -148,7 +148,6 @@ class TesterSignInManager {
           .addOnFailureListener(
               handleTaskFailure(
                   FirebaseAppDistributionException.ErrorMessages.UNKNOWN_ERROR, Status.UNKNOWN));
-      LogWrapper.getInstance().e("DONE WITH SIGN IN");
       return signInTaskCompletionSource.getTask();
     }
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TesterSignInManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/TesterSignInManagerTest.java
@@ -216,7 +216,7 @@ public class TesterSignInManagerTest {
     Task signInTask = testerSignInManager.signInTester();
 
     // Simulate re-entering app before completing sign in
-    testerSignInManager.onActivityStarted(activity);
+    testerSignInManager.onActivityResumed(activity);
 
     assertFalse(signInTask.isSuccessful());
     Exception e = signInTask.getException();


### PR DESCRIPTION
Changing the cancellation of the sign in task from onActivityStarted too onActivityResume. This is because in the original implementation if the user hit back before being redirected to the web the task would hang. This fix makes it so that if the user clicks back into the app at any point the task will be cancelled. 