### PR TITLE
Change DocumentOverlayCache.saveOverlays() to require non-null values in the given Map

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalDocumentsView.java
@@ -189,7 +189,10 @@ class LocalDocumentsView {
       Map<DocumentKey, Mutation> overlays = new HashMap<>();
       for (DocumentKey key : entry.getValue()) {
         if (!processed.contains(key)) {
-          overlays.put(key, Mutation.calculateOverlayMutation(docs.get(key), masks.get(key)));
+          Mutation mutation = Mutation.calculateOverlayMutation(docs.get(key), masks.get(key));
+          if (mutation != null) {
+            overlays.put(key, mutation);
+          }
           processed.add(key);
         }
       }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryDocumentOverlayCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryDocumentOverlayCache.java
@@ -50,11 +50,7 @@ public class MemoryDocumentOverlayCache implements DocumentOverlayCache {
     return result;
   }
 
-  private void saveOverlay(int largestBatchId, @Nullable Mutation mutation) {
-    if (mutation == null) {
-      return;
-    }
-
+  private void saveOverlay(int largestBatchId, Mutation mutation) {
     // Remove the association of the overlay to its batch id.
     Overlay existing = this.overlays.get(mutation.getKey());
     if (existing != null) {

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryDocumentOverlayCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryDocumentOverlayCache.java
@@ -71,7 +71,7 @@ public class MemoryDocumentOverlayCache implements DocumentOverlayCache {
   @Override
   public void saveOverlays(int largestBatchId, Map<DocumentKey, Mutation> overlays) {
     for (Map.Entry<DocumentKey, Mutation> entry : overlays.entrySet()) {
-      Mutation overlay = checkNotNull(entry.getValue(), "null value for key: " + entry.getKey());
+      Mutation overlay = checkNotNull(entry.getValue(), "null value for key: %s", entry.getKey());
       saveOverlay(largestBatchId, overlay);
     }
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryDocumentOverlayCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryDocumentOverlayCache.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.firestore.local;
 
+import static com.google.firebase.firestore.util.Preconditions.checkNotNull;
+
 import androidx.annotation.Nullable;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.ResourcePath;
@@ -69,7 +71,8 @@ public class MemoryDocumentOverlayCache implements DocumentOverlayCache {
   @Override
   public void saveOverlays(int largestBatchId, Map<DocumentKey, Mutation> overlays) {
     for (Map.Entry<DocumentKey, Mutation> entry : overlays.entrySet()) {
-      saveOverlay(largestBatchId, entry.getValue());
+      Mutation overlay = checkNotNull(entry.getValue(), "null value for key: " + entry.getKey());
+      saveOverlay(largestBatchId, overlay);
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteDocumentOverlayCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteDocumentOverlayCache.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore.local;
 
 import static com.google.firebase.firestore.util.Assert.fail;
 import static com.google.firebase.firestore.util.Assert.hardAssert;
+import static com.google.firebase.firestore.util.Preconditions.checkNotNull;
 
 import android.database.Cursor;
 import androidx.annotation.Nullable;
@@ -125,7 +126,9 @@ public class SQLiteDocumentOverlayCache implements DocumentOverlayCache {
   @Override
   public void saveOverlays(int largestBatchId, Map<DocumentKey, Mutation> overlays) {
     for (Map.Entry<DocumentKey, Mutation> entry : overlays.entrySet()) {
-      saveOverlay(largestBatchId, entry.getKey(), entry.getValue());
+      DocumentKey key = entry.getKey();
+      Mutation overlay = checkNotNull(entry.getValue(), "null value for key: " + key);
+      saveOverlay(largestBatchId, key, overlay);
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteDocumentOverlayCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteDocumentOverlayCache.java
@@ -127,7 +127,7 @@ public class SQLiteDocumentOverlayCache implements DocumentOverlayCache {
   public void saveOverlays(int largestBatchId, Map<DocumentKey, Mutation> overlays) {
     for (Map.Entry<DocumentKey, Mutation> entry : overlays.entrySet()) {
       DocumentKey key = entry.getKey();
-      Mutation overlay = checkNotNull(entry.getValue(), "null value for key: " + key);
+      Mutation overlay = checkNotNull(entry.getValue(), "null value for key: %s", key);
       saveOverlay(largestBatchId, key, overlay);
     }
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteDocumentOverlayCache.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteDocumentOverlayCache.java
@@ -106,7 +106,7 @@ public class SQLiteDocumentOverlayCache implements DocumentOverlayCache {
     }
   }
 
-  private void saveOverlay(int largestBatchId, DocumentKey key, @Nullable Mutation mutation) {
+  private void saveOverlay(int largestBatchId, DocumentKey key, Mutation mutation) {
     String group = key.getCollectionGroup();
     String collectionPath = EncodedPath.encode(key.getPath().popLast());
     String documentId = key.getPath().getLastSegment();
@@ -125,9 +125,7 @@ public class SQLiteDocumentOverlayCache implements DocumentOverlayCache {
   @Override
   public void saveOverlays(int largestBatchId, Map<DocumentKey, Mutation> overlays) {
     for (Map.Entry<DocumentKey, Mutation> entry : overlays.entrySet()) {
-      if (entry.getValue() != null) {
-        saveOverlay(largestBatchId, entry.getKey(), entry.getValue());
-      }
+      saveOverlay(largestBatchId, entry.getKey(), entry.getValue());
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/Mutation.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/Mutation.java
@@ -87,6 +87,7 @@ public abstract class Mutation {
    * of the document, and a {@link FieldMask} representing the fields that are mutated by the local
    * mutations.
    */
+  @Nullable
   public static Mutation calculateOverlayMutation(MutableDocument doc, @Nullable FieldMask mask) {
     if ((!doc.hasLocalMutations()) || (mask != null && mask.getMask().isEmpty())) {
       return null;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/MutationBatch.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/model/mutation/MutationBatch.java
@@ -147,7 +147,9 @@ public final class MutationBatch {
       MutableDocument document = (MutableDocument) documentMap.get(key);
       FieldMask mutatedFields = applyToLocalView(document);
       Mutation overlay = Mutation.calculateOverlayMutation(document, mutatedFields);
-      overlays.put(key, overlay);
+      if (overlay != null) {
+        overlays.put(key, overlay);
+      }
       if (!document.isValidDocument()) {
         document.convertToNoDocument(SnapshotVersion.NONE);
       }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Preconditions.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/Preconditions.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.firestore.util;
 
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -145,6 +146,24 @@ public class Preconditions {
       @Nonnull T reference, @Nullable Object errorMessage) {
     if (reference == null) {
       throw new NullPointerException(String.valueOf(errorMessage));
+    }
+    return reference;
+  }
+
+  /**
+   * Ensures that an object reference passed as a parameter to the calling method is not null.
+   *
+   * @param reference an object reference
+   * @param errorFormatString the exception message to use if the check fails; will be formatted
+   *     using {@link String#format}.
+   * @param formatArgs the args to specify when formatting the given {@code errorFormatString}.
+   * @return the non-null reference that was validated
+   * @throws NullPointerException if {@code reference} is null
+   */
+  public static <T extends Object> T checkNotNull(
+      @Nonnull T reference, String errorFormatString, @Nullable Object... formatArgs) {
+    if (reference == null) {
+      throw new NullPointerException(String.format(Locale.US, errorFormatString, formatArgs));
     }
     return reference;
   }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/DocumentOverlayCacheTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/DocumentOverlayCacheTestCase.java
@@ -23,6 +23,7 @@ import static com.google.firebase.firestore.testutil.TestUtil.path;
 import static com.google.firebase.firestore.testutil.TestUtil.setMutation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.firebase.firestore.auth.User;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 /**
  * These are tests for any implementation of the DocumentOverlayCache interface.
@@ -250,6 +252,24 @@ public abstract class DocumentOverlayCacheTestCase {
     // Verify that `removeOverlaysForBatchId()` removes the overlay completely.
     cache.removeOverlaysForBatchId(2);
     assertNull(cache.getOverlay(DocumentKey.fromPathString("coll/doc")));
+  }
+
+  @Test
+  public void testSaveOverlaysThrowsNullPointerExceptionOnNullMapValue() {
+    Map<DocumentKey, Mutation> data = new HashMap<>();
+    data.put(key("coll/doc"), null);
+
+    NullPointerException e =
+        assertThrows(
+            NullPointerException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() {
+                cache.saveOverlays(1, data);
+              }
+            });
+
+    assertThat(e.getMessage()).contains("coll/doc");
   }
 
   void verifyOverlayContains(Map<DocumentKey, Overlay> overlays, String... keys) {

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -51,10 +51,6 @@ android {
     }
   }
 
-  packagingOptions {
-    exclude 'META-INF/DEPENDENCIES'
-  }
-
   compileOptions {
     sourceCompatibility 1.8
     targetCompatibility 1.8

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -51,6 +51,10 @@ android {
     }
   }
 
+  packagingOptions {
+    exclude 'META-INF/DEPENDENCIES'
+  }
+
   compileOptions {
     sourceCompatibility 1.8
     targetCompatibility 1.8


### PR DESCRIPTION
The current implementations of `DocumentOverlayCache.saveOverlays()` checks that each value in the given `Map` is non-null, and if it is null it ignores it, as if the key/value pair wasn't even present in the map.

This PR changes the logic to _assume_ that none of the values in the `Map` are null and modifies the call sites to ensure that they avoid putting null values into the map.

This is a slightly cleaner implementation and makes the null behavior more explicit at the call site.