### PR TITLE
Upgrade Gradle to 6.9

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/api.txt
+++ b/appcheck/firebase-appcheck-debug-testing/api.txt
@@ -1,0 +1,15 @@
+// Signature format: 2.0
+package com.google.firebase.appcheck.debug.testing {
+
+  public final class DebugAppCheckTestHelper {
+    method @NonNull public static com.google.firebase.appcheck.debug.testing.DebugAppCheckTestHelper fromInstrumentationArgs();
+    method public <E extends java.lang.Throwable> void withDebugProvider(@NonNull com.google.firebase.appcheck.debug.testing.DebugAppCheckTestHelper.MaybeThrowingRunnable<E>) throws E;
+    method public <E extends java.lang.Throwable> void withDebugProvider(@NonNull com.google.firebase.FirebaseApp, @NonNull com.google.firebase.appcheck.debug.testing.DebugAppCheckTestHelper.MaybeThrowingRunnable<E>) throws E;
+  }
+
+  public static interface DebugAppCheckTestHelper.MaybeThrowingRunnable<E extends java.lang.Throwable> {
+    method public void run() throws E;
+  }
+
+}
+

--- a/appcheck/firebase-appcheck-debug/api.txt
+++ b/appcheck/firebase-appcheck-debug/api.txt
@@ -1,0 +1,10 @@
+// Signature format: 2.0
+package com.google.firebase.appcheck.debug {
+
+  public class DebugAppCheckProviderFactory implements com.google.firebase.appcheck.AppCheckProviderFactory {
+    method @NonNull public com.google.firebase.appcheck.AppCheckProvider create(@NonNull com.google.firebase.FirebaseApp);
+    method @NonNull public static com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory getInstance();
+  }
+
+}
+

--- a/appcheck/firebase-appcheck-interop/api.txt
+++ b/appcheck/firebase-appcheck-interop/api.txt
@@ -1,0 +1,25 @@
+// Signature format: 2.0
+package com.google.firebase.appcheck {
+
+  public abstract class AppCheckTokenResult {
+    ctor public AppCheckTokenResult();
+    method @Nullable public abstract com.google.firebase.FirebaseException getError();
+    method @NonNull public abstract String getToken();
+  }
+
+}
+
+package com.google.firebase.appcheck.interop {
+
+  public interface AppCheckTokenListener {
+    method public void onAppCheckTokenChanged(@NonNull com.google.firebase.appcheck.AppCheckTokenResult);
+  }
+
+  public interface InternalAppCheckTokenProvider {
+    method public void addAppCheckTokenListener(@NonNull com.google.firebase.appcheck.interop.AppCheckTokenListener);
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.appcheck.AppCheckTokenResult> getToken(boolean);
+    method public void removeAppCheckTokenListener(@NonNull com.google.firebase.appcheck.interop.AppCheckTokenListener);
+  }
+
+}
+

--- a/appcheck/firebase-appcheck-playintegrity/api.txt
+++ b/appcheck/firebase-appcheck-playintegrity/api.txt
@@ -1,0 +1,11 @@
+// Signature format: 2.0
+package com.google.firebase.appcheck.playintegrity {
+
+  public class PlayIntegrityAppCheckProviderFactory implements com.google.firebase.appcheck.AppCheckProviderFactory {
+    ctor public PlayIntegrityAppCheckProviderFactory();
+    method @NonNull public com.google.firebase.appcheck.AppCheckProvider create(@NonNull com.google.firebase.FirebaseApp);
+    method @NonNull public static com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory getInstance();
+  }
+
+}
+

--- a/appcheck/firebase-appcheck-safetynet/api.txt
+++ b/appcheck/firebase-appcheck-safetynet/api.txt
@@ -1,0 +1,10 @@
+// Signature format: 2.0
+package com.google.firebase.appcheck.safetynet {
+
+  public class SafetyNetAppCheckProviderFactory implements com.google.firebase.appcheck.AppCheckProviderFactory {
+    method @NonNull public com.google.firebase.appcheck.AppCheckProvider create(@NonNull com.google.firebase.FirebaseApp);
+    method @NonNull public static com.google.firebase.appcheck.safetynet.SafetyNetAppCheckProviderFactory getInstance();
+  }
+
+}
+

