### PR TITLE
Refactor FID logic into FirebaseAppDistributionTesterApiClient

### DIFF
--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation project(':firebase-components')
     implementation project(':firebase-installations-interop')
     implementation project(':firebase-common')
+    testImplementation project(path: ':firebase-appdistribution')
     runtimeOnly project(':firebase-installations')
 
     testImplementation 'junit:junit:4.13.2'

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ErrorMessages.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ErrorMessages.java
@@ -15,7 +15,7 @@
 package com.google.firebase.appdistribution.impl;
 
 class ErrorMessages {
-  static final String NETWORK_ERROR = "Failed to fetch releases due to unknown network error.";
+  static final String NETWORK_ERROR = "Request failed with unknown network error.";
 
   static final String JSON_PARSING_ERROR =
       "Error parsing service response when checking for new release. This was most likely due to a transient condition and may be corrected by retrying.";
@@ -32,7 +32,7 @@ class ErrorMessages {
       "Release not found. An update was not available for the current tester and app. Make sure that FirebaseAppDistribution#checkForNewRelease returns with a non-null  AppDistributionRelease before calling FirebaseAppDistribution#updateApp";
 
   static final String TIMEOUT_ERROR =
-      "Failed to fetch releases due to timeout. Check the tester's internet connection and try again.";
+      "Request timed out. Check the tester's internet connection and try again.";
 
   static final String UPDATE_CANCELED = "Tester canceled the update.";
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
@@ -70,7 +70,7 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
             firebaseApp,
             new TesterSignInManager(firebaseApp, firebaseInstallationsApiProvider, signInStorage),
             new NewReleaseFetcher(
-                firebaseApp, testerApiClient, firebaseInstallationsApiProvider, apkHashExtractor),
+                firebaseApp.getApplicationContext(), testerApiClient, apkHashExtractor),
             new ApkUpdater(firebaseApp, new ApkInstaller()),
             new AabUpdater(),
             signInStorage,

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
@@ -61,7 +61,7 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
         container.getProvider(FirebaseInstallationsApi.class);
     SignInStorage signInStorage = new SignInStorage(context);
     FirebaseAppDistributionTesterApiClient testerApiClient =
-        new FirebaseAppDistributionTesterApiClient();
+        new FirebaseAppDistributionTesterApiClient(firebaseApp, firebaseInstallationsApiProvider);
     FirebaseAppDistributionLifecycleNotifier lifecycleNotifier =
         FirebaseAppDistributionLifecycleNotifier.getInstance();
     ApkHashExtractor apkHashExtractor = new ApkHashExtractor(firebaseApp.getApplicationContext());

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
@@ -114,40 +114,6 @@ class FirebaseAppDistributionTesterApiClient {
         });
   }
 
-  /**
-   * Fetches and returns the name of the installed release given the hash of the installed APK, or
-   * null if it could not be found.
-   */
-  @NonNull
-  Task<String> findReleaseUsingApkHash(String apkHash) {
-    return Tasks.forException(
-        new FirebaseAppDistributionException("Not implemented", Status.UNKNOWN));
-  }
-
-  /**
-   * Fetches and returns the name of the installed release given the IAS artifact ID of the
-   * installed app bundle, or null if it could not be found.
-   */
-  @NonNull
-  Task<String> findReleaseUsingIasArtifactId(String iasArtifactId) {
-    return Tasks.forException(
-        new FirebaseAppDistributionException("Not implemented", Status.UNKNOWN));
-  }
-
-  /** Creates a new feedback from the given text, and returns the feedback name. */
-  @NonNull
-  Task<String> createFeedback(String testerReleaseName, String feedbackText) {
-    return Tasks.forException(
-        new FirebaseAppDistributionException("Not implemented", Status.UNKNOWN));
-  }
-
-  /** Commits the feedback with the given name. */
-  @NonNull
-  Task<Void> commitFeedback(String feedbackName) {
-    return Tasks.forException(
-        new FirebaseAppDistributionException("Not implemented", Status.UNKNOWN));
-  }
-
   private String readResponse(HttpsURLConnection connection)
       throws FirebaseAppDistributionException {
     int responseCode;
@@ -163,14 +129,10 @@ class FirebaseAppDistributionTesterApiClient {
         connection.disconnect();
       }
     }
