### PR TITLE
Upgrade Firelog priority from telemetry to data

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/MessagingAnalytics.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/MessagingAnalytics.java
@@ -344,7 +344,7 @@ public class MessagingAnalytics {
               Encoding.of("proto"),
               MessagingClientEventExtension::toByteArray)
           .send(
-              Event.ofTelemetry(
+              Event.ofData(
                   MessagingClientEventExtension.newBuilder()
                       .setMessagingClientEvent(clientEvent)
                       .build()));


### PR DESCRIPTION
Upgrade logging priority so that message delivered logs are reported from devices with increased background restrictions or network restrictions.