### PR TITLE
Use unmodifiableList for CompositeFilters.

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/CompositeFilter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/CompositeFilter.java
@@ -16,11 +16,11 @@ package com.google.firebase.firestore.core;
 
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
-import com.google.common.collect.ImmutableList;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.util.Function;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** Represents a filter that is the conjunction or disjunction of other filters. */
@@ -41,21 +41,21 @@ public class CompositeFilter extends Filter {
     }
   }
 
-  private final ImmutableList<Filter> filters;
+  private final List<Filter> filters;
   private final Operator operator;
 
   // Memoized list of all field filters that can be found by traversing the tree of filters
   // contained in this composite filter.
-  private ImmutableList<FieldFilter> memoizedFlattenedFilters;
+  private List<FieldFilter> memoizedFlattenedFilters;
 
   public CompositeFilter(List<Filter> filters, Operator operator) {
-    this.filters = ImmutableList.copyOf(filters);
+    this.filters = new ArrayList<>(filters);
     this.operator = operator;
   }
 
   @Override
   public List<Filter> getFilters() {
-    return filters;
+    return Collections.unmodifiableList(filters);
   }
 
   public Operator getOperator() {
@@ -65,14 +65,13 @@ public class CompositeFilter extends Filter {
   @Override
   public List<FieldFilter> getFlattenedFilters() {
     if (memoizedFlattenedFilters != null) {
-      return memoizedFlattenedFilters;
+      return Collections.unmodifiableList(memoizedFlattenedFilters);
     }
-    ImmutableList.Builder<FieldFilter> builder = ImmutableList.builder();
+    memoizedFlattenedFilters = new ArrayList<>();
     for (Filter subfilter : filters) {
-      builder.addAll(subfilter.getFlattenedFilters());
+      memoizedFlattenedFilters.addAll(subfilter.getFlattenedFilters());
     }
-    memoizedFlattenedFilters = builder.build();
-    return memoizedFlattenedFilters;
+    return Collections.unmodifiableList(memoizedFlattenedFilters);
   }
 
   /**

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/CompositeFilter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/CompositeFilter.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore.core;
 
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
+import com.google.common.collect.ImmutableList;
 import com.google.firebase.firestore.model.Document;
 import com.google.firebase.firestore.model.FieldPath;
 import com.google.firebase.firestore.util.Function;
@@ -40,15 +41,15 @@ public class CompositeFilter extends Filter {
     }
   }
 
-  private final List<Filter> filters;
+  private final ImmutableList<Filter> filters;
   private final Operator operator;
 
   // Memoized list of all field filters that can be found by traversing the tree of filters
   // contained in this composite filter.
-  private List<FieldFilter> memoizedFlattenedFilters;
+  private ImmutableList<FieldFilter> memoizedFlattenedFilters;
 
   public CompositeFilter(List<Filter> filters, Operator operator) {
-    this.filters = filters;
+    this.filters = ImmutableList.copyOf(filters);
     this.operator = operator;
   }
 
@@ -66,10 +67,11 @@ public class CompositeFilter extends Filter {
     if (memoizedFlattenedFilters != null) {
       return memoizedFlattenedFilters;
     }
-    memoizedFlattenedFilters = new ArrayList<>();
+    ImmutableList.Builder<FieldFilter> builder = ImmutableList.builder();
     for (Filter subfilter : filters) {
-      memoizedFlattenedFilters.addAll(subfilter.getFlattenedFilters());
+      builder.addAll(subfilter.getFlattenedFilters());
     }
+    memoizedFlattenedFilters = builder.build();
     return memoizedFlattenedFilters;
   }
 


### PR DESCRIPTION
We want a composite filter object to be immutable (the list of filters stored in a composite filter shouldn't change). We had marked the list as `final`, but we should also make sure getters are not able to modify the list.

To avoid adding Guava as a dependency, we're not going to use `ImmutableList`. Instead, we'll return `unmodifiableList` in the getters.