### PR TITLE
Adding file path check to avoid NumberFormatException due to empt path

### DIFF
--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManager.java
@@ -70,7 +70,6 @@ public class ModelFileManager {
   void deleteNonLatestCustomModels() throws FirebaseMlException {
     File root = getDirImpl("");
 
-    boolean ret = true;
     if (root.isDirectory()) {
       for (File f : root.listFiles()) {
         // for each custom model sub directory - extract customModelName and clean up old models.
@@ -212,7 +211,7 @@ public class ModelFileManager {
   public synchronized void deleteOldModels(
       @NonNull String modelName, @NonNull String latestModelFilePath) {
     File modelFolder = getModelDirUnsafe(modelName);
-    if (!modelFolder.exists()) {
+    if (!modelFolder.exists() || latestModelFilePath.isEmpty()) {
       return;
     }
 

--- a/firebase-ml-modeldownloader/src/test/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManagerTest.java
+++ b/firebase-ml-modeldownloader/src/test/java/com/google/firebase/ml/modeldownloader/internal/ModelFileManagerTest.java
@@ -189,6 +189,29 @@ public class ModelFileManagerTest {
   }
 
   @Test
+  public void deleteNonLatestCustomModels_whenModelOnDiskButNotInPreferences()
+      throws FirebaseMlException, IOException {
+    String modelDestinationFolder2 = setUpTestingFiles(app, MODEL_NAME_2);
+
+    // Was just downloaded
+    MoveFileToDestination(modelDestinationFolder, testModelFile, CUSTOM_MODEL_NO_FILE, 0);
+    // Was downloaded previously via FirebaseModelManager
+    MoveFileToDestination(modelDestinationFolder2, testModelFile2, CUSTOM_MODEL_NO_FILE_2, 0);
+
+    sharedPreferencesUtil.setLoadedCustomModelDetails(
+        new CustomModel(MODEL_NAME, MODEL_HASH, 100, 0, modelDestinationFolder + "/0"));
+
+    // Download in progress, hence file path is not present
+    sharedPreferencesUtil.setLoadedCustomModelDetails(
+        new CustomModel(MODEL_NAME_2, MODEL_HASH_2, 100, 0));
+
+    fileManager.deleteNonLatestCustomModels();
+
+    assertTrue(new File(modelDestinationFolder + "/0").exists());
+    assertTrue(new File(modelDestinationFolder2 + "/0").exists());
+  }
+
+  @Test
   public void deleteNonLatestCustomModels_noFileToDelete()
       throws FirebaseMlException, FileNotFoundException {
     MoveFileToDestination(modelDestinationFolder, testModelFile, CUSTOM_MODEL_NO_FILE, 0);


### PR DESCRIPTION
As the issue https://github.com/firebase/firebase-android-sdk/issues/3864 details, this is an edge case I would like to fix and shouldn't occur in regular occurrence.

An alternative to this fix is to potentially change

CUSTOM_MODEL_ROOT_PATH = "com.google.firebase.ml.custom.models";

to something different than what [FirebaseModelManager](https://firebase.google.com/docs/reference/android/com/google/firebase/ml/common/modeldownload/FirebaseModelManager) was using.