### PR TITLE
Add fragment trace sampling rate config flag

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
@@ -643,7 +643,7 @@ final class ConfigurationConstants {
       // Sampling rate range is [0.00f, 1.00f]. By default, sampling rate is 0.20f, which is 20%.
       // 0.00f means 0%, Fireperf will not capture any event for fragment trace from the device,
       // 1.00f means 100%, Fireperf will capture all events for fragment trace from the device.
-      return 0.20f;
+      return 1.00f;
     }
 
     @Override

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
@@ -640,7 +640,7 @@ final class ConfigurationConstants {
 
     @Override
     protected Float getDefault() {
-      // Sampling rate range is [0.00f, 1.00f]. By default, sampling rate is 0.20f, which is 20%.
+      // Sampling rate range is [0.00f, 1.00f]. By default, sampling rate is 1.00f, which is 100%.
       // 0.00f means 0%, Fireperf will not capture any event for fragment trace from the device,
       // 1.00f means 100%, Fireperf will capture all events for fragment trace from the device.
       return 1.00f;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
@@ -623,4 +623,42 @@ final class ConfigurationConstants {
       return "com.google.firebase.perf.LogSourceName";
     }
   }
+
+  protected static final class FragmentSamplingRate extends ConfigurationFlag<Float> {
+    private static FragmentSamplingRate instance;
+
+    private FragmentSamplingRate() {
+      super();
+    }
+
+    protected static synchronized FragmentSamplingRate getInstance() {
+      if (instance == null) {
+        instance = new FragmentSamplingRate();
+      }
+      return instance;
+    }
+
+    @Override
+    protected Float getDefault() {
+      // Sampling rate range is [0.00f, 1.00f]. By default, sampling rate is 0.20f, which is 20%.
+      // 0.00f means 0%, Fireperf will not capture any event for fragment trace from the device,
+      // 1.00f means 100%, Fireperf will capture all events for fragment trace from the device.
+      return 0.20f;
+    }
+
+    @Override
+    protected String getRemoteConfigFlag() {
+      return "fpr_vc_fragment_sampling_rate";
+    }
+
+    @Override
+    protected String getDeviceCacheFlag() {
+      return "com.google.firebase.perf.FragmentSamplingRate";
+    }
+
+    @Override
+    protected String getMetadataFlag() {
+      return "fragment_sampling_rate";
+    }
+  }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
@@ -658,7 +658,7 @@ final class ConfigurationConstants {
 
     @Override
     protected String getMetadataFlag() {
-      return "fragment_sampling_rate";
+      return "fragment_sampling_percentage";
     }
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
@@ -2510,7 +2510,7 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
     bundle.putFloat("fragment_sampling_percentage", 20.0f);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
 
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
@@ -2510,7 +2510,7 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
     bundle.putFloat("fragment_sampling_percentage", 20.0f);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
 
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }
@@ -2522,21 +2522,21 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
     when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
 
     // Case #1: Android Metadata bundle value is too high.
     Bundle bundle = new Bundle();
     bundle.putFloat("fragment_sampling_percentage", 200.00f);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
 
     // Case #2: Android Metadata bundle value is too low.
     bundle = new Bundle();
     bundle.putFloat("fragment_sampling_percentage", -1.00f);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
   }
 
   @Test
@@ -2626,14 +2626,14 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
     when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.of(1.01f));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
 
     // Case #2: Firebase Remote Config value is too low.
     when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.of(-0.1f));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }
 
@@ -2679,13 +2679,13 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
     when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.of(10.0f));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
 
     // Case #2: Device Cache value is too low.
     when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.of(-1.0f));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
@@ -2626,14 +2626,14 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
     when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.of(1.01f));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
 
     // Case #2: Firebase Remote Config value is too low.
     when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.of(-0.1f));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
@@ -2638,7 +2638,7 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getFragnebtSamplingRate_invalidRemoteConfig_returnCacheValue() {
+  public void getFragmentSamplingRate_invalidRemoteConfig_returnCacheValue() {
     // Mock behavior that device cache doesn't have session sampling rate value.
     when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.of(0.25f));

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigurationConstantsTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigurationConstantsTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.firebase.perf.config.ConfigurationConstants.CollectionDeactivated;
 import com.google.firebase.perf.config.ConfigurationConstants.CollectionEnabled;
+import com.google.firebase.perf.config.ConfigurationConstants.FragmentSamplingRate;
 import com.google.firebase.perf.config.ConfigurationConstants.LogSourceName;
 import com.google.firebase.perf.config.ConfigurationConstants.NetworkEventCountBackground;
 import com.google.firebase.perf.config.ConfigurationConstants.NetworkEventCountForeground;
@@ -256,11 +257,11 @@ public class ConfigurationConstantsTest {
 
   @Test
   public void getInstance_FragmentSamplingRate_validateConstants() {
-    SessionsSamplingRate configFlag = SessionsSamplingRate.getInstance();
+    FragmentSamplingRate configFlag = FragmentSamplingRate.getInstance();
 
     assertThat(configFlag.getDefault()).isEqualTo(0.2f);
     assertThat(configFlag.getDeviceCacheFlag())
-        .isEqualTo("com.google.firebase.perf.SessionSamplingRate");
+        .isEqualTo("com.google.firebase.perf.FragmentSamplingRate");
     assertThat(configFlag.getRemoteConfigFlag()).isEqualTo("fpr_vc_fragment_sampling_rate");
     assertThat(configFlag.getMetadataFlag()).isEqualTo("fragment_sampling_percentage");
   }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigurationConstantsTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigurationConstantsTest.java
@@ -259,7 +259,7 @@ public class ConfigurationConstantsTest {
   public void getInstance_FragmentSamplingRate_validateConstants() {
     FragmentSamplingRate configFlag = FragmentSamplingRate.getInstance();
 
-    assertThat(configFlag.getDefault()).isEqualTo(0.2f);
+    assertThat(configFlag.getDefault()).isEqualTo(1.0f);
     assertThat(configFlag.getDeviceCacheFlag())
         .isEqualTo("com.google.firebase.perf.FragmentSamplingRate");
     assertThat(configFlag.getRemoteConfigFlag()).isEqualTo("fpr_vc_fragment_sampling_rate");

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigurationConstantsTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigurationConstantsTest.java
@@ -253,4 +253,15 @@ public class ConfigurationConstantsTest {
     assertThat(LogSourceName.getLogSourceName(675L)).isEqualTo("FIREPERF_INTERNAL_LOW");
     assertThat(LogSourceName.getLogSourceName(676L)).isEqualTo("FIREPERF_INTERNAL_HIGH");
   }
+
+  @Test
+  public void getInstance_FragmentSamplingRate_validateConstants() {
+    SessionsSamplingRate configFlag = SessionsSamplingRate.getInstance();
+
+    assertThat(configFlag.getDefault()).isEqualTo(0.2f);
+    assertThat(configFlag.getDeviceCacheFlag())
+        .isEqualTo("com.google.firebase.perf.SessionSamplingRate");
+    assertThat(configFlag.getRemoteConfigFlag()).isEqualTo("fpr_vc_fragment_sampling_rate");
+    assertThat(configFlag.getMetadataFlag()).isEqualTo("fragment_sampling_percentage");
+  }
 }


### PR DESCRIPTION
A new flag is added for fragment trace sampling flag. This flag is fetched from remote config, but overridable from the manifest file.