### PR TITLE
Add @Retention to TopicOperation.TopicOperations annotation.

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmExecutors.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmExecutors.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 class FcmExecutors {
   // TODO(b/117848373): TikTok applications need to comply with go/tiktok-tattletale. Before we
   // migrate to use TikTok thread pools, threads need to use the whitelisted prefix
-  // "Firebase-Messaing".
+  // "Firebase-Messaging".
   private static final String THREAD_NETWORK_IO = "Firebase-Messaging-Network-Io";
   private static final String THREAD_TASK = "Firebase-Messaging-Task";
   private static final String THREAD_FILE = "Firebase-Messaging-File";

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/TopicOperation.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/TopicOperation.java
@@ -22,6 +22,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringDef;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.internal.Objects;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.regex.Pattern;
 
 final class TopicOperation {
@@ -117,6 +119,7 @@ final class TopicOperation {
   }
 
   @StringDef({TopicOperations.OPERATION_SUBSCRIBE, TopicOperations.OPERATION_UNSUBSCRIBE})
+  @Retention(RetentionPolicy.SOURCE)
   @interface TopicOperations {
     String OPERATION_SUBSCRIBE = "S";
     String OPERATION_UNSUBSCRIBE = "U";


### PR DESCRIPTION
https://github.com/firebase/firebase-android-sdk/issues/3740
* Added @Retention(RetentionPolicy.SOURCE) to TopicOperation.TopicOperations annotation declaration to avoid having it included in the library.
* Also fixed a typo in FcmExecutors.