### PR TITLE
If modelHash is null pass emptyString to logger which requires non-nu…

### DIFF
--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/CustomModelDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/CustomModelDownloadService.java
@@ -176,7 +176,9 @@ public class CustomModelDownloadService {
                 exceptionCode = FirebaseMlException.NO_NETWORK_CONNECTION;
               }
               eventLogger.logDownloadFailureWithReason(
-                  new CustomModel(modelName, modelHash, 0, 0L), false, errorCode.getValue());
+                  new CustomModel(modelName, modelHash != null ? modelHash : "", 0, 0L),
+                  false,
+                  errorCode.getValue());
               return Tasks.forException(new FirebaseMlException(errorMessage, exceptionCode));
             }
 


### PR DESCRIPTION
…ll modelHash

Fixes https://github.com/firebase/firebase-android-sdk/issues/3940 