### PR TITLE
Pass "Locale-US" to SimpleDateFormat while formatting first-open time to ensure that the digits are not formatted as per the local non-english language.

### DIFF
--- a/firebase-config/firebase-config.gradle
+++ b/firebase-config/firebase-config.gradle
@@ -78,6 +78,4 @@ dependencies {
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "org.skyscreamer:jsonassert:1.5.0"
-
-    api 'joda-time:joda-time:2.10.14'
 }

--- a/firebase-config/firebase-config.gradle
+++ b/firebase-config/firebase-config.gradle
@@ -78,4 +78,6 @@ dependencies {
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.25.0'
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "org.skyscreamer:jsonassert:1.5.0"
+
+    api 'joda-time:joda-time:2.10.14'
 }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
@@ -48,7 +48,8 @@ public final class RemoteConfigConstants {
     RequestFieldKey.APP_VERSION,
     RequestFieldKey.PACKAGE_NAME,
     RequestFieldKey.SDK_VERSION,
-    RequestFieldKey.ANALYTICS_USER_PROPERTIES
+    RequestFieldKey.ANALYTICS_USER_PROPERTIES,
+    RequestFieldKey.FIRST_OPEN_TIME
   })
   @Retention(RetentionPolicy.SOURCE)
   public @interface RequestFieldKey {
@@ -64,6 +65,7 @@ public final class RemoteConfigConstants {
     String PACKAGE_NAME = "packageName";
     String SDK_VERSION = "sdkVersion";
     String ANALYTICS_USER_PROPERTIES = "analyticsUserProperties";
+    String FIRST_OPEN_TIME = "firstOpenTime";
   }
 
   /** Keys of fields in the Fetch response body from the Firebase Remote Config server. */

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -80,7 +80,7 @@ public class ConfigFetchHandler {
   @VisibleForTesting static final int HTTP_TOO_MANY_REQUESTS = 429;
 
   /**
-   * First-open-time key name in GA user-properties. First-open time is a predefined user-dimension
+   * First-open time key name in GA user-properties. First-open time is a predefined user-dimension
    * automatically collected by GA.
    */
   @VisibleForTesting static final String FIRST_OPEN_TIME_KEY = "_fot";

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java
@@ -52,7 +52,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executor;
-import org.joda.time.Instant;
 
 /**
  * A handler for fetch requests to the Firebase Remote Config backend.
@@ -80,7 +79,10 @@ public class ConfigFetchHandler {
    */
   @VisibleForTesting static final int HTTP_TOO_MANY_REQUESTS = 429;
 
-  /** First Open time key in GA user-properties. */
+  /**
+   * First-open-time key name in GA user-properties. First-open time is a predefined user-dimension
+   * automatically collected by GA.
+   */
   @VisibleForTesting static final String FIRST_OPEN_TIME_KEY = "_fot";
 
   private final FirebaseInstallationsApi firebaseInstallations;
@@ -519,16 +521,13 @@ public class ConfigFetchHandler {
    * does not have first-open time for the app, this method returns null.
    */
   @WorkerThread
-  private Instant getFirstOpenTime() {
+  private Long getFirstOpenTime() {
     AnalyticsConnector connector = this.analyticsConnector.get();
     if (connector == null) {
       return null;
     }
-    Map<String, Object> userPropertiesMap = connector.getUserProperties(/*includeInternal=*/ true);
 
-    return userPropertiesMap.containsKey(FIRST_OPEN_TIME_KEY)
-        ? Instant.ofEpochMilli((long) userPropertiesMap.get(FIRST_OPEN_TIME_KEY))
-        : null;
+    return (Long) connector.getUserProperties(/*includeInternal=*/ true).get(FIRST_OPEN_TIME_KEY);
   }
 
   /** Used to verify that the fetch handler is getting Analytics as expected. */

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -348,12 +348,12 @@ public class ConfigFetchHttpClient {
     if (firstOpenTime != null) {
       requestBodyMap.put(FIRST_OPEN_TIME, convertToISOString(firstOpenTime));
     }
-
+    System.out.println(requestBodyMap);
     return new JSONObject(requestBodyMap);
   }
 
   private String convertToISOString(long millisFromEpoch) {
-    SimpleDateFormat isoDateFormat = new SimpleDateFormat(ISO_DATE_PATTERN);
+    SimpleDateFormat isoDateFormat = new SimpleDateFormat(ISO_DATE_PATTERN, Locale.US);
     isoDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     return isoDateFormat.format(millisFromEpoch);
   }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -26,6 +26,7 @@ import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFie
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.STATE;
 import static com.google.firebase.remoteconfig.internal.ConfigFetchHandler.BACKOFF_TIME_DURATIONS_IN_MINUTES;
 import static com.google.firebase.remoteconfig.internal.ConfigFetchHandler.DEFAULT_MINIMUM_FETCH_INTERVAL_IN_SECONDS;
+import static com.google.firebase.remoteconfig.internal.ConfigFetchHandler.FIRST_OPEN_TIME_KEY;
 import static com.google.firebase.remoteconfig.internal.ConfigFetchHandler.HTTP_TOO_MANY_REQUESTS;
 import static com.google.firebase.remoteconfig.internal.ConfigMetadataClient.LAST_FETCH_TIME_NO_FETCH_YET;
 import static com.google.firebase.remoteconfig.internal.ConfigMetadataClient.NO_BACKOFF_TIME;
@@ -42,6 +43,7 @@ import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -77,6 +79,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executor;
+import org.joda.time.Instant;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -195,6 +198,7 @@ public class ConfigFetchHandlerTest {
             /* analyticsUserProperties= */ any(),
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
             /* currentTime= */ any());
   }
 
@@ -394,7 +398,7 @@ public class ConfigFetchHandlerTest {
 
   @Test
   public void fetch_fetchBackendCallFails_taskThrowsException() throws Exception {
-    when(mockBackendFetchApiClient.fetch(any(), any(), any(), any(), any(), any(), any()))
+    when(mockBackendFetchApiClient.fetch(any(), any(), any(), any(), any(), any(), any(), any()))
         .thenThrow(
             new FirebaseRemoteConfigClientException("Fetch failed due to an unexpected error."));
 
@@ -628,21 +632,46 @@ public class ConfigFetchHandlerTest {
   }
 
   @Test
-  public void fetch_hasAnalyticsSdk_sendsUserProperties() throws Exception {
+  public void fetch_hasAnalyticsSdk_sendsUserPropertiesAndFirstOpenTime() throws Exception {
+    // Provide the mock Analytics SDK.
+    AnalyticsConnector mockAnalyticsConnector = mock(AnalyticsConnector.class);
+    fetchHandler = getNewFetchHandler(mockAnalyticsConnector);
+    long testFirstOpenTimeVal = 1636146000000L;
+
+    Map<String, String> customUserProperties =
+        ImmutableMap.of("up_key1", "up_val1", "up_key2", "up_val2");
+    Map<String, Object> allUserProperties =
+        ImmutableMap.of(
+            "up_key1", "up_val1", "up_key2", "up_val2", FIRST_OPEN_TIME_KEY, testFirstOpenTimeVal);
+    when(mockAnalyticsConnector.getUserProperties(/*includeInternal=*/ false))
+        .thenReturn(ImmutableMap.copyOf(customUserProperties));
+    when(mockAnalyticsConnector.getUserProperties(/*includeInternal=*/ true))
+        .thenReturn(ImmutableMap.copyOf(allUserProperties));
+
+    fetchCallToHttpClientUpdatesClockAndReturnsConfig(firstFetchedContainer);
+
+    assertWithMessage("Fetch() failed!").that(fetchHandler.fetch().isSuccessful()).isTrue();
+
+    Instant expectedFirstOpenTime = Instant.ofEpochMilli(testFirstOpenTimeVal);
+    verifyBackendIsCalled(customUserProperties, expectedFirstOpenTime);
+  }
+
+  @Test
+  public void fetch_hasAnalyticsSdk_sendsUserPropertiesNoFirstOpenTime() throws Exception {
     // Provide the mock Analytics SDK.
     AnalyticsConnector mockAnalyticsConnector = mock(AnalyticsConnector.class);
     fetchHandler = getNewFetchHandler(mockAnalyticsConnector);
 
     Map<String, String> userProperties =
         ImmutableMap.of("up_key1", "up_val1", "up_key2", "up_val2");
-    when(mockAnalyticsConnector.getUserProperties(/*includeInternal=*/ false))
+    when(mockAnalyticsConnector.getUserProperties(anyBoolean()))
         .thenReturn(ImmutableMap.copyOf(userProperties));
 
     fetchCallToHttpClientUpdatesClockAndReturnsConfig(firstFetchedContainer);
 
     assertWithMessage("Fetch() failed!").that(fetchHandler.fetch().isSuccessful()).isTrue();
 
-    verifyBackendIsCalled(userProperties);
+    verifyBackendIsCalled(userProperties, null);
   }
 
   @Test
@@ -751,6 +780,7 @@ public class ConfigFetchHandlerTest {
             /* analyticsUserProperties= */ any(),
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
             /* currentTime= */ any());
   }
 
@@ -762,6 +792,7 @@ public class ConfigFetchHandlerTest {
             /* analyticsUserProperties= */ any(),
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
             /* currentTime= */ any()))
         .thenReturn(FetchResponse.forBackendHasNoUpdates(date));
   }
@@ -776,6 +807,7 @@ public class ConfigFetchHandlerTest {
             /* analyticsUserProperties= */ any(),
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
             /* currentTime= */ any());
   }
 
@@ -855,10 +887,12 @@ public class ConfigFetchHandlerTest {
             /* analyticsUserProperties= */ any(),
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
             /* currentTime= */ any());
   }
 
-  private void verifyBackendIsCalled(Map<String, String> userProperties) throws Exception {
+  private void verifyBackendIsCalled(Map<String, String> userProperties, Instant firstOpenTime)
+      throws Exception {
     verify(mockBackendFetchApiClient)
         .fetch(
             any(HttpURLConnection.class),
@@ -867,6 +901,7 @@ public class ConfigFetchHandlerTest {
             /* analyticsUserProperties= */ eq(userProperties),
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
+            /* firstOpenTime= */ eq(firstOpenTime),
             /* currentTime= */ any());
   }
 
@@ -879,6 +914,7 @@ public class ConfigFetchHandlerTest {
             /* analyticsUserProperties= */ any(),
             /* lastFetchETag= */ any(),
             /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
             /* currentTime= */ any());
   }
 
@@ -891,6 +927,7 @@ public class ConfigFetchHandlerTest {
             /* analyticsUserProperties= */ any(),
             /* lastFetchETag= */ eq(requestETag),
             /* customHeaders= */ any(),
+            /* firstOpenTime= */ any(),
             /* currentTime= */ any());
     assertThat(metadataClient.getLastFetchETag()).isEqualTo(responseETag);
   }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -79,7 +79,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executor;
-import org.joda.time.Instant;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -636,13 +635,13 @@ public class ConfigFetchHandlerTest {
     // Provide the mock Analytics SDK.
     AnalyticsConnector mockAnalyticsConnector = mock(AnalyticsConnector.class);
     fetchHandler = getNewFetchHandler(mockAnalyticsConnector);
-    long testFirstOpenTimeVal = 1636146000000L;
+    long firstOpenTime = 1636146000000L;
 
     Map<String, String> customUserProperties =
         ImmutableMap.of("up_key1", "up_val1", "up_key2", "up_val2");
     Map<String, Object> allUserProperties =
         ImmutableMap.of(
-            "up_key1", "up_val1", "up_key2", "up_val2", FIRST_OPEN_TIME_KEY, testFirstOpenTimeVal);
+            "up_key1", "up_val1", "up_key2", "up_val2", FIRST_OPEN_TIME_KEY, firstOpenTime);
     when(mockAnalyticsConnector.getUserProperties(/*includeInternal=*/ false))
         .thenReturn(ImmutableMap.copyOf(customUserProperties));
     when(mockAnalyticsConnector.getUserProperties(/*includeInternal=*/ true))
@@ -652,8 +651,7 @@ public class ConfigFetchHandlerTest {
 
     assertWithMessage("Fetch() failed!").that(fetchHandler.fetch().isSuccessful()).isTrue();
 
-    Instant expectedFirstOpenTime = Instant.ofEpochMilli(testFirstOpenTimeVal);
-    verifyBackendIsCalled(customUserProperties, expectedFirstOpenTime);
+    verifyBackendIsCalled(customUserProperties, firstOpenTime);
   }
 
   @Test
@@ -891,7 +889,7 @@ public class ConfigFetchHandlerTest {
             /* currentTime= */ any());
   }
 
