### PR TITLE
Do not throw when FileStore cannot create a dir.

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStore.java
@@ -101,12 +101,16 @@ public class FileStore {
     return fileOrDirectory.delete();
   }
 
-  /** @return internal File used by Crashlytics, that is not specific to a session */
+  /**
+   * @return internal File used by Crashlytics, that is not specific to a session
+   */
   public File getCommonFile(String filename) {
     return new File(rootDir, filename);
   }
 
-  /** @return all common (non session specific) files matching the given filter. */
+  /**
+   * @return all common (non session specific) files matching the given filter.
+   */
   public List<File> getCommonFiles(FilenameFilter filter) {
     return safeArrayToList(rootDir.listFiles(filter));
   }
@@ -185,7 +189,7 @@ public class FileStore {
       }
     }
     if (!file.mkdirs()) {
-      throw new IllegalStateException("Could not create Crashlytics-specific directory: " + file);
+      Logger.getLogger().d("Could not create Crashlytics-specific directory: " + file);
     }
     return file;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStore.java
@@ -185,7 +185,7 @@ public class FileStore {
       }
     }
     if (!file.mkdirs()) {
-      Logger.getLogger().d("Could not create Crashlytics-specific directory: " + file);
+      Logger.getLogger().e("Could not create Crashlytics-specific directory: " + file);
     }
     return file;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStore.java
@@ -101,16 +101,12 @@ public class FileStore {
     return fileOrDirectory.delete();
   }
 
-  /**
-   * @return internal File used by Crashlytics, that is not specific to a session
-   */
+  /** @return internal File used by Crashlytics, that is not specific to a session */
   public File getCommonFile(String filename) {
     return new File(rootDir, filename);
   }
 
-  /**
-   * @return all common (non session specific) files matching the given filter.
-   */
+  /** @return all common (non session specific) files matching the given filter. */
   public List<File> getCommonFiles(FilenameFilter filter) {
     return safeArrayToList(rootDir.listFiles(filter));
   }


### PR DESCRIPTION
There is a problem with the file structure on some devices #3269. When we did the FileStore refactor, we turned a silent failure into a runtime exception, causing apps to crash on some of these devices. Although this does not fix the root problem, it reverts to the silent behaviour we had before. We still need to investigate the root cause of this.