### PR TITLE
Revert "[firehorn] Workaround to make smoke-test pass. (#3531)"

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -51,10 +51,6 @@ android {
     }
   }
 
-  packagingOptions {
-    exclude 'META-INF/DEPENDENCIES'
-  }
-
   compileOptions {
     sourceCompatibility 1.8
     targetCompatibility 1.8


### PR DESCRIPTION
This reverts #3531 .

#3531 was a workaround for #3526 . Now that the issue was fixed, the workaround is no longer needed.