### PR TITLE
Perf: add "No parent" constant string when parent fragment does not exist

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FragmentStateMonitor.java
@@ -66,11 +66,10 @@ public class FragmentStateMonitor extends FragmentManager.FragmentLifecycleCallb
         new Trace(getFragmentScreenTraceName(f), transportManager, clock, appStateMonitor);
     fragmentTrace.start();
 
-    if (f.getParentFragment() != null) {
-      fragmentTrace.putAttribute(
-          Constants.PARENT_FRAGMENT_ATTRIBUTE_KEY,
-          f.getParentFragment().getClass().getSimpleName());
-    }
+    Fragment parent = f.getParentFragment();
+    fragmentTrace.putAttribute(
+        Constants.PARENT_FRAGMENT_ATTRIBUTE_KEY,
+        parent == null ? Constants.NO_PARENT_FRAGMENT : parent.getClass().getSimpleName());
     if (f.getActivity() != null) {
       fragmentTrace.putAttribute(
           Constants.ACTIVITY_ATTRIBUTE_KEY, f.getActivity().getClass().getSimpleName());

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Constants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Constants.java
@@ -58,6 +58,9 @@ public class Constants {
   /** Attribute key for the hosting activity of a fragment screen trace. */
   public static final String ACTIVITY_ATTRIBUTE_KEY = "Hosting_activity";
 
+  /** Attribute value for when the current fragment does not have a parent fragment. */
+  public static final String NO_PARENT_FRAGMENT = "No parent";
+
   /** frames longer than 16 ms are slow frames */
   public static final int SLOW_FRAME_TIME = 16;
 


### PR DESCRIPTION
b/231632433

### Change
Add `No parent` constant string as the value of `Parent_fragment` custom attribute when a fragment does not have a parent fragment.

### Rationale
The root fragment does not have a parent fragment. In those cases, the Fireperf console has a jarring UX.

For example, if Fragment `C` is used in 2 places in an app. One as a child of Fragment `P`, and one as a root fragment without parent. The console would display only 1 option for `Parent_fragment`, which is `P`. However in the filter and the graph, you can see some data for `All data`, and when you filter by `Parent_fragment`, you can see some data for fragments with parent `P`. That leads users to think: `C` is only used in one place in my app, and that is as a child of `P`, so why is the data for `All data` and parent `P` different?

