### PR TITLE
Enable conditional opt out of automatically posting notifications to system tray

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java
@@ -145,6 +145,22 @@ public class FirebaseMessagingService extends EnhancedIntentService {
   public void onNewToken(@NonNull String token) {}
   ;
 
+  /**
+   * Called when this service is evaluating whether a given RemoteMessage should use standard
+   * behavior when it has a notification payload - that is, automatically show a Notification in the
+   * system tray and do not invoke {@link onMessageReceived} when the app is backgrounded.
+   *
+   * <p>A subclass can override this to return false for specific classes of messages if it wishes
+   * to suppress the default system tray behavior and handle display itself via onMessageReceived.
+   *
+   * @param message The messge object that has been parsed from an incoming push payload.
+   * @return True if default behavior should be used; false if no system tray Notification should be
+   *     displayed and onMessageReceived should be invoked while backgrounded.
+   */
+  public boolean shouldUseDefaultNotificationBehavior(@NonNull RemoteMessage message) {
+    return true;
+  }
+
   /** @hide */
   @Override
   protected Intent getStartCommandIntent(Intent originalIntent) {
@@ -212,7 +228,8 @@ public class FirebaseMessagingService extends EnhancedIntentService {
     // First remove any parameters that shouldn't be passed to the app
     // * The wakelock ID set by the WakefulBroadcastReceiver
     data.remove("androidx.content.wakelockid");
-    if (NotificationParams.isNotification(data)) {
+    RemoteMessage message = new RemoteMessage(data);
+    if (shouldUseDefaultNotificationBehavior(message) && NotificationParams.isNotification(data)) {
       NotificationParams params = new NotificationParams(data);
 
       ExecutorService executor = FcmExecutors.newNetworkIOExecutor();
@@ -232,7 +249,7 @@ public class FirebaseMessagingService extends EnhancedIntentService {
         MessagingAnalytics.logNotificationForeground(intent);
       }
     }
-    onMessageReceived(new RemoteMessage(data));
+    onMessageReceived(message);
   }
 
   private boolean alreadyReceivedMessage(String messageId) {


### PR DESCRIPTION
This change adds an extension point to `FirebaseMessagingService` such that an application can avoid the default behavior where a **display message** (an FCM message with a "notification" payload), received while the app is in the **background**, will automatically post a default-styled Android notification to the system tray without ever calling back into app code.

This is a stab at addressing longstanding community feedback about how `onMessageReceived` is not called for display messages when the app is backgrounded, which can be a point of confusion and frustration:

https://github.com/firebase/firebase-android-sdk/issues/46
https://github.com/firebase/firebase-android-sdk/issues/1807
Fixes #2639 I believe
https://github.com/firebase/quickstart-android/issues/4
https://stackoverflow.com/q/37711082/244184
https://stackoverflow.com/q/37358462/244184

It is desirable as a developer to be able to opt out of this default behavior on a per-notification basis.
This allows an app to leverage the default, convenient behavior "for free" until there's time to customize the display with rich behavior using Android platform features. When that happens, the developer can use this new API to opt-out of the default handling and own their own display based on the message payload.

The proposed API change is a single new overrideable method on `FirebaseMessagingService`, called `shouldUseDefaultNotificationBehavior` - default implementation is just "return true".

If this method is overridden to return false for a given `RemoteMessage`, the current notification logic will be bypassed and the message will fall-through to `onMessageReceived` - the same way "data messages" are handled and the same way display messages while the app is foregrounded get handled.

I tested these changes on:
*  an Android 7/SDK 24 emulator
* a physical Pixel 6 (Android 12/SDK 31)
* a Wear OS 2 (Android 9/SDK 28) emulator 

Behavior is as expected - when my delegate returns false, the default notification is suppressed and `onMessageReceived` is called, as desired. When the delegate returns true, I get default SDK behavior.

# API considerations

* Backwards compatible, maintain current behavior by default but allow "progressive enhancement" by the app
* Leverage existing public types (`RemoteMessage`) instead of exposing the full FCM `Intent` to the app
* Aiming to be as surgical as possible here to unblock developer scenarios while not overhauling the FCM client API surface

Given the history in this space and comments from Firebase folks on linked issues (especially #46) - I feel like I must be missing something on the why of the current SDK design, so looking forward to feedback here! Is there a scenario where this doesn't work and the OS doesn't invoke the SDK, or a reason Google/Firebase would not be okay allowing an app to bypass the current SDK logic for background notifications to configure its own display?