-  private void verifyBackendIsCalled(Map<String, String> userProperties, Instant firstOpenTime)
+  private void verifyBackendIsCalled(Map<String, String> userProperties, Long firstOpenTime)
       throws Exception {
     verify(mockBackendFetchApiClient)
         .fetch(

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -35,6 +35,7 @@ import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFiel
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.ENTRIES;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.EXPERIMENT_DESCRIPTIONS;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.STATE;
+import static com.google.firebase.remoteconfig.testutil.Assert.assertFalse;
 import static com.google.firebase.remoteconfig.testutil.Assert.assertThrows;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -236,7 +237,7 @@ public class ConfigFetchHttpClientTest {
 
     assertThat(requestBody.getJSONObject(ANALYTICS_USER_PROPERTIES).toString())
         .isEqualTo(new JSONObject(customUserProperties).toString());
-    assertThat(requestBody.isNull(FIRST_OPEN_TIME));
+    assertFalse(requestBody.has(FIRST_OPEN_TIME));
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -57,7 +57,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-import org.joda.time.Instant;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -203,7 +202,7 @@ public class ConfigFetchHttpClientTest {
     // ISO-8601 value corresponding to 1636146000000 ms-from-epoch in UTC
     String firstOpenTimeIsoString = "2021-11-05T21:00:00.000Z";
 
-    fetch(FIRST_ETAG, customUserProperties, Instant.ofEpochMilli(firstOpenTimeEpochFromMillis));
+    fetch(FIRST_ETAG, customUserProperties, firstOpenTimeEpochFromMillis);
 
     JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
     assertThat(requestBody.get(INSTANCE_ID)).isEqualTo(INSTALLATION_ID_STRING);
@@ -329,8 +328,8 @@ public class ConfigFetchHttpClientTest {
         /* currentTime= */ new Date(mockClock.currentTimeMillis()));
   }
 
-  private FetchResponse fetch(
-      String eTag, Map<String, String> userProperties, Instant firstOpenTime) throws Exception {
+  private FetchResponse fetch(String eTag, Map<String, String> userProperties, Long firstOpenTime)
+      throws Exception {
     return configFetchHttpClient.fetch(
         fakeHttpURLConnection,
         INSTALLATION_ID_STRING,

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -24,6 +24,7 @@ import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFiel
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_ID;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.APP_VERSION;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.COUNTRY_CODE;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.FIRST_OPEN_TIME;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.INSTANCE_ID;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.INSTANCE_ID_TOKEN;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.LANGUAGE_CODE;
@@ -56,6 +57,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import org.joda.time.Instant;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -187,7 +189,7 @@ public class ConfigFetchHttpClientTest {
     // Custom user-defined headers.
     expectedHeaders.putAll(customHeaders);
 
-    fetch(FIRST_ETAG, /* userProperties= */ ImmutableMap.of(), customHeaders);
+    fetch(FIRST_ETAG, customHeaders);
 
     assertThat(fakeHttpURLConnection.getRequestHeaders()).isEqualTo(expectedHeaders);
   }
@@ -195,9 +197,13 @@ public class ConfigFetchHttpClientTest {
   @Test
   public void fetch_setsAllElementsOfRequestBody_sendsRequestBodyToServer() throws Exception {
     setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
-    Map<String, String> userProperties = ImmutableMap.of("up1", "hello", "up2", "world");
+    Map<String, String> customUserProperties = ImmutableMap.of("up1", "hello", "up2", "world");
 
-    fetch(FIRST_ETAG, userProperties);
+    long firstOpenTimeEpochFromMillis = 1636146000000L;
+    // ISO-8601 value corresponding to 1636146000000 ms-from-epoch in UTC
+    String firstOpenTimeIsoString = "2021-11-05T21:00:00.000Z";
+
+    fetch(FIRST_ETAG, customUserProperties, Instant.ofEpochMilli(firstOpenTimeEpochFromMillis));
 
     JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
     assertThat(requestBody.get(INSTANCE_ID)).isEqualTo(INSTALLATION_ID_STRING);
@@ -215,8 +221,23 @@ public class ConfigFetchHttpClientTest {
         .isEqualTo(Long.toString(packageInfo.getLongVersionCode()));
     assertThat(requestBody.get(PACKAGE_NAME)).isEqualTo(context.getPackageName());
     assertThat(requestBody.get(SDK_VERSION)).isEqualTo(BuildConfig.VERSION_NAME);
+    assertThat(requestBody.get(FIRST_OPEN_TIME)).isEqualTo(firstOpenTimeIsoString);
     assertThat(requestBody.getJSONObject(ANALYTICS_USER_PROPERTIES).toString())
-        .isEqualTo(new JSONObject(userProperties).toString());
+        .isEqualTo(new JSONObject(customUserProperties).toString());
+  }
+
+  @Test
+  public void fetch_nullFirstOpenTime_fieldNotPresentInRequestBody() throws Exception {
+    setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
+    Map<String, String> customUserProperties = ImmutableMap.of("up1", "hello", "up2", "world");
+
+    fetch(FIRST_ETAG, customUserProperties, null);
+
+    JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
+
+    assertThat(requestBody.getJSONObject(ANALYTICS_USER_PROPERTIES).toString())
+        .isEqualTo(new JSONObject(customUserProperties).toString());
+    assertThat(requestBody.isNull(FIRST_OPEN_TIME));
   }
 
   @Test
@@ -226,8 +247,7 @@ public class ConfigFetchHttpClientTest {
 
     setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
 
-    Map<String, String> userProperties = ImmutableMap.of("up1", "hello", "up2", "world");
-    fetch(FIRST_ETAG, userProperties);
+    fetch(FIRST_ETAG);
 
     JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
     assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(languageTag);
@@ -242,8 +262,7 @@ public class ConfigFetchHttpClientTest {
 
     setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
 
-    Map<String, String> userProperties = ImmutableMap.of("up1", "hello", "up2", "world");
-    fetch(FIRST_ETAG, userProperties);
+    fetch(FIRST_ETAG);
 
     JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
     assertThat(requestBody.get(LANGUAGE_CODE)).isEqualTo(languageString);
@@ -306,10 +325,12 @@ public class ConfigFetchHttpClientTest {
         /* analyticsUserProperties= */ ImmutableMap.of(),
         eTag,
         /* customHeaders= */ ImmutableMap.of(),
+        /* firstOpenTime= */ null,
         /* currentTime= */ new Date(mockClock.currentTimeMillis()));
   }
 
-  private FetchResponse fetch(String eTag, Map<String, String> userProperties) throws Exception {
+  private FetchResponse fetch(
+      String eTag, Map<String, String> userProperties, Instant firstOpenTime) throws Exception {
     return configFetchHttpClient.fetch(
         fakeHttpURLConnection,
         INSTALLATION_ID_STRING,
@@ -317,19 +338,19 @@ public class ConfigFetchHttpClientTest {
         userProperties,
         eTag,
         /* customHeaders= */ ImmutableMap.of(),
+        firstOpenTime,
         new Date(mockClock.currentTimeMillis()));
   }
 
-  private FetchResponse fetch(
-      String eTag, Map<String, String> userProperties, Map<String, String> customHeaders)
-      throws Exception {
+  private FetchResponse fetch(String eTag, Map<String, String> customHeaders) throws Exception {
     return configFetchHttpClient.fetch(
         fakeHttpURLConnection,
         INSTALLATION_ID_STRING,
         INSTALLATION_AUTH_TOKEN_STRING,
-        userProperties,
+        /* analyticsUserProperties= */ ImmutableMap.of(),
         eTag,
         customHeaders,
+        /* firstOpenTime= */ null,
         new Date(mockClock.currentTimeMillis()));
   }
 
@@ -341,6 +362,7 @@ public class ConfigFetchHttpClientTest {
         /* analyticsUserProperties= */ ImmutableMap.of(),
         /* lastFetchETag= */ "bogus-etag",
         /* customHeaders= */ ImmutableMap.of(),
+        /* firstOpenTime= */ null,
         new Date(mockClock.currentTimeMillis()));
   }
 
@@ -352,6 +374,7 @@ public class ConfigFetchHttpClientTest {
         /* analyticsUserProperties= */ ImmutableMap.of(),
         /* lastFetchETag= */ "bogus-etag",
         /* customHeaders= */ ImmutableMap.of(),
+        /* firstOpenTime= */ null,
         new Date(mockClock.currentTimeMillis()));
   }
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -241,6 +241,25 @@ public class ConfigFetchHttpClientTest {
   }
 
   @Test
+  public void fetch_firstOpenTimeFromNonEnglishLanguageLocale_digitsInEnglishInRequestBody()
+      throws Exception {
+    String languageTag = "ar-AE"; // Language Tag for UAE Arabic
+    Locale.setDefault(Locale.forLanguageTag(languageTag));
+
+    setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
+
+    Map<String, String> customUserProperties = ImmutableMap.of("up1", "hello", "up2", "world");
+    long firstOpenTimeEpochFromMillis = 1636146000000L;
+    // ISO-8601 value corresponding to 1636146000000 ms-from-epoch in UTC
+    String firstOpenTimeIsoString = "2021-11-05T21:00:00.000Z";
+
+    fetch(FIRST_ETAG, customUserProperties, firstOpenTimeEpochFromMillis);
+
+    JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
+    assertThat(requestBody.get(FIRST_OPEN_TIME)).isEqualTo(firstOpenTimeIsoString);
+  }
+
+  @Test
   public void fetch_requestEncodesLanguageSubtags() throws Exception {
     String languageTag = "zh-Hant-TW"; // Taiwan Chinese in traditional script
     context.getResources().getConfiguration().setLocale(Locale.forLanguageTag(languageTag));


### PR DESCRIPTION
Fix for https://github.com/firebase/firebase-android-sdk/issues/3757. The bug was introduced in https://github.com/firebase/firebase-android-sdk/pull/3653