### PR TITLE
Revert "Add Firebase App Distribution to smoke tests"

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -71,7 +71,6 @@ dependencies {
   // Firebase
   implementation "com.google.firebase:firebase-analytics"
   implementation "com.google.firebase:firebase-annotations"
-  implementation "com.google.firebase:firebase-appdistribution"
   implementation "com.google.firebase:firebase-appindexing"
   implementation "com.google.firebase:firebase-auth"
   implementation "com.google.firebase:firebase-common"

--- a/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
@@ -21,7 +21,6 @@ import com.google.firebase.inappmessaging.FirebaseInAppMessaging;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.ml.modeldownloader.FirebaseModelDownloader;
 import com.google.firebase.perf.FirebasePerformance;
-import com.google.firebase.appdistribution.FirebaseAppDistribution;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -55,10 +54,5 @@ public final class BuildOnlyTest {
   @Test
   public void performance_IsNotNull() {
     assertThat(FirebasePerformance.getInstance()).isNotNull();
-  }
-
-  @Test
-  public void appDistribution_IsNotNull(){
-    assertThat(FirebaseAppDistribution.getInstance()).isNotNull();
   }
 }


### PR DESCRIPTION
Reverts firebase/firebase-android-sdk#3555

Because app-distro has not been included in the BoM, it is causing smoke test failures for some other products. This removes app-distribution from smoke test temporarily. We will add it back when the product is out of beta (and added to the BoM).