### PR TITLE
Fireperf: start screen trace in `onResume`

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -146,20 +146,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   public void onActivityDestroyed(Activity activity) {}
 
   @Override
-  public synchronized void onActivityStarted(Activity activity) {
-    if (isScreenTraceSupported(activity) && configResolver.isPerformanceMonitoringEnabled()) {
-      // Starts recording frame metrics for this activity.
-      /**
-       * TODO: Only add activities that are hardware acceleration enabled so that calling {@link
-       * FrameMetricsAggregator#remove(Activity)} will not throw exceptions.
-       */
-      frameMetricsAggregator.add(activity);
-      // Start the Trace
-      Trace screenTrace = new Trace(getScreenTraceName(activity), transportManager, clock, this);
-      screenTrace.start();
-      activityToScreenTraceMap.put(activity, screenTrace);
-    }
-  }
+  public synchronized void onActivityStarted(Activity activity) {}
 
   @Override
   public synchronized void onActivityStopped(Activity activity) {
@@ -181,7 +168,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     // cases:
     // 1. At app startup, first activity comes to foreground.
     // 2. app switch from background to foreground.
-    // 3. app already in foreground, current activity is replaced by another activity.
+    // 3. app already in foreground, current activity is replaced by another activity, or the current activity was paused then resumed without onStop (ex: a dialog pauses the activity, then closing it resumes)
     if (activityToResumedMap.isEmpty()) {
       // The first resumed activity means app comes to foreground.
       resumeTime = clock.getTime();
@@ -198,8 +185,21 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
         updateAppState(ApplicationProcessState.FOREGROUND);
       }
     } else {
-      // case 3: app already in foreground, current activity is replaced by another activity.
+      // case 3: app already in foreground, current activity is replaced by another activity, or the current activity was paused then resumed without onStop (ex: a dialog pauses the activity, then closing it resumes)
       activityToResumedMap.put(activity, true);
+    }
+
+    if (isScreenTraceSupported(activity) && configResolver.isPerformanceMonitoringEnabled()) {
+      // Starts recording frame metrics for this activity.
+      /**
+       * TODO: Only add activities that are hardware acceleration enabled so that calling {@link
+       * FrameMetricsAggregator#remove(Activity)} will not throw exceptions.
+       */
+      frameMetricsAggregator.add(activity);
+      // Start the Trace
+      Trace screenTrace = new Trace(getScreenTraceName(activity), transportManager, clock, this);
+      screenTrace.start();
+      activityToScreenTraceMap.put(activity, screenTrace);
     }
   }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -168,7 +168,8 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
     // cases:
     // 1. At app startup, first activity comes to foreground.
     // 2. app switch from background to foreground.
-    // 3. app already in foreground, current activity is replaced by another activity, or the current activity was paused then resumed without onStop (ex: a dialog pauses the activity, then closing it resumes)
+    // 3. app already in foreground, current activity is replaced by another activity, or the
+    // current activity was paused then resumed without onStop, for example by an AlertDialog
     if (activityToResumedMap.isEmpty()) {
       // The first resumed activity means app comes to foreground.
       resumeTime = clock.getTime();
@@ -185,7 +186,8 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
         updateAppState(ApplicationProcessState.FOREGROUND);
       }
     } else {
-      // case 3: app already in foreground, current activity is replaced by another activity, or the current activity was paused then resumed without onStop (ex: a dialog pauses the activity, then closing it resumes)
+      // case 3: app already in foreground, current activity is replaced by another activity, or the
+      // current activity was paused then resumed without onStop, for example by an AlertDialog
       activityToResumedMap.put(activity, true);
     }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -191,6 +191,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
       activityToResumedMap.put(activity, true);
     }
 
+    // Screen trace is after session update so the sessionId is not added twice to the Trace
     if (isScreenTraceSupported(activity) && configResolver.isPerformanceMonitoringEnabled()) {
       // Starts recording frame metrics for this activity.
       /**

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/AppStateMonitorTest.java
@@ -366,7 +366,7 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
       int startTime = i * 100;
       int endTime = startTime + 10;
       currentTime = startTime;
-      monitor.onActivityStarted(activity);
+      monitor.onActivityResumed(activity);
       assertThat(monitor.getActivity2ScreenTrace()).hasSize(1);
       currentTime = endTime;
       monitor.onActivityPostPaused(activity);
@@ -418,7 +418,7 @@ public class AppStateMonitorTest extends FirebasePerformanceTestBase {
 
     // Assert that screen trace has been created.
     currentTime = 100;
-    monitor.onActivityStarted(activityWithNonHardwareAcceleratedView);
+    monitor.onActivityResumed(activityWithNonHardwareAcceleratedView);
     assertThat(monitor.getActivity2ScreenTrace()).hasSize(1);
     currentTime = 200;
     monitor.onActivityPostPaused(activityWithNonHardwareAcceleratedView);


### PR DESCRIPTION
followup to https://github.com/firebase/firebase-android-sdk/pull/3311