### PR TITLE
Add FirebaseFunctions.getHttpsCallableFromURL

### DIFF
--- a/firebase-functions/api.txt
+++ b/firebase-functions/api.txt
@@ -3,7 +3,7 @@ package com.google.firebase.functions {
 
   public class FirebaseFunctions {
     method @NonNull public com.google.firebase.functions.HttpsCallableReference getHttpsCallable(@NonNull String);
-    method @NonNull public com.google.firebase.functions.HttpsCallableReference getHttpsCallableFromUrl(@NonNull URL url);
+    method @NonNull public com.google.firebase.functions.HttpsCallableReference getHttpsCallableFromUrl(@NonNull java.net.URL);
     method @NonNull public static com.google.firebase.functions.FirebaseFunctions getInstance(@NonNull com.google.firebase.FirebaseApp, @NonNull String);
     method @NonNull public static com.google.firebase.functions.FirebaseFunctions getInstance(@NonNull com.google.firebase.FirebaseApp);
     method @NonNull public static com.google.firebase.functions.FirebaseFunctions getInstance(@NonNull String);

--- a/firebase-functions/api.txt
+++ b/firebase-functions/api.txt
@@ -3,6 +3,7 @@ package com.google.firebase.functions {
 
   public class FirebaseFunctions {
     method @NonNull public com.google.firebase.functions.HttpsCallableReference getHttpsCallable(@NonNull String);
+    method @NonNull public com.google.firebase.functions.HttpsCallableReference getHttpsCallableFromUrl(@NonNull URL url);
     method @NonNull public static com.google.firebase.functions.FirebaseFunctions getInstance(@NonNull com.google.firebase.FirebaseApp, @NonNull String);
     method @NonNull public static com.google.firebase.functions.FirebaseFunctions getInstance(@NonNull com.google.firebase.FirebaseApp);
     method @NonNull public static com.google.firebase.functions.FirebaseFunctions getInstance(@NonNull String);

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
@@ -275,7 +275,7 @@ public class FirebaseFunctions {
                 return Tasks.forException(task.getException());
               }
               HttpsCallableContext context = task.getResult();
-                URL url = getURL(name);
+              URL url = getURL(name);
               return call(url, data, context, options);
             });
   }

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
@@ -205,8 +205,8 @@ public class FirebaseFunctions {
   }
 
   @NonNull
-  public HttpsCallableReference getHttpsCallableFromUrl(@NonNull String url) throws MalformedURLException {
-     return new HttpsCallableReference(this, new URL(url));
+  public HttpsCallableReference getHttpsCallableFromUrl(@NonNull URL url) {
+     return new HttpsCallableReference(this, url);
   }
 
   /**

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
@@ -204,9 +204,10 @@ public class FirebaseFunctions {
     return new HttpsCallableReference(this, name);
   }
 
+  /** Returns a reference to the Callable HTTPS trigger with the provided url. */
   @NonNull
   public HttpsCallableReference getHttpsCallableFromUrl(@NonNull URL url) {
-     return new HttpsCallableReference(this, url);
+    return new HttpsCallableReference(this, url);
   }
 
   /**
@@ -279,26 +280,27 @@ public class FirebaseFunctions {
               return call(url, data, context, options);
             });
   }
-    /**
-     * Calls a Callable HTTPS trigger endpoint.
-     *
-     * @param url The url of the HTTPS trigger
-     * @param data Parameters to pass to the function. Can be anything encodable as JSON.
-     * @return A Task that will be completed when the request is complete.
-     */
-    Task<HttpsCallableResult> call(URL url, @Nullable Object data, HttpsCallOptions options) {
-        return providerInstalled
-            .getTask()
-            .continueWithTask(task -> contextProvider.getContext())
-            .continueWithTask(
-                task -> {
-                    if (!task.isSuccessful()) {
-                        return Tasks.forException(task.getException());
-                    }
-                    HttpsCallableContext context = task.getResult();
-                    return call(url, data, context, options);
-                });
-    }
+
+  /**
+   * Calls a Callable HTTPS trigger endpoint.
+   *
+   * @param url The url of the HTTPS trigger
+   * @param data Parameters to pass to the function. Can be anything encodable as JSON.
+   * @return A Task that will be completed when the request is complete.
+   */
+  Task<HttpsCallableResult> call(URL url, @Nullable Object data, HttpsCallOptions options) {
+    return providerInstalled
+        .getTask()
+        .continueWithTask(task -> contextProvider.getContext())
+        .continueWithTask(
+            task -> {
+              if (!task.isSuccessful()) {
+                return Tasks.forException(task.getException());
+              }
+              HttpsCallableContext context = task.getResult();
+              return call(url, data, context, options);
+            });
+  }
 
   /**
    * Calls a Callable HTTPS trigger endpoint.

--- a/firebase-functions/src/main/java/com/google/firebase/functions/HttpsCallableReference.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/HttpsCallableReference.java
@@ -17,7 +17,6 @@ package com.google.firebase.functions;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
-
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 

--- a/firebase-functions/src/main/java/com/google/firebase/functions/HttpsCallableReference.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/HttpsCallableReference.java
@@ -17,6 +17,8 @@ package com.google.firebase.functions;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
+
+import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 /** A reference to a particular Callable HTTPS trigger in Cloud Functions. */
@@ -26,7 +28,12 @@ public class HttpsCallableReference {
   private final FirebaseFunctions functionsClient;
 
   // The name of the HTTPS endpoint this reference refers to.
+  // Is null if url is set.
   private final String name;
+
+  // The url of the HTTPS endpoint this reference refers to.
+  // Is null if name is set.
+  private final URL url;
 
   // Options for how to do the HTTPS call.
   HttpsCallOptions options = new HttpsCallOptions();
@@ -35,6 +42,14 @@ public class HttpsCallableReference {
   HttpsCallableReference(FirebaseFunctions functionsClient, String name) {
     this.functionsClient = functionsClient;
     this.name = name;
+    this.url = null;
+  }
+
+  /** Creates a new reference with the given options. */
+  HttpsCallableReference(FirebaseFunctions functionsClient, URL url) {
+    this.functionsClient = functionsClient;
+    this.name = null;
+    this.url = url;
   }
 
   /**
@@ -80,7 +95,11 @@ public class HttpsCallableReference {
    */
   @NonNull
   public Task<HttpsCallableResult> call(@Nullable Object data) {
-    return functionsClient.call(name, data, options);
+    if (name != null) {
+      return functionsClient.call(name, data, options);
+    } else {
+      return functionsClient.call(url, data, options);
+    }
   }
 
   /**
@@ -99,7 +118,11 @@ public class HttpsCallableReference {
    */
   @NonNull
   public Task<HttpsCallableResult> call() {
-    return functionsClient.call(name, null, options);
+    if (name != null) {
+      return functionsClient.call(name, null, options);
+    } else {
+      return functionsClient.call(url, null, options);
+    }
   }
 
   /**


### PR DESCRIPTION
Sorry for a late-coming urgent change; AFAICT nobody on the SDK team could staff these changes, so I'm trying to write the change for the top 3 SDKs before I/O freeze.

For context, see [go/cf3v2-crash-landing](http://go/cf3v2-crash-landing).
For API approval, see [go/callable-functions-custom-urls](http://go/callable-functions-custom-urls)