### PR TITLE
Shortened prefix and capped concatenated string

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/logging/Logging.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/logging/Logging.java
@@ -14,13 +14,26 @@
 
 package com.google.android.datatransport.runtime.logging;
 
+import android.os.Build;
 import android.util.Log;
 
 public final class Logging {
   private Logging() {}
 
   private static String getTag(String tag) {
-    return "TransportRuntime." + tag;
+    String prefix = "TRuntime.";
+    return prefix + concatTag(prefix, tag);
+  }
+
+  private static String concatTag(String prefix, String tag){
+    int loggableLimit = 23;
+    int remainingSpace = loggableLimit - prefix.length();
+
+    if(android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.N)
+      if(tag.length() > remainingSpace)
+        tag = tag.substring(0, remainingSpace);
+
+    return tag;
   }
 
   public static void d(String tag, String message) {


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-android-sdk/issues/3716.

Android version 7.0 has a limit of 23 characters when using isLoggable. Since this limit cannot be bypassed or changed, the preferred solution is to shorten the prefix and cap the concatenated string.

The concatenated string with prefix would look like this. Limited at 23 chars.
e.g.
```
TRuntime.SQLiteEventSto
TRuntime.CctTransportBa
TRuntime.AlarmManagerSc
TRuntime.JobInfoSchedul
TRuntime.Uploader
TRuntime.Executor
```