### PR TITLE
Fix sync job between OSS and private repository

### DIFF
--- a/.github/workflows/private-mirror-sync.yml
+++ b/.github/workflows/private-mirror-sync.yml
@@ -16,9 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           submodules: true
           token: ${{ secrets.GOOGLE_OSS_BOT_TOKEN }}
       - name: Force push HEAD to private repo main branch
         run: |
-          git remote add mirror git@github.com:FirebasePrivate/firebase-android-sdk.git
+          git remote add mirror https://github.com/FirebasePrivate/firebase-android-sdk.git
           git push mirror HEAD:main --force --verbose


### PR DESCRIPTION
The current setup of the workflow is not working:

https://github.com/firebase/firebase-android-sdk/actions/workflows/private-mirror-sync.yml

There are two problems:
- `actions/checkout` checks out a shallow copy of the code, which is not push-able
- the token supplied to `actions/checkout` can only be used for authentication with http but not with ssh