### PR TITLE
Hides the constructors for FirebaseAppDistributionException.

### DIFF
--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -24,10 +24,6 @@ package com.google.firebase.appdistribution {
   }
 
   public class FirebaseAppDistributionException extends com.google.firebase.FirebaseException {
-    ctor public FirebaseAppDistributionException(@NonNull String, @NonNull com.google.firebase.appdistribution.FirebaseAppDistributionException.Status);
-    ctor public FirebaseAppDistributionException(@NonNull String, @NonNull com.google.firebase.appdistribution.FirebaseAppDistributionException.Status, @Nullable com.google.firebase.appdistribution.AppDistributionRelease);
-    ctor public FirebaseAppDistributionException(@NonNull String, @NonNull com.google.firebase.appdistribution.FirebaseAppDistributionException.Status, @NonNull Throwable);
-    ctor public FirebaseAppDistributionException(@NonNull String, @NonNull com.google.firebase.appdistribution.FirebaseAppDistributionException.Status, @Nullable com.google.firebase.appdistribution.AppDistributionRelease, @NonNull Throwable);
     method @NonNull public com.google.firebase.appdistribution.FirebaseAppDistributionException.Status getErrorCode();
     method @Nullable public com.google.firebase.appdistribution.AppDistributionRelease getRelease();
   }
@@ -50,8 +46,8 @@ package com.google.firebase.appdistribution {
   }
 
   public interface UpdateProgress {
-    method @NonNull public long getApkBytesDownloaded();
-    method @NonNull public long getApkFileTotalBytes();
+    method public long getApkBytesDownloaded();
+    method public long getApkFileTotalBytes();
     method @NonNull public com.google.firebase.appdistribution.UpdateStatus getUpdateStatus();
   }
 

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
@@ -83,10 +83,12 @@ public class FirebaseAppDistributionException extends FirebaseException {
   @NonNull private final Status status;
   @Nullable private final AppDistributionRelease release;
 
+  /** @hide */
   public FirebaseAppDistributionException(@NonNull String message, @NonNull Status status) {
     this(message, status, (AppDistributionRelease) null);
   }
 
+  /** @hide */
   public FirebaseAppDistributionException(
       @NonNull String message, @NonNull Status status, @Nullable AppDistributionRelease release) {
     super(message);
@@ -94,11 +96,13 @@ public class FirebaseAppDistributionException extends FirebaseException {
     this.release = release;
   }
 
+  /** @hide */
   public FirebaseAppDistributionException(
       @NonNull String message, @NonNull Status status, @NonNull Throwable cause) {
     this(message, status, null, cause);
   }
 
+  /** @hide */
   public FirebaseAppDistributionException(
       @NonNull String message,
       @NonNull Status status,


### PR DESCRIPTION
The constructors need to be public, because they are called from other packages (i.e. internal/impl).
But there is no reason for customers to create these exceptions themselves.
So having them show up in JavaDoc is confusing and not helpful.