### PR TITLE
Ywmei/parallel unit tests

### DIFF
--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -96,10 +96,6 @@ tasks.withType(Test) {
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
-tasks.withType(Test).configureEach {
-    forkEvery = 100
-}
-
 android.libraryVariants.all { variant ->
     if (findProperty("useProdBackendForTests")) {
         variant.buildConfigField("boolean", "USE_EMULATOR_FOR_TESTS", "false")

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -92,6 +92,14 @@ android {
     ext.useProdBackendForTests = false
 }
 
+tasks.withType(Test) {
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}
+
+tasks.withType(Test).configureEach {
+    forkEvery = 100
+}
+
 android.libraryVariants.all { variant ->
     if (findProperty("useProdBackendForTests")) {
         variant.buildConfigField("boolean", "USE_EMULATOR_FOR_TESTS", "false")

--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -48,10 +48,6 @@ tasks.withType(Test) {
     maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
-tasks.withType(Test).configureEach {
-    forkEvery = 100
-}
-
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation project(':firebase-common')

--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -44,6 +44,14 @@ android {
     }
 }
 
+tasks.withType(Test) {
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}
+
+tasks.withType(Test).configureEach {
+    forkEvery = 100
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation project(':firebase-common')


### PR DESCRIPTION
Enable parallel run for unit test for firebase-firestore library
Ref: https://docs.gradle.org/current/userguide/performance.html

1. After [enable the parallel run of the unit test](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution), the 2200+ unit tests' run time can be reduced to 3 mins 25 seconds (current run time is 6 mins 27 seconds) on my cloud top (about 50% improvement).
2. The improvement depends on the number of cores on the CPU. On my i7 PC, the improvement is not significant (from 5 mins 23 seconds to 4 mins 50 seconds).
3. I also tried to [enable a new VM fork per 100 tasks](https://docs.gradle.org/current/userguide/performance.html#forking_options), but the improvement is not significant on neither my cloud top nor my PC, so I didn't include the forking options in this PR.