-
-    LogWrapper.getInstance().v("Response code: " + responseCode);
-    LogWrapper.getInstance().v("Response body: " + responseBody);
-
+    LogWrapper.getInstance().v(String.format("Response (%d): %s", responseCode, responseBody));
     if (!isResponseSuccess(responseCode)) {
       throw getExceptionForHttpResponse(responseCode);
     }
-
     return responseBody;
   }
 

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/AabUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/AabUpdaterTest.java
@@ -67,7 +67,7 @@ public class AabUpdaterTest {
 
   private AabUpdater aabUpdater;
   private ShadowActivity shadowActivity;
-  private static ExecutorService testExecutor;
+  private ExecutorService testExecutor;
   @Mock private HttpsURLConnection mockHttpsUrlConnection;
   @Mock private HttpsUrlConnectionFactory mockHttpsUrlConnectionFactory;
   @Mock private FirebaseAppDistributionLifecycleNotifier mockLifecycleNotifier;

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/AabUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/AabUpdaterTest.java
@@ -55,7 +55,6 @@ import org.robolectric.shadows.ShadowActivity;
 public class AabUpdaterTest {
   private static final String TEST_URL = "https://test-url";
   private static final String REDIRECT_TO_PLAY = "https://redirect-to-play-url";
-  private static final ExecutorService testExecutor = Executors.newSingleThreadExecutor();
 
   private static final AppDistributionReleaseInternal TEST_RELEASE_NEWER_AAB_INTERNAL =
       AppDistributionReleaseInternal.builder()
@@ -68,6 +67,7 @@ public class AabUpdaterTest {
 
   private AabUpdater aabUpdater;
   private ShadowActivity shadowActivity;
+  private static ExecutorService testExecutor;
   @Mock private HttpsURLConnection mockHttpsUrlConnection;
   @Mock private HttpsUrlConnectionFactory mockHttpsUrlConnectionFactory;
   @Mock private FirebaseAppDistributionLifecycleNotifier mockLifecycleNotifier;
@@ -81,6 +81,7 @@ public class AabUpdaterTest {
 
     FirebaseApp.clearInstancesForTest();
 
+    testExecutor = Executors.newSingleThreadExecutor();
     activity = Robolectric.buildActivity(TestActivity.class).create().get();
     shadowActivity = shadowOf(activity);
 
@@ -151,6 +152,7 @@ public class AabUpdaterTest {
     updateTask.addOnProgressListener(testExecutor, progressEvents::add);
     awaitAsyncOperations(testExecutor);
 
+    // Task is not completed in this case, because app is expected to terminate during update
     assertThat(shadowActivity.getNextStartedActivity().getData())
         .isEqualTo(Uri.parse(REDIRECT_TO_PLAY));
     assertEquals(1, progressEvents.size());

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java
@@ -95,7 +95,7 @@ public class NewReleaseFetcherTest {
             new NewReleaseFetcher(
                 ApplicationProvider.getApplicationContext(),
                 mockFirebaseAppDistributionTesterApiClient,
-    mockApkHashExtractor));
+                mockApkHashExtractor));
   }
 
   @Test

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java
@@ -18,18 +18,12 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.appdistribution.BinaryType.APK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
-import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.os.Bundle;
@@ -37,15 +31,10 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.core.content.pm.ApplicationInfoBuilder;
 import androidx.test.core.content.pm.PackageInfoBuilder;
 import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.FirebaseOptions;
 import com.google.firebase.appdistribution.BinaryType;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
-import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
-import com.google.firebase.inject.Provider;
-import com.google.firebase.installations.FirebaseInstallationsApi;
-import com.google.firebase.installations.InstallationTokenResult;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.junit.Before;
@@ -58,11 +47,7 @@ import org.robolectric.shadows.ShadowPackageManager;
 
 @RunWith(RobolectricTestRunner.class)
 public class NewReleaseFetcherTest {
-  private static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
-  private static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
-  private static final String TEST_PROJECT_ID = "777777777777";
-  private static final String TEST_FID_1 = "cccccccccccccccccccccc";
-  private static final String TEST_AUTH_TOKEN = "fad.auth.token";
+
   private static final String TEST_IAS_ARTIFACT_ID = "ias-artifact-id";
   private static final String IAS_ARTIFACT_ID_KEY = "com.android.vending.internal.apk.id";
   private static final String NEW_CODEHASH = "abcdef";
@@ -74,12 +59,8 @@ public class NewReleaseFetcherTest {
 
   private NewReleaseFetcher newReleaseFetcher;
   private ShadowPackageManager shadowPackageManager;
-  private Context applicationContext;
 
-  @Mock private Provider<FirebaseInstallationsApi> mockFirebaseInstallationsProvider;
-  @Mock private FirebaseInstallationsApi mockFirebaseInstallations;
   @Mock private FirebaseAppDistributionTesterApiClient mockFirebaseAppDistributionTesterApiClient;
-  @Mock private InstallationTokenResult mockInstallationTokenResult;
   @Mock private ApkHashExtractor mockApkHashExtractor;
 
   Executor testExecutor = Executors.newSingleThreadExecutor();
@@ -88,27 +69,8 @@ public class NewReleaseFetcherTest {
   public void setup() throws FirebaseAppDistributionException {
     MockitoAnnotations.initMocks(this);
 
-    FirebaseApp.clearInstancesForTest();
-
-    FirebaseApp firebaseApp =
-        FirebaseApp.initializeApp(
-            ApplicationProvider.getApplicationContext(),
-            new FirebaseOptions.Builder()
-                .setApplicationId(TEST_APP_ID_1)
-                .setProjectId(TEST_PROJECT_ID)
-                .setApiKey(TEST_API_KEY)
-                .build());
-
-    when(mockFirebaseInstallationsProvider.get()).thenReturn(mockFirebaseInstallations);
-    when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
-    when(mockFirebaseInstallations.getToken(false))
-        .thenReturn(Tasks.forResult(mockInstallationTokenResult));
-
-    when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
-
     shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
-    applicationContext = ApplicationProvider.getApplicationContext();
 
     ApplicationInfo applicationInfo =
         ApplicationInfoBuilder.newBuilder()
@@ -131,22 +93,17 @@ public class NewReleaseFetcherTest {
     newReleaseFetcher =
         spy(
             new NewReleaseFetcher(
-                firebaseApp,
+                ApplicationProvider.getApplicationContext(),
                 mockFirebaseAppDistributionTesterApiClient,
-                mockFirebaseInstallationsProvider,
-                mockApkHashExtractor,
-                testExecutor));
+    mockApkHashExtractor));
   }
 
   @Test
-  public void checkForNewRelease_whenCalled_getsFidAndAuthToken() {
-    newReleaseFetcher.checkForNewRelease();
-    verify(mockFirebaseInstallations, times(1)).getId();
-    verify(mockFirebaseInstallations, times(1)).getToken(false);
-  }
+  public void checkForNewRelease_whenCalledMultipleTimes_returnsTheSameTask() {
+    // Start a new task completion source and do not complete it, to mimic an in progress task
+    TaskCompletionSource<AppDistributionReleaseInternal> task = new TaskCompletionSource<>();
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease()).thenReturn(task.getTask());
 
-  @Test
-  public void checkForNewReleaseTask_whenCalledMultipleTimes_returnsTheSameTask() {
     Task<AppDistributionReleaseInternal> checkForNewReleaseTask1 =
         newReleaseFetcher.checkForNewRelease();
     Task<AppDistributionReleaseInternal> checkForNewReleaseTask2 =
@@ -157,9 +114,8 @@ public class NewReleaseFetcherTest {
 
   @Test
   public void checkForNewRelease_succeeds() throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            any(), any(), any(), any(), any()))
-        .thenReturn(getTestNewRelease().build());
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease())
+        .thenReturn(Tasks.forResult(getTestNewRelease().build()));
 
     TestOnCompleteListener<AppDistributionReleaseInternal> onCompleteListener =
         new TestOnCompleteListener<>();
@@ -168,138 +124,66 @@ public class NewReleaseFetcherTest {
 
     AppDistributionReleaseInternal appDistributionReleaseInternal = onCompleteListener.await();
     assertEquals(getTestNewRelease().build(), appDistributionReleaseInternal);
-    verify(mockFirebaseInstallations, times(1)).getId();
-    verify(mockFirebaseInstallations, times(1)).getToken(false);
   }
 
   @Test
-  public void checkForNewRelease_fisFailure() throws Exception {
-    Exception expectedException = new Exception("test ex");
-    when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forException(expectedException));
-
-    TestOnCompleteListener<AppDistributionReleaseInternal> onCompleteListener =
-        new TestOnCompleteListener<>();
-    Task<AppDistributionReleaseInternal> task = newReleaseFetcher.checkForNewRelease();
-    task.addOnCompleteListener(testExecutor, onCompleteListener);
-
-    FirebaseAppDistributionException actualException =
-        assertThrows(FirebaseAppDistributionException.class, onCompleteListener::await);
-
-    assertThat(actualException).hasMessageThat().contains(ErrorMessages.UNKNOWN_ERROR);
-    assertThat(actualException).hasMessageThat().contains("test ex");
-    assertThat(actualException.getErrorCode()).isEqualTo(Status.UNKNOWN);
-    assertThat(actualException).hasCauseThat().isEqualTo(expectedException);
-  }
-
-  @Test
-  public void checkForNewRelease_uncaughtExceptionFailure() throws Exception {
-    RuntimeException expectedException = new RuntimeException("test ex");
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            any(), any(), any(), any(), any()))
-        .thenThrow(expectedException);
-
-    TestOnCompleteListener<AppDistributionReleaseInternal> onCompleteListener =
-        new TestOnCompleteListener<>();
-    Task<AppDistributionReleaseInternal> task = newReleaseFetcher.checkForNewRelease();
-    task.addOnCompleteListener(testExecutor, onCompleteListener);
-
-    FirebaseAppDistributionException actualException =
-        assertThrows(FirebaseAppDistributionException.class, onCompleteListener::await);
-
-    assertThat(actualException).hasMessageThat().contains(ErrorMessages.UNKNOWN_ERROR);
-    assertThat(actualException).hasMessageThat().contains("test ex");
-    assertThat(actualException.getErrorCode()).isEqualTo(Status.UNKNOWN);
-    assertThat(actualException).hasCauseThat().isEqualTo(expectedException);
-  }
-
-  @Test
-  public void checkForNewRelease_appDistroFailure() throws Exception {
+  public void checkForNewRelease_apiClientFailure() {
     FirebaseAppDistributionException expectedException =
         new FirebaseAppDistributionException(
             "test", FirebaseAppDistributionException.Status.UNKNOWN);
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            any(), any(), any(), any(), any()))
-        .thenThrow(expectedException);
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease())
+        .thenReturn(Tasks.forException(expectedException));
 
