### PR TITLE
Firestore: Migrate unit tests to assertThrows()

### DIFF
--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/FieldPathTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/FieldPathTest.java
@@ -16,8 +16,10 @@ package com.google.firebase.firestore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -32,24 +34,52 @@ public class FieldPathTest {
     assertEquals("a.b.c", fieldPath.toString());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void emptyPathIsInvalid() {
-    FieldPath.fromDotSeparatedPath("");
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            FieldPath.fromDotSeparatedPath("");
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void emptyFirstSegmentIsInvalid() {
-    FieldPath.fromDotSeparatedPath(".a");
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            FieldPath.fromDotSeparatedPath(".a");
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void emptyLastSegmentIsInvalid() {
-    FieldPath.fromDotSeparatedPath("a.");
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            FieldPath.fromDotSeparatedPath("a.");
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void emptyMiddleSegmentIsInvalid() {
-    FieldPath.fromDotSeparatedPath("a..b");
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            FieldPath.fromDotSeparatedPath("a..b");
+          }
+        });
   }
 
   @Test

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/bundle/BundleReaderTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/bundle/BundleReaderTest.java
@@ -21,6 +21,7 @@ import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
 import static com.google.firebase.firestore.testutil.TestUtil.version;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.core.Target;
@@ -38,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import org.json.JSONException;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -219,35 +221,58 @@ public class BundleReaderTest {
     verifyAllElements(bundleReader);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testThrowsWithoutLengthPrefix() throws IOException, JSONException {
     String bundle = "{metadata: 'no length prefix' }";
 
     BundleReader bundleReader =
         new BundleReader(SERIALIZER, new ByteArrayInputStream(bundle.getBytes(UTF8_CHARSET)));
 
-    bundleReader.getBundleMetadata();
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            bundleReader.getBundleMetadata();
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testThrowsWithMissingBrackets() throws IOException, JSONException {
     String bundle = "3abc";
 
     BundleReader bundleReader =
         new BundleReader(SERIALIZER, new ByteArrayInputStream(bundle.getBytes(UTF8_CHARSET)));
-    bundleReader.getBundleMetadata();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            bundleReader.getBundleMetadata();
+          }
+        });
   }
 
-  @Test(expected = JSONException.class)
+  @Test
   public void testThrowsWithInvalidJSON() throws IOException, JSONException {
     String bundle = "3{abc}";
 
     BundleReader bundleReader =
         new BundleReader(SERIALIZER, new ByteArrayInputStream(bundle.getBytes(UTF8_CHARSET)));
-    bundleReader.getBundleMetadata();
+
+    assertThrows(
+        JSONException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            bundleReader.getBundleMetadata();
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testThrowsWhenSecondElementIsMissing() throws IOException, JSONException {
     TestBundleBuilder bundleBuilder = new TestBundleBuilder(TEST_PROJECT);
     String bundle =
@@ -255,19 +280,35 @@ public class BundleReaderTest {
 
     BundleReader bundleReader =
         new BundleReader(SERIALIZER, new ByteArrayInputStream(bundle.getBytes(UTF8_CHARSET)));
-    bundleReader.getNextElement();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            bundleReader.getNextElement();
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testThrowsWhenBundleDoesNotContainEnoughData() throws IOException, JSONException {
     String bundle = "3{}";
 
     BundleReader bundleReader =
         new BundleReader(SERIALIZER, new ByteArrayInputStream(bundle.getBytes(UTF8_CHARSET)));
-    bundleReader.getBundleMetadata();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            bundleReader.getBundleMetadata();
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testWhenFirstElementIsNotBundleMetadata() throws IOException, JSONException {
     String json =
         String.format(
@@ -283,7 +324,14 @@ public class BundleReaderTest {
     BundleReader bundleReader =
         new BundleReader(SERIALIZER, new ByteArrayInputStream(bundle.getBytes(UTF8_CHARSET)));
 
-    bundleReader.getBundleMetadata();
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            bundleReader.getBundleMetadata();
+          }
+        });
   }
 
   @Test

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/bundle/BundleSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/bundle/BundleSerializerTest.java
@@ -20,6 +20,7 @@ import static com.google.firebase.firestore.testutil.TestUtil.key;
 import static com.google.firebase.firestore.testutil.TestUtil.orderBy;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.google.firebase.firestore.core.Query;
 import com.google.firebase.firestore.core.Target;
@@ -43,6 +44,7 @@ import java.util.List;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -596,32 +598,60 @@ public class BundleSerializerTest {
     assertDecodesNamedQuery(json, query);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDoesNotDecodeOffset() throws JSONException {
     String json = "{ from: [ { collectionId: 'coll' } ], offset: 5 }";
     Query query = TestUtil.query("coll");
-    assertDecodesNamedQuery(json, query);
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            assertDecodesNamedQuery(json, query);
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDoesNotDecodeSelect() throws JSONException {
     String json = "{ from: [ { collectionId: 'coll' } ], select: [] }";
     Query query = TestUtil.query("coll");
-    assertDecodesNamedQuery(json, query);
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            assertDecodesNamedQuery(json, query);
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDoesNotDecodeMissingCollection() throws JSONException {
     String json = "{ from: [ ] }";
     Query query = TestUtil.query("coll");
-    assertDecodesNamedQuery(json, query);
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            assertDecodesNamedQuery(json, query);
+          }
+        });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDoesNotDecodeMultipleCollections() throws JSONException {
     String json = "{ from: [ { collectionId: 'c1' }, { collectionId: 'c2' } ] }";
     Query query = TestUtil.query("coll");
-    assertDecodesNamedQuery(json, query);
+    assertThrows(
+        IllegalArgumentException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            assertDecodesNamedQuery(json, query);
+          }
+        });
   }
 
   // BundleMetadata tests

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/model/DocumentKeyTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/model/DocumentKeyTest.java
@@ -17,10 +17,13 @@ package com.google.firebase.firestore.model;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.google.firebase.firestore.testutil.ComparatorTester;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -57,8 +60,16 @@ public class DocumentKeyTest {
         .testCompare();
   }
 
-  @Test(expected = Throwable.class)
+  @Test
   public void testUnevenNumberOfSegmentsAreRejected() {
-    DocumentKey.fromSegments(Collections.singletonList("a"));
+    List<String> segments = Collections.singletonList("a");
+    assertThrows(
+        Throwable.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            DocumentKey.fromSegments(segments);
+          }
+        });
   }
 }


### PR DESCRIPTION
Some Firestore unit tests were using the problematic `@Test(expected = Exception.class)` annotation to test for expected exceptions. This pattern, however, is problematic because it can easily hide test failures if some other part of the test were to throw the expected exception type (or any subclass thereof). Using `assertThrows()` is far less problematic because it only checks exceptions of a specific block of code, not the entire test case. This PR converts Firestore unit tests to use `assertThrows()`. Googlers can see go/lsc-assertthrows and go/assertthrows for more details.