### PR TITLE
Fireperf fragments: trace creation and adding custom attributes

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -148,8 +148,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
         fragmentActivity
             .getSupportFragmentManager()
             .registerFragmentLifecycleCallbacks(
-                new FragmentStateMonitor(
-                    clock, transportManager, this, frameMetricsAggregator),
+                new FragmentStateMonitor(clock, transportManager, this, frameMetricsAggregator),
                 true);
       }
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -149,7 +149,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
             .getSupportFragmentManager()
             .registerFragmentLifecycleCallbacks(
                 new FragmentStateMonitor(
-                    fragmentActivity, clock, transportManager, this, frameMetricsAggregator),
+                    clock, transportManager, this, frameMetricsAggregator),
                 true);
       }
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/AppStateMonitor.java
@@ -90,13 +90,22 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   }
 
   AppStateMonitor(TransportManager transportManager, Clock clock) {
+    this(
+        transportManager,
+        clock,
+        ConfigResolver.getInstance(),
+        hasFrameMetricsAggregatorClass() ? new FrameMetricsAggregator() : null);
+  }
+
+  AppStateMonitor(
+      TransportManager transportManager,
+      Clock clock,
+      ConfigResolver configResolver,
+      FrameMetricsAggregator frameMetricsAggregator) {
     this.transportManager = transportManager;
     this.clock = clock;
-    configResolver = ConfigResolver.getInstance();
-    hasFrameMetricsAggregator = hasFrameMetricsAggregatorClass();
-    if (hasFrameMetricsAggregator) {
-      frameMetricsAggregator = new FrameMetricsAggregator();
-    }
+    this.configResolver = configResolver;
+    this.frameMetricsAggregator = frameMetricsAggregator;
   }
 
   public synchronized void registerActivityLifecycleCallbacks(Context context) {
@@ -142,7 +151,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
 
   @Override
   public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-    if (isScreenTraceSupported(activity) && configResolver.isPerformanceMonitoringEnabled()) {
+    if (isScreenTraceSupported() && configResolver.isPerformanceMonitoringEnabled()) {
       if (activity instanceof FragmentActivity) {
         FragmentActivity fragmentActivity = (FragmentActivity) activity;
         fragmentActivity
@@ -159,7 +168,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
 
   @Override
   public synchronized void onActivityStarted(Activity activity) {
-    if (isScreenTraceSupported(activity) && configResolver.isPerformanceMonitoringEnabled()) {
+    if (isScreenTraceSupported() && configResolver.isPerformanceMonitoringEnabled()) {
       // Starts recording frame metrics for this activity.
       /**
        * TODO: Only add activities that are hardware acceleration enabled so that calling {@link
@@ -306,7 +315,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   /** Stops screen trace right after onPause because of b/210055697 */
   @Override
   public void onActivityPostPaused(@NonNull Activity activity) {
-    if (isScreenTraceSupported(activity)) {
+    if (isScreenTraceSupported()) {
       sendScreenTrace(activity);
     }
   }
@@ -427,10 +436,9 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
   /**
    * Only send screen trace if FrameMetricsAggregator exists.
    *
-   * @param activity The Activity for which we're monitoring the screen rendering performance.
    * @return true if supported, false if not.
    */
-  private boolean isScreenTraceSupported(Activity activity) {
+  protected boolean isScreenTraceSupported() {
     return hasFrameMetricsAggregator;
   }
 
@@ -439,7 +447,7 @@ public class AppStateMonitor implements ActivityLifecycleCallbacks {
    * updated to 26.1.0 (b/69954793), there will be ClassNotFoundException. This method is to check
    * if FrameMetricsAggregator exists to avoid ClassNotFoundException.
    */
-  private boolean hasFrameMetricsAggregatorClass() {
+  private static boolean hasFrameMetricsAggregatorClass() {
     try {
       Class<?> initializerClass = Class.forName(FRAME_METRICS_AGGREGATOR_CLASSNAME);
       return true;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
@@ -83,7 +83,7 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     // Stop Fragment screen trace
     logger.debug("FragmentMonitor %s.onFragmentPaused ", f.getClass().getSimpleName());
     if (!fragmentToTraceMap.containsKey(f)) {
-      logger.error(
+      logger.warn(
           "FragmentMonitor: missed a fragment trace from %s", f.getClass().getSimpleName());
       return;
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
@@ -17,28 +17,28 @@ package com.google.firebase.perf.application;
 import androidx.annotation.NonNull;
 import androidx.core.app.FrameMetricsAggregator;
 import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import com.google.firebase.perf.logging.AndroidLogger;
+import com.google.firebase.perf.metrics.Trace;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
 
+import java.util.WeakHashMap;
+
 public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallbacks {
   private static final AndroidLogger logger = AndroidLogger.getInstance();
-  private final FragmentActivity activity;
+  private final WeakHashMap<Fragment, Trace> fragmentToTraceMap = new WeakHashMap<>();
   private final Clock clock;
   private final TransportManager transportManager;
   private final AppStateMonitor appStateMonitor;
   private final FrameMetricsAggregator frameMetricsAggregator;
 
   public FragmentStateMonitor(
-      FragmentActivity activity,
       Clock clock,
       TransportManager transportManager,
       AppStateMonitor appStateMonitor,
       FrameMetricsAggregator fma) {
-    this.activity = activity;
     this.clock = clock;
     this.transportManager = transportManager;
     this.appStateMonitor = appStateMonitor;
@@ -60,6 +60,17 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     super.onFragmentResumed(fm, f);
     // Start Fragment screen trace
     logger.debug("FragmentMonitor %s.onFragmentResumed", f.getClass().getSimpleName());
+    Trace fragmentTrace = new Trace(getFragmentScreenTraceName(f), transportManager, clock, appStateMonitor);
+    fragmentTrace.start();
+
+    if (f.getParentFragment() != null) {
+      fragmentTrace.putAttribute(Constants.PARENT_FRAGMENT_ATTRIBUTE_KEY, f.getParentFragment().getClass().getSimpleName());
+    }
+    if (f.getActivity() != null) {
+      fragmentTrace.putAttribute(Constants.ACTIVITY_ATTRIBUTE_KEY, f.getActivity().getClass().getSimpleName());
+    }
+
+    fragmentToTraceMap.put(f, fragmentTrace);
   }
 
   @Override
@@ -67,5 +78,15 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     super.onFragmentPaused(fm, f);
     // Stop Fragment screen trace
     logger.debug("FragmentMonitor %s.onFragmentPaused ", f.getClass().getSimpleName());
+    if (!fragmentToTraceMap.containsKey(f)) {
+      logger.error("FragmentMonitor: missed a fragment trace from %s", f.getClass().getSimpleName());
+    }
+
+    Trace fragmentTrace = fragmentToTraceMap.get(f);
+    fragmentToTraceMap.remove(f);
+
+    // TODO: Add frame metrics
+
+    fragmentTrace.stop();
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
@@ -23,7 +23,6 @@ import com.google.firebase.perf.metrics.Trace;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
-
 import java.util.WeakHashMap;
 
 public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallbacks {
@@ -60,14 +59,18 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     super.onFragmentResumed(fm, f);
     // Start Fragment screen trace
     logger.debug("FragmentMonitor %s.onFragmentResumed", f.getClass().getSimpleName());
-    Trace fragmentTrace = new Trace(getFragmentScreenTraceName(f), transportManager, clock, appStateMonitor);
+    Trace fragmentTrace =
+        new Trace(getFragmentScreenTraceName(f), transportManager, clock, appStateMonitor);
     fragmentTrace.start();
 
     if (f.getParentFragment() != null) {
-      fragmentTrace.putAttribute(Constants.PARENT_FRAGMENT_ATTRIBUTE_KEY, f.getParentFragment().getClass().getSimpleName());
+      fragmentTrace.putAttribute(
+          Constants.PARENT_FRAGMENT_ATTRIBUTE_KEY,
+          f.getParentFragment().getClass().getSimpleName());
     }
     if (f.getActivity() != null) {
-      fragmentTrace.putAttribute(Constants.ACTIVITY_ATTRIBUTE_KEY, f.getActivity().getClass().getSimpleName());
+      fragmentTrace.putAttribute(
+          Constants.ACTIVITY_ATTRIBUTE_KEY, f.getActivity().getClass().getSimpleName());
     }
 
     fragmentToTraceMap.put(f, fragmentTrace);
@@ -79,7 +82,8 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     // Stop Fragment screen trace
     logger.debug("FragmentMonitor %s.onFragmentPaused ", f.getClass().getSimpleName());
     if (!fragmentToTraceMap.containsKey(f)) {
-      logger.error("FragmentMonitor: missed a fragment trace from %s", f.getClass().getSimpleName());
+      logger.error(
+          "FragmentMonitor: missed a fragment trace from %s", f.getClass().getSimpleName());
     }
 
     Trace fragmentTrace = fragmentToTraceMap.get(f);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
@@ -18,6 +18,7 @@ import androidx.annotation.NonNull;
 import androidx.core.app.FrameMetricsAggregator;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import com.google.android.gms.common.util.VisibleForTesting;
 import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.metrics.Trace;
 import com.google.firebase.perf.transport.TransportManager;
@@ -50,7 +51,7 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
    * @param fragment fragment object.
    * @return Fragment screen trace name.
    */
-  public static String getFragmentScreenTraceName(Fragment fragment) {
+  public String getFragmentScreenTraceName(Fragment fragment) {
     return Constants.SCREEN_TRACE_PREFIX + fragment.getClass().getSimpleName();
   }
 
@@ -93,5 +94,10 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     // TODO: Add frame metrics
 
     fragmentTrace.stop();
+  }
+
+  @VisibleForTesting
+  WeakHashMap<Fragment, Trace> getFragmentToTraceMap() {
+    return fragmentToTraceMap;
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
@@ -84,6 +84,7 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
     if (!fragmentToTraceMap.containsKey(f)) {
       logger.error(
           "FragmentMonitor: missed a fragment trace from %s", f.getClass().getSimpleName());
+      return;
     }
 
     Trace fragmentTrace = fragmentToTraceMap.get(f);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Constants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Constants.java
@@ -52,6 +52,12 @@ public class Constants {
   /** Screen trace name is the prefix plus activity class name. */
   public static final String SCREEN_TRACE_PREFIX = "_st_";
 
+  /** Attribute key for the parent fragment of a fragment screen trace. */
+  public static final String PARENT_FRAGMENT_ATTRIBUTE_KEY = "Parent_fragment";
+
+  /** Attribute key for the hosting activity of a fragment screen trace. */
+  public static final String ACTIVITY_ATTRIBUTE_KEY = "Hosting_activity";
+
   /** frames longer than 16 ms are slow frames */
   public static final int SLOW_FRAME_TIME = 16;
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
@@ -1,19 +1,16 @@
 package com.google.firebase.perf.application;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import android.app.Activity;
-
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.FrameMetricsAggregator;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
-
 import com.google.firebase.perf.FirebasePerformanceTestBase;
 import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.config.DeviceCacheManager;
@@ -22,8 +19,6 @@ import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.TraceMetric;
 import com.google.testing.timing.FakeDirectExecutorService;
-
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,8 +40,7 @@ public class FragmentStateMonitorTest extends FirebasePerformanceTestBase {
   @Mock private AppStateMonitor appStateMonitor;
   @Mock private FrameMetricsAggregator fma;
 
-  @Captor
-  private ArgumentCaptor<TraceMetric> argTraceMetric;
+  @Captor private ArgumentCaptor<TraceMetric> argTraceMetric;
 
   private long currentTime = 0;
 
@@ -63,12 +57,12 @@ public class FragmentStateMonitorTest extends FirebasePerformanceTestBase {
 
     ConfigResolver configResolver = ConfigResolver.getInstance();
     configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
-
   }
 
   @Test
   public void fragmentLifecycleCallbacks_logFragmentScreenTrace() {
-    FragmentStateMonitor monitor = new FragmentStateMonitor(clock, mockTransportManager, appStateMonitor, fma);
+    FragmentStateMonitor monitor =
+        new FragmentStateMonitor(clock, mockTransportManager, appStateMonitor, fma);
     monitor.onFragmentResumed(mockfragmentManager, mockFragment);
     verify(mockTransportManager, times(0)).log(any(TraceMetric.class), any());
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
@@ -133,7 +133,7 @@ public class FragmentStateMonitorTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void fragmentTraceCreation_truncatesName_whenFragmentNameTooLong() {
+  public void fragmentTraceCreation_dropsTrace_whenFragmentNameTooLong() {
     AppStateMonitor appStateMonitor =
         spy(new AppStateMonitor(mockTransportManager, clock, configResolver, fma));
     FragmentStateMonitor fragmentMonitor =
@@ -144,7 +144,9 @@ public class FragmentStateMonitorTest extends FirebasePerformanceTestBase {
         .getFragmentScreenTraceName(nullable(Fragment.class));
 
     fragmentMonitor.onFragmentResumed(mockFragmentManager, mockFragment);
+    verify(mockTransportManager, times(0)).log(any(TraceMetric.class), any());
     fragmentMonitor.onFragmentPaused(mockFragmentManager, mockFragment);
+    verify(mockTransportManager, times(0)).log(any(TraceMetric.class), any());
   }
 
   /************ FrameMetrics Collection Tests ****************/
@@ -164,10 +166,13 @@ public class FragmentStateMonitorTest extends FirebasePerformanceTestBase {
     appStateMonitor.onActivityPaused(mockActivity);
     // reset() was not called at the time of fragments collecting its frame metrics
     verify(fma, times(0)).reset();
+    verify(fma, times(0)).remove(nullable(Activity.class));
     fragmentMonitor.onFragmentPaused(mockFragmentManager, mockFragment);
     verify(fma, times(0)).reset();
+    verify(fma, times(0)).remove(nullable(Activity.class));
     // reset() is only called after fragment is done collecting its metrics
     appStateMonitor.onActivityPostPaused(mockActivity);
     verify(fma, times(1)).reset();
+    verify(fma, times(1)).remove(nullable(Activity.class));
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
@@ -101,7 +101,7 @@ public class FragmentStateMonitorTest extends FirebasePerformanceTestBase {
     monitor.onFragmentResumed(mockFragmentManager, mockFragment);
     verify(mockTransportManager, times(1)).log(any(TraceMetric.class), any());
 
-    monitor.onFragmentResumed(mockFragmentManager, mockFragment);
+    monitor.onFragmentPaused(mockFragmentManager, mockFragment);
     verify(mockTransportManager, times(2)).log(any(TraceMetric.class), any());
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
@@ -1,0 +1,78 @@
+package com.google.firebase.perf.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import android.app.Activity;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.FrameMetricsAggregator;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
+import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.config.ConfigResolver;
+import com.google.firebase.perf.config.DeviceCacheManager;
+import com.google.firebase.perf.transport.TransportManager;
+import com.google.firebase.perf.util.Clock;
+import com.google.firebase.perf.util.Timer;
+import com.google.firebase.perf.v1.TraceMetric;
+import com.google.testing.timing.FakeDirectExecutorService;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
+
+/** Unit tests for {@link com.google.firebase.perf.application.FragmentStateMonitor}. */
+@RunWith(RobolectricTestRunner.class)
+public class FragmentStateMonitorTest extends FirebasePerformanceTestBase {
+
+  @Mock private Clock clock;
+  @Mock private Fragment mockFragment;
+  @Mock private FragmentManager mockfragmentManager;
+  @Mock private TransportManager mockTransportManager;
+  @Mock private AppCompatActivity mockActivity;
+  @Mock private AppStateMonitor appStateMonitor;
+  @Mock private FrameMetricsAggregator fma;
+
+  @Captor
+  private ArgumentCaptor<TraceMetric> argTraceMetric;
+
+  private long currentTime = 0;
+
+  private Activity activity1;
+
+  @Before
+  public void setUp() {
+    currentTime = 0;
+    initMocks(this);
+    doAnswer((Answer<Timer>) invocationOnMock -> new Timer(currentTime)).when(clock).getTime();
+
+    DeviceCacheManager.clearInstance();
+    ConfigResolver.clearInstance();
+
+    ConfigResolver configResolver = ConfigResolver.getInstance();
+    configResolver.setDeviceCacheManager(new DeviceCacheManager(new FakeDirectExecutorService()));
+
+  }
+
+  @Test
+  public void fragmentLifecycleCallbacks_logFragmentScreenTrace() {
+    FragmentStateMonitor monitor = new FragmentStateMonitor(clock, mockTransportManager, appStateMonitor, fma);
+    monitor.onFragmentResumed(mockfragmentManager, mockFragment);
+    verify(mockTransportManager, times(0)).log(any(TraceMetric.class), any());
+
+    monitor.onFragmentPaused(mockfragmentManager, mockFragment);
+    verify(mockTransportManager, times(1)).log(any(TraceMetric.class), any());
+  }
+}

--- a/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/application/FragmentStateMonitorTest.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.perf.application;
 
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
b/208271842

Currently there's a validation error:

> W/FirebasePerformance: non-positive totalFrames in screen trace _st_SupportRequestManagerFragment
W/FirebasePerformance: Invalid Trace:_st_SupportRequestManagerFragment
W/FirebasePerformance: Unable to process the PerfMetric (trace metric: _st_SupportRequestManagerFragment (duration: 118339.913ms)) due to missing or invalid values. See earlier log statements for additional information on the specific missing/invalid values.

This is due to no frame metrics for the "total_frames" validation check, because we have not implemented that yet.