-    TestOnCompleteListener<AppDistributionReleaseInternal> onCompleteListener =
-        new TestOnCompleteListener<>();
     Task<AppDistributionReleaseInternal> task = newReleaseFetcher.checkForNewRelease();
-    task.addOnCompleteListener(testExecutor, onCompleteListener);
 
-    FirebaseAppDistributionException actualException =
-        assertThrows(FirebaseAppDistributionException.class, onCompleteListener::await);
-
-    assertEquals(expectedException, actualException);
+    assertThat(task.isSuccessful()).isFalse();
+    assertThat(task.getException()).isEqualTo(expectedException);
   }
 
   @Test
-  public void getNewReleaseFromClient_whenNewReleaseIsNewerBuildThanInstalled_returnsRelease()
-      throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext))
-        .thenReturn(getTestNewRelease().build());
+  public void checkForNewRelease_whenNewReleaseIsSameRelease_returnsNull() {
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease())
+        .thenReturn(Tasks.forResult(getTestInstalledRelease().build()));
 
-    AppDistributionReleaseInternal release =
-        newReleaseFetcher.getNewReleaseFromClient(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    Task<AppDistributionReleaseInternal> releaseTask = newReleaseFetcher.checkForNewRelease();
 
-    assertNotNull(release);
-    assertEquals(Long.toString(NEW_VERSION_CODE), release.getBuildVersion());
+    assertThat(releaseTask.getResult()).isNull();
   }
 
   @Test
