### PR TITLE
Use more explanatory name for API information job

### DIFF
--- a/.github/workflows/api-information.yml
+++ b/.github/workflows/api-information.yml
@@ -3,7 +3,7 @@ name: API Information
 on: [ pull_request ]
 
 jobs:
-  check:
+  api-information-check:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When configuring required status checks to pass in branch protection rules, the status checks are distinguished only by the job names, regardless of their workflow name. Therefore, individual job names need to be more self-explanatory.