### PR TITLE
Changing condition statement API version < 26 for log limit

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/logging/Logging.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/logging/Logging.java
@@ -24,7 +24,7 @@ public final class Logging {
   private Logging() {}
 
   private static String getTag(String tag) {
-    if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return concatTag(LOG_PREFIX, tag);
+    if (android.os.Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) return concatTag(LOG_PREFIX, tag);
 
     return LOG_PREFIX + tag;
   }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/logging/Logging.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/logging/Logging.java
@@ -24,7 +24,7 @@ public final class Logging {
   private Logging() {}
 
   private static String getTag(String tag) {
-    if (android.os.Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) return concatTag(LOG_PREFIX, tag);
+    if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return concatTag(LOG_PREFIX, tag);
 
     return LOG_PREFIX + tag;
   }


### PR DESCRIPTION
Previously #3728 which fixes #3716.

Initially, condition checker was for version (API < 24), but now will change to (API < 26).

[Android documentation](https://developer.android.com/reference/android/util/Log#isLoggable(java.lang.String,%20int)):
> `IllegalArgumentException` is thrown if the tag.length() > 23 for Nougat (7.0) and prior releases (API <= 25), there is no tag limit of concern after this API level.