### PR TITLE
E2e deflake

### DIFF
--- a/firebase-perf/e2e-app/e2e-app.gradle
+++ b/firebase-perf/e2e-app/e2e-app.gradle
@@ -77,11 +77,14 @@ dependencies {
     if (project.hasProperty("fireperfBuildForAutopush")) {
         println("Building with HEAD version ':firebase-perf' of SDK")
         implementation project(":firebase-perf")
-
     } else {
         println("Building with latest public version ':firebase-perf:$latestReleasedVersion' of SDK")
         implementation "com.google.firebase:firebase-perf:$latestReleasedVersion"
     }
+    implementation project(":transport:transport-api")
+    implementation project(":transport:transport-backend-cct")
+    implementation project(":transport:transport-runtime")
+    implementation project(":transport:transport-runtime-testing")
 
     // Google Deps
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
@@ -97,11 +100,13 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment:2.3.5'
     implementation 'androidx.navigation:navigation-ui:2.3.5'
     implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.3.0'
 
     // 3rd party Deps
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
 
     // Integration Test Deps
+    androidTestImplementation project(":firebase-perf")
     androidTestImplementation 'junit:junit:4.13.1'
     androidTestImplementation "androidx.test.ext:junit:1.1.2"
     androidTestImplementation "androidx.test:core:1.3.0"

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.testing.fireperf;
 
+import static androidx.test.espresso.Espresso.onIdle;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -46,7 +47,7 @@ public class FirebasePerformanceFragmentScreenTracesTest {
       new ActivityScenarioRule<>(FirebasePerfFragmentsActivity.class);
 
   @Test
-  public void scrollAndCycleThroughAllFragments() throws InterruptedException {
+  public void scrollAndCycleThroughAllFragments() {
     ActivityScenario scenario = activityRule.getScenario();
     scrollRecyclerViewToEnd(HomeFragment.NUM_LIST_ITEMS, R.id.rv_numbers_home);
     scenario.onActivity(new NavigateAction(R.id.navigation_fast));
@@ -54,10 +55,10 @@ public class FirebasePerformanceFragmentScreenTracesTest {
     scenario.onActivity(new NavigateAction(R.id.navigation_slow));
     scrollRecyclerViewToEnd(SlowFragment.NUM_LIST_ITEMS, R.id.rv_numbers_slow);
     assertThat(scenario.getState()).isEqualTo(State.RESUMED);
-    scenario.moveToState(State.STARTED).moveToState(State.CREATED);
-
-    // End Activity screen trace by relaunching the activity to ensure the screen trace is sent.
-    scenario.launch(FirebasePerfFragmentsActivity.class);
+    scenario.moveToState(State.STARTED).moveToState(State.CREATED); // trigger activity screen trace
+    onIdle();
+    // Block until all Fireperf events are sent by Firelog
+    FireperfUtils.flgForceUploadSync();
   }
 
   private void scrollRecyclerViewToEnd(int itemCount, int viewId) {

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java
@@ -14,10 +14,13 @@
 
 package com.google.firebase.testing.fireperf;
 
+import static androidx.test.espresso.Espresso.onIdle;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.contrib.RecyclerViewActions.scrollToPosition;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static com.google.common.truth.Truth.assertThat;
 
+import androidx.lifecycle.Lifecycle.State;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.filters.MediumTest;
@@ -49,7 +52,10 @@ public class FirebasePerformanceScreenTracesTest {
       onView(withId(R.id.rv_numbers)).perform(scrollToPosition(currItemCount));
       currItemCount += 5;
     }
-    // End Activity screen trace by switching to another Activity
-    scenario.launch(FirebasePerfScreenTracesActivity.class);
+    assertThat(scenario.getState()).isEqualTo(State.RESUMED);
+    scenario.moveToState(State.STARTED).moveToState(State.CREATED); // trigger activity screen trace
+    onIdle();
+    // Block until all Fireperf events are sent by Firelog
+    FireperfUtils.flgForceUploadSync();
   }
 }

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
@@ -65,7 +65,7 @@ public class FirebasePerformanceTest {
   @Test
   public void waitForBothTracesAndNetworkRequestsBatch()
       throws ExecutionException, InterruptedException {
-    final int iterations = 1;
+    final int iterations = 15;
     final List<Future<?>> futureList = new ArrayList<>();
     ActivityScenario scenario = rule.getScenario();
     scenario.onActivity(

--- a/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
+++ b/firebase-perf/e2e-app/src/main/java/com/google/firebase/testing/fireperf/FireperfUtils.java
@@ -14,6 +14,10 @@
 
 package com.google.firebase.testing.fireperf;
 
+import com.google.android.datatransport.Priority;
+import com.google.android.datatransport.cct.CCTDestination;
+import com.google.android.datatransport.runtime.TransportRuntimeTesting;
+import com.google.android.datatransport.runtime.backends.BackendResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
@@ -67,5 +71,13 @@ public class FireperfUtils {
         (float) (Math.sqrt(-2 * Math.log(randomValue1)) * Math.cos(2 * Math.PI * randomValue2));
 
     return mean + (deviation * gaussianValue);
+  }
+
+  /**
+   * Blocks calling thread until all of Fireperf's persisted events are sent by Firelog. Must be
+   * called after events have persisted.
+   */
+  static BackendResponse flgForceUploadSync() {
+    return TransportRuntimeTesting.forceUpload(CCTDestination.LEGACY_INSTANCE, Priority.DEFAULT);
   }
 }

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -107,6 +107,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "androidx.annotation:annotation:1.1.0"
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.3.0'
 
     // 3rd Party Deps
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/FlgTransport.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/FlgTransport.java
@@ -23,6 +23,7 @@ import com.google.android.datatransport.TransportFactory;
 import com.google.firebase.inject.Provider;
 import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.v1.PerfMetric;
+import java.util.concurrent.CountDownLatch;
 
 /** Manages Flg client for dispatching performance events. */
 final class FlgTransport {
@@ -53,7 +54,17 @@ final class FlgTransport {
       return;
     }
 
-    flgTransport.send(Event.ofData(perfMetric));
+    // Block until Firelog persisted logs
+    CountDownLatch latch = new CountDownLatch(1);
+    flgTransport.schedule(
+        Event.ofData(perfMetric),
+        result -> {
+          latch.countDown();
+        });
+    try {
+      latch.await();
+    } catch (Exception ignored) {
+    }
   }
 
   private boolean initializeFlgTransportClient() {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportIdlingResource.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportIdlingResource.java
@@ -1,0 +1,20 @@
+package com.google.firebase.perf.transport;
+
+import androidx.test.espresso.idling.CountingIdlingResource;
+
+public class TransportIdlingResource {
+  private static final CountingIdlingResource idlingResource =
+      new CountingIdlingResource("FIREPERF_TRANSPORT_THREADS");
+
+  public static CountingIdlingResource get() {
+    return idlingResource;
+  }
+
+  public static void increment() {
+    idlingResource.increment();
+  }
+
+  public static void decrement() {
+    idlingResource.decrement();
+  }
+}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/TransportManager.java
@@ -240,6 +240,7 @@ public class TransportManager implements AppStateCallback {
     while (!pendingEventsQueue.isEmpty()) {
       PendingPerfEvent pendingPerfEvent = pendingEventsQueue.poll();
       if (pendingPerfEvent != null) {
+        TransportIdlingResource.increment();
         executorService.execute(
             () -> syncLog(pendingPerfEvent.perfMetricBuilder, pendingPerfEvent.appState));
       }
@@ -294,6 +295,7 @@ public class TransportManager implements AppStateCallback {
    * {@link #isAllowedToDispatch(PerfMetric)}).
    */
   public void log(final TraceMetric traceMetric, final ApplicationProcessState appState) {
+    TransportIdlingResource.increment();
     executorService.execute(
         () -> syncLog(PerfMetric.newBuilder().setTraceMetric(traceMetric), appState));
   }
@@ -322,6 +324,7 @@ public class TransportManager implements AppStateCallback {
    */
   public void log(
       final NetworkRequestMetric networkRequestMetric, final ApplicationProcessState appState) {
+    TransportIdlingResource.increment();
     executorService.execute(
         () ->
             syncLog(
@@ -351,6 +354,7 @@ public class TransportManager implements AppStateCallback {
    * {@link #isAllowedToDispatch(PerfMetric)}).
    */
   public void log(final GaugeMetric gaugeMetric, final ApplicationProcessState appState) {
+    TransportIdlingResource.increment();
     executorService.execute(
         () -> syncLog(PerfMetric.newBuilder().setGaugeMetric(gaugeMetric), appState));
   }
@@ -369,7 +373,7 @@ public class TransportManager implements AppStateCallback {
 
         pendingEventsQueue.add(new PendingPerfEvent(perfMetricBuilder, appState));
       }
-
+      TransportIdlingResource.decrement();
       return;
     }
 
@@ -382,6 +386,7 @@ public class TransportManager implements AppStateCallback {
       //  callback in the SessionManager itself.
       SessionManager.getInstance().updatePerfSessionIfExpired();
     }
+    TransportIdlingResource.decrement();
   }
 
   @WorkerThread


### PR DESCRIPTION
1. Is it possible for `flgForceUploadSync()` to get the `Destination` and `Priority` somewhere so it's not hardcoded?
2. Espresso Idling Resource does add quite a bit of code, I wonder if it's not worth the extra maintenance cost and just use `Thread.sleep()`?