### PR TITLE
Adding unit tests to ApkUpdater class

### DIFF
--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -48,7 +48,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-inline:3.4.0'
-    testImplementation("org.powermock:powermock-mockito-release-full:1.5.4")
     androidTestImplementation "org.mockito:mockito-android:3.4.0"
     testImplementation 'androidx.test:core:1.2.0'
 

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-inline:3.4.0'
+    testImplementation("org.powermock:powermock-mockito-release-full:1.5.4")
     androidTestImplementation "org.mockito:mockito-android:3.4.0"
     testImplementation 'androidx.test:core:1.2.0'
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
@@ -246,6 +246,7 @@ class ApkUpdater {
     return bytesDownloaded;
   }
 
+  @VisibleForTesting
   void validateJarFile(File apkFile, long totalSize, boolean showNotification, long bytesDownloaded)
       throws FirebaseAppDistributionException {
     try {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
@@ -84,6 +84,7 @@ class ApkUpdater {
     this.appDistributionNotificationsManager = appDistributionNotificationsManager;
     this.httpsUrlConnectionFactory = httpsUrlConnectionFactory;
     this.lifeCycleNotifier = lifeCycleNotifier;
+    cachedUpdateTask = new UpdateTaskImpl();
   }
 
   UpdateTaskImpl updateApk(
@@ -159,7 +160,8 @@ class ApkUpdater {
     return downloadTaskCompletionSource.getTask();
   }
 
-  private void makeApkDownloadRequest(
+  @VisibleForTesting
+  void makeApkDownloadRequest(
       @NonNull AppDistributionReleaseInternal newRelease, boolean showNotification)
       throws FirebaseAppDistributionException {
     String downloadUrl = newRelease.getDownloadUrl();
@@ -203,7 +205,8 @@ class ApkUpdater {
     return responseCode >= 200 && responseCode < 300;
   }
 
-  private long downloadToDisk(
+  @VisibleForTesting
+  long downloadToDisk(
       HttpsURLConnection connection, long totalSize, String fileName, boolean showNotification)
       throws FirebaseAppDistributionException {
     context.deleteFile(fileName);
@@ -246,8 +249,8 @@ class ApkUpdater {
     return bytesDownloaded;
   }
 
-  private void validateJarFile(
-      File apkFile, long totalSize, boolean showNotification, long bytesDownloaded)
+  @VisibleForTesting
+  void validateJarFile(File apkFile, long totalSize, boolean showNotification, long bytesDownloaded)
       throws FirebaseAppDistributionException {
     try {
       new JarFile(apkFile).close();

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
@@ -84,7 +84,6 @@ class ApkUpdater {
     this.appDistributionNotificationsManager = appDistributionNotificationsManager;
     this.httpsUrlConnectionFactory = httpsUrlConnectionFactory;
     this.lifeCycleNotifier = lifeCycleNotifier;
-    cachedUpdateTask = new UpdateTaskImpl();
   }
 
   UpdateTaskImpl updateApk(
@@ -96,7 +95,6 @@ class ApkUpdater {
 
       cachedUpdateTask = new UpdateTaskImpl();
     }
-
     downloadApk(newRelease, showNotification)
         .addOnSuccessListener(taskExecutor, file -> installApk(file, showNotification))
         .addOnFailureListener(
@@ -204,8 +202,7 @@ class ApkUpdater {
     return responseCode >= 200 && responseCode < 300;
   }
 
-  @VisibleForTesting
-  long downloadToDisk(
+  private long downloadToDisk(
       HttpsURLConnection connection, long totalSize, String fileName, boolean showNotification)
       throws FirebaseAppDistributionException {
     context.deleteFile(fileName);
@@ -248,7 +245,6 @@ class ApkUpdater {
     return bytesDownloaded;
   }
 
-  @VisibleForTesting
   void validateJarFile(File apkFile, long totalSize, boolean showNotification, long bytesDownloaded)
       throws FirebaseAppDistributionException {
     try {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
@@ -160,8 +160,7 @@ class ApkUpdater {
     return downloadTaskCompletionSource.getTask();
   }
 
-  @VisibleForTesting
-  void makeApkDownloadRequest(
+  private void makeApkDownloadRequest(
       @NonNull AppDistributionReleaseInternal newRelease, boolean showNotification)
       throws FirebaseAppDistributionException {
     String downloadUrl = newRelease.getDownloadUrl();

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/ApkUpdater.java
@@ -95,6 +95,7 @@ class ApkUpdater {
 
       cachedUpdateTask = new UpdateTaskImpl();
     }
+
     downloadApk(newRelease, showNotification)
         .addOnSuccessListener(taskExecutor, file -> installApk(file, showNotification))
         .addOnFailureListener(

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
@@ -49,14 +49,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
-// @RunWith(PowerMockRunner.class)
-// @PrepareForTest(ApkUpdaterTest.class)
 @RunWith(RobolectricTestRunner.class)
-@PrepareForTest(ApkUpdaterTest.class)
 public class ApkUpdaterTest {
 
   private static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
@@ -268,7 +264,7 @@ public class ApkUpdaterTest {
   }
 
   @Test
-  public void downloadToDisk_whenHasInputStream_notificationSetCorrectlyHasCorrectInputLength()
+  public void downloadToDisk_withInputStream_notificationSetCorrectlyHasCorrectInputLength()
       throws IOException, FirebaseAppDistributionException {
     doReturn(new ByteArrayInputStream(TEST_FILE.getBytes()))
         .when(mockHttpsUrlConnection)
@@ -280,5 +276,15 @@ public class ApkUpdaterTest {
     verify(mockNotificationsManager)
         .updateNotification(1000, TEST_FILE.length(), R.string.downloading_app_update);
     assertThat(result).isEqualTo(TEST_FILE.length());
+  }
+
+  @Test
+  public void downloadToDisk_withoutInputStream_notificationSetDownloadFailed() throws IOException {
+    when(mockHttpsUrlConnection.getInputStream()).thenThrow(new IOException());
+    assertThrows(
+        FirebaseAppDistributionException.class,
+        () ->
+            apkUpdater.downloadToDisk(mockHttpsUrlConnection, TEST_FILE_LENGTH, "fileName", true));
+    verify(mockNotificationsManager).updateNotification(1000, 0, R.string.download_failed);
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
@@ -78,7 +78,6 @@ public class ApkUpdaterTest {
           .build();
 
   private ApkUpdater apkUpdater;
-  private ApkUpdater apkUpdater2;
   private TestOnCompleteListener<Void> onCompleteListener;
   @Mock private File mockFile;
   @Mock private HttpsURLConnection mockHttpsUrlConnection;
@@ -208,7 +207,7 @@ public class ApkUpdaterTest {
   }
 
   @Test
-  public void s() throws IOException {
+  public void updateApk_invalidJarFile_throwsException() throws IOException {
     doReturn(new ByteArrayInputStream(TEST_FILE.getBytes()))
         .when(mockHttpsUrlConnection)
         .getInputStream();

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
-import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
@@ -83,7 +82,6 @@ public class ApkUpdaterTest {
   @Mock private ApkInstaller mockApkInstaller;
   @Mock private FirebaseAppDistributionNotificationsManager mockNotificationsManager;
   @Mock private FirebaseAppDistributionLifecycleNotifier mockLifecycleNotifier;
-  private Context mockContext;
 
   private final Executor testExecutor = Executors.newSingleThreadExecutor();
 
@@ -95,11 +93,9 @@ public class ApkUpdaterTest {
 
     FirebaseApp.clearInstancesForTest();
 
-    mockContext = Mockito.spy(ApplicationProvider.getApplicationContext());
-
     FirebaseApp firebaseApp =
         FirebaseApp.initializeApp(
-            mockContext,
+            ApplicationProvider.getApplicationContext(),
             new FirebaseOptions.Builder()
                 .setApplicationId(TEST_APP_ID_1)
                 .setProjectId(TEST_PROJECT_ID)
@@ -120,7 +116,7 @@ public class ApkUpdaterTest {
         Mockito.spy(
             new ApkUpdater(
                 testExecutor,
-                mockContext,
+                ApplicationProvider.getApplicationContext(),
                 mockApkInstaller,
                 mockNotificationsManager,
                 mockHttpsUrlConnectionFactory,

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
@@ -197,6 +197,7 @@ public class ApkUpdaterTest {
         .getInputStream();
     when(mockApkInstaller.installApk(any(), any())).thenReturn(Tasks.forResult(null));
 
+    // If validateJarFile is not mocked it will be called with an invalid jar file.
     UpdateTask updateTask = apkUpdater.updateApk(TEST_RELEASE, true);
     updateTask.addOnCompleteListener(testExecutor, onCompleteListener);
     FirebaseAppDistributionException e =

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/ApkUpdaterTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -38,7 +37,6 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -174,16 +172,6 @@ public class ApkUpdaterTest {
   }
 
   @Test
-  public void updateApk_whenInstallSuccessful_setsResult() throws Exception {
-    doReturn(Tasks.forResult(mockFile)).when(apkUpdater).downloadApk(TEST_RELEASE, false);
-    when(mockApkInstaller.installApk(any(), any())).thenReturn(Tasks.forResult(null));
-    UpdateTaskImpl updateTask = apkUpdater.updateApk(TEST_RELEASE, false);
-    updateTask.addOnCompleteListener(testExecutor, onCompleteListener);
-    onCompleteListener.await();
-    assertThat(updateTask.isSuccessful()).isTrue();
-  }
-
-  @Test
   public void updateApk_whenSuccessfullyUpdated_notificationsSetCorrectly()
       throws FirebaseAppDistributionException, ExecutionException, InterruptedException,
           IOException {
@@ -212,9 +200,6 @@ public class ApkUpdaterTest {
         .when(mockHttpsUrlConnection)
         .getInputStream();
     when(mockApkInstaller.installApk(any(), any())).thenReturn(Tasks.forResult(null));
-    FileInputStream fileInputStream =
-        (FileInputStream) ApkUpdaterTest.class.getResourceAsStream("file does not exist");
-    doReturn(fileInputStream).when(mockContext).openFileInput(anyString());
 
     UpdateTask updateTask = apkUpdater.updateApk(TEST_RELEASE, true);
     updateTask.addOnCompleteListener(testExecutor, onCompleteListener);


### PR DESCRIPTION
ApkUpdater class was missing some unit test coverage on classes such as downloadToDisk and updateApk where we were not testing some paths of success.

Added in testing to verify all of the notifications used in the ApkUpdater class. 
Test the happy path of the updateApk method going through download apk -> makeApkDownloadRequest -> downloadToDisk.

As well as testing the fail case of validateJarFile. 