### PR TITLE
Install NDK r21 on GitHub Actions

### DIFF
--- a/.github/workflows/ci_tests_experimental.yml
+++ b/.github/workflows/ci_tests_experimental.yml
@@ -22,12 +22,15 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
-      - name: Setup NDK
+      - name: Set up NDK 21.4.7075529
         run: |
           ANDROID_ROOT=/usr/local/lib/android
           ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
           ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-          ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK_ROOT
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+          ln -sfn ${ANDROID_SDK_ROOT}/ndk/21.4.7075529 ${ANDROID_NDK_ROOT}
+          echo "ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}" >> $GITHUB_ENV
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -56,12 +59,15 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
-      - name: Setup NDK
+      - name: Set up NDK 21.4.7075529
         run: |
           ANDROID_ROOT=/usr/local/lib/android
           ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
           ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-          ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK_ROOT
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+          ln -sfn ${ANDROID_SDK_ROOT}/ndk/21.4.7075529 ${ANDROID_NDK_ROOT}
+          echo "ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}" >> $GITHUB_ENV
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -112,12 +118,15 @@ jobs:
         with:
           fetch-depth: 2
           submodules: true
-      - name: Setup NDK
+      - name: Set up NDK 21.4.7075529
         run: |
           ANDROID_ROOT=/usr/local/lib/android
           ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
           ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-          ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK_ROOT
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+          ln -sfn ${ANDROID_SDK_ROOT}/ndk/21.4.7075529 ${ANDROID_NDK_ROOT}
+          echo "ANDROID_NDK_HOME=${ANDROID_NDK_ROOT}" >> $GITHUB_ENV
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2


### PR DESCRIPTION
NDK r21 is no longer provided by default on GitHub Actions.

https://github.com/actions/virtual-environments/issues/5930