### PR TITLE
chore: update gradle, kotlin and kotlin-dsl versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ import com.google.firebase.gradle.plugins.license.LicenseResolverPlugin
 import com.google.firebase.gradle.MultiProjectReleasePlugin
 
 buildscript {
-    ext.kotlinVersion = '1.3.72'
+    ext.kotlinVersion = '1.6.20'
     repositories {
         google()
         mavenCentral()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 plugins {
-    id "org.gradle.kotlin.kotlin-dsl" version "1.2.9"
+    id "org.gradle.kotlin.kotlin-dsl" version "1.3.3"
     id "org.jlleitschuh.gradle.ktlint" version "9.2.1"
     id 'com.github.sherter.google-java-format' version '0.9'
 }
@@ -52,7 +52,7 @@ dependencies {
     implementation "com.google.auto.value:auto-value-annotations:1.7"
     annotationProcessor "com.google.auto.value:auto-value:1.6.5"
     implementation 'digital.wup:android-maven-publish:3.6.3'
-    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72'
+    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20'
     implementation 'org.json:json:20180813'
 
     implementation "org.eclipse.aether:aether-api:1.0.0.v20140518"

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Metalava.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Metalava.kt
@@ -20,6 +20,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SourceSet
@@ -50,6 +51,7 @@ fun Project.runMetalavaWithArgs(
 
 abstract class GenerateStubsTask : DefaultTask() {
     /** Source files against which API signatures will be validated. */
+    @Input
     lateinit var sourceSet: Object
 
     @get:InputFiles

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo/ApiInformationTask.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo/ApiInformationTask.java
@@ -46,6 +46,7 @@ public abstract class ApiInformationTask extends DefaultTask {
   @InputFile
   abstract File getApiTxt();
 
+  @Input
   abstract Object getSourceSet();
 
   @InputFiles

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo/GenerateApiTxtFileTask.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo/GenerateApiTxtFileTask.java
@@ -38,6 +38,7 @@ public abstract class GenerateApiTxtFileTask extends DefaultTask {
   @OutputFile
   abstract File getApiTxt();
 
+  @Input
   abstract Object getSourceSet();
 
   @InputFiles

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/Coverage.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/Coverage.java
@@ -66,28 +66,30 @@ public final class Coverage {
                       .add("**Manifest*.*")
                       .build();
 
-              task.setClassDirectories(
-                  project.files(
+              task.getClassDirectories()
+                  .from(
+                      project.files(
+                          project.fileTree(
+                              ImmutableMap.of(
+                                  "dir",
+                                  project.getBuildDir() + "/intermediates/javac/release",
+                                  "excludes",
+                                  excludes)),
+                          project.fileTree(
+                              ImmutableMap.of(
+                                  "dir",
+                                  project.getBuildDir() + "/tmp/kotlin-classes/release",
+                                  "excludes",
+                                  excludes))));
+              task.getSourceDirectories().from(project.files("src/main/java", "src/main/kotlin"));
+              task.getExecutionData()
+                  .from(
                       project.fileTree(
                           ImmutableMap.of(
                               "dir",
-                              project.getBuildDir() + "/intermediates/javac/release",
-                              "excludes",
-                              excludes)),
-                      project.fileTree(
-                          ImmutableMap.of(
-                              "dir",
-                              project.getBuildDir() + "/tmp/kotlin-classes/release",
-                              "excludes",
-                              excludes))));
-              task.setSourceDirectories(project.files("src/main/java", "src/main/kotlin"));
-              task.setExecutionData(
-                  project.fileTree(
-                      ImmutableMap.of(
-                          "dir",
-                          project.getBuildDir(),
-                          "includes",
-                          ImmutableList.of("jacoco/*.exec"))));
+                              project.getBuildDir(),
+                              "includes",
+                              ImmutableList.of("jacoco/*.exec"))));
               task.reports(
                   reports -> {
                     reports

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates some of our dependencies: 
- gradle 5.6.4 --> 6.1.1
- kotlin 1.3.72 --> 1.6.20
- kotlin-dsl 1.2.9 --> 1.3.3

It also unblocks some feature requests such as #1252 