-  public void getNewReleaseFromClient_whenNewReleaseIsSameRelease_returnsNull() throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext))
-        .thenReturn(getTestInstalledRelease().build());
-
-    AppDistributionReleaseInternal release =
-        newReleaseFetcher.getNewReleaseFromClient(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
-
-    assertNull(release);
-  }
-
-  @Test
-  public void getNewReleaseFromClient_whenNewReleaseIsLowerVersionCode_returnsNull()
-      throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN, applicationContext))
+  public void checkForNewRelease_whenNewReleaseIsLowerVersionCode_returnsNull() {
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease())
         .thenReturn(
-            getTestInstalledRelease()
-                .setBuildVersion(Long.toString(INSTALLED_VERSION_CODE - 1))
-                .build());
+            Tasks.forResult(
+                getTestInstalledRelease()
+                    .setBuildVersion(Long.toString(INSTALLED_VERSION_CODE - 1))
+                    .build()));
 
-    AppDistributionReleaseInternal release =
-        newReleaseFetcher.getNewReleaseFromClient(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    Task<AppDistributionReleaseInternal> releaseTask = newReleaseFetcher.checkForNewRelease();
 
-    assertNull(release);
+    assertThat(releaseTask.isSuccessful()).isTrue();
+    assertThat(releaseTask.getResult()).isNull();
   }
 
   @Test
