### PR TITLE
Increase the Data Transfer read timeout default to 130 seconds

### DIFF
--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
@@ -71,7 +71,7 @@ final class CctTransportBackend implements TransportBackend {
   private static final String LOG_TAG = "CctTransportBackend";
 
   private static final int CONNECTION_TIME_OUT = 30000;
-  private static final int READ_TIME_OUT = 40000;
+  private static final int READ_TIME_OUT = 130000;
   private static final int INVALID_VERSION_CODE = -1;
   private static final String ACCEPT_ENCODING_HEADER_KEY = "Accept-Encoding";
   private static final String CONTENT_ENCODING_HEADER_KEY = "Content-Encoding";


### PR DESCRIPTION
There is a deadline mismatch between the client and the server. The client has a deadline of 40 seconds, and server has 2 minutes, causing the client to repeat requests (with backoff), until they are delivered. This will increase the client deadline to 130 seconds.