### PR TITLE
feat(rtdb): create suspend function to run transactions

### DIFF
--- a/firebase-database/ktx/ktx.gradle
+++ b/firebase-database/ktx/ktx.gradle
@@ -39,10 +39,16 @@ android {
         }
     }
     testOptions.unitTests.includeAndroidResources = true
+
+    // Kotlin Coroutines requires JVM target 1.8
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-database/ktx/src/main/kotlin/com/google/firebase/database/ktx/Database.kt
+++ b/firebase-database/ktx/src/main/kotlin/com/google/firebase/database/ktx/Database.kt
@@ -18,12 +18,18 @@ import androidx.annotation.Keep
 import com.google.firebase.FirebaseApp
 import com.google.firebase.components.Component
 import com.google.firebase.components.ComponentRegistrar
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.GenericTypeIndicator
 import com.google.firebase.database.MutableData
+import com.google.firebase.database.Transaction
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.platforminfo.LibraryVersionComponent
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /** Returns the [FirebaseDatabase] instance of the default [FirebaseApp]. */
 val Firebase.database: FirebaseDatabase
@@ -57,6 +63,39 @@ inline fun <reified T> DataSnapshot.getValue(): T? {
  */
 inline fun <reified T> MutableData.getValue(): T? {
     return getValue(object : GenericTypeIndicator<T>() {})
+}
+
+/**
+ * Run a transaction on the data at this location.
+ * Returns the new data at the location.
+ *
+ * @param fireLocalEvents Defaults to true. If set to false, events will only be fired for the
+ *     final result state of the transaction, and not for any intermediate states
+ * @param handler An object to handle running the transaction
+ */
+suspend fun DatabaseReference.runTransaction(
+    fireLocalEvents: Boolean = true,
+    handler: (MutableData) -> Transaction.Result
+) = suspendCancellableCoroutine<DataSnapshot> { continuation ->
+    runTransaction(object : Transaction.Handler {
+        override fun doTransaction(currentData: MutableData): Transaction.Result {
+            return handler(currentData)
+        }
+
+        override fun onComplete(
+            error: DatabaseError?,
+            committed: Boolean,
+            currentData: DataSnapshot?
+        ) {
+            if (error != null) {
+                continuation.resumeWithException(error.toException())
+            } else {
+                if (currentData != null) {
+                    continuation.resume(currentData)
+                }
+            }
+        }
+    }, fireLocalEvents)
 }
 
 internal const val LIBRARY_NAME: String = "fire-db-ktx"


### PR DESCRIPTION
This is the implementation of go/rtdb-transaction-ktx which proposes an out-of-the-box suspend function for developers to run transactions on the Realtime Database.