### PR TITLE
Pass "Locale-US" to SimpleDateFormat while formatting first-open time…

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -353,7 +353,8 @@ public class ConfigFetchHttpClient {
   }
 
   private String convertToISOString(long millisFromEpoch) {
-    // Locale.US ensures that the english numerals are not converted to the local language numerals.
+    // ISO-8601 Timestamp expects Western Arabic numerals. Locale.US ensures that the english
+    // numerals are not converted to the local language numerals.
     SimpleDateFormat isoDateFormat = new SimpleDateFormat(ISO_DATE_PATTERN, Locale.US);
     isoDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     return isoDateFormat.format(millisFromEpoch);

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -353,7 +353,8 @@ public class ConfigFetchHttpClient {
   }
 
   private String convertToISOString(long millisFromEpoch) {
-    SimpleDateFormat isoDateFormat = new SimpleDateFormat(ISO_DATE_PATTERN);
+    // Locale.US ensures that the english numerals are not converted to the local language numerals.
+    SimpleDateFormat isoDateFormat = new SimpleDateFormat(ISO_DATE_PATTERN, Locale.US);
     isoDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     return isoDateFormat.format(millisFromEpoch);
   }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -241,6 +241,25 @@ public class ConfigFetchHttpClientTest {
   }
 
   @Test
+  public void fetch_firstOpenTimeFromNonEnglishLanguageLocale_digitsInEnglishInRequestBody()
+      throws Exception {
+    String languageTag = "ar-AE"; // Language Tag for UAE Arabic
+    Locale.setDefault(Locale.forLanguageTag(languageTag));
+
+    setServerResponseTo(noChangeResponseBody, SECOND_ETAG);
+
+    Map<String, String> customUserProperties = ImmutableMap.of("up1", "hello", "up2", "world");
+    long firstOpenTimeEpochFromMillis = 1636146000000L;
+    // ISO-8601 value corresponding to 1636146000000 ms-from-epoch in UTC
+    String firstOpenTimeIsoString = "2021-11-05T21:00:00.000Z";
+
+    fetch(FIRST_ETAG, customUserProperties, firstOpenTimeEpochFromMillis);
+
+    JSONObject requestBody = new JSONObject(fakeHttpURLConnection.getOutputStream().toString());
+    assertThat(requestBody.get(FIRST_OPEN_TIME)).isEqualTo(firstOpenTimeIsoString);
+  }
+
+  @Test
   public void fetch_requestEncodesLanguageSubtags() throws Exception {
     String languageTag = "zh-Hant-TW"; // Taiwan Chinese in traditional script
     context.getResources().getConfiguration().setLocale(Locale.forLanguageTag(languageTag));


### PR DESCRIPTION
…. This ensures that the english numerals in the timestamp are not converted to the local language numerals.

This is a fix for #3757. The issue was introduced in https://github.com/firebase/firebase-android-sdk/pull/3653