### PR TITLE
Fix vendoring plugin issues in future AGP versions

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VendorPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VendorPlugin.kt
@@ -139,6 +139,15 @@ class VendorTransform(
                             Format.DIRECTORY)
                     directoryInput.file.copyRecursively(directoryOutput, overwrite = true)
                 }
+                for (jarInput in input.jarInputs) {
+                    val jarOutput = transformInvocation.outputProvider.getContentLocation(
+                        jarInput.name,
+                        setOf(QualifiedContent.DefaultContentType.CLASSES),
+                        mutableSetOf(QualifiedContent.Scope.PROJECT),
+                        Format.JAR)
+
+                    jarInput.file.copyTo(jarOutput, overwrite = true)
+                }
             }
             return
         }
@@ -176,6 +185,9 @@ class VendorTransform(
         for (input in transformInvocation.inputs) {
             for (directoryInput in input.directoryInputs) {
                 directoryInput.file.copyRecursively(unzippedDir)
+            }
+            for (jarInput in input.jarInputs) {
+                unzipJar(jarInput.file, unzippedDir)
             }
         }
 

--- a/firebase-inappmessaging/src/androidTest/java/com/google/firebase/inappmessaging/TestApiClientModule.java
+++ b/firebase-inappmessaging/src/androidTest/java/com/google/firebase/inappmessaging/TestApiClientModule.java
@@ -26,9 +26,9 @@ import com.google.firebase.inappmessaging.internal.TestDeviceHelper;
 import com.google.firebase.inappmessaging.internal.injection.scopes.FirebaseAppScope;
 import com.google.firebase.inappmessaging.internal.time.Clock;
 import com.google.firebase.installations.FirebaseInstallationsApi;
-import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 /** Test bindings for API client */
@@ -77,7 +77,9 @@ public class TestApiClientModule {
   @Provides
   @FirebaseAppScope
   ApiClient providesApiClient(
-      Lazy<GrpcClient> grpcClient, Application application, ProviderInstaller providerInstaller) {
+      Provider<GrpcClient> grpcClient,
+      Application application,
+      ProviderInstaller providerInstaller) {
     return new ApiClient(grpcClient, firebaseApp, application, clock, providerInstaller);
   }
 }

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ApiClient.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ApiClient.java
@@ -27,11 +27,11 @@ import com.google.internal.firebase.inappmessaging.v1.sdkserving.CampaignImpress
 import com.google.internal.firebase.inappmessaging.v1.sdkserving.ClientAppInfo;
 import com.google.internal.firebase.inappmessaging.v1.sdkserving.FetchEligibleCampaignsRequest;
 import com.google.internal.firebase.inappmessaging.v1.sdkserving.FetchEligibleCampaignsResponse;
-import dagger.Lazy;
 import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.inject.Provider;
 
 /**
  * Interface to speak to the fiam backend
@@ -43,14 +43,14 @@ public class ApiClient {
 
   private static final String FETCHING_CAMPAIGN_MESSAGE = "Fetching campaigns from service.";
 
-  private final Lazy<GrpcClient> grpcClient;
+  private final Provider<GrpcClient> grpcClient;
   private final FirebaseApp firebaseApp;
   private final Application application;
   private final Clock clock;
   private final ProviderInstaller providerInstaller;
 
   public ApiClient(
-      Lazy<GrpcClient> grpcClient,
+      Provider<GrpcClient> grpcClient,
       FirebaseApp firebaseApp,
       Application application,
       Clock clock,

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/injection/modules/ApiClientModule.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/injection/modules/ApiClientModule.java
@@ -26,9 +26,9 @@ import com.google.firebase.inappmessaging.internal.TestDeviceHelper;
 import com.google.firebase.inappmessaging.internal.injection.scopes.FirebaseAppScope;
 import com.google.firebase.inappmessaging.internal.time.Clock;
 import com.google.firebase.installations.FirebaseInstallationsApi;
-import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
+import javax.inject.Provider;
 
 /**
  * Provider for ApiClient
@@ -77,7 +77,9 @@ public class ApiClientModule {
   @Provides
   @FirebaseAppScope
   ApiClient providesApiClient(
-      Lazy<GrpcClient> grpcClient, Application application, ProviderInstaller providerInstaller) {
+      Provider<GrpcClient> grpcClient,
+      Application application,
+      ProviderInstaller providerInstaller) {
     return new ApiClient(grpcClient, firebaseApp, application, clock, providerInstaller);
   }
 }

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStoreTest.java
@@ -33,13 +33,13 @@ import com.google.android.datatransport.runtime.time.Clock;
 import com.google.android.datatransport.runtime.time.TestClock;
 import com.google.android.datatransport.runtime.time.UptimeClock;
 import com.google.common.truth.Correspondence;
-import dagger.Lazy;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import javax.inject.Provider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -115,12 +115,12 @@ public class SQLiteEventStoreTest {
   private static final String LOG_SOURCE_3 = "source3";
 
   private final TestClock clock = new TestClock(1);
-  private final Lazy<String> packageName =
+  private final Provider<String> packageName =
       () -> ApplicationProvider.getApplicationContext().getPackageName();
   private final SQLiteEventStore store = newStoreWithConfig(clock, CONFIG, packageName);
 
   private static SQLiteEventStore newStoreWithConfig(
-      Clock clock, EventStoreConfig config, Lazy<String> packageName) {
+      Clock clock, EventStoreConfig config, Provider<String> packageName) {
     return new SQLiteEventStore(
         clock,
         new UptimeClock(),

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SpyEventStoreModule.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/scheduling/persistence/SpyEventStoreModule.java
@@ -22,10 +22,10 @@ import com.google.android.datatransport.runtime.time.Clock;
 import com.google.android.datatransport.runtime.time.Monotonic;
 import com.google.android.datatransport.runtime.time.WallTime;
 import dagger.Binds;
-import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 @Module
@@ -42,7 +42,7 @@ public abstract class SpyEventStoreModule {
       @Monotonic Clock clock,
       EventStoreConfig config,
       SchemaManager schemaManager,
-      @Named("PACKAGE_NAME") Lazy<String> packageName) {
+      @Named("PACKAGE_NAME") Provider<String> packageName) {
     return spy(new SQLiteEventStore(wallClock, clock, config, schemaManager, packageName));
   }
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreModule.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/EventStoreModule.java
@@ -20,6 +20,7 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 @Module
 public abstract class EventStoreModule {
@@ -51,6 +52,7 @@ public abstract class EventStoreModule {
   }
 
   @Provides
+  @Singleton
   @Named("PACKAGE_NAME")
   static String packageName(Context context) {
     return context.getPackageName();

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/persistence/SQLiteEventStore.java
@@ -42,7 +42,6 @@ import com.google.android.datatransport.runtime.time.Clock;
 import com.google.android.datatransport.runtime.time.Monotonic;
 import com.google.android.datatransport.runtime.time.WallTime;
 import com.google.android.datatransport.runtime.util.PriorityMapping;
-import dagger.Lazy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -54,6 +53,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 /** {@link EventStore} implementation backed by a SQLite database. */
@@ -73,7 +73,7 @@ public class SQLiteEventStore
   private final Clock wallClock;
   private final Clock monotonicClock;
   private final EventStoreConfig config;
-  private final Lazy<String> packageName;
+  private final Provider<String> packageName;
 
   @Inject
   SQLiteEventStore(
@@ -81,7 +81,7 @@ public class SQLiteEventStore
       @Monotonic Clock clock,
       EventStoreConfig config,
       SchemaManager schemaManager,
-      @Named("PACKAGE_NAME") Lazy<String> packageName) {
+      @Named("PACKAGE_NAME") Provider<String> packageName) {
 
     this.schemaManager = schemaManager;
     this.wallClock = wallClock;

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/SchemaManagerTest.java
@@ -28,9 +28,9 @@ import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.time.TestClock;
 import com.google.android.datatransport.runtime.time.UptimeClock;
 import com.google.android.datatransport.runtime.util.PriorityMapping;
-import dagger.Lazy;
 import java.nio.charset.Charset;
 import java.util.Map;
+import javax.inject.Provider;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,7 +71,7 @@ public class SchemaManagerTest {
       EventStoreConfig.DEFAULT.toBuilder().setLoadBatchSize(5).setEventCleanUpAge(HOUR).build();
 
   private final TestClock clock = new TestClock(1);
-  private final Lazy<String> packageName =
+  private final Provider<String> packageName =
       () -> ApplicationProvider.getApplicationContext().getPackageName();
 
   @Test


### PR DESCRIPTION
1. Transform jar inputs in addition to directory inputs.

Future AGP will generate r_classes.jar instead of creating R classes in
a directory.

2. Replace Lazy with Provider to avoid vendoring issues.

It looks like AGP has stopped "transforming" test classes, so switching
to Provider instead of `dagger.Lazy` to avoid the problem. It's not an
issue since the injected classes are effectively singletons.