### PR TITLE
Fixed bug where connectiontest was building the wrong hostinfo url

### DIFF
--- a/firebase-database/src/androidTest/java/com/google/firebase/database/DataTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/DataTest.java
@@ -1084,10 +1084,10 @@ public class DataTest {
 
     DatabaseReference ref =
         new DatabaseReference(
-            IntegrationTestValues.getNamespace() + "/a%b&c@d/space: /non-ascii:ø", ctx);
+            IntegrationTestValues.getDatabaseUrl() + "/a%b&c@d/space: /non-ascii:ø", ctx);
     String result = ref.toString();
     String encoded =
-        IntegrationTestValues.getNamespace() + "/a%25b%26c%40d/space%3A%20/non-ascii%3A%C3%B8";
+        IntegrationTestValues.getDatabaseUrl() + "/a%25b%26c%40d/space%3A%20/non-ascii%3A%C3%B8";
     assertEquals(encoded, result);
 
     String child = "" + new Random().nextInt(100000000);
@@ -1102,7 +1102,7 @@ public class DataTest {
           InterruptedException {
     DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
-    DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getNamespace(), ctx);
+    DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getDatabaseUrl(), ctx);
     assertNull(ref.getKey());
     assertEquals("a", ref.child("a").getKey());
     assertEquals("c", ref.child("b/c").getKey());
@@ -1114,7 +1114,7 @@ public class DataTest {
           InterruptedException {
     DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
-    DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getNamespace(), ctx);
+    DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getDatabaseUrl(), ctx);
     // Clear any data there
     new WriteFuture(ref, new MapBuilder().put("foo", 10).build()).timedGet();
 
@@ -1133,7 +1133,7 @@ public class DataTest {
   public void parentWorksForRootAndNonRootLocations() throws DatabaseException {
     DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
 
-    DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getNamespace(), ctx);
+    DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getDatabaseUrl(), ctx);
     assertNull(ref.getParent());
     DatabaseReference child = ref.child("a");
     assertEquals(ref, child.getParent());
@@ -1146,9 +1146,9 @@ public class DataTest {
     DatabaseReference ref = IntegrationTestHelpers.getRandomNode();
 
     ref = ref.getRoot();
-    assertEquals(IntegrationTestValues.getNamespace(), ref.toString());
+    assertEquals(IntegrationTestValues.getDatabaseUrl(), ref.toString());
     ref = ref.getRoot(); // Should be a no-op
-    assertEquals(IntegrationTestValues.getNamespace(), ref.toString());
+    assertEquals(IntegrationTestValues.getDatabaseUrl(), ref.toString());
   }
 
   // NOTE: skip test about child accepting numbers. Not applicable in a type-safe language
