### PR TITLE
remove dismiss listener

### DIFF
--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DeveloperListenerManager.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DeveloperListenerManager.java
@@ -164,11 +164,16 @@ public class DeveloperListenerManager {
       FirebaseInAppMessagingDisplayErrorListener displayErrorListener) {
     registeredErrorListeners.remove(displayErrorListener);
   }
+  
+  public void removeDismissListener(FirebaseInAppMessagingDismissListener dismissListener) {
+    registeredDismissListeners.remove(dismissListener);
+  }
 
   public void removeAllListeners() {
     registeredClickListeners.clear();
     registeredImpressionListeners.clear();
     registeredErrorListeners.clear();
+    registeredDismissListeners.clear();
   }
 
   /** The thread factory for Storage threads. */


### PR DESCRIPTION
There is no way to remove dismiss listeners.
So I add this part at `removeDismissListener` and `removeAllListeners`.