-  public void handleNewReleaseFromClient_whenNewAabIsAvailable_returnsRelease() throws Exception {
+  public void checkForNewRelease_whenNewAabIsAvailable_returnsRelease() {
     AppDistributionReleaseInternal expectedRelease =
         getTestNewRelease()
             .setDownloadUrl("http://fake-download-url")
             .setIasArtifactId("test-ias-artifact-id-2")
             .setBinaryType(BinaryType.AAB)
             .build();
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            any(), any(), any(), any(), any()))
-        .thenReturn(expectedRelease);
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease())
+        .thenReturn(Tasks.forResult(expectedRelease));
 
-    AppDistributionReleaseInternal result =
-        newReleaseFetcher.getNewReleaseFromClient(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
+    Task<AppDistributionReleaseInternal> result = newReleaseFetcher.checkForNewRelease();
 
-    assertEquals(expectedRelease, result);
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResult()).isEqualTo(expectedRelease);
   }
 
   @Test
-  public void
-      handleNewReleaseFromClient_whenNewReleaseHasDifferentVersionNameThanInstalled_returnsRelease()
-          throws Exception {
+  public void checkForNewRelease_differentVersionNameThanInstalled_returnsRelease() {
     AppDistributionReleaseInternal expectedRelease =
         getTestNewRelease()
             .setDownloadUrl("http://fake-download-url")
@@ -307,36 +191,34 @@ public class NewReleaseFetcherTest {
             .setBinaryType(BinaryType.AAB)
             .setDisplayVersion("2.0")
             .build();
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            any(), any(), any(), any(), any()))
-        .thenReturn(expectedRelease);
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease())
+        .thenReturn(Tasks.forResult(expectedRelease));
 
-    AppDistributionReleaseInternal result =
-        newReleaseFetcher.getNewReleaseFromClient(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
-    assertEquals(expectedRelease, result);
+    Task<AppDistributionReleaseInternal> result = newReleaseFetcher.checkForNewRelease();
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResult()).isEqualTo(expectedRelease);
   }
 
   @Test
-  public void handleNewReleaseFromClient_whenNewReleaseIsSameAsInstalledAab_returnsNull()
-      throws Exception {
-    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease(
-            any(), any(), any(), any(), any()))
+  public void handleNewReleaseFromClient_whenNewReleaseIsSameAsInstalledAab_returnsNull() {
+    when(mockFirebaseAppDistributionTesterApiClient.fetchNewRelease())
         .thenReturn(
-            getTestInstalledRelease()
-                .setDownloadUrl("http://fake-download-url")
-                .setIasArtifactId(TEST_IAS_ARTIFACT_ID)
-                .setBinaryType(BinaryType.AAB)
-                .build());
+            Tasks.forResult(
+                getTestInstalledRelease()
+                    .setDownloadUrl("http://fake-download-url")
+                    .setIasArtifactId(TEST_IAS_ARTIFACT_ID)
+                    .setBinaryType(BinaryType.AAB)
+                    .build()));
 
