### PR TITLE
Remove Firebase Predictions from the Firebase installation ID delete …

### DIFF
--- a/firebase-installations-interop/src/main/java/com/google/firebase/installations/FirebaseInstallationsApi.java
+++ b/firebase-installations-interop/src/main/java/com/google/firebase/installations/FirebaseInstallationsApi.java
@@ -48,9 +48,9 @@ public interface FirebaseInstallationsApi {
   Task<InstallationTokenResult> getToken(boolean forceRefresh);
 
   /**
-   * Async function that deletes this Firebase app installation from Firebase backend. This call
-   * may cause Firebase Cloud Messaging, Firebase Remote Config, Firebase A/B Testing, or
-   * Firebase In-App Messaging to not function properly.
+   * Async function that deletes this Firebase app installation from Firebase backend. This call may
+   * cause Firebase Cloud Messaging, Firebase Remote Config, Firebase A/B Testing, or Firebase
+   * In-App Messaging to not function properly.
    */
   @NonNull
   Task<Void> delete();

--- a/firebase-installations-interop/src/main/java/com/google/firebase/installations/FirebaseInstallationsApi.java
+++ b/firebase-installations-interop/src/main/java/com/google/firebase/installations/FirebaseInstallationsApi.java
@@ -49,8 +49,8 @@ public interface FirebaseInstallationsApi {
 
   /**
    * Async function that deletes this Firebase app installation from Firebase backend. This call
-   * would possibly lead Firebase Notification, Firebase RemoteConfig, Firebase Predictions or
-   * Firebase In-App Messaging not function properly.
+   * may cause Firebase Cloud Messaging, Firebase Remote Config, Firebase A/B Testing, or
+   * Firebase In-App Messaging to not function properly.
    */
   @NonNull
   Task<Void> delete();

--- a/firebase-installations/src/main/java/com/google/firebase/installations/FirebaseInstallations.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/FirebaseInstallations.java
@@ -266,7 +266,7 @@ public class FirebaseInstallations implements FirebaseInstallationsApi {
 
   /**
    * Call to delete this Firebase app installation from the Firebase backend. This call may cause
-   * Firebase Cloud Messaging, Firebase Remote Config, Firebase Predictions, or Firebase In-App
+   * Firebase Cloud Messaging, Firebase Remote Config, Firebase A/B Testing, or Firebase In-App
    * Messaging to not function properly.
    */
   @NonNull


### PR DESCRIPTION
…comment as it was recently shut down; replace with Firebase A/B Testing, which also requires a FID.