### PR TITLE
Firestore: Add @CanIgnoreReturnValue annotations in tests

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -29,6 +29,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.firebase.firestore.FirebaseFirestoreException.Code;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import com.google.firebase.firestore.util.AsyncQueue.TimerId;
@@ -88,16 +89,19 @@ public class TransactionTest {
       db = inputDb;
     }
 
+    @CanIgnoreReturnValue
     public TransactionTester withExistingDoc() {
       fromExistingDoc = true;
       return this;
     }
 
+    @CanIgnoreReturnValue
     public TransactionTester withNonexistentDoc() {
       fromExistingDoc = false;
       return this;
     }
 
+    @CanIgnoreReturnValue
     public TransactionTester run(TransactionStage... inputStages) {
       stages = Arrays.asList(inputStages);
       return this;

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalSerializerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/LocalSerializerTest.java
@@ -29,6 +29,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.bundle.BundledQuery;
 import com.google.firebase.firestore.core.Query;
@@ -81,6 +82,7 @@ public final class LocalSerializerTest {
       this.builder = Write.newBuilder();
     }
 
+    @CanIgnoreReturnValue
     TestWriteBuilder addSet() {
       builder.setUpdate(
           com.google.firestore.v1.Document.newBuilder()
@@ -90,6 +92,7 @@ public final class LocalSerializerTest {
       return this;
     }
 
+    @CanIgnoreReturnValue
     TestWriteBuilder addPatch() {
       builder
           .setUpdate(
@@ -102,11 +105,13 @@ public final class LocalSerializerTest {
       return this;
     }
 
+    @CanIgnoreReturnValue
     TestWriteBuilder addDelete() {
       builder.setDelete("projects/p/databases/d/documents/baz/quux");
       return this;
     }
 
+    @CanIgnoreReturnValue
     TestWriteBuilder addUpdateTransforms() {
       builder
           .addUpdateTransforms(
@@ -120,6 +125,7 @@ public final class LocalSerializerTest {
       return this;
     }
 
+    @CanIgnoreReturnValue
     TestWriteBuilder addLegacyTransform() {
       builder
           .setTransform(

--- a/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/ComparatorTester.java
+++ b/firebase-firestore/src/testUtil/java/com/google/firebase/firestore/testutil/ComparatorTester.java
@@ -22,6 +22,7 @@ import static com.google.common.truth.Truth.assert_;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.firebase.firestore.util.Preconditions;
 import java.util.Comparator;
 import java.util.List;
@@ -101,6 +102,7 @@ public class ComparatorTester {
    * Activates enforcement of {@code a.equals(b) == (a.compareTo(b) == 0)}. This is off by default
    * when testing {@link Comparator}s, but can be turned on if required.
    */
+  @CanIgnoreReturnValue
   public ComparatorTester requireConsistencyWithEquals() {
     testForEqualsCompatibility = true;
     return this;
@@ -110,6 +112,7 @@ public class ComparatorTester {
    * Deactivates enforcement of {@code a.equals(b) == (a.compareTo(b) == 0)}. This is on by default
    * when testing {@link Comparable}s, but can be turned off if required.
    */
+  @CanIgnoreReturnValue
   public ComparatorTester permitInconsistencyWithEquals() {
     testForEqualsCompatibility = false;
     return this;
@@ -122,6 +125,7 @@ public class ComparatorTester {
    *
    * @return {@code this} (to allow chaining of calls)
    */
+  @CanIgnoreReturnValue
   public ComparatorTester addEqualityGroup(Object... objects) {
     Preconditions.checkNotNull(objects);
     Preconditions.checkArgument(objects.length > 0, "Array must not be empty");


### PR DESCRIPTION
Googlers see cl/457735855 from which this PR was ported.