### PR TITLE
Set minSdkVersion to 16 for non-gradle Crashlytics NDK builds

### DIFF
--- a/firebase-crashlytics-ndk/src/main/AndroidManifest.xml
+++ b/firebase-crashlytics-ndk/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.firebase.crashlytics.ndk" >
+    <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
+    <!--<uses-sdk android:minSdkVersion="16"/>-->
     <application>
         <service android:name="com.google.firebase.components.ComponentDiscoveryService" android:exported="false">
             <meta-data android:name="com.google.firebase.components:com.google.firebase.crashlytics.ndk.CrashlyticsNdkRegistrar"


### PR DESCRIPTION
This was already done for firebase-crashlytics here: https://github.com/firebase/firebase-android-sdk/commit/c273d038dea6059b9445f6057821ee2e99fbeda0#diff-18ac2b16d430fa9fde18b02a9859eb1bdb2e731d1e27406b1fdbd9843d4a2f19