### PR TITLE
Revert "Remove In-App Feedback functionality from firebase-appdistribution (#3926)

### DIFF
--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -15,6 +15,7 @@ package com.google.firebase.appdistribution {
 
   public interface FirebaseAppDistribution {
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.appdistribution.AppDistributionRelease> checkForNewRelease();
+    method public void collectAndSendFeedback();
     method @NonNull public static com.google.firebase.appdistribution.FirebaseAppDistribution getInstance();
     method public boolean isTesterSignedIn();
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -109,6 +109,20 @@ public interface FirebaseAppDistribution {
   @NonNull
   UpdateTask updateApp();
 
+  /**
+   * Takes a screenshot, and starts an activity to collect and submit feedback from the tester.
+   *
+   * <p>Performs the following actions:
+   *
+   * <ol>
+   *   <li>Takes a screenshot of the current activity
+   *   <li>If tester is not signed in, presents the tester with a Google Sign-in UI
+   *   <li>Looks up the currently installed App Distribution release
+   *   <li>Starts a full screen activity for the tester to compose and submit the feedback
+   * </ol>
+   */
+  void collectAndSendFeedback();
+
   /** Gets the singleton {@link FirebaseAppDistribution} instance. */
   @NonNull
   static FirebaseAppDistribution getInstance() {

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
@@ -71,4 +71,9 @@ public class FirebaseAppDistributionProxy implements FirebaseAppDistribution {
   public UpdateTask updateApp() {
     return delegate.updateApp();
   }
+
+  @Override
+  public void collectAndSendFeedback() {
+    delegate.collectAndSendFeedback();
+  }
 }

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
@@ -73,6 +73,11 @@ public class FirebaseAppDistributionStub implements FirebaseAppDistribution {
     return new NotImplementedUpdateTask();
   }
 
+  @Override
+  public void collectAndSendFeedback() {
+    return;
+  }
+
   private static <TResult> Task<TResult> getNotImplementedTask() {
     return Tasks.forException(
         new FirebaseAppDistributionException(

--- a/firebase-appdistribution/src/main/AndroidManifest.xml
+++ b/firebase-appdistribution/src/main/AndroidManifest.xml
@@ -46,6 +46,11 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".FeedbackActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+
         <provider
             android:name="com.google.firebase.appdistribution.impl.FirebaseAppDistributionFileProvider"
             android:authorities="${applicationId}.FirebaseAppDistributionFileProvider"

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -1,0 +1,97 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.Toast;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import java.io.File;
+
+/** Activity for tester to compose and submit feedback. */
+public class FeedbackActivity extends AppCompatActivity {
+
+  private static final String TAG = "FeedbackActivity";
+  private static final int THUMBNAIL_WIDTH = 200;
+  private static final int THUMBNAIL_HEIGHT = 200;
+
+  public static final String RELEASE_NAME_EXTRA_KEY =
+      "com.google.firebase.appdistribution.FeedbackActivity.RELEASE_NAME";
+  public static final String SCREENSHOT_FILENAME_EXTRA_KEY =
+      "com.google.firebase.appdistribution.FeedbackActivity.SCREENSHOT_FILE_NAME";
+
+  private FeedbackSender feedbackSender;
+  private String releaseName;
+  @Nullable private File screenshotFile;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    releaseName = getIntent().getStringExtra(RELEASE_NAME_EXTRA_KEY);
+    if (getIntent().hasExtra(SCREENSHOT_FILENAME_EXTRA_KEY)) {
+      screenshotFile = getFileStreamPath(getIntent().getStringExtra(SCREENSHOT_FILENAME_EXTRA_KEY));
+    }
+    feedbackSender = FeedbackSender.getInstance();
+    setupView();
+  }
+
+  private void setupView() {
+    setContentView(R.layout.activity_feedback);
+    Bitmap thumbnail = readThumbnail();
+    if (thumbnail != null) {
+      ImageView screenshotImageView = (ImageView) this.findViewById(R.id.thumbnail);
+      screenshotImageView.setImageBitmap(thumbnail);
+    } else {
+      View screenshotErrorLabel = this.findViewById(R.id.screenshotErrorLabel);
+      screenshotErrorLabel.setVisibility(View.VISIBLE);
+    }
+  }
+
+  @Nullable
+  private Bitmap readThumbnail() {
+    if (screenshotFile == null) {
+      return null;
+    }
+    return ImageUtils.readScaledImage(screenshotFile, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+  }
+
+  public void submitFeedback(View view) {
+    setSubmittingStateEnabled(true);
+    EditText feedbackText = (EditText) findViewById(R.id.feedbackText);
+    feedbackSender
+        .sendFeedback(releaseName, feedbackText.getText().toString(), screenshotFile)
+        .addOnSuccessListener(
+            unused -> {
+              LogWrapper.getInstance().i(TAG, "Feedback submitted");
+              Toast.makeText(this, "Feedback submitted", Toast.LENGTH_LONG).show();
+              finish();
+            })
+        .addOnFailureListener(
+            e -> {
+              LogWrapper.getInstance().e(TAG, "Failed to submit feedback", e);
+              Toast.makeText(this, "Error submitting feedback", Toast.LENGTH_LONG).show();
+              setSubmittingStateEnabled(false);
+            });
+  }
+
+  public void setSubmittingStateEnabled(boolean loading) {
+    findViewById(R.id.submitButton).setVisibility(loading ? View.INVISIBLE : View.VISIBLE);
+    findViewById(R.id.loadingLabel).setVisibility(loading ? View.VISIBLE : View.INVISIBLE);
+  }
+}

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
@@ -1,0 +1,51 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import androidx.annotation.Nullable;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.FirebaseApp;
+import java.io.File;
+
+/** Sends tester feedback to the Tester API. */
+class FeedbackSender {
+
+  private final FirebaseAppDistributionTesterApiClient testerApiClient;
+
+  FeedbackSender(FirebaseAppDistributionTesterApiClient testerApiClient) {
+    this.testerApiClient = testerApiClient;
+  }
+
+  /** Get an instance of FeedbackSender. */
+  static FeedbackSender getInstance() {
+    return FirebaseApp.getInstance().get(FeedbackSender.class);
+  }
+
+  /** Send feedback text and optionally a screenshot to the Tester API for the given release. */
+  Task<Void> sendFeedback(String releaseName, String feedbackText, @Nullable File screenshotFile) {
+    return testerApiClient
+        .createFeedback(releaseName, feedbackText)
+        .onSuccessTask(feedbackName -> attachScreenshot(feedbackName, screenshotFile))
+        .onSuccessTask(testerApiClient::commitFeedback);
+  }
+
+  private Task<String> attachScreenshot(String feedbackName, @Nullable File screenshotFile) {
+    if (screenshotFile == null) {
+      return Tasks.forResult(feedbackName);
+    }
+    return testerApiClient.attachScreenshot(feedbackName, screenshotFile);
+  }
+}

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
@@ -51,7 +51,22 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
             // activity lifecycle callbacks before the API is called
             .alwaysEager()
             .build(),
+        Component.builder(FeedbackSender.class)
+            .add(Dependency.required(FirebaseApp.class))
+            .add(Dependency.requiredProvider(FirebaseInstallationsApi.class))
+            .factory(this::buildFeedbackSender)
+            .build(),
         LibraryVersionComponent.create("fire-appdistribution", BuildConfig.VERSION_NAME));
+  }
+
+  private FeedbackSender buildFeedbackSender(ComponentContainer container) {
+    FirebaseApp firebaseApp = container.get(FirebaseApp.class);
+    Provider<FirebaseInstallationsApi> firebaseInstallationsApiProvider =
+        container.getProvider(FirebaseInstallationsApi.class);
+    FirebaseAppDistributionTesterApiClient testerApiClient =
+        new FirebaseAppDistributionTesterApiClient(
+            firebaseApp, firebaseInstallationsApiProvider, new TesterApiHttpClient(firebaseApp));
+    return new FeedbackSender(testerApiClient);
   }
 
   private FirebaseAppDistribution buildFirebaseAppDistribution(ComponentContainer container) {
@@ -75,7 +90,9 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
             new ApkUpdater(firebaseApp, new ApkInstaller()),
             new AabUpdater(),
             signInStorage,
-            lifecycleNotifier);
+            lifecycleNotifier,
+            releaseIdentifier,
+            new ScreenshotTaker(firebaseApp, lifecycleNotifier));
 
     if (context instanceof Application) {
       Application firebaseApplication = (Application) context;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
@@ -1,0 +1,81 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import androidx.annotation.Nullable;
+import com.google.auto.value.AutoValue;
+import java.io.File;
+
+public class ImageUtils {
+
+  @AutoValue
+  abstract static class ImageSize {
+    abstract int width();
+
+    abstract int height();
+
+    static ImageSize read(File file) {
+      final BitmapFactory.Options options = new BitmapFactory.Options();
+      options.inJustDecodeBounds = true;
+      BitmapFactory.decodeFile(file.getAbsolutePath(), options);
+      return new AutoValue_ImageUtils_ImageSize(options.outWidth, options.outHeight);
+    }
+  }
+
+  /**
+   * Read an image from a file, scaled as small as possible according to the target size.
+   *
+   * <p>The returned bitmap will be scaled down, preserving the aspect ratio, by the largest power
+   * of 2 that results in the width and height still being larger than the target.
+   *
+   * <p>Based on https://developer.android.com/topic/performance/graphics/load-bitmap#load-bitmap.
+   *
+   * @return the image, or null if it could not be decoded
+   * @throws IllegalArgumentException if target height or width are less than or equal to zero
+   */
+  @Nullable
+  public static Bitmap readScaledImage(File file, int targetWidth, int targetHeight) {
+    if (targetWidth <= 0 || targetHeight <= 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Tried to read image with bad dimensions: %dx%d", targetWidth, targetHeight));
+    }
+    ImageSize imageSize = ImageSize.read(file);
+    final BitmapFactory.Options options = new BitmapFactory.Options();
+    options.inSampleSize =
+        calculateInSampleSize(imageSize.width(), imageSize.height(), targetWidth, targetHeight);
+    return BitmapFactory.decodeFile(file.getAbsolutePath(), options);
+  }
+
+  private static int calculateInSampleSize(
+      int sourceWidth, int sourceHeight, int targetWidth, int targetHeight) {
+    int inSampleSize = 1;
+    if (sourceHeight > targetHeight || sourceWidth > targetWidth) {
+      final int halfHeight = sourceHeight / 2;
+      final int halfWidth = sourceWidth / 2;
+
+      // Calculate the largest inSampleSize value that is a power of 2 and keeps both
+      // height and width larger than the target height and width
+      while ((halfHeight / inSampleSize) >= targetHeight
+          && (halfWidth / inSampleSize) >= targetWidth) {
+        inSampleSize *= 2;
+      }
+    }
+
+    return inSampleSize;
+  }
+}

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -1,0 +1,120 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.view.View;
+import androidx.annotation.VisibleForTesting;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.appdistribution.FirebaseAppDistributionException;
+import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/** A class that takes screenshots of the host app. */
+class ScreenshotTaker {
+
+  static final String SCREENSHOT_FILE_NAME =
+      "com.google.firebase.appdistribution_feedback_screenshot.png";
+
+  private final FirebaseApp firebaseApp;
+  private final FirebaseAppDistributionLifecycleNotifier lifecycleNotifier;
+  private final Executor taskExecutor;
+
+  ScreenshotTaker(
+      FirebaseApp firebaseApp, FirebaseAppDistributionLifecycleNotifier lifecycleNotifier) {
+    this(firebaseApp, lifecycleNotifier, Executors.newSingleThreadExecutor());
+  }
+
+  @VisibleForTesting
+  ScreenshotTaker(
+      FirebaseApp firebaseApp,
+      FirebaseAppDistributionLifecycleNotifier lifecycleNotifier,
+      Executor taskExecutor) {
+    this.firebaseApp = firebaseApp;
+    this.lifecycleNotifier = lifecycleNotifier;
+    this.taskExecutor = taskExecutor;
+  }
+
+  /**
+   * Take a screenshot of the running host app and write it to a file.
+   *
+   * @return a {@link Task} that will complete with the filename in app-level storage where the
+   *     screenshot was written.
+   */
+  Task<String> takeScreenshot() {
+    return deleteScreenshot()
+        .onSuccessTask(unused -> captureScreenshot())
+        .onSuccessTask(this::writeToFile);
+  }
+
+  /** Deletes any previously taken screenshot. */
+  Task<Void> deleteScreenshot() {
+    return TaskUtils.runAsyncInTask(
+        taskExecutor,
+        () -> {
+          // throw new IllegalStateException("We got this far");
+          firebaseApp.getApplicationContext().deleteFile(SCREENSHOT_FILE_NAME);
+          return null;
+        });
+  }
+
+  @VisibleForTesting
+  Task<Bitmap> captureScreenshot() {
+    return lifecycleNotifier.applyToForegroundActivity(
+        activity -> {
+          // We only take the screenshot here because this will be called on the main thread, so we
+          // want to do as little work as possible
+          try {
+            View view = activity.getWindow().getDecorView().getRootView();
+            Bitmap bitmap =
+                Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.RGB_565);
+            Canvas canvas = new Canvas(bitmap);
+            view.draw(canvas);
+            return bitmap;
+          } catch (Exception | OutOfMemoryError e) {
+            throw new FirebaseAppDistributionException(
+                "Failed to take screenshot", Status.UNKNOWN, e);
+          }
+        });
+  }
+
+  private Task<String> writeToFile(Bitmap bitmap) {
+    return TaskUtils.runAsyncInTask(
+        taskExecutor,
+        () -> {
+          try (FileOutputStream outputStream = openFileOutputStream()) {
+            // PNG is a lossless format, the compression factor (100) is ignored
+            bitmap.compress(Bitmap.CompressFormat.PNG, /* quality= */ 100, outputStream);
+          } catch (IOException e) {
+            throw new FirebaseAppDistributionException(
+                "Failed to write screenshot to storage", Status.UNKNOWN, e);
+          }
+          return SCREENSHOT_FILE_NAME;
+        });
+  }
+
+  private FileOutputStream openFileOutputStream() throws FileNotFoundException {
+    return firebaseApp
+        .getApplicationContext()
+        .openFileOutput(SCREENSHOT_FILE_NAME, Context.MODE_PRIVATE);
+  }
+}

--- a/firebase-appdistribution/src/main/res/layout/activity_feedback.xml
+++ b/firebase-appdistribution/src/main/res/layout/activity_feedback.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FeedbackActivity">
+
+  <TextView
+      android:id="@+id/title"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="48dp"
+      android:text="Enter feedback:"
+      android:textSize="24sp"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+  <EditText
+      android:id="@+id/feedbackText"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:ems="5"
+      android:gravity="start|top"
+      android:inputType="textMultiLine"
+      android:lines="6"
+      android:layout_margin="24dp"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintVertical_bias="0.25" />
+  <Button
+      android:id="@+id/submitButton"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="32dp"
+      android:text="Submit"
+      android:onClick="submitFeedback"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/feedbackText" />
+  <TextView
+      android:id="@+id/loadingLabel"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="44dp"
+      android:text="Submitting feedback..."
+      android:visibility="invisible"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/feedbackText" />
+  <!-- Width and height should match bitmap created in setupView() -->
+  <ImageView
+      android:id="@+id/thumbnail"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:scaleType="centerInside"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/submitButton"
+      app:layout_constraintVertical_bias="0.312"/>
+  <TextView
+      android:id="@+id/screenshotErrorLabel"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="Failed to take screenshot"
+      android:visibility="invisible"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/submitButton"
+      app:layout_constraintVertical_bias="0.403" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FeedbackSenderTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FeedbackSenderTest.java
@@ -1,0 +1,129 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.test.core.app.ApplicationProvider;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.appdistribution.FirebaseAppDistributionException;
+import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
+import java.io.File;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class FeedbackSenderTest {
+  private static final String TEST_RELEASE_NAME = "release-name";
+  private static final String TEST_FEEDBACK_NAME = "feedback-name";
+  private static final String TEST_FEEDBACK_TEXT = "Feedback text";
+  private static final File TEST_SCREENSHOT_FILE =
+      ApplicationProvider.getApplicationContext().getFileStreamPath("test.png");
+
+  @Mock private FirebaseAppDistributionTesterApiClient mockTesterApiClient;
+
+  private FeedbackSender feedbackSender;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    feedbackSender = new FeedbackSender(mockTesterApiClient);
+  }
+
+  @Test
+  public void sendFeedback_success() throws Exception {
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
+        .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
+    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_FILE))
+        .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
+    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME)).thenReturn(Tasks.forResult(null));
+
+    Task<Void> task =
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_FILE);
+    TestUtils.awaitTask(task);
+
+    verify(mockTesterApiClient).createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT);
+    verify(mockTesterApiClient).attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_FILE);
+    verify(mockTesterApiClient).commitFeedback(TEST_FEEDBACK_NAME);
+  }
+
+  @Test
+  public void sendFeedback_withoutScreenshot_success() throws Exception {
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
+        .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
+    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME)).thenReturn(Tasks.forResult(null));
+
+    Task<Void> task =
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, /* screenshot= */ null);
+    TestUtils.awaitTask(task);
+
+    verify(mockTesterApiClient).createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT);
+    verify(mockTesterApiClient).commitFeedback(TEST_FEEDBACK_NAME);
+    verify(mockTesterApiClient, never()).attachScreenshot(any(), any());
+  }
+
+  @Test
+  public void sendFeedback_createFeedbackFails_failsTask() {
+    FirebaseAppDistributionException cause =
+        new FirebaseAppDistributionException("test ex", Status.AUTHENTICATION_FAILURE);
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
+        .thenReturn(Tasks.forException(cause));
+
+    Task<Void> task =
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_FILE);
+
+    TestUtils.awaitTaskFailure(task, Status.AUTHENTICATION_FAILURE, "test ex");
+  }
+
+  @Test
+  public void sendFeedback_attachScreenshotFails_failsTask() {
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
+        .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
+    FirebaseAppDistributionException cause =
+        new FirebaseAppDistributionException("test ex", Status.AUTHENTICATION_FAILURE);
+    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_FILE))
+        .thenReturn(Tasks.forException(cause));
+
+    Task<Void> task =
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_FILE);
+
+    TestUtils.awaitTaskFailure(task, Status.AUTHENTICATION_FAILURE, "test ex");
+  }
+
+  @Test
+  public void sendFeedback_commitFeedbackFails_failsTask() {
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
+        .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
+    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_FILE))
+        .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
+    FirebaseAppDistributionException cause =
+        new FirebaseAppDistributionException("test ex", Status.AUTHENTICATION_FAILURE);
+    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME))
+        .thenReturn(Tasks.forException(cause));
+
+    Task<Void> task =
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_FILE);
+
+    TestUtils.awaitTaskFailure(task, Status.AUTHENTICATION_FAILURE, "test ex");
+  }
+}

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
@@ -1,0 +1,138 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Bitmap.CompressFormat;
+import android.graphics.Bitmap.Config;
+import androidx.test.core.app.ApplicationProvider;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowBitmapFactory;
+
+@RunWith(RobolectricTestRunner.class)
+public class ImageUtilsTest {
+  private static final String TEST_FILENAME = "test.png";
+  private static final int TEST_SCREENSHOT_WIDTH = 1080;
+  private static final int TEST_SCREENSHOT_HEIGHT = 2280;
+  private static final Bitmap TEST_SCREENSHOT =
+      Bitmap.createBitmap(TEST_SCREENSHOT_WIDTH, TEST_SCREENSHOT_HEIGHT, Config.RGB_565);
+
+  @Before
+  public void setUp() {
+    // Makes the shadow behave like the real BitmapFactory, for example returning null for
+    // nonexistent files
+    ShadowBitmapFactory.setAllowInvalidImageData(false);
+  }
+
+  @Test
+  public void readScaledImage_targetIsLessThanHalf_scalesDown() throws IOException {
+    File file = writeBitmapToTmpFile();
+
+    Bitmap result =
+        ImageUtils.readScaledImage(
+            file, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
+
+    assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
+    assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
+  }
+
+  @Test
+  public void readScaledImage_targetExactlyPowerOfTwoSmaller_scalesDown() throws IOException {
+    File file = writeBitmapToTmpFile();
+
+    Bitmap result =
+        ImageUtils.readScaledImage(file, TEST_SCREENSHOT_WIDTH / 4, TEST_SCREENSHOT_HEIGHT / 4);
+
+    assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 4);
+    assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 4);
+  }
+
+  @Test
+  public void readScaledImage_targetWidthIsSmaller_scalesDownToFitHeight() throws IOException {
+    File file = writeBitmapToTmpFile();
+
+    Bitmap result =
+        ImageUtils.readScaledImage(
+            file, TEST_SCREENSHOT_WIDTH / 4 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
+
+    assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
+    assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
+  }
+
+  @Test
+  public void readScaledImage_targetHeightIsSmaller_scalesDownToFitWidth() throws IOException {
+    File file = writeBitmapToTmpFile();
+
+    Bitmap result =
+        ImageUtils.readScaledImage(
+            file, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 4 - 100);
+
+    assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
+    assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
+  }
+
+  @Test
+  public void readScaledImage_targetIsGreaterThanHalf_returnsOriginal() throws IOException {
+    File file = writeBitmapToTmpFile();
+    Bitmap result =
+        ImageUtils.readScaledImage(file, TEST_SCREENSHOT_WIDTH - 100, TEST_SCREENSHOT_HEIGHT - 100);
+
+    assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
+    assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
+  }
+
+  @Test
+  public void readScaledImage_targetIsGreater_returnsOriginal() throws IOException {
+    File file = writeBitmapToTmpFile();
+    Bitmap result =
+        ImageUtils.readScaledImage(file, TEST_SCREENSHOT_WIDTH * 2, TEST_SCREENSHOT_HEIGHT * 2);
+
+    assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
+    assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
+  }
+
+  @Test
+  public void readScaledImage_zeroDimension_throws() throws IOException {
+    File file = writeBitmapToTmpFile();
+    assertThrows(IllegalArgumentException.class, () -> ImageUtils.readScaledImage(file, 500, 0));
+  }
+
+  @Test
+  public void readScaledImage_doesntExist_throws() throws IOException {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ImageUtils.readScaledImage(new File("nonexistent.png"), 500, 0));
+  }
+
+  private static File writeBitmapToTmpFile() throws IOException {
+    // Write bitmap to file
+    try (FileOutputStream outputStream =
+        ApplicationProvider.getApplicationContext()
+            .openFileOutput(TEST_FILENAME, Context.MODE_PRIVATE)) {
+      TEST_SCREENSHOT.compress(CompressFormat.PNG, 100, outputStream);
+    }
+    return ApplicationProvider.getApplicationContext().getFileStreamPath(TEST_FILENAME);
+  }
+}

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ScreenshotTakerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ScreenshotTakerTest.java
@@ -1,0 +1,104 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import static android.os.Looper.getMainLooper;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.appdistribution.impl.ScreenshotTaker.SCREENSHOT_FILE_NAME;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.graphics.Bitmap;
+import android.graphics.Bitmap.Config;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import java.util.concurrent.Executor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class ScreenshotTakerTest {
+  private static final String TEST_API_KEY = "AIzaSyabcdefghijklmnopqrstuvwxyz1234567";
+  private static final String TEST_APP_ID_1 = "1:123456789:android:abcdef";
+  private static final String TEST_PROJECT_ID = "project-id";
+  private static final String TEST_PROJECT_NUMBER = "123456789";
+  private static final Bitmap TEST_SCREENSHOT = Bitmap.createBitmap(400, 400, Config.RGB_565);
+  private static final Executor TEST_EXECUTOR = Runnable::run;
+
+  private FirebaseApp firebaseApp;
+  @Mock private FirebaseAppDistributionLifecycleNotifier mockLifecycleNotifier;
+
+  private ScreenshotTaker screenshotTaker;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    FirebaseApp.clearInstancesForTest();
+
+    firebaseApp =
+        FirebaseApp.initializeApp(
+            ApplicationProvider.getApplicationContext(),
+            new FirebaseOptions.Builder()
+                .setApplicationId(TEST_APP_ID_1)
+                .setProjectId(TEST_PROJECT_ID)
+                .setGcmSenderId(TEST_PROJECT_NUMBER)
+                .setApiKey(TEST_API_KEY)
+                .build());
+
+    screenshotTaker = spy(new ScreenshotTaker(firebaseApp, mockLifecycleNotifier, TEST_EXECUTOR));
+
+    // Taking a screenshot of an actual activity would require an instrumentation test
+    doReturn(Tasks.forResult(TEST_SCREENSHOT)).when(screenshotTaker).captureScreenshot();
+  }
+
+  @After
+  public void tearDown() {
+    ApplicationProvider.getApplicationContext().deleteFile(SCREENSHOT_FILE_NAME);
+  }
+
+  @Test
+  public void takeAndDeleteScreenshot_success() throws Exception {
+    // Take a screenshot
+    Task<String> task = screenshotTaker.takeScreenshot();
+    shadowOf(getMainLooper()).idle();
+    String screenshotFilename = TestUtils.awaitTask(task);
+
+    assertThat(screenshotFilename).isEqualTo(SCREENSHOT_FILE_NAME);
+    assertThat(
+            ApplicationProvider.getApplicationContext()
+                .getFileStreamPath(SCREENSHOT_FILE_NAME)
+                .length())
+        .isGreaterThan(0);
+
+    // Delete the screenshot
+    Task<Void> deleteScreenshot = screenshotTaker.deleteScreenshot();
+    TestUtils.awaitTask(deleteScreenshot);
+
+    assertThat(
+            ApplicationProvider.getApplicationContext()
+                .getFileStreamPath(SCREENSHOT_FILE_NAME)
+                .exists())
+        .isFalse();
+  }
+}


### PR DESCRIPTION
This reverts commit 78d28880e0c3897fda8055e988127da67a122466, merging it into `fad-in-app-feedback`.

This will establish the new feature branch for developing the In-App Feedback feature.