### PR TITLE
Use the more common stdlib dep now that we ship java8 bytecode.

### DIFF
--- a/appcheck/firebase-appcheck/ktx/ktx.gradle
+++ b/appcheck/firebase-appcheck/ktx/ktx.gradle
@@ -51,7 +51,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Dokka.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Dokka.java
@@ -57,6 +57,10 @@ final class Dokka {
 
     Configuration javadocClasspath = project.getConfigurations().create("javadocClasspath");
     project.getDependencies().add("javadocClasspath", "com.google.code.findbugs:jsr305:3.0.2");
+    project
+        .getDependencies()
+        .add("javadocClasspath", "com.google.errorprone:error_prone_annotations:2.15.0");
+
     if (android != null) {
       javadocClasspath
           .getAttributes()

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/Publisher.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/Publisher.java
@@ -105,7 +105,7 @@ public class Publisher {
       }
 
       Element type = dep.getOwnerDocument().createElement("type");
-      type.setTextContent(deps.get(groupId + ":" + artifactId));
+      type.setTextContent(deps.getOrDefault(groupId + ":" + artifactId, "jar"));
       dep.appendChild(type);
 
       NodeList scopes = dep.getElementsByTagName("scope");

--- a/firebase-appdistribution-api/ktx/ktx.gradle
+++ b/firebase-appdistribution-api/ktx/ktx.gradle
@@ -51,7 +51,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-common/firebase-common.gradle
+++ b/firebase-common/firebase-common.gradle
@@ -75,7 +75,7 @@ dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
     // needed for Kotlin detection to compile, but not necessarily present at runtime.
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'

--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-crashlytics/ktx/ktx.gradle
+++ b/firebase-crashlytics/ktx/ktx.gradle
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-database/ktx/ktx.gradle
+++ b/firebase-database/ktx/ktx.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-dynamic-links/ktx/ktx.gradle
+++ b/firebase-dynamic-links/ktx/ktx.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -49,7 +49,7 @@ tasks.withType(Test) {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation project(':firebase-common')
     implementation project(':firebase-components')
     implementation project(':firebase-common:ktx')

--- a/firebase-functions/ktx/ktx.gradle
+++ b/firebase-functions/ktx/ktx.gradle
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-inappmessaging-display/ktx/ktx.gradle
+++ b/firebase-inappmessaging-display/ktx/ktx.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-inappmessaging/ktx/ktx.gradle
+++ b/firebase-inappmessaging/ktx/ktx.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-common:ktx')

--- a/firebase-installations/ktx/ktx.gradle
+++ b/firebase-installations/ktx/ktx.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-common:ktx')

--- a/firebase-messaging/ktx/ktx.gradle
+++ b/firebase-messaging/ktx/ktx.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-common:ktx')

--- a/firebase-ml-modeldownloader/ktx/ktx.gradle
+++ b/firebase-ml-modeldownloader/ktx/ktx.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-common:ktx')

--- a/firebase-perf/ktx/ktx.gradle
+++ b/firebase-perf/ktx/ktx.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')

--- a/firebase-storage/ktx/ktx.gradle
+++ b/firebase-storage/ktx/ktx.gradle
@@ -53,7 +53,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation project(':firebase-common')
     implementation project(':firebase-components')


### PR DESCRIPTION
Additionally fix pom dependency type resolution.