### PR TITLE
Support leaf modules in changed modules task.

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/ChangedModulesTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/ChangedModulesTask.kt
@@ -33,13 +33,13 @@ abstract class ChangedModulesTask : DefaultTask() {
             AffectedProjectFinder(project, changedGitPaths.toSet(), listOf()).find().map { it.path }
                 .toSet()
 
-        val result = project.rootProject.subprojects.associateTo(mutableMapOf()) {
+        val result = project.rootProject.subprojects.associate {
             it.path to mutableSetOf<String>()
         }
         project.rootProject.subprojects.forEach { p ->
             p.configurations.forEach { c ->
                 c.dependencies.filterIsInstance<ProjectDependency>().forEach {
-                    result.getOrPut(it.dependencyProject.path) { mutableSetOf() }.add(p.path)
+                    result[it.dependencyProject.path]?.add(p.path)
                 }
             }
         }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/ChangedModulesTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/ChangedModulesTask.kt
@@ -33,7 +33,9 @@ abstract class ChangedModulesTask : DefaultTask() {
             AffectedProjectFinder(project, changedGitPaths.toSet(), listOf()).find().map { it.path }
                 .toSet()
 
-        val result = mutableMapOf<String, MutableSet<String>>()
+        val result = project.rootProject.subprojects.associateTo(mutableMapOf()) {
+            it.path to mutableSetOf<String>()
+        }
         project.rootProject.subprojects.forEach { p ->
             p.configurations.forEach { c ->
                 c.dependencies.filterIsInstance<ProjectDependency>().forEach {


### PR DESCRIPTION
The task should return the module even if nothing depends on it since it
likely has tests of its own.