### PR TITLE
Add mutability flag to pending intent

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionNotificationsManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionNotificationsManager.java
@@ -111,6 +111,19 @@ class FirebaseAppDistributionNotificationsManager {
       return null;
     }
     return PendingIntent.getActivity(
-        context, 0, intent, PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
+        context, 0, intent, getPendingIntentFlags(PendingIntent.FLAG_ONE_SHOT));
+  }
+
+  /**
+   * Adds {@link PendingIntent#FLAG_IMMUTABLE} to a PendingIntent's flags since any PendingIntents
+   * used here don't need to be modified.
+   *
+   * <p>Specifying mutability is required starting at SDK level 31.
+   */
+  private static int getPendingIntentFlags(int baseFlags) {
+    // Only add on platform levels that support FLAG_IMMUTABLE.
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+        ? baseFlags | PendingIntent.FLAG_IMMUTABLE
+        : baseFlags;
   }
 }


### PR DESCRIPTION
Add a mutability flag to the pending intent to support apps targeting android 12. 

See https://developer.android.com/guide/components/intents-filters#DeclareMutabilityPendingIntent

We use a pending intent because this is sent to the Notifications Manager. See https://developer.android.com/guide/components/intents-filters#PendingIntent 