### PR TITLE
Add support for return values to applyToForegroundActivity()

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/AabUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/AabUpdater.java
@@ -97,7 +97,7 @@ class AabUpdater {
       runAsyncInTask(executor, () -> fetchDownloadRedirectUrl(newRelease.getDownloadUrl()))
           .onSuccessTask(
               redirectUrl ->
-                  lifecycleNotifier.applyToForegroundActivity(
+                  lifecycleNotifier.consumeForegroundActivity(
                       activity -> openRedirectUrlInPlay(redirectUrl, activity)))
           .addOnFailureListener(this::setUpdateTaskCompletionError);
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -334,7 +334,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   }
 
   private Task<Void> launchFeedbackActivity(String releaseName, Bitmap screenshot) {
-    return lifecycleNotifier.applyToForegroundActivity(
+    return lifecycleNotifier.consumeForegroundActivity(
         activity -> {
           Intent intent = new Intent(activity, FeedbackActivity.class);
           intent.putExtra(RELEASE_NAME_EXTRA_KEY, releaseName);

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
@@ -145,7 +145,7 @@ class TesterSignInManager {
   }
 
   private Task<Void> getForegroundActivityAndOpenSignInFlow(String fid) {
-    return lifecycleNotifier.applyToForegroundActivity(
+    return lifecycleNotifier.consumeForegroundActivity(
         activity -> {
           // Launch the intent outside of the synchronized block because we don't need to wait
           // for the lock, and we don't want to risk the activity leaving the foreground in

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/AabUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/AabUpdaterTest.java
@@ -14,11 +14,9 @@
 package com.google.firebase.appdistribution.impl;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.firebase.appdistribution.impl.TestUtils.applyToForegroundActivityAnswer;
 import static com.google.firebase.appdistribution.impl.TestUtils.assertTaskFailure;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitAsyncOperations;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 import static org.robolectric.annotation.LooperMode.Mode.PAUSED;
@@ -95,8 +93,7 @@ public class AabUpdaterTest {
         Mockito.spy(
             new AabUpdater(mockLifecycleNotifier, mockHttpsUrlConnectionFactory, testExecutor));
 
-    when(mockLifecycleNotifier.applyToForegroundActivity(any()))
-        .thenAnswer(applyToForegroundActivityAnswer(activity));
+    TestUtils.mockForegroundActivity(mockLifecycleNotifier, activity);
   }
 
   @Test

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
@@ -112,8 +112,7 @@ public class ApkUpdaterTest {
     when(mockFile.length()).thenReturn(TEST_FILE_LENGTH);
     when(mockHttpsUrlConnectionFactory.openConnection(TEST_URL)).thenReturn(mockHttpsUrlConnection);
     when(mockHttpsUrlConnection.getResponseCode()).thenReturn(200);
-    when(mockLifecycleNotifier.applyToForegroundActivityTask(any()))
-        .thenAnswer(TestUtils.applyToForegroundActivityTaskAnswer(activity));
+    TestUtils.mockForegroundActivity(mockLifecycleNotifier, activity);
     onCompleteListener = new TestOnCompleteListener<>();
 
     apkUpdater =

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -167,6 +166,7 @@ public class FirebaseAppDistributionServiceImplTest {
                 mockScreenshotTaker));
 
     when(mockTesterSignInManager.signInTester()).thenReturn(Tasks.forResult(null));
+    when(mockSignInStorage.getSignInStatus()).thenReturn(true);
 
     when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
 
@@ -188,11 +188,7 @@ public class FirebaseAppDistributionServiceImplTest {
     shadowPackageManager.installPackage(packageInfo);
 
     activity = spy(Robolectric.buildActivity(TestActivity.class).create().get());
-    when(mockLifecycleNotifier.applyToForegroundActivityTask(any()))
-        .thenAnswer(TestUtils.applyToForegroundActivityTaskAnswer(activity));
-    when(mockLifecycleNotifier.applyToForegroundActivity(any()))
-        .thenAnswer(TestUtils.applyToForegroundActivityAnswer(activity));
-    when(mockSignInStorage.getSignInStatus()).thenReturn(true);
+    TestUtils.mockForegroundActivity(mockLifecycleNotifier, activity);
 
     when(mockScreenshotTaker.takeScreenshot()).thenReturn(Tasks.forResult(TEST_SCREENSHOT));
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterSignInManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterSignInManagerTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.appdistribution.impl;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.AUTHENTICATION_CANCELED;
-import static com.google.firebase.appdistribution.impl.TestUtils.applyToForegroundActivityAnswer;
 import static com.google.firebase.appdistribution.impl.TestUtils.assertTaskFailure;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -128,9 +127,7 @@ public class TesterSignInManagerTest {
 
     activity = Robolectric.buildActivity(TestActivity.class).create().get();
     shadowActivity = shadowOf(activity);
-
-    when(mockLifecycleNotifier.applyToForegroundActivity(any()))
-        .thenAnswer(applyToForegroundActivityAnswer(activity));
+    TestUtils.mockForegroundActivity(mockLifecycleNotifier, activity);
 
     testerSignInManager =
         new TesterSignInManager(
@@ -154,8 +151,8 @@ public class TesterSignInManagerTest {
   @Test
   public void signInTester_whenUnexpectedFailureInTask_failsWithUnknownError() {
     Exception unexpectedException = new Exception("unexpected exception");
-    // Raise an unexpected exception in our handler passed to applyToForegroundActivity
-    when(mockLifecycleNotifier.applyToForegroundActivity(any()))
+    // Raise an unexpected exception in our handler passed to consumeForegroundActivity
+    when(mockLifecycleNotifier.consumeForegroundActivity(any()))
         .thenAnswer(unused -> Tasks.forException(unexpectedException));
 
     Task signInTask = testerSignInManager.signInTester();


### PR DESCRIPTION
The old `applyToForegroundActivity()` which accepted a `void` callback, is now called `consumeForegroundActivity()`.

Also, adds `TestUtils.mockForegroundActivity()` for mocking all of these types of methods to return a given activity.