### PR TITLE
Log notification open after onActivityCreated() on Android 7.1.

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmLifecycleCallbacks.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmLifecycleCallbacks.java
@@ -42,8 +42,8 @@ class FcmLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
       return;
     }
 
-    if (VERSION.SDK_INT <= VERSION_CODES.N) {
-      // On Android 7.0 and lower Bundle unparceling is not thread safe. Wait to log notification
+    if (VERSION.SDK_INT <= VERSION_CODES.N_MR1) {
+      // On Android 7.1 and lower Bundle unparceling is not thread safe. Wait to log notification
       // open after Activity.onCreate() has completed to try to avoid race conditions with other
       // code that may be trying to access the Intent extras Bundle in onCreate() on a different
       // thread.


### PR DESCRIPTION
https://github.com/firebase/firebase-android-sdk/pull/3432
* Also included delaying checking for notification open logging on Android 7.1 (N MR1/25) to avoid Bundle unparceling race condition.