### PR TITLE
Handle API disabled errors in firebase-appdistribution

### DIFF
--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -30,6 +30,7 @@ package com.google.firebase.appdistribution {
   }
 
   public enum FirebaseAppDistributionException.Status {
+    enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status API_DISABLED;
     enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status AUTHENTICATION_CANCELED;
     enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status AUTHENTICATION_FAILURE;
     enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status DOWNLOAD_FAILURE;

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
@@ -79,6 +79,17 @@ public class FirebaseAppDistributionException extends FirebaseException {
      * com.google.firebase:firebase-appdistribution}.
      */
     NOT_IMPLEMENTED,
+
+    /**
+     * The Firebase App Distribution Tester API is disabled for this project.
+     *
+     * <p>The developer of this app must enable the API in the Google Cloud Console before using
+     * the App Distribution SDK. See the
+     * <a href="https://firebase.google.com/docs/app-distribution/set-up-alerts?platform=android">documentation</a>
+     * for more information. If you enabled this API recently, wait a few minutes for the action to
+     * propagate to our systems and retry.
+     */
+    API_DISABLED,
   }
 
   @NonNull private final Status status;

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistributionException.java
@@ -83,9 +83,9 @@ public class FirebaseAppDistributionException extends FirebaseException {
     /**
      * The Firebase App Distribution Tester API is disabled for this project.
      *
-     * <p>The developer of this app must enable the API in the Google Cloud Console before using
-     * the App Distribution SDK. See the
-     * <a href="https://firebase.google.com/docs/app-distribution/set-up-alerts?platform=android">documentation</a>
+     * <p>The developer of this app must enable the API in the Google Cloud Console before using the
+     * App Distribution SDK. See the <a
+     * href="https://firebase.google.com/docs/app-distribution/set-up-alerts?platform=android">documentation</a>
      * for more information. If you enabled this API recently, wait a few minutes for the action to
      * propagate to our systems and retry.
      */

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ErrorMessages.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ErrorMessages.java
@@ -15,6 +15,7 @@
 package com.google.firebase.appdistribution.impl;
 
 class ErrorMessages {
+
   static final String NETWORK_ERROR = "Request failed with unknown network error.";
 
   static final String JSON_PARSING_ERROR =
@@ -50,6 +51,9 @@ class ErrorMessages {
 
   static final String APK_INSTALLATION_FAILED =
       "The APK failed to install or installation was canceled by the tester.";
+
+  static final String API_DISABLED =
+      "The App Distribution Tester API is disabled. It must be enabled in the Google Cloud Console. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.";
 
   private ErrorMessages() {}
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterApiDisabledErrorDetails.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterApiDisabledErrorDetails.java
@@ -1,0 +1,110 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Details about a {@code SERVICE_DISABLED} error returned by the Tester API.
+ *
+ * <p>Error structure is described in the <a
+ * href="https://cloud.google.com/apis/design/errors#error_details">Cloud APIs documentation</a>.
+ */
+@AutoValue
+abstract class TesterApiDisabledErrorDetails {
+
+  @AutoValue
+  abstract static class HelpLink {
+    abstract String description();
+
+    abstract String url();
+
+    static HelpLink create(String description, String url) {
+      return new AutoValue_TesterApiDisabledErrorDetails_HelpLink(description, url);
+    }
+  }
+
+  abstract List<HelpLink> helpLinks();
+
+  String formatLinks() {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (HelpLink link : helpLinks()) {
+      stringBuilder.append(String.format("%s: %s\n", link.description(), link.url()));
+    }
+    return stringBuilder.toString();
+  }
+
+  /**
+   * Try to parse API disabled error details from a response body.
+   *
+   * <p>If the response is an API disabled error but there is a failure parsing the help links, it
+   * will still return the details with any links it could parse before the failure.
+   *
+   * @param responseBody
+   * @return the details, or {@code null} if the response was not in the expected format
+   */
+  @Nullable
+  static TesterApiDisabledErrorDetails tryParse(String responseBody) {
+    try {
+      // Get the error details object
+      JSONArray details =
+          new JSONObject(responseBody).getJSONObject("error").getJSONArray("details");
+      JSONObject errorInfo = getDetailWithType(details, "type.googleapis.com/google.rpc.ErrorInfo");
+      if (errorInfo.getString("reason").equals("SERVICE_DISABLED")) {
+        return new AutoValue_TesterApiDisabledErrorDetails(parseHelpLinks(details));
+      }
+    } catch (JSONException e) {
+      // Error was not in expected API disabled error format
+    }
+    return null;
+  }
+
+  private static JSONObject getDetailWithType(JSONArray details, String type) throws JSONException {
+    for (int i = 0; i < details.length(); i++) {
+      JSONObject detail = details.getJSONObject(i);
+      if (detail.getString("@type").equals(type)) {
+        return detail;
+      }
+    }
+    throw new JSONException("No detail present with type: " + type);
+  }
+
+  static List<HelpLink> parseHelpLinks(JSONArray details) {
+    List<HelpLink> helpLinks = new ArrayList<>();
+    try {
+      JSONObject help = getDetailWithType(details, "type.googleapis.com/google.rpc.Help");
+      JSONArray linksJson = help.getJSONArray("links");
+      for (int i = 0; i < linksJson.length(); i++) {
+        helpLinks.add(parseHelpLink(linksJson.getJSONObject(i)));
+      }
+    } catch (JSONException e) {
+      // If we have an issue parsing the links, we don't want to fail the entire error parsing, so
+      // go ahead and return what we have
+    }
+    return helpLinks;
+  }
+
+  private static HelpLink parseHelpLink(JSONObject json) throws JSONException {
+    String description = json.getString("description");
+    String url = json.getString("url");
+    return HelpLink.create(description, url);
+  }
+}

--- a/firebase-appdistribution/src/test/assets/apiDisabledBadLinkResponse.json
+++ b/firebase-appdistribution/src/test/assets/apiDisabledBadLinkResponse.json
@@ -1,0 +1,38 @@
+{
+  "error": {
+    "code": 403,
+    "message": "Firebase App Testers API has not been used in project 123456789 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/firebaseapptesters.googleapis.com/overview?project=123456789 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "status": "PERMISSION_DENIED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "One link",
+            "url": "http://google.com"
+          },
+          {
+            "description": "Another link",
+            "url": "http://gmail.com"
+          },
+          {
+            "bad": "link"
+          },
+          {
+            "description": "One more link",
+            "url": "http://somethingelse.com"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "SERVICE_DISABLED",
+        "domain": "googleapis.com",
+        "metadata": {
+          "consumer": "projects/123456789",
+          "service": "firebaseapptesters.googleapis.com"
+        }
+      }
+    ]
+  }
+}

--- a/firebase-appdistribution/src/test/assets/apiDisabledResponse.json
+++ b/firebase-appdistribution/src/test/assets/apiDisabledResponse.json
@@ -1,0 +1,27 @@
+{
+  "error": {
+    "code": 403,
+    "message": "Firebase App Testers API has not been used in project 123456789 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/firebaseapptesters.googleapis.com/overview?project=123456789 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "status": "PERMISSION_DENIED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "Google developers console API activation",
+            "url": "https://console.developers.google.com/apis/api/firebaseapptesters.googleapis.com/overview?project=123456789"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "SERVICE_DISABLED",
+        "domain": "googleapis.com",
+        "metadata": {
+          "consumer": "projects/123456789",
+          "service": "firebaseapptesters.googleapis.com"
+        }
+      }
+    ]
+  }
+}

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
@@ -138,8 +138,12 @@ final class TestUtils {
     };
   }
 
