### PR TITLE
Remove Android ID check heuristic from isEmulator check.

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
@@ -169,10 +169,10 @@ public class CommonUtilsTest extends CrashlyticsTestCase {
   public void testIsRooted() {
     // No good way to test the alternate case,
     // just want to ensure we can complete the call without an exception here.
-    final boolean isRooted = CommonUtils.isRooted(getContext());
+    final boolean isRooted = CommonUtils.isRooted();
     Log.d(
         Logger.TAG,
-        "isRooted: " + isRooted + " isEmulator: " + CommonUtils.isEmulator(getContext()));
+        "isRooted: " + isRooted + " isEmulator: " + CommonUtils.isEmulator());
 
     // We don't care about the actual result of isRooted, just that we didn't cause an exception
     assertTrue(true);
@@ -192,10 +192,10 @@ public class CommonUtilsTest extends CrashlyticsTestCase {
 
   public void testGetDeviceState() {
 
-    final int state = CommonUtils.getDeviceState(getContext());
+    final int state = CommonUtils.getDeviceState();
     Log.d(Logger.TAG, "testGetDeviceState: state=" + state);
 
-    if (CommonUtils.isEmulator(getContext())) {
+    if (CommonUtils.isEmulator()) {
       assertTrue(isBitSet(state, CommonUtils.DEVICE_STATE_ISSIMULATOR));
     } else {
       assertFalse(isBitSet(state, CommonUtils.DEVICE_STATE_ISSIMULATOR));
@@ -207,7 +207,7 @@ public class CommonUtilsTest extends CrashlyticsTestCase {
       assertFalse(isBitSet(state, CommonUtils.DEVICE_STATE_DEBUGGERATTACHED));
     }
 
-    if (CommonUtils.isRooted(getContext())) {
+    if (CommonUtils.isRooted()) {
       assertTrue(isBitSet(state, CommonUtils.DEVICE_STATE_JAILBROKEN));
     } else {
       assertFalse(isBitSet(state, CommonUtils.DEVICE_STATE_JAILBROKEN));

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
@@ -170,9 +170,7 @@ public class CommonUtilsTest extends CrashlyticsTestCase {
     // No good way to test the alternate case,
     // just want to ensure we can complete the call without an exception here.
     final boolean isRooted = CommonUtils.isRooted();
-    Log.d(
-        Logger.TAG,
-        "isRooted: " + isRooted + " isEmulator: " + CommonUtils.isEmulator());
+    Log.d(Logger.TAG, "isRooted: " + isRooted + " isEmulator: " + CommonUtils.isEmulator());
 
     // We don't care about the actual result of isRooted, just that we didn't cause an exception
     assertTrue(true);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -30,7 +30,6 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Debug;
 import android.os.StatFs;
-import android.provider.Settings.Secure;
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
 import com.google.firebase.crashlytics.internal.Logger;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -333,7 +333,7 @@ public class CommonUtils {
   }
 
   public static boolean getProximitySensorEnabled(Context context) {
-    if (isEmulator(context)) {
+    if (isEmulator()) {
       // For whatever reason, accessing the sensor manager locks up the emulator. Just return
       // false since it's doesn't really have one anyway.
       return false;
@@ -400,15 +400,14 @@ public class CommonUtils {
    *
    * @return boolean value indicating that we are or are not running in an emulator.
    */
-  public static boolean isEmulator(Context context) {
-    final String androidId = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
+  public static boolean isEmulator() {
+    // TODO(mrober): Consider other heuristics to decide if we are running on an Android emulator.
     return Build.PRODUCT.contains(SDK)
         || Build.HARDWARE.contains(GOLDFISH)
-        || Build.HARDWARE.contains(RANCHU)
-        || androidId == null;
+        || Build.HARDWARE.contains(RANCHU);
   }
 
-  public static boolean isRooted(Context context) {
+  public static boolean isRooted() {
     // No reliable way to determine if an android phone is rooted, since a rooted phone could
     // always disguise itself as non-rooted. Some common approaches can be found on SO:
     //   http://stackoverflow.com/questions/1101380/determine-if-running-on-a-rooted-device
@@ -416,7 +415,7 @@ public class CommonUtils {
     // http://stackoverflow.com/questions/3576989/how-can-you-detect-if-the-device-is-rooted-in-the-app
     //
     // http://stackoverflow.com/questions/7727021/how-can-androids-copy-protection-check-if-the-device-is-rooted
-    final boolean isEmulator = isEmulator(context);
+    final boolean isEmulator = isEmulator();
     final String buildTags = Build.TAGS;
     if (!isEmulator && buildTags != null && buildTags.contains("test-keys")) {
       return true;
@@ -451,13 +450,13 @@ public class CommonUtils {
   public static final int DEVICE_STATE_VENDORINTERNAL = 1 << 4;
   public static final int DEVICE_STATE_COMPROMISEDLIBRARIES = 1 << 5;
 
-  public static int getDeviceState(Context context) {
+  public static int getDeviceState() {
     int deviceState = 0;
-    if (CommonUtils.isEmulator(context)) {
+    if (CommonUtils.isEmulator()) {
       deviceState |= DEVICE_STATE_ISSIMULATOR;
     }
 
-    if (CommonUtils.isRooted(context)) {
+    if (CommonUtils.isRooted()) {
       deviceState |= DEVICE_STATE_JAILBROKEN;
     }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -544,8 +544,8 @@ class CrashlyticsController {
         String.format(Locale.US, GENERATOR_FORMAT, CrashlyticsCore.getVersion());
 
     StaticSessionData.AppData appData = createAppData(idManager, this.appData);
-    StaticSessionData.OsData osData = createOsData(getContext());
-    StaticSessionData.DeviceData deviceData = createDeviceData(getContext());
+    StaticSessionData.OsData osData = createOsData();
+    StaticSessionData.DeviceData deviceData = createDeviceData();
 
     nativeComponent.prepareNativeSession(
         sessionIdentifier,
@@ -671,12 +671,12 @@ class CrashlyticsController {
         appData.developmentPlatformProvider);
   }
 
-  private static StaticSessionData.OsData createOsData(Context context) {
+  private static StaticSessionData.OsData createOsData() {
     return StaticSessionData.OsData.create(
-        VERSION.RELEASE, VERSION.CODENAME, CommonUtils.isRooted(context));
+        VERSION.RELEASE, VERSION.CODENAME, CommonUtils.isRooted());
   }
 
-  private static StaticSessionData.DeviceData createDeviceData(Context context) {
+  private static StaticSessionData.DeviceData createDeviceData() {
     final StatFs statFs = new StatFs(Environment.getDataDirectory().getPath());
     final long diskSpace = (long) statFs.getBlockCount() * (long) statFs.getBlockSize();
 
@@ -686,8 +686,8 @@ class CrashlyticsController {
         Runtime.getRuntime().availableProcessors(),
         CommonUtils.getTotalRamInBytes(),
         diskSpace,
-        CommonUtils.isEmulator(context),
-        CommonUtils.getDeviceState(context),
+        CommonUtils.isEmulator(),
+        CommonUtils.getDeviceState(),
         Build.MANUFACTURER,
         Build.PRODUCT);
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
@@ -164,7 +164,7 @@ public class CrashlyticsReportDataCapture {
         .setPlatform(SESSION_ANDROID_PLATFORM)
         .setVersion(VERSION.RELEASE)
         .setBuildVersion(VERSION.CODENAME)
-        .setJailbroken(CommonUtils.isRooted(context))
+        .setJailbroken(CommonUtils.isRooted())
         .build();
   }
 
@@ -174,8 +174,8 @@ public class CrashlyticsReportDataCapture {
     final int availableProcessors = Runtime.getRuntime().availableProcessors();
     final long totalRam = CommonUtils.getTotalRamInBytes();
     final long diskSpace = (long) statFs.getBlockCount() * (long) statFs.getBlockSize();
-    final boolean isEmulator = CommonUtils.isEmulator(context);
-    final int state = CommonUtils.getDeviceState(context);
+    final boolean isEmulator = CommonUtils.isEmulator();
+    final int state = CommonUtils.getDeviceState();
     final String manufacturer = Build.MANUFACTURER;
     final String modelClass = Build.PRODUCT;
 


### PR DESCRIPTION
Remove Android ID check heuristic from isEmulator check.

Tested with unit tests, the default emulators with Android Studio, and a physical device. There might be more heuristics we can replace this with if needed.