### PR TITLE
Fix CI issuses with AppDistro

### DIFF
--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ScreenshotTakerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ScreenshotTakerTest.java
@@ -54,6 +54,7 @@ public class ScreenshotTakerTest {
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
+    FirebaseApp.clearInstancesForTest();
 
     firebaseApp =
         FirebaseApp.initializeApp(


### PR DESCRIPTION
Test `ScreenshotTakerTest.takeAndDeleteScreenshot_success` is consistently failing with `FirebaseApp already initialized` error.