-    AppDistributionReleaseInternal result =
-        newReleaseFetcher.getNewReleaseFromClient(
-            TEST_FID_1, TEST_APP_ID_1, TEST_API_KEY, TEST_AUTH_TOKEN);
-    assertNull(result);
+    Task<AppDistributionReleaseInternal> result = newReleaseFetcher.checkForNewRelease();
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getResult()).isNull();
   }
 
   @Test
-  public void iisSameAsInstalledRelease_whenApkHashesEqual_returnsTrue()
+  public void isSameAsInstalledRelease_whenApkHashesEqual_returnsTrue()
       throws FirebaseAppDistributionException {
     assertTrue(newReleaseFetcher.isSameAsInstalledRelease(getTestInstalledRelease().build()));
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
@@ -27,7 +27,6 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException.Stat
 import com.google.firebase.appdistribution.impl.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import junit.framework.AssertionFailedError;
 import org.mockito.stubbing.Answer;
 
 final class TestUtils {
@@ -50,18 +49,9 @@ final class TestUtils {
     assertThat(task.getException()).hasCauseThat().isEqualTo(cause);
   }
 
-  static void awaitAsyncOperations(ExecutorService executorService) throws AssertionFailedError {
-    // Shut down and await anything enqueued to the executor
-    executorService.shutdown();
-    boolean finished;
-    try {
-      finished = executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
-    } catch (InterruptedException e) {
-      throw new AssertionFailedError("Executor interrupted while awaiting async operations");
-    }
-    if (!finished) {
-      throw new AssertionFailedError("Timed out while awaiting async operations");
-    }
+  static void awaitAsyncOperations(ExecutorService executorService) throws InterruptedException {
+    // Await anything enqueued to the executor
+    executorService.awaitTermination(100, TimeUnit.MILLISECONDS);
 
     // Idle the main looper, which is also running these tests, so any Task or lifecycle callbacks
     // can be handled. See http://robolectric.org/blog/2019/06/04/paused-looper/ for more info.

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
@@ -27,6 +27,7 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException.Stat
 import com.google.firebase.appdistribution.impl.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import junit.framework.AssertionFailedError;
 import org.mockito.stubbing.Answer;
 
 final class TestUtils {
@@ -34,6 +35,7 @@ final class TestUtils {
 
   static FirebaseAppDistributionException assertTaskFailure(
       Task task, Status status, String messageSubstring) {
+    assertThat(task.isComplete()).isTrue();
     assertThat(task.isSuccessful()).isFalse();
     assertThat(task.getException()).isInstanceOf(FirebaseAppDistributionException.class);
     FirebaseAppDistributionException e = (FirebaseAppDistributionException) task.getException();
@@ -48,9 +50,18 @@ final class TestUtils {
     assertThat(task.getException()).hasCauseThat().isEqualTo(cause);
   }
 
-  static void awaitAsyncOperations(ExecutorService executorService) throws InterruptedException {
-    // Await anything enqueued to the executor
-    executorService.awaitTermination(100, TimeUnit.MILLISECONDS);
+  static void awaitAsyncOperations(ExecutorService executorService) throws AssertionFailedError {
+    // Shut down and await anything enqueued to the executor
+    executorService.shutdown();
+    boolean finished;
+    try {
+      finished = executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      throw new AssertionFailedError("Executor interrupted while awaiting async operations");
+    }
+    if (!finished) {
+      throw new AssertionFailedError("Timed out while awaiting async operations");
+    }
 
     // Idle the main looper, which is also running these tests, so any Task or lifecycle callbacks
     // can be handled. See http://robolectric.org/blog/2019/06/04/paused-looper/ for more info.


### PR DESCRIPTION
Refactors the FID/FIS auth token fetching into the API client, since that will be needed by the feedback stuff.