### PR TITLE
Fix App Check version numbers in `gradle.properties`

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/gradle.properties
+++ b/appcheck/firebase-appcheck-debug-testing/gradle.properties
@@ -1,1 +1,1 @@
-version=16.0.1
+version=16.0.0-beta06

--- a/appcheck/firebase-appcheck-debug/gradle.properties
+++ b/appcheck/firebase-appcheck-debug/gradle.properties
@@ -1,1 +1,1 @@
-version=16.0.1
+version=16.0.0-beta06

--- a/appcheck/firebase-appcheck-interop/gradle.properties
+++ b/appcheck/firebase-appcheck-interop/gradle.properties
@@ -1,2 +1,2 @@
-version=16.0.1
-latestReleasedVersion=16.0.0-beta02
+version=16.0.0-beta06
+latestReleasedVersion=16.0.0-beta05

--- a/appcheck/firebase-appcheck-safetynet/gradle.properties
+++ b/appcheck/firebase-appcheck-safetynet/gradle.properties
@@ -1,1 +1,1 @@
-version=16.0.1
+version=16.0.0-beta06

--- a/appcheck/firebase-appcheck/gradle.properties
+++ b/appcheck/firebase-appcheck/gradle.properties
@@ -1,1 +1,1 @@
-version=16.0.1
+version=16.0.0-beta06


### PR DESCRIPTION
Correct the version listed in `gradle.properties` files to be version number of the upcoming App Check release.