### PR TITLE
Fireperf: significantly simplify android instrumentation tests

### DIFF
--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
@@ -29,7 +29,6 @@ import androidx.test.filters.MediumTest;
 import com.google.firebase.testing.fireperf.ui.fast.FastFragment;
 import com.google.firebase.testing.fireperf.ui.home.HomeFragment;
 import com.google.firebase.testing.fireperf.ui.slow.SlowFragment;
-import java.util.Arrays;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,7 +53,7 @@ public class FirebasePerformanceFragmentScreenTracesTest {
     scrollRecyclerViewToEnd(FastFragment.NUM_LIST_ITEMS, R.id.rv_numbers_fast);
     scenario.onActivity(new NavigateAction(R.id.navigation_slow));
     scrollRecyclerViewToEnd(SlowFragment.NUM_LIST_ITEMS, R.id.rv_numbers_slow);
-    assertThat(scenario.getState()).isIn(Arrays.asList(State.RESUMED));
+    assertThat(scenario.getState()).isEqualTo(State.RESUMED);
     scenario.moveToState(State.STARTED).moveToState(State.CREATED);
 
     // End Activity screen trace by relaunching the activity to ensure the screen trace is sent.

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java
@@ -18,10 +18,9 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
-import android.content.Intent;
-import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.filters.MediumTest;
-import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnit4;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,16 +36,13 @@ public class FirebasePerformanceScreenTracesTest {
   private static final int LAUNCH_TIMEOUT = 5000;
 
   @Rule
-  public ActivityTestRule<FirebasePerfScreenTracesActivity> activityRule =
-      new ActivityTestRule<>(
-          FirebasePerfScreenTracesActivity.class,
-          /* initialTouchMode= */ false,
-          /* launchActivity= */ true);
+  public ActivityScenarioRule<FirebasePerfScreenTracesActivity> activityRule =
+      new ActivityScenarioRule<>(FirebasePerfScreenTracesActivity.class);
 
   @Test
   public void scrollRecyclerViewToEnd() {
-    RecyclerView recyclerView = activityRule.getActivity().findViewById(R.id.rv_numbers);
-    int itemCount = recyclerView.getAdapter().getItemCount();
+    ActivityScenario scenario = activityRule.getScenario();
+    int itemCount = FirebasePerfScreenTracesActivity.NUM_LIST_ITEMS;
     int currItemCount = 0;
 
     while (currItemCount < itemCount) {
@@ -54,7 +50,6 @@ public class FirebasePerformanceScreenTracesTest {
       currItemCount += 5;
     }
     // End Activity screen trace by switching to another Activity
-    activityRule.launchActivity(
-        new Intent(activityRule.getActivity(), FirebasePerfScreenTracesActivity.class));
+    scenario.launch(FirebasePerfScreenTracesActivity.class);
   }
 }

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
@@ -49,12 +49,13 @@ public class FirebasePerformanceTest {
   @Test
   public void waitForBothTracesAndNetworkRequestsBatch()
       throws ExecutionException, InterruptedException {
+    final int iterations = 15;
     final List<Future<?>> futureList = new ArrayList<>();
     ActivityScenario scenario = rule.getScenario();
     scenario.onActivity(
         activity -> {
-          futureList.add(FireperfUtils.startTraces(15));
-          futureList.add(FireperfUtils.startNetworkRequests(15));
+          futureList.add(FireperfUtils.startTraces(iterations));
+          futureList.add(FireperfUtils.startNetworkRequests(iterations));
         });
     for (Future<?> future : futureList) {
       future.get();

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
@@ -54,8 +54,8 @@ public class FirebasePerformanceTest {
     ActivityScenario scenario = rule.getScenario();
     scenario.onActivity(
         activity -> {
-          futureList.add(FireperfUtils.startTraces(iterations));
-          futureList.add(FireperfUtils.startNetworkRequests(iterations));
+          futureList.add(FireperfUtils.generateTraces(iterations));
+          futureList.add(FireperfUtils.generateNetworkRequests(iterations));
         });
     for (Future<?> future : futureList) {
       future.get();

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FirebasePerfActivity.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FirebasePerfActivity.java
@@ -15,13 +15,6 @@
 package com.google.firebase.testing.fireperf;
 
 import android.app.Activity;
-import android.os.Bundle;
 
 /** Activity used to help end to end testing of FirebasePerformance. */
-public class FirebasePerfActivity extends Activity {
-
-  @Override
-  public void onCreate(Bundle onSavedInstanceState) {
-    super.onCreate(onSavedInstanceState);
-  }
-}
+public class FirebasePerfActivity extends Activity {}

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FirebasePerfActivity.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FirebasePerfActivity.java
@@ -15,53 +15,13 @@
 package com.google.firebase.testing.fireperf;
 
 import android.app.Activity;
-import android.content.Intent;
 import android.os.Bundle;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /** Activity used to help end to end testing of FirebasePerformance. */
 public class FirebasePerfActivity extends Activity {
 
-  public static final String START_TRACES = "START_TRACES";
-  public static final String START_NETWORK_REQUESTS = "START_NETWORK_REQUESTS";
-  public static final String NUMBER_OF_ITERATIONS = "NUMBER_OF_ITERATIONS";
-  public static final String NUMBER_OF_TRACE_ITERATIONS = "NUMBER_OF_TRACE_ITERATIONS";
-  public static final String NUMBER_OF_NETWORK_ITERATIONS = "NUMBER_OF_NETWORK_ITERATIONS";
-
   @Override
   public void onCreate(Bundle onSavedInstanceState) {
     super.onCreate(onSavedInstanceState);
-
-    Intent intent = getIntent();
-
-    int iterations = intent.getIntExtra(NUMBER_OF_ITERATIONS, /* defaultValue= */ 15);
-    int traceIterations = intent.getIntExtra(NUMBER_OF_TRACE_ITERATIONS, /* defaultValue= */ 15);
-    int networkIterations =
-        intent.getIntExtra(NUMBER_OF_NETWORK_ITERATIONS, /* defaultValue= */ 15);
-
-    ExecutorService executorService =
-        new ThreadPoolExecutor(
-            /* corePoolSize= */ 1,
-            /* maximumPoolSize= */ 3,
-            /* keepAliveTime= */ 1,
-            TimeUnit.MINUTES,
-            new LinkedBlockingQueue<>());
-
-    if (intent.getBooleanExtra(START_TRACES, /* defaultValue= */ false)) {
-      executorService.execute(() -> FireperfUtils.startTraces(traceIterations));
-    }
-
-    if (intent.getBooleanExtra(START_NETWORK_REQUESTS, /* defaultValue= */ false)) {
-      executorService.execute(() -> FireperfUtils.startNetworkRequests(networkIterations));
-    }
-
-    // If neither network or trace event is specified in Intent, start both events in sequence.
-    if (!intent.getBooleanExtra(START_TRACES, /* defaultValue= */ false)
-        && !intent.getBooleanExtra(START_NETWORK_REQUESTS, /* defaultValue= */ false)) {
-      executorService.execute(() -> FireperfUtils.startEvents(iterations));
-    }
   }
 }

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FirebasePerfScreenTracesActivity.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FirebasePerfScreenTracesActivity.java
@@ -23,7 +23,7 @@ import androidx.recyclerview.widget.RecyclerView;
 /** This activity displays a ListView which when scrolled generates slow and frozen frames. */
 public class FirebasePerfScreenTracesActivity extends Activity {
 
-  private static final int NUM_LIST_ITEMS = 100;
+  public static final int NUM_LIST_ITEMS = 100;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
@@ -25,18 +25,18 @@ public class FireperfUtils {
   private static final int REQUESTS_PER_ITERATION = 32;
 
   /** Creates all the traces and network requests. */
-  static List<Future<?>> startEvents(final int iterations) {
+  static List<Future<?>> generateEvents(final int iterations) {
     List<Future<?>> futures = new ArrayList<>();
-    futures.add(startTraces(iterations));
-    futures.add(startNetworkRequests(iterations));
+    futures.add(generateTraces(iterations));
+    futures.add(generateNetworkRequests(iterations));
     return futures;
   }
 
-  static Future<?> startTraces(int iterations) {
+  static Future<?> generateTraces(int iterations) {
     return new TraceGenerator().launchTraces(/* totalTraces= */ TRACES_PER_ITERATION, iterations);
   }
 
-  static Future<?> startNetworkRequests(int iterations) {
+  static Future<?> generateNetworkRequests(int iterations) {
     return new NetworkRequestGenerator()
         .launchRequests(/* totalRequests= */ REQUESTS_PER_ITERATION, iterations);
   }

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
@@ -21,6 +21,8 @@ import java.util.concurrent.Future;
 /** A helper class that generates all of the traces and network requests. */
 public class FireperfUtils {
   private static final int MILLIS_IN_SECONDS = 1000;
+  private static final int TRACES_PER_ITERATION = 32;
+  private static final int REQUESTS_PER_ITERATION = 32;
 
   /** Creates all the traces and network requests. */
   static List<Future<?>> startEvents(final int iterations) {
@@ -31,11 +33,12 @@ public class FireperfUtils {
   }
 
   static Future<?> startTraces(int iterations) {
-    return new TraceGenerator().launchTraces(/* totalTraces= */ 32, iterations);
+    return new TraceGenerator().launchTraces(/* totalTraces= */ TRACES_PER_ITERATION, iterations);
   }
 
   static Future<?> startNetworkRequests(int iterations) {
-    return new NetworkRequestGenerator().launchRequests(/* totalRequests= */ 32, iterations);
+    return new NetworkRequestGenerator()
+        .launchRequests(/* totalRequests= */ REQUESTS_PER_ITERATION, iterations);
   }
 
   /**

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
@@ -33,12 +33,12 @@ public class FireperfUtils {
   }
 
   static Future<?> generateTraces(int iterations) {
-    return new TraceGenerator().launchTraces(/* totalTraces= */ TRACES_PER_ITERATION, iterations);
+    return new TraceGenerator().generateTraces(/* totalTraces= */ TRACES_PER_ITERATION, iterations);
   }
 
   static Future<?> generateNetworkRequests(int iterations) {
     return new NetworkRequestGenerator()
-        .launchRequests(/* totalRequests= */ REQUESTS_PER_ITERATION, iterations);
+        .generateRequests(/* totalRequests= */ REQUESTS_PER_ITERATION, iterations);
   }
 
   /**

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
@@ -14,62 +14,28 @@
 
 package com.google.firebase.testing.fireperf;
 
-import android.util.Log;
-import java.util.concurrent.Executors;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
 
 /** A helper class that generates all of the traces and network requests. */
 public class FireperfUtils {
-
-  private static final String LOG_TAG = FireperfUtils.class.getSimpleName();
   private static final int MILLIS_IN_SECONDS = 1000;
-  private static final int MAX_SEMAPHORE_PERMITS = 2;
-  private static final Semaphore SEMAPHORE = new Semaphore(MAX_SEMAPHORE_PERMITS);
 
   /** Creates all the traces and network requests. */
-  static void startEvents(final int iterations) {
-    if (SEMAPHORE.availablePermits() < MAX_SEMAPHORE_PERMITS) {
-      return;
-    }
-
-    final TraceGenerator traceGenerator = new TraceGenerator(SEMAPHORE);
-    final NetworkRequestGenerator networkRequestGenerator = new NetworkRequestGenerator(SEMAPHORE);
-
-    @SuppressWarnings("FutureReturnValueIgnored")
-    Future<?> unusedFuture =
-        Executors.newSingleThreadExecutor()
-            .submit(
-                () -> {
-                  try {
-                    traceGenerator.launchTraces(/* totalTraces= */ 32, iterations).get();
-                    networkRequestGenerator
-                        .launchRequests(/* totalRequests= */ 32, iterations)
-                        .get();
-                  } catch (Exception e) {
-                    Log.e(LOG_TAG, e.getMessage(), e);
-                  }
-                });
+  static List<Future<?>> startEvents(final int iterations) {
+    List<Future<?>> futures = new ArrayList<>();
+    futures.add(startTraces(iterations));
+    futures.add(startNetworkRequests(iterations));
+    return futures;
   }
 
-  static void startTraces(int iterations) {
-    if (SEMAPHORE.availablePermits() < 1) {
-      return;
-    }
-
-    @SuppressWarnings("FutureReturnValueIgnored")
-    Future<?> unusedTraceFuture =
-        new TraceGenerator(SEMAPHORE).launchTraces(/* totalTraces= */ 32, iterations);
+  static Future<?> startTraces(int iterations) {
+    return new TraceGenerator().launchTraces(/* totalTraces= */ 32, iterations);
   }
 
-  static void startNetworkRequests(int iterations) {
-    if (SEMAPHORE.availablePermits() < 1) {
-      return;
-    }
-
-    @SuppressWarnings("FutureReturnValueIgnored")
-    Future<?> unusedNetworkFuture =
-        new NetworkRequestGenerator(SEMAPHORE).launchRequests(/* totalRequests= */ 32, iterations);
+  static Future<?> startNetworkRequests(int iterations) {
+    return new NetworkRequestGenerator().launchRequests(/* totalRequests= */ 32, iterations);
   }
 
   /**
@@ -98,14 +64,5 @@ public class FireperfUtils {
         (float) (Math.sqrt(-2 * Math.log(randomValue1)) * Math.cos(2 * Math.PI * randomValue2));
 
     return mean + (deviation * gaussianValue);
-  }
-
-  /**
-   * Tries to acquire all allocated semaphore permits, and blocks the thread until they are all
-   * available.
-   */
-  public static void blockUntilAllEventsSent() throws InterruptedException {
-    SEMAPHORE.acquire(MAX_SEMAPHORE_PERMITS);
-    SEMAPHORE.release(MAX_SEMAPHORE_PERMITS);
   }
 }

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/NetworkRequestGenerator.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/NetworkRequestGenerator.java
@@ -25,7 +25,6 @@ import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -59,18 +58,13 @@ public class NetworkRequestGenerator {
   private static final ImmutableList<Integer> STATUS_CODES =
       ImmutableList.of(200, 201, 300, 400, 502, 503, 504);
 
-  private final Semaphore sem;
   private final Random rand;
-  private boolean isSemaphoreAcquired;
 
-  NetworkRequestGenerator(Semaphore sem) {
-    this.sem = sem;
+  NetworkRequestGenerator() {
     this.rand = new Random();
   }
 
   Future<?> launchRequests(final int totalRequests, final int totalSets) {
-    isSemaphoreAcquired = sem.tryAcquire();
-
     return Executors.newSingleThreadExecutor()
         .submit(
             () -> {
@@ -113,10 +107,6 @@ public class NetworkRequestGenerator {
                 } catch (Exception e) {
                   Log.e(LOG_TAG, e.getMessage());
                 }
-              }
-
-              if (isSemaphoreAcquired) {
-                sem.release();
               }
             });
   }

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/NetworkRequestGenerator.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/NetworkRequestGenerator.java
@@ -64,7 +64,7 @@ public class NetworkRequestGenerator {
     this.rand = new Random();
   }
 
-  Future<?> launchRequests(final int totalRequests, final int totalSets) {
+  Future<?> generateRequests(final int totalRequests, final int totalSets) {
     return Executors.newSingleThreadExecutor()
         .submit(
             () -> {

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/SlowListAdapter.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/SlowListAdapter.java
@@ -30,6 +30,7 @@ public class SlowListAdapter extends ListAdapter {
 
   @Override
   public void onBindViewHolder(@NotNull NumberViewHolder holder, int position) {
+    // sleep thread to simulate jank
     try {
       if (position % 15 == 0) {
         Thread.sleep(900);
@@ -40,6 +41,6 @@ public class SlowListAdapter extends ListAdapter {
       Log.e(LOG_TAG, e.getMessage(), e);
     }
 
-    holder.bind(position);
+    super.onBindViewHolder(holder, position);
   }
 }

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/TraceGenerator.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/TraceGenerator.java
@@ -32,7 +32,7 @@ public class TraceGenerator {
   private static final int TRACE_MEAN_DURATION = 3;
   private static final float TRACE_DURATION_STD_DEVIATION = .3f;
 
-  Future<?> launchTraces(final int totalTraces, final int totalSets) {
+  Future<?> generateTraces(final int totalTraces, final int totalSets) {
     return Executors.newSingleThreadExecutor()
         .submit(
             () -> {

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/TraceGenerator.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/TraceGenerator.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.Semaphore;
 
 /** Generates traces with all the appropriate information. */
 public class TraceGenerator {
@@ -33,16 +32,7 @@ public class TraceGenerator {
   private static final int TRACE_MEAN_DURATION = 3;
   private static final float TRACE_DURATION_STD_DEVIATION = .3f;
 
-  private final Semaphore sem;
-  private boolean isSemaphoreAcquired;
-
-  TraceGenerator(Semaphore sem) {
-    this.sem = sem;
-  }
-
   Future<?> launchTraces(final int totalTraces, final int totalSets) {
-    isSemaphoreAcquired = sem.tryAcquire();
-
     return Executors.newSingleThreadExecutor()
         .submit(
             () -> {
@@ -77,10 +67,6 @@ public class TraceGenerator {
                 for (TraceHolder traceHolder : traceHolderList) {
                   traceHolder.stopTrace();
                 }
-              }
-
-              if (isSemaphoreAcquired) {
-                sem.release();
               }
             });
   }


### PR DESCRIPTION
This PR addresses some problems with E2E test app setup:
1. Removes unnecessary `block` and `notify` (because `Espresso`/`ActivityScenario` methods like `onView` `onActivity` [already wait for main thread to be idle before running](https://g3doc.corp.google.com/java/com/google/android/apps/searchlite/g3doc/testing/deflake_playbook.md?cl=head#unnecessary-espressoonidle-before-onviewondata)) 
2. Removes semaphores (which had a race condition b/231739863), and use `Future` instead
3. Simplify `FirebasePerformanceTest.waitForBothTracesAndNetworkRequestsBatch` and `FireperfUtils` by a lot. Previous code had executors calling executors calling executors...only one is enough. Without this, `Future` is enough, which means no `Semaphore` or `CountDownLatch` needed. `Future` is a lot less error-prone and a lot more abstracted than handling async manually with `Semaphore` or `CountDownLatch`. 
4. `ActivityTestRule` is deprecated, moved all tests to use the newer `ActivityScenarioRule`.
