### PR TITLE
Add an extension point to ComponentRuntime.

### DIFF
--- a/firebase-components/src/main/java/com/google/firebase/components/ComponentRegistrarProcessor.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/ComponentRegistrarProcessor.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.components;
 
 import java.util.List;

--- a/firebase-components/src/main/java/com/google/firebase/components/ComponentRegistrarProcessor.java
+++ b/firebase-components/src/main/java/com/google/firebase/components/ComponentRegistrarProcessor.java
@@ -1,0 +1,18 @@
+package com.google.firebase.components;
+
+import java.util.List;
+
+/**
+ * Provides the ability to customize/decorate components as they are requested by {@link
+ * ComponentRuntime}.
+ *
+ * <p>This makes it possible to do validation, change/add dependencies, or customize components'
+ * initialization logic by decorating their {@link ComponentFactory factories}.
+ */
+public interface ComponentRegistrarProcessor {
+
+  /** Default "noop" processor. */
+  ComponentRegistrarProcessor NOOP = ComponentRegistrar::getComponents;
+
+  List<Component<?>> processRegistrar(ComponentRegistrar registrar);
+}

--- a/firebase-components/src/test/java/com/google/firebase/components/ComponentTest.java
+++ b/firebase-components/src/test/java/com/google/firebase/components/ComponentTest.java
@@ -195,4 +195,30 @@ public class ComponentTest {
         Component.builder(TestClass.class).factory(nullFactory).build();
     assertThat(component.getFactory()).isSameInstanceAs(nullFactory);
   }
+
+  @Test
+  public void withFactory_shouldReplaceTheFactorySetInBuilder() {
+    Component<TestClass> component =
+        Component.builder(TestClass.class).factory(nullFactory).build();
+
+    ComponentFactory<TestClass> newFactory = c -> null;
+    assertThat(component.withFactory(newFactory).getFactory()).isSameInstanceAs(newFactory);
+  }
+
+  @Test
+  public void name_shouldDefaultToNull() {
+    Component<TestClass> component =
+        Component.builder(TestClass.class).factory(nullFactory).build();
+
+    assertThat(component.getName()).isNull();
+  }
+
+  @Test
+  public void name_shouldReturnNameSetInBuilder() {
+    String name = "myName";
+    Component<TestClass> component =
+        Component.builder(TestClass.class).name(name).factory(nullFactory).build();
+
+    assertThat(component.getName()).isEqualTo(name);
+  }
 }


### PR DESCRIPTION
It allows augmenting/replacing components as they are requested from
ComponentRegistrars.

The motivation is to be able to measure initialization time of
certain components and at the same time not to introduce this
measurement logic directly to the components framework.