+  static InputStream getTestFileInputStream(String fileName) throws IOException {
+    return getContext().getResources().getAssets().open(fileName);
+  }
+
   static String readTestFile(String fileName) throws IOException {
-    final InputStream jsonInputStream = getContext().getResources().getAssets().open(fileName);
+    final InputStream jsonInputStream = getTestFileInputStream(fileName);
     return streamToString(jsonInputStream);
   }
 

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterApiDisabledErrorDetailsTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterApiDisabledErrorDetailsTest.java
@@ -1,0 +1,76 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.appdistribution.impl.TesterApiDisabledErrorDetails.HelpLink;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class TesterApiDisabledErrorDetailsTest {
+
+  @Test
+  public void tryParse_success() throws IOException {
+    String responseBody = TestUtils.readTestFile("apiDisabledResponse.json");
+
+    TesterApiDisabledErrorDetails details = TesterApiDisabledErrorDetails.tryParse(responseBody);
+
+    assertThat(details.helpLinks())
+        .containsExactly(
+            HelpLink.create(
+                "Google developers console API activation",
+                "https://console.developers.google.com/apis/api/firebaseapptesters.googleapis.com/overview?project=123456789"));
+  }
+
+  @Test
+  public void tryParse_badResponseBody_returnsNull() {
+    String responseBody = "not json";
+
+    TesterApiDisabledErrorDetails details = TesterApiDisabledErrorDetails.tryParse(responseBody);
+
+    assertThat(details).isNull();
+  }
+
+  @Test
+  public void tryParse_errorParsingLinks_stillReturnsDetails() throws IOException {
+    String responseBody = TestUtils.readTestFile("apiDisabledBadLinkResponse.json");
+
+    TesterApiDisabledErrorDetails details = TesterApiDisabledErrorDetails.tryParse(responseBody);
+
+    assertThat(details.helpLinks())
+        .containsExactly(
+            HelpLink.create("One link", "http://google.com"),
+            HelpLink.create("Another link", "http://gmail.com"));
+  }
+
+  @Test
+  public void formatLinks_success() {
+    List<HelpLink> helpLinks = new ArrayList<>();
+    helpLinks.add(HelpLink.create("One link", "http://google.com"));
+    helpLinks.add(HelpLink.create("Another link", "http://gmail.com"));
+    TesterApiDisabledErrorDetails details = new AutoValue_TesterApiDisabledErrorDetails(helpLinks);
+
+    String formattedLinks = details.formatLinks();
+
+    assertThat(formattedLinks)
+        .isEqualTo("One link: http://google.com\nAnother link: http://gmail.com\n");
+  }
+}


### PR DESCRIPTION
See [go/fad-sdk-auth-errors](http://go/fad-sdk-auth-errors) for more information.