@@ -1187,14 +1187,14 @@ public class DataTest {
       }
 
       try {
-        new DatabaseReference(IntegrationTestValues.getNamespace() + "/" + path, ctx);
+        new DatabaseReference(IntegrationTestValues.getDatabaseUrl() + "/" + path, ctx);
         fail("Should not be a valid path: " + path);
       } catch (DatabaseException e) {
         // No-op, expected
       }
 
       try {
-        new DatabaseReference(IntegrationTestValues.getNamespace() + "/tests/" + path, ctx);
+        new DatabaseReference(IntegrationTestValues.getDatabaseUrl() + "/tests/" + path, ctx);
         fail("Should not be a valid path: " + path);
       } catch (DatabaseException e) {
         // No-op, expected
@@ -1478,7 +1478,7 @@ public class DataTest {
 
     String child = "" + new Random().nextInt(100000000);
     DatabaseReference ref1 =
-        new DatabaseReference(IntegrationTestValues.getNamespace() + "/" + child, ctx1);
+        new DatabaseReference(IntegrationTestValues.getDatabaseUrl() + "/" + child, ctx1);
     DatabaseReference ref2 =
         new DatabaseReference(
             "http://"
@@ -1497,7 +1497,7 @@ public class DataTest {
   @Test
   public void namespacesAreCaseInsensitiveInToString() throws DatabaseException {
     DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
-    DatabaseReference ref1 = new DatabaseReference(IntegrationTestValues.getNamespace(), ctx);
+    DatabaseReference ref1 = new DatabaseReference(IntegrationTestValues.getDatabaseUrl(), ctx);
     DatabaseReference ref2 =
         new DatabaseReference(
             "http://"

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -107,9 +107,9 @@ public class FirebaseDatabaseTest {
   public void getInstanceForAppWithUrl() {
     FirebaseApp app =
         appForDatabaseUrl(IntegrationTestValues.getAltNamespace(), "getInstanceForAppWithUrl");
-    FirebaseDatabase db = FirebaseDatabase.getInstance(app, IntegrationTestValues.getNamespace());
+    FirebaseDatabase db = FirebaseDatabase.getInstance(app, IntegrationTestValues.getDatabaseUrl());
 
-    assertEquals(IntegrationTestValues.getNamespace(), db.getReference().toString());
+    assertEquals(IntegrationTestValues.getDatabaseUrl(), db.getReference().toString());
   }
 
   @Test
@@ -140,15 +140,15 @@ public class FirebaseDatabaseTest {
   public void getDifferentInstanceForAppWithUrl() {
     FirebaseApp app =
         appForDatabaseUrl(
-            IntegrationTestValues.getNamespace(), "getDifferentInstanceForAppWithUrl");
+            IntegrationTestValues.getDatabaseUrl(), "getDifferentInstanceForAppWithUrl");
     FirebaseDatabase unspecified = FirebaseDatabase.getInstance(app);
     FirebaseDatabase original =
-        FirebaseDatabase.getInstance(app, IntegrationTestValues.getNamespace());
+        FirebaseDatabase.getInstance(app, IntegrationTestValues.getDatabaseUrl());
     FirebaseDatabase alternate =
         FirebaseDatabase.getInstance(app, IntegrationTestValues.getAltNamespace());
 
-    assertEquals(IntegrationTestValues.getNamespace(), unspecified.getReference().toString());
-    assertEquals(IntegrationTestValues.getNamespace(), original.getReference().toString());
+    assertEquals(IntegrationTestValues.getDatabaseUrl(), unspecified.getReference().toString());
+    assertEquals(IntegrationTestValues.getDatabaseUrl(), original.getReference().toString());
     assertEquals(IntegrationTestValues.getAltNamespace(), alternate.getReference().toString());
   }
 
@@ -201,7 +201,7 @@ public class FirebaseDatabaseTest {
   @Test
   public void getReference() {
     FirebaseDatabase db = FirebaseDatabase.getInstance();
-    assertEquals(IntegrationTestValues.getNamespace() + "/foo", db.getReference("foo").toString());
+    assertEquals(IntegrationTestValues.getDatabaseUrl() + "/foo", db.getReference("foo").toString());
   }
 
   @Test
@@ -235,16 +235,16 @@ public class FirebaseDatabaseTest {
   @Test
   public void getReferenceFromURLWithEmptyPath() {
     FirebaseDatabase db = FirebaseDatabase.getInstance();
-    DatabaseReference ref = db.getReferenceFromUrl(IntegrationTestValues.getNamespace());
-    assertEquals(IntegrationTestValues.getNamespace(), ref.toString());
+    DatabaseReference ref = db.getReferenceFromUrl(IntegrationTestValues.getDatabaseUrl());
+    assertEquals(IntegrationTestValues.getDatabaseUrl(), ref.toString());
   }
 
   @Test
   public void getReferenceFromURLWithPath() {
     FirebaseDatabase db = FirebaseDatabase.getInstance();
     DatabaseReference ref =
-        db.getReferenceFromUrl(IntegrationTestValues.getNamespace() + "/foo/bar");
-    assertEquals(IntegrationTestValues.getNamespace() + "/foo/bar", ref.toString());
+        db.getReferenceFromUrl(IntegrationTestValues.getDatabaseUrl() + "/foo/bar");
+    assertEquals(IntegrationTestValues.getDatabaseUrl() + "/foo/bar", ref.toString());
   }
 
   @Test(expected = DatabaseException.class)
@@ -261,8 +261,8 @@ public class FirebaseDatabaseTest {
 
   @Test
   public void referenceEqualityForDatabase() {
-    FirebaseDatabase db1 = dbForDatabaseUrl(IntegrationTestValues.getNamespace(), "db1");
-    FirebaseDatabase db2 = dbForDatabaseUrl(IntegrationTestValues.getNamespace(), "db2");
+    FirebaseDatabase db1 = dbForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), "db1");
+    FirebaseDatabase db2 = dbForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), "db2");
     FirebaseDatabase altDb = dbForDatabaseUrl(IntegrationTestValues.getAltNamespace(), "altdb");
 
     DatabaseReference testRef1 = db1.getReference();

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/InfoTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/InfoTest.java
@@ -48,16 +48,16 @@ public class InfoTest {
   public void canGetAReferenceToDotInfoNodes() throws DatabaseException {
     DatabaseReference root = getRootNode();
 
-    assertEquals(IntegrationTestValues.getNamespace() + "/.info", root.child(".info").toString());
+    assertEquals(IntegrationTestValues.getDatabaseUrl() + "/.info", root.child(".info").toString());
     assertEquals(
-        IntegrationTestValues.getNamespace() + "/.info/foo", root.child(".info/foo").toString());
+        IntegrationTestValues.getDatabaseUrl() + "/.info/foo", root.child(".info/foo").toString());
 
     DatabaseConfig ctx = IntegrationTestHelpers.getContext(0);
     DatabaseReference ref =
-        new DatabaseReference(IntegrationTestValues.getNamespace() + "/.info", ctx);
-    assertEquals(IntegrationTestValues.getNamespace() + "/.info", ref.toString());
-    ref = new DatabaseReference(IntegrationTestValues.getNamespace() + "/.info/foo", ctx);
-    assertEquals(IntegrationTestValues.getNamespace() + "/.info/foo", ref.toString());
+        new DatabaseReference(IntegrationTestValues.getDatabaseUrl() + "/.info", ctx);
+    assertEquals(IntegrationTestValues.getDatabaseUrl() + "/.info", ref.toString());
+    ref = new DatabaseReference(IntegrationTestValues.getDatabaseUrl() + "/.info/foo", ctx);
+    assertEquals(IntegrationTestValues.getDatabaseUrl() + "/.info/foo", ref.toString());
   }
 
   @Test

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/IntegrationTestHelpers.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/IntegrationTestHelpers.java
@@ -218,7 +218,7 @@ public class IntegrationTestHelpers {
   }
 
   public static DatabaseReference rootWithConfig(DatabaseConfig config) {
-    return new DatabaseReference(IntegrationTestValues.getNamespace(), config);
+    return new DatabaseReference(IntegrationTestValues.getDatabaseUrl(), config);
   }
 
   public static DatabaseReference getRandomNode() throws DatabaseException {
@@ -240,7 +240,7 @@ public class IntegrationTestHelpers {
     String name = null;
     for (int i = 0; i < count; ++i) {
       DatabaseReference ref =
-          new DatabaseReference(IntegrationTestValues.getNamespace(), contexts.get(i));
+          new DatabaseReference(IntegrationTestValues.getDatabaseUrl(), contexts.get(i));
       if (name == null) {
         name = ref.push().getKey();
       }
@@ -307,7 +307,7 @@ public class IntegrationTestHelpers {
     if (testSecret == null) {
       try {
         InputStream response =
-            new URL(IntegrationTestValues.getNamespace() + "/.nsadmin/.json?key=1234").openStream();
+            new URL(IntegrationTestValues.getDatabaseUrl() + "/.nsadmin/.json?key=1234").openStream();
         TypeReference<Map<String, Object>> t = new TypeReference<Map<String, Object>>() {};
         Map<String, Object> data = new ObjectMapper().readValue(response, t);
         testSecret = (String) ((List) data.get("secrets")).get(0);

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/IntegrationTestValues.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/IntegrationTestValues.java
@@ -17,6 +17,9 @@ package com.google.firebase.database;
 import android.content.Context;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 public class IntegrationTestValues {
   private static final String TEST_ALT_NAMESPACE = "https://test.firebaseio.com";
   private static final String TEST_SERVER = "firebaseio.com";
@@ -24,9 +27,20 @@ public class IntegrationTestValues {
 
   private IntegrationTestValues() {}
 
-  public static String getNamespace() {
+  public static String getDatabaseUrl() {
     Context c = InstrumentationRegistry.getInstrumentation().getContext();
     return c.getResources().getString(R.string.firebase_database_url);
+  }
+
+  public static String getNamespace() {
+    String dbUrl = getDatabaseUrl();
+    String namespaceWithScheme = dbUrl.substring(0, dbUrl.indexOf('.'));
+    return namespaceWithScheme.substring(namespaceWithScheme.lastIndexOf("/") + 1);
+  }
+
+  public static String getHostname() {
+    String dbUrl = getDatabaseUrl();
+    return dbUrl.substring(dbUrl.lastIndexOf("/") + 1);
   }
 
   public static String getAltNamespace() {

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/QueryTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/QueryTest.java
@@ -4552,7 +4552,7 @@ public class QueryTest {
   public void testGetReturnsNullForEmptyNodeWhenOnline()
       throws DatabaseException, InterruptedException, ExecutionException {
     FirebaseApp app =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseDatabase db = FirebaseDatabase.getInstance(app);
     assertNull(Tasks.await(db.getReference(UUID.randomUUID().toString()).get()).getValue());
   }
@@ -4560,7 +4560,7 @@ public class QueryTest {
   @Test
   public void testGetWaitsForConnection() throws DatabaseException, InterruptedException {
     FirebaseApp app =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseDatabase db = FirebaseDatabase.getInstance(app);
     DatabaseReference node =
         db.getReference().child(Objects.requireNonNull(db.getReference().push().getKey()));
@@ -4589,7 +4589,7 @@ public class QueryTest {
   public void testGetSendsServerGetForNodeWithNoListenerWhenOnline()
       throws DatabaseException, InterruptedException, ExecutionException {
     FirebaseApp app =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseDatabase db = FirebaseDatabase.getInstance(app);
     DatabaseReference node = db.getReference();
     Tasks.await(node.setValue(42));
@@ -4601,9 +4601,9 @@ public class QueryTest {
       throws DatabaseException, InterruptedException, ExecutionException, TestFailure,
           TimeoutException {
     FirebaseApp readerApp =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseApp writerApp =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseDatabase readerDb = FirebaseDatabase.getInstance(readerApp);
     readerDb.setPersistenceEnabled(true);
     FirebaseDatabase writerDb = FirebaseDatabase.getInstance(writerApp);
@@ -4676,9 +4676,9 @@ public class QueryTest {
       throws DatabaseException, InterruptedException, ExecutionException, TestFailure,
           TimeoutException {
     FirebaseApp readerApp =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseApp writerApp =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseDatabase readerDb = FirebaseDatabase.getInstance(readerApp);
     readerDb.setPersistenceEnabled(true);
     FirebaseDatabase writerDb = FirebaseDatabase.getInstance(writerApp);
@@ -4721,9 +4721,9 @@ public class QueryTest {
       throws DatabaseException, InterruptedException, ExecutionException, TestFailure,
           TimeoutException {
     FirebaseApp readerApp =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseApp writerApp =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseDatabase readerDb = FirebaseDatabase.getInstance(readerApp);
     readerDb.setPersistenceEnabled(true);
     FirebaseDatabase writerDb = FirebaseDatabase.getInstance(writerApp);
@@ -4749,9 +4749,9 @@ public class QueryTest {
   public void testGetSkipsPersistenceCacheWhenOnline()
       throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
     FirebaseApp readerApp =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseApp writerApp =
-        appForDatabaseUrl(IntegrationTestValues.getNamespace(), UUID.randomUUID().toString());
+        appForDatabaseUrl(IntegrationTestValues.getDatabaseUrl(), UUID.randomUUID().toString());
     FirebaseDatabase readerDb = FirebaseDatabase.getInstance(readerApp);
     readerDb.setPersistenceEnabled(true);
     FirebaseDatabase writerDb = FirebaseDatabase.getInstance(writerApp);

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/RealtimeTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/RealtimeTest.java
@@ -900,7 +900,7 @@ public class RealtimeTest {
       throws InterruptedException, ExecutionException, TestFailure, TimeoutException {
     DatabaseConfig config = IntegrationTestHelpers.newTestConfig();
     config.setLogLevel(Logger.Level.DEBUG);
-    DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getNamespace(), config);
+    DatabaseReference ref = new DatabaseReference(IntegrationTestValues.getDatabaseUrl(), config);
 
     // Shut it down right away
     DatabaseReference.goOffline(config);

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/connection/ConnectionTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/connection/ConnectionTest.java
@@ -62,8 +62,8 @@ public class ConnectionTest {
         };
     HostInfo info =
         new HostInfo(
-            IntegrationTestValues.getProjectId() + "." + IntegrationTestValues.getServer(),
-            IntegrationTestValues.getProjectId(),
+                IntegrationTestValues.getNamespace(),
+                IntegrationTestValues.getHostname(),
             /*secure=*/ true);
     DatabaseConfig config = IntegrationTestHelpers.newFrozenTestConfig();
     Connection conn = new Connection(config.getConnectionContext(), info, null, del, null, "");

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/snapshot/CompoundHashingIntegrationTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/snapshot/CompoundHashingIntegrationTest.java
@@ -149,7 +149,7 @@ public class CompoundHashingIntegrationTest {
   private void oneRound() throws Throwable {
     final Node initialState = randomNode(random.nextInt(5000));
     Node currentState = initialState;
-    SynchronousConnection conn = new SynchronousConnection(IntegrationTestValues.getNamespace());
+    SynchronousConnection conn = new SynchronousConnection(IntegrationTestValues.getDatabaseUrl());
     conn.connect();
     conn.setValue(Path.getEmptyPath(), initialState, /*wait=*/ false);
     int numUpdates = random.nextInt(30);


### PR DESCRIPTION
Fixed issue where  `ConnectionTest.ObtainSessionID` would use the `projectId` from `google-services.json` and appending `firebaseio.com` to build the connection URL instead of using the `firebase_url` without the scheme. 