### PR TITLE
Catch RuntimeException when getting analytics Bundle.

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmLifecycleCallbacks.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmLifecycleCallbacks.java
@@ -13,6 +13,8 @@
 // limitations under the License.
 package com.google.firebase.messaging;
 
+import static com.google.firebase.messaging.Constants.TAG;
+
 import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
@@ -21,6 +23,7 @@ import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -74,12 +77,19 @@ class FcmLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
   public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {}
 
   private void logNotificationOpen(Intent startingIntent) {
-    Bundle extras = startingIntent.getExtras();
-    if (extras != null) {
-      Bundle analyticsData = extras.getBundle(Constants.MessageNotificationKeys.ANALYTICS_DATA);
-      if (MessagingAnalytics.shouldUploadScionMetrics(analyticsData)) {
-        MessagingAnalytics.logNotificationOpen(analyticsData);
+    Bundle analyticsData = null;
+    try {
+      Bundle extras = startingIntent.getExtras();
+      if (extras != null) {
+        analyticsData = extras.getBundle(Constants.MessageNotificationKeys.ANALYTICS_DATA);
       }
+    } catch (RuntimeException e) {
+      // Don't crash if there was a problem trying to get the analytics data Bundle since the
+      // Intent could be coming from anywhere and could be incorrectly formatted.
+      Log.w(TAG, "Failed trying to get analytics data from Intent extras.", e);
+    }
+    if (MessagingAnalytics.shouldUploadScionMetrics(analyticsData)) {
+      MessagingAnalytics.logNotificationOpen(analyticsData);
     }
   }
 }


### PR DESCRIPTION
https://github.com/firebase/firebase-android-sdk/issues/3538
* Added catching RuntimeException when trying to get the analytics data Bundle from the Activity Intent since it's possible that the extras could contain invalid or incorrectly formatted data that will throw an Exception when trying to get the Bundle.