### PR TITLE
Update comment of logToFirelog method

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/MessagingAnalytics.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/MessagingAnalytics.java
@@ -319,8 +319,8 @@ public class MessagingAnalytics {
   /**
    * Asynchronously log an event to Firelog.
    *
-   * <p>Firelog batch-send delivery metrics every 24 hours when the device is idle and have network
-   * connection in a background thread.
+   * <p>Firelog batch-send usually delivery metrics within 1 hour (at most 24 hours) when the device
+   * is idle and have network connection in a background thread.
    */
   private static void logToFirelog(
       MessagingClientEvent.Event event,


### PR DESCRIPTION
After changing the priority to DEFAULT, it usually takes less than 1 hour to deliver the data.