### PR TITLE
Correcting typo in FiamListener.java.

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FiamListener.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FiamListener.java
@@ -27,7 +27,7 @@ import androidx.annotation.Keep;
  *       transitions
  *   <li>{@link FiamListener#onFiamClick()} is called when a message with a configured action is
  *       clicked. If the clicked message does not have a configured action, it is dismissed and
- *       {@link FiamListener#onFiamClick()} is invoked
+ *       {@link FiamListener#onFiamDismiss()} is invoked
  *   <li>Called when the message is dismissed either automatically after a timeout or by the user or
  *       when a clicked message has no associated action
  * </ul>


### PR DESCRIPTION
Updating java doc string for the FiamListener to correctly indicate that the `FiamDismiss()` method is invoked when there is no configured action for a clicked message.