### PR TITLE
Remove MaxPermSize Java Option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=8g
+org.gradle.jvmargs=-Xmx8g
 
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/health-metrics/apk-size/gradle.properties
+++ b/health-metrics/apk-size/gradle.properties
@@ -15,4 +15,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
 
-org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=8g
+org.gradle.jvmargs=-Xmx8g

--- a/smoke-tests/gradle.properties
+++ b/smoke-tests/gradle.properties
@@ -15,4 +15,4 @@
 android.enableR8=true
 android.useAndroidX=true
 
-org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=8g
+org.gradle.jvmargs=-Xmx8g


### PR DESCRIPTION
Removing the `MaxPermSize` option has [it started being ignored in Java8](https://stackoverflow.com/questions/18339707/permgen-elimination-in-jdk-8) and causes Java 17 (and maybe others) to fail with an unrecognized argument error