### PR TITLE
Attempt to fix flaky E2E screen trace by relaunching the activity.

### DIFF
--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
@@ -79,6 +79,9 @@ public class FirebasePerformanceFragmentScreenTracesTest {
     assertThat(activityRule.getScenario().getState())
         .isIn(Arrays.asList(State.CREATED, State.RESUMED));
     activityRule.getScenario().moveToState(State.CREATED);
+
+    // End Activity screen trace by relaunching the activity to ensure the screen trace is sent.
+    activityRule.getScenario().launch(FirebasePerfFragmentsActivity.class);
   }
 
   private void scrollRecyclerViewToEnd(int itemCount, int viewId) {


### PR DESCRIPTION
The other test with `_st_FirebasePerfScreenTracesActivity` is not flaky and [relaunches the activity](https://github.com/firebase/firebase-android-sdk/blob/9ab121fbb8c21dd093483f8cf4a0a6d12c6f0cda/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java#L56-L58) at the end of the test, so I am trying to relaunch the activity to ensure the screen trace is sent.