### PR TITLE
Update IDE URL to troubleshooting page

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/logging/ConsoleUrlGenerator.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/logging/ConsoleUrlGenerator.java
@@ -40,7 +40,7 @@ public final class ConsoleUrlGenerator {
   public static String generateCustomTraceUrl(String projectId, String packageName, String name) {
     String rootUrl = getRootUrl(projectId, packageName);
     return String.format(
-        "%s/metrics/trace/DURATION_TRACE/%s?utm_source=%s&utm_medium=%s",
+        "%s/troubleshooting/trace/DURATION_TRACE/%s?utm_source=%s&utm_medium=%s",
         rootUrl, name, UTM_SOURCE, UTM_MEDIUM);
   }
 
@@ -54,7 +54,7 @@ public final class ConsoleUrlGenerator {
   public static String generateScreenTraceUrl(String projectId, String packageName, String name) {
     String rootUrl = getRootUrl(projectId, packageName);
     return String.format(
-        "%s/metrics/trace/SCREEN_TRACE/%s?utm_source=%s&utm_medium=%s",
+        "%s/troubleshooting/trace/SCREEN_TRACE/%s?utm_source=%s&utm_medium=%s",
         rootUrl, name, UTM_SOURCE, UTM_MEDIUM);
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/logging/ConsoleUrlGeneratorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/logging/ConsoleUrlGeneratorTest.java
@@ -35,7 +35,7 @@ public class ConsoleUrlGeneratorTest {
         ConsoleUrlGenerator.generateCustomTraceUrl("test-project", "test-package", "test-trace");
     assertThat(url)
         .isEqualTo(
-            "https://console.firebase.google.com/project/test-project/performance/app/android:test-package/metrics/trace/DURATION_TRACE/test-trace?utm_source=perf-android-sdk&utm_medium=android-ide");
+            "https://console.firebase.google.com/project/test-project/performance/app/android:test-package/troubleshooting/trace/DURATION_TRACE/test-trace?utm_source=perf-android-sdk&utm_medium=android-ide");
   }
 
   @Test
@@ -44,6 +44,6 @@ public class ConsoleUrlGeneratorTest {
         ConsoleUrlGenerator.generateScreenTraceUrl("test-project", "test-package", "test-trace");
     assertThat(url)
         .isEqualTo(
-            "https://console.firebase.google.com/project/test-project/performance/app/android:test-package/metrics/trace/SCREEN_TRACE/test-trace?utm_source=perf-android-sdk&utm_medium=android-ide");
+            "https://console.firebase.google.com/project/test-project/performance/app/android:test-package/troubleshooting/trace/SCREEN_TRACE/test-trace?utm_source=perf-android-sdk&utm_medium=android-ide");
   }
 }


### PR DESCRIPTION
The Firebase console metrics page is getting deprecated. 