### PR TITLE
Prevent gradle daemon from crashing

### DIFF
--- a/smoke-tests/gradle.properties
+++ b/smoke-tests/gradle.properties
@@ -15,4 +15,4 @@
 android.enableR8=true
 android.useAndroidX=true
 
-org.gradle.jvmargs=-Xmx8g -XX:MaxPermSize=8g
+org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=4g


### PR DESCRIPTION
Smoke tests have been occasionally failing due to:

```
FAILURE: Build failed with an exception.

* What went wrong:
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```

This pull request seems to fix the issue. With the change in this pull request, the above error does not appear in any of the 5 total runs of smoke tests (see attempt 1-5 of https://github.com/firebase/firebase-android-sdk/actions/runs/2905798357).