--- a/appcheck/firebase-appcheck/api.txt
+++ b/appcheck/firebase-appcheck/api.txt
@@ -1,0 +1,35 @@
+// Signature format: 2.0
+package com.google.firebase.appcheck {
+
+  public interface AppCheckProvider {
+    method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.appcheck.AppCheckToken> getToken();
+  }
+
+  public interface AppCheckProviderFactory {
+    method @NonNull public com.google.firebase.appcheck.AppCheckProvider create(@NonNull com.google.firebase.FirebaseApp);
+  }
+
+  public abstract class AppCheckToken {
+    ctor public AppCheckToken();
+    method public abstract long getExpireTimeMillis();
+    method @NonNull public abstract String getToken();
+  }
+
+  public abstract class FirebaseAppCheck implements com.google.firebase.appcheck.interop.InternalAppCheckTokenProvider {
+    ctor public FirebaseAppCheck();
+    method public abstract void addAppCheckListener(@NonNull com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener);
+    method @NonNull public abstract com.google.android.gms.tasks.Task<com.google.firebase.appcheck.AppCheckToken> getAppCheckToken(boolean);
+    method @NonNull public static com.google.firebase.appcheck.FirebaseAppCheck getInstance();
+    method @NonNull public static com.google.firebase.appcheck.FirebaseAppCheck getInstance(@NonNull com.google.firebase.FirebaseApp);
+    method public abstract void installAppCheckProviderFactory(@NonNull com.google.firebase.appcheck.AppCheckProviderFactory);
+    method public abstract void installAppCheckProviderFactory(@NonNull com.google.firebase.appcheck.AppCheckProviderFactory, boolean);
+    method public abstract void removeAppCheckListener(@NonNull com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener);
+    method public abstract void setTokenAutoRefreshEnabled(boolean);
+  }
+
+  public static interface FirebaseAppCheck.AppCheckListener {
+    method public void onAppCheckTokenChanged(@NonNull com.google.firebase.appcheck.AppCheckToken);
+  }
+
+}
+

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 plugins {
-    id "org.gradle.kotlin.kotlin-dsl" version "1.2.9"
+    id "org.gradle.kotlin.kotlin-dsl" version "1.4.9"
     id "org.jlleitschuh.gradle.ktlint" version "9.2.1"
     id 'com.github.sherter.google-java-format' version '0.9'
 }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Metalava.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Metalava.kt
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
@@ -50,7 +51,8 @@ fun Project.runMetalavaWithArgs(
 
 abstract class GenerateStubsTask : DefaultTask() {
     /** Source files against which API signatures will be validated. */
-    lateinit var sourceSet: Object
+    @Nested
+    lateinit var sourceSet: Any
 
     @get:InputFiles
     lateinit var classPath: FileCollection

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo/ApiInformationTask.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo/ApiInformationTask.java
@@ -30,6 +30,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
@@ -46,6 +47,7 @@ public abstract class ApiInformationTask extends DefaultTask {
   @InputFile
   abstract File getApiTxt();
 
+  @Nested
   abstract Object getSourceSet();
 
   @InputFiles

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo/GenerateApiTxtFileTask.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo/GenerateApiTxtFileTask.java
@@ -26,6 +26,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
@@ -35,31 +36,32 @@ public abstract class GenerateApiTxtFileTask extends DefaultTask {
   @Input
   abstract String getMetalavaJarPath();
 
+  public abstract void setMetalavaJarPath(String value);
+
   @OutputFile
   abstract File getApiTxt();
 
+  public abstract void setApiTxt(File value);
+
+  @Nested
   abstract Object getSourceSet();
+
+  public abstract void setSourceSet(Object value);
 
   @InputFiles
   public abstract FileCollection getClassPath();
 
+  public abstract void setClassPath(FileCollection value);
+
   @OutputFile
   abstract File getBaselineFile();
+
+  public abstract void setBaselineFile(File value);
 
   @Input
   abstract boolean getUpdateBaseline();
 
-  public abstract void setSourceSet(Object value);
-
-  public abstract void setClassPath(FileCollection value);
-
-  public abstract void setBaselineFile(File value);
-
   public abstract void setUpdateBaseline(boolean value);
-
-  public abstract void setMetalavaJarPath(String value);
-
-  public abstract void setApiTxt(File value);
 
   private Set<File> getSourceDirs() {
     if (getSourceSet() instanceof SourceSet) {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/Coverage.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/Coverage.java
@@ -66,7 +66,7 @@ public final class Coverage {
                       .add("**Manifest*.*")
                       .build();
 
-              task.setClassDirectories(
+              task.getClassDirectories().setFrom(
                   project.files(
                       project.fileTree(
                           ImmutableMap.of(
@@ -80,8 +80,8 @@ public final class Coverage {
                               project.getBuildDir() + "/tmp/kotlin-classes/release",
                               "excludes",
                               excludes))));
-              task.setSourceDirectories(project.files("src/main/java", "src/main/kotlin"));
-              task.setExecutionData(
+              task.getSourceDirectories().setFrom(project.files("src/main/java", "src/main/kotlin"));
+              task.getExecutionData().setFrom(
                   project.fileTree(
                       ImmutableMap.of(
                           "dir",

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/Coverage.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/Coverage.java
@@ -26,6 +26,7 @@ import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
 import org.gradle.testing.jacoco.tasks.JacocoReport;
 
 public final class Coverage {
+
   private Coverage() {}
 
   public static void apply(FirebaseLibraryExtension firebaseLibrary) {
@@ -66,28 +67,31 @@ public final class Coverage {
                       .add("**Manifest*.*")
                       .build();
 
-              task.getClassDirectories().setFrom(
-                  project.files(
+              task.getClassDirectories()
+                  .setFrom(
+                      project.files(
+                          project.fileTree(
+                              ImmutableMap.of(
+                                  "dir",
+                                  project.getBuildDir() + "/intermediates/javac/release",
+                                  "excludes",
+                                  excludes)),
+                          project.fileTree(
+                              ImmutableMap.of(
+                                  "dir",
+                                  project.getBuildDir() + "/tmp/kotlin-classes/release",
+                                  "excludes",
+                                  excludes))));
+              task.getSourceDirectories()
+                  .setFrom(project.files("src/main/java", "src/main/kotlin"));
+              task.getExecutionData()
+                  .setFrom(
                       project.fileTree(
                           ImmutableMap.of(
                               "dir",
-                              project.getBuildDir() + "/intermediates/javac/release",
-                              "excludes",
-                              excludes)),
-                      project.fileTree(
-                          ImmutableMap.of(
-                              "dir",
-                              project.getBuildDir() + "/tmp/kotlin-classes/release",
-                              "excludes",
-                              excludes))));
-              task.getSourceDirectories().setFrom(project.files("src/main/java", "src/main/kotlin"));
-              task.getExecutionData().setFrom(
-                  project.fileTree(
-                      ImmutableMap.of(
-                          "dir",
-                          project.getBuildDir(),
-                          "includes",
-                          ImmutableList.of("jacoco/*.exec"))));
+                              project.getBuildDir(),
+                              "includes",
+                              ImmutableList.of("jacoco/*.exec"))));
               task.reports(
                   reports -> {
                     reports

--- a/firebase-annotations/api.txt
+++ b/firebase-annotations/api.txt
@@ -1,0 +1,8 @@
+// Signature format: 2.0
+package com.google.firebase.annotations {
+
+  @java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.CLASS) public @interface PreviewApi {
+  }
+
+}
+

--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -50,8 +50,8 @@ package com.google.firebase.appdistribution {
   }
 
   public interface UpdateProgress {
-    method @NonNull public long getApkBytesDownloaded();
-    method @NonNull public long getApkFileTotalBytes();
+    method public long getApkBytesDownloaded();
+    method public long getApkFileTotalBytes();
     method @NonNull public com.google.firebase.appdistribution.UpdateStatus getUpdateStatus();
   }
 

--- a/firebase-dynamic-links/api.txt
+++ b/firebase-dynamic-links/api.txt
@@ -116,7 +116,7 @@ package com.google.firebase.dynamiclinks {
   public abstract class FirebaseDynamicLinks {
     ctor public FirebaseDynamicLinks();
     method @NonNull public abstract com.google.firebase.dynamiclinks.DynamicLink.Builder createDynamicLink();
-    method @NonNull public abstract com.google.android.gms.tasks.Task<com.google.firebase.dynamiclinks.PendingDynamicLinkData> getDynamicLink(@NonNull android.content.Intent);
+    method @NonNull public abstract com.google.android.gms.tasks.Task<com.google.firebase.dynamiclinks.PendingDynamicLinkData> getDynamicLink(@Nullable android.content.Intent);
     method @NonNull public abstract com.google.android.gms.tasks.Task<com.google.firebase.dynamiclinks.PendingDynamicLinkData> getDynamicLink(@NonNull android.net.Uri);
     method @NonNull public static com.google.firebase.dynamiclinks.FirebaseDynamicLinks getInstance();
     method @NonNull public static com.google.firebase.dynamiclinks.FirebaseDynamicLinks getInstance(@NonNull com.google.firebase.FirebaseApp);

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu May 19 12:08:35 CDT 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
We're currently utilizing a very old version of Gradle (5.4), wheres the current LTS for Gradle is 7.4.2

In an effort to get the SDK up-to-date, this PR gets Gradle up to 6.9
Moving to 7.x will require some additional work, but this is the first step.

Buganizer tickets: _233146890, 233139769, 233146881_

_233146878_ as well, but that's associated with a different PR that has [already been merged](https://github.com/google/play-services-plugins/pull/227).