### PR TITLE
added pending intent mutability

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -19,6 +19,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Base64;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.datatransport.runtime.TransportContext;
@@ -74,7 +75,12 @@ public class AlarmManagerScheduler implements WorkScheduler {
 
   @VisibleForTesting
   boolean isJobServiceOn(Intent intent) {
-    return (PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_NO_CREATE) != null);
+    int flags =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+            ? PendingIntent.FLAG_NO_CREATE | PendingIntent.FLAG_IMMUTABLE
+            : PendingIntent.FLAG_NO_CREATE;
+
+    return (PendingIntent.getBroadcast(context, 0, intent, flags) != null);
   }
 
   @Override
@@ -121,7 +127,12 @@ public class AlarmManagerScheduler implements WorkScheduler {
         backendTime,
         attemptNumber);
 
-    PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
+    PendingIntent pendingIntent =
+        PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0);
     this.alarmManager.set(
         AlarmManager.ELAPSED_REALTIME, clock.getTime() + scheduleDelay, pendingIntent);
   }


### PR DESCRIPTION
Fixes #3805.

As stated:
> Android 12 need to specify the [mutability flag](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability) with every PendingIntent. This seems to be missing in the above two lines.

I added the condition to check for version `Build.VERSION_CODES.M` or higher, before setting the `PendingIntent.FLAG_IMMUTABLE` flag. 

This is the same condition checker for other files e.g. `FirebaseMessaging.java` [Line 502](https://github.com/firebase/firebase-android-sdk/blob/8e28b5b1bd38a4356a40e7546290ce857cdd1d0a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java#L502).