### PR TITLE
Add a new plugin for Dackka

### DIFF
--- a/appcheck/firebase-appcheck/ktx/src/main/kotlin/com/google/firebase/appcheck/ktx/FirebaseAppCheck.kt
+++ b/appcheck/firebase-appcheck/ktx/src/main/kotlin/com/google/firebase/appcheck/ktx/FirebaseAppCheck.kt
@@ -46,6 +46,7 @@ operator fun AppCheckToken.component2() = expireTimeMillis
 
 internal const val LIBRARY_NAME: String = "fire-app-check-ktx"
 
+/** @suppress */
 class FirebaseAppCheckKtxRegistrar : ComponentRegistrar {
     override fun getComponents(): List<Component<*>> =
             listOf(LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME))

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ buildscript {
         }
         maven {
             url 'https://storage.googleapis.com/android-ci/mvn/'
+            metadataSources {
+                artifact()
+            }
         }
 
     }

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ configure(subprojects) {
         mavenCentral()
         maven {
             url 'https://storage.googleapis.com/android-ci/mvn/'
+            metadataSources {
+                artifact()
+            }
         }
     }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -72,6 +72,10 @@ gradlePlugin {
             id = "LicenseResolverPlugin"
             implementationClass = "com.google.firebase.gradle.plugins.license.LicenseResolverPlugin"
         }
+        register("dackkaPlugin") {
+            id = "DackkaPlugin"
+            implementationClass = "com.google.firebase.gradle.plugins.DackkaPlugin"
+        }
         register("multiProjectReleasePlugin") {
             id = "MultiProjectReleasePlugin"
             implementationClass = "com.google.firebase.gradle.MultiProjectReleasePlugin"

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
@@ -68,6 +68,7 @@ abstract class GenerateDocumentationTask @Inject constructor(
     }
 
     private fun constructArguments(): JSONObject {
+        // TODO(b/243675474): Move these to a task input for caching purposes
         val linksMap = mapOf(
             "android" to "https://developer.android.com/reference/kotlin/",
             "google" to "https://developer.android.com/reference/",

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
@@ -52,7 +52,7 @@ abstract class GenerateDocumentationTaskExtension : DefaultTask() {
 /**
  * Task to run Dackka on a project.
  *
- * Since dackka needs to be ran on the command line, we have to organize the arguments for dackka into
+ * Since dackka needs to be run on the command line, we have to organize the arguments for dackka into
  * a json file. We then pass that json file to dackka as an argument.
  *
  * @see GenerateDocumentationTaskExtension

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
@@ -1,0 +1,154 @@
+package com.google.firebase.gradle.plugins
+
+import java.io.File
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import org.json.JSONObject
+
+/**
+ * Extension class for [GenerateDocumentationTask].
+ *
+ * Provides public configurations for the task.
+ *
+ * @property dackkaJarFile a [File] of the Dackka fat jar
+ * @property dependencies a list of all dependent jars (the classpath)
+ * @property kotlinSources a list of kotlin source roots
+ * @property javaSources a list of java source roots
+ * @property suppressedFiles a list of files to exclude from documentation
+ * @property outputDirectory where to store the generated files
+ */
+abstract class GenerateDocumentationTaskExtension : DefaultTask() {
+    @get:InputFile
+    abstract val dackkaJarFile: Property<File>
+
+    @get:Input
+    abstract val dependencies: ListProperty<File>
+
+    @get:InputFiles
+    abstract val kotlinSources: ListProperty<File>
+
+    @get:InputFiles
+    abstract val javaSources: ListProperty<File>
+
+    @get:InputFiles
+    abstract val suppressedFiles: ListProperty<File>
+
+    @get:OutputDirectory
+    abstract val outputDirectory: Property<File>
+}
+
+/**
+ * Task to run Dackka on a project.
+ *
+ * Since dackka needs to be ran on the command line, we have to organize the arguments for dackka into
+ * a json file. We then pass that json file to dackka as an argument.
+ *
+ * @see GenerateDocumentationTaskExtension
+ */
+abstract class GenerateDocumentationTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor
+) : GenerateDocumentationTaskExtension() {
+
+    @TaskAction
+    fun build() {
+        val configFile = saveToJsonFile(constructArguments())
+        launchDackka(configFile, workerExecutor)
+    }
+
+    private fun constructArguments(): JSONObject {
+        val linksMap = mapOf(
+            "android" to "https://developer.android.com/reference/kotlin/",
+            "google" to "https://developer.android.com/reference/",
+            "firebase" to "https://firebase.google.com/docs/reference/kotlin/",
+            "coroutines" to "https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/"
+        )
+
+        val jsonMap = mapOf(
+            "moduleName" to "",
+            "outputDir" to outputDirectory.get().path,
+            "globalLinks" to "",
+            "sourceSets" to listOf(mutableMapOf(
+                "sourceSetID" to mapOf(
+                    "scopeId" to "androidx",
+                    "sourceSetName" to "main"
+                ),
+                "sourceRoots" to kotlinSources.get().map { it.path } + javaSources.get().map { it.path },
+                "classpath" to dependencies.get().map { it.path },
+                "documentedVisibilities" to listOf("PUBLIC", "PROTECTED"),
+                "skipEmptyPackages" to "true",
+                "suppressedFiles" to suppressedFiles.get().map { it.path },
+                "externalDocumentationLinks" to linksMap.map { (name, url) -> mapOf(
+                    "url" to url,
+                    "packageListUrl" to "file://${project.rootDir.absolutePath}/kotlindoc/package-lists/$name/package-list"
+                ) }
+            )),
+            "offlineMode" to "true",
+            "noJdkLink" to "true"
+        )
+
+        return JSONObject(jsonMap)
+    }
+
+    private fun saveToJsonFile(jsonObject: JSONObject): File {
+        val outputFile = File.createTempFile("dackkaArgs", ".json")
+
+        outputFile.deleteOnExit()
+        outputFile.writeText(jsonObject.toString(2))
+
+        return outputFile
+    }
+
+    private fun launchDackka(argsFile: File, workerExecutor: WorkerExecutor) {
+        val workQueue = workerExecutor.noIsolation()
+
+        workQueue.submit(DackkaWorkAction::class.java) {
+            args.set(listOf(argsFile.path, "-loggingLevel", "WARN"))
+            classpath.set(setOf(dackkaJarFile.get()))
+            projectName.set(project.name)
+        }
+    }
+}
+
+/**
+ * Parameters needs to launch the Dackka fat jar on the command line.
+ *
+ * @property args a list of arguments to pass to Dackka- should include the json arguments file
+ * @property classpath the classpath to use during execution of the jar file
+ * @property projectName name of the calling project, used for the devsite tenant (output directory)
+ */
+interface DackkaParams : WorkParameters {
+    val args: ListProperty<String>
+    val classpath: SetProperty<File>
+    val projectName: Property<String>
+}
+
+/**
+ * Work action to launch dackka with a [DackkaParams].
+ *
+ * Work actions are organized sections of work, offered by gradle.
+ */
+abstract class DackkaWorkAction @Inject constructor(
+    private val execOperations: ExecOperations
+) : WorkAction<DackkaParams> {
+    override fun execute() {
+        execOperations.javaexec {
+            mainClass.set("org.jetbrains.dokka.MainKt")
+            args = parameters.args.get()
+            classpath(parameters.classpath.get())
+
+            environment("DEVSITE_TENANT", "client/${parameters.projectName.get()}")
+        }
+    }
+}

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -38,7 +38,7 @@ abstract class DackkaPlugin : Plugin<Project> {
                 val firesiteTransform = registerFiresiteTransformTask(project, outputDirectory)
                 val deleteJavaReferences = registerDeleteDackkaGeneratedJavaReferencesTask(project, outputDirectory)
                 val copyOutputToCommonDirectory =
-                    registerCopyDackkaOutputToCommonDirectoryTask(project)
+                    registerCopyDackkaOutputToCommonDirectoryTask(project, outputDirectory)
 
                 project.tasks.register("kotlindoc") {
                     group = "documentation"
@@ -150,13 +150,16 @@ abstract class DackkaPlugin : Plugin<Project> {
             delete(filesToDelete)
         }
 
-    private fun registerCopyDackkaOutputToCommonDirectoryTask(project: Project) =
+    private fun registerCopyDackkaOutputToCommonDirectoryTask(project: Project, outputDirectory: Provider<File>) =
         project.tasks.register<Copy>("copyDackkaOutputToCommonDirectory") {
             mustRunAfter("deleteDackkaGeneratedJavaReferences")
             mustRunAfter("firesiteTransform")
 
-            from("${project.buildDir}/dackkaDocumentation/reference")
-            destinationDir = project.file("${project.rootProject.buildDir}/firebase-kotlindoc")
+            val referenceFolder = outputDirectory.map { project.file("${it.path}/reference") }
+            val outputFolder = project.file("${project.rootProject.buildDir}/firebase-kotlindoc")
+
+            from(referenceFolder)
+            destinationDir = outputFolder
         }
 
     // Useful for local testing, but may not be desired for standard use (that's why it's not depended on)

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -1,0 +1,162 @@
+package com.google.firebase.gradle.plugins
+
+import com.android.build.api.attributes.BuildTypeAttr
+import com.android.build.gradle.LibraryExtension
+import java.io.File
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Delete
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Facilitates the creation of Firesite compliant reference documentation.
+ *
+ * This plugin handles a procedure of processes, all registered under the "kotlindoc" task.
+ *
+ * Those tasks are:
+ *  - Collect the arguments needed to run Dackka
+ *  - Run Dackka with [GenerateDocumentationTask] to create the initial reference docs
+ *  - Clean up the output with [FiresiteTransformTask] to fix minor inconsistencies
+ *  - Remove the java references generated from the task (we do not currently support them)
+ *  - Copies the output files to a common directory under the root project's build directory
+ *
+ *  @see GenerateDocumentationTask
+ *  @see FiresiteTransformTask
+ *  @see JavadocPlugin
+ */
+abstract class DackkaPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        prepareJavadocConfiguration(project)
+        registerCleanDackkaDocumentation(project)
+        project.afterEvaluate {
+            if (shouldWePublish(project)) {
+                val generateDocumentation = registerGenerateDackkaDocumentationTask(project)
+                val firesiteTransform = registerFiresiteTransformTask(project)
+                val deleteJavaReferences = registerDeleteDackkaGeneratedJavaReferencesTask(project)
+                val copyOutputToCommonDirectory =
+                    registerCopyDackkaOutputToCommonDirectoryTask(project)
+
+                project.tasks.register("kotlindoc") {
+                    group = "documentation"
+                    dependsOn(
+                        generateDocumentation,
+                        firesiteTransform,
+                        deleteJavaReferences,
+                        copyOutputToCommonDirectory
+                    )
+                }
+            } else {
+                project.tasks.register("kotlindoc")
+            }
+        }
+    }
+
+    private fun shouldWePublish(project: Project) =
+        project.extensions.getByType<FirebaseLibraryExtension>().publishJavadoc
+
+    private fun prepareJavadocConfiguration(project: Project) {
+        val javadocConfig = project.javadocConfig
+        javadocConfig.dependencies += project.dependencies.create("com.google.code.findbugs:jsr305:3.0.2")
+        javadocConfig.dependencies += project.dependencies.create("com.google.errorprone:error_prone_annotations:2.15.0")
+        javadocConfig.attributes.attribute(
+            BuildTypeAttr.ATTRIBUTE,
+            project.objects.named(BuildTypeAttr::class.java, "release")
+        )
+    }
+
+    private fun registerGenerateDackkaDocumentationTask(project: Project) =
+        project.tasks.register<GenerateDocumentationTask>("generateDackkaDocumentation") {
+            project.extensions.getByType<LibraryExtension>().libraryVariants.all {
+                if (name == "release") {
+                    mustRunAfter("createFullJarRelease")
+                    dependsOn("createFullJarRelease")
+
+                    val classpath = project.provider {
+                        runtimeConfiguration.getJars() + project.javadocConfig.getJars() + project.bootClasspath
+                    }
+
+                    val sourcesForJava = sourceSets.flatMap {
+                        it.javaDirectories.map { it.absoluteFile } + projectSpecificSources(project)
+                    }
+
+                    // this will become useful with the agp upgrade, as they're separate in 7.x+
+                    val sourcesForKotlin = emptyList<File>()
+                    val excludedFiles = emptyList<File>() + projectSpecificSuppressedFiles(project)
+
+                    dependencies.set(classpath)
+                    javaSources.set(sourcesForJava)
+                    kotlinSources.set(sourcesForKotlin)
+                    suppressedFiles.set(excludedFiles)
+
+                    applyCommonConfigurations()
+                }
+            }
+        }
+
+    // Remove when fixed: b/243534168
+    private fun projectSpecificSources(project: Project) =
+        when (project.name) {
+            "firebase-common" -> {
+                project.project(":firebase-firestore").files("src/main/java/com/google/firebase").toList()
+            }
+            else -> emptyList()
+        }
+
+    // Remove when fixed: b/243534168
+    private fun projectSpecificSuppressedFiles(project: Project): List<File> =
+        when (project.name) {
+            "firebase-common" -> {
+                val firestoreProject = project.project(":firebase-firestore")
+                firestoreProject.files("src/main/java/com/google/firebase/firestore").toList()
+            }
+            "firebase-firestore" -> {
+                project.files("src/main/java/com/google/firebase/Timestamp.java").toList()
+            }
+            else -> emptyList()
+        }
+
+    private fun GenerateDocumentationTask.applyCommonConfigurations() {
+        val dackkaFile = project.provider { project.dackkaConfig.singleFile }
+        val dackkaOutputDirectory = File(project.buildDir, "dackkaDocumentation")
+
+        dackkaJarFile.set(dackkaFile)
+        outputDirectory.set(dackkaOutputDirectory)
+    }
+
+    private fun registerFiresiteTransformTask(project: Project) =
+        project.tasks.register<FiresiteTransformTask>("firesiteTransform") {
+            mustRunAfter("generateDackkaDocumentation")
+
+            val dackkaDocumentation = project.file("${project.buildDir}/dackkaDocumentation")
+            dackkaFiles.set(project.provider { dackkaDocumentation })
+        }
+
+    // If we decide to publish java variants, we'll need to address the generated format as well
+    private fun registerDeleteDackkaGeneratedJavaReferencesTask(project: Project) =
+        project.tasks.register<Delete>("deleteDackkaGeneratedJavaReferences") {
+            mustRunAfter("generateDackkaDocumentation")
+
+            val referenceFolder = "${project.buildDir}/dackkaDocumentation/reference"
+            delete(project.file("$referenceFolder/client"))
+            delete(project.file("$referenceFolder/com"))
+        }
+
+    private fun registerCopyDackkaOutputToCommonDirectoryTask(project: Project) =
+        project.tasks.register<Copy>("copyDackkaOutputToCommonDirectory") {
+            mustRunAfter("deleteDackkaGeneratedJavaReferences")
+            mustRunAfter("firesiteTransform")
+
+            from("${project.buildDir}/dackkaDocumentation/reference")
+            destinationDir = project.file("${project.rootProject.buildDir}/firebase-kotlindoc")
+        }
+
+    // Useful for local testing, but may not be desired for standard use (that's why it's not depended on)
+    private fun registerCleanDackkaDocumentation(project: Project) =
+        project.tasks.register<Delete>("cleanDackkaDocumentation") {
+            group = "cleanup"
+
+            delete("${project.buildDir}/dackkaDocumentation")
+        }
+}

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -106,7 +106,7 @@ abstract class DackkaPlugin : Plugin<Project> {
             else -> emptyList()
         }
 
-    // Remove when fixed: b/243534168
+    // TODO(b/243534168): Remove when fixed
     private fun projectSpecificSuppressedFiles(project: Project): List<File> =
         when (project.name) {
             "firebase-common" -> {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -97,7 +97,7 @@ abstract class DackkaPlugin : Plugin<Project> {
             }
         }
 
-    // Remove when fixed: b/243534168
+    // TODO(b/243534168): Remove when fixed
     private fun projectSpecificSources(project: Project) =
         when (project.name) {
             "firebase-common" -> {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
@@ -109,7 +109,7 @@ public class FirebaseLibraryPlugin implements Plugin<Project> {
                     .setFreeCompilerArgs(
                         ImmutableList.of("-module-name", kotlinModuleName(project))));
 
-    Dokka.configure(project, android, firebaseLibrary);
+    project.getPluginManager().apply(DackkaPlugin.class);
   }
 
   private static void setupApiInformationAnalysis(Project project, LibraryExtension android) {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -1,0 +1,79 @@
+package com.google.firebase.gradle.plugins
+
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Fixes minor inconsistencies between what dackka generates, and what firesite actually expects.
+ *
+ * Should dackka ever expand to offer configurations for these procedures, this class can be replaced.
+ *
+ * More specifically, it:
+ *  - Deletes unnecessary files
+ *  - Removes Class and Index headers from _toc.yaml files
+ *  - Appends /docs/ to hyperlinks in html files
+ *  - Removes the prefix path from book_path
+ *  - Removes the firebase prefix from all links
+ *
+ *  **Please note:**
+ *  This task is idempotent- meaning it can safely be ran multiple times on the same set of files.
+ */
+abstract class FiresiteTransformTask : DefaultTask() {
+    @get:InputDirectory
+    abstract val dackkaFiles: Property<File>
+
+    @TaskAction
+    fun build() {
+        val namesOfFilesWeDoNotNeed = listOf(
+            "index.html",
+            "classes.html",
+            "packages.html",
+            "package-list"
+        )
+
+        dackkaFiles.get().walkTopDown().forEach {
+            if (it.name in namesOfFilesWeDoNotNeed) {
+                it.delete()
+            } else {
+                when (it.extension) {
+                    "html" -> it.fixHTMLFile()
+                    "yaml" -> it.fixYamlFile()
+                }
+            }
+        }
+    }
+
+    private fun File.fixHTMLFile() {
+        val fixedContent = readText().fixBookPath().fixHyperlinks().removeLeadingFirebaseDomainInLinks()
+        writeText(fixedContent)
+    }
+
+    private fun File.fixYamlFile() {
+        val fixedContent = readText().removeClassHeader().removeIndexHeader().removeLeadingFirebaseDomainInLinks()
+        writeText(fixedContent)
+    }
+
+    // We don't actually upload class or index files,
+    // so these headers will throw not found errors if not removed.
+    private fun String.removeClassHeader() =
+        remove(Regex("- title: \"Class Index\"\n {2}path: \".+\"\n\n"))
+    private fun String.removeIndexHeader() =
+        remove(Regex("- title: \"Package Index\"\n {2}path: \".+\"\n\n"))
+
+    // We use a common book for all sdks, wheres dackka expects each sdk to have its own book.
+    private fun String.fixBookPath() =
+        remove(Regex("(?<=setvar book_path ?%})(.+)(?=/_book.yaml\\{% ?endsetvar)"))
+
+    // Our documentation lives under /docs/reference/ versus the expected /reference/
+    private fun String.fixHyperlinks() =
+        replace(Regex("(?<=href=\")(/)(?=reference/.*\\.html)"), "/docs/")
+
+    // The documentation will work fine without this. This is primarily to make sure that links
+    // resolve to their local counter part. Meaning when the docs are staged, they will resolve to
+    // staged docs instead of prod docs- and vise versa.
+    private fun String.removeLeadingFirebaseDomainInLinks() =
+        remove(Regex("(?<=\")(https://firebase\\.google\\.com)(?=/docs/reference)"))
+}

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -65,6 +65,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
         remove(Regex("- title: \"Package Index\"\n {2}path: \".+\"\n\n"))
 
     // We use a common book for all sdks, wheres dackka expects each sdk to have its own book.
+    // TODO(b/243674303): Remove when dackka supports this behavior
     private fun String.fixBookPath() =
         remove(Regex("(?<=setvar book_path ?%})(.+)(?=/_book.yaml\\{% ?endsetvar)"))
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -70,6 +70,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
         remove(Regex("(?<=setvar book_path ?%})(.+)(?=/_book.yaml\\{% ?endsetvar)"))
 
     // Our documentation lives under /docs/reference/ versus the expected /reference/
+    // TODO(b/243674305): Remove when dackka supports this behavior
     private fun String.fixHyperlinks() =
         replace(Regex("(?<=href=\")(/)(?=reference/.*\\.html)"), "/docs/")
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -58,6 +58,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
 
     // We don't actually upload class or index files,
     // so these headers will throw not found errors if not removed.
+    // TODO(b/243674302): Remove when dackka supports this behavior
     private fun String.removeClassHeader() =
         remove(Regex("- title: \"Class Index\"\n {2}path: \".+\"\n\n"))
     private fun String.removeIndexHeader() =

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -77,6 +77,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
     // The documentation will work fine without this. This is primarily to make sure that links
     // resolve to their local counter part. Meaning when the docs are staged, they will resolve to
     // staged docs instead of prod docs- and vise versa.
+    // TODO(b/243673063): Remove when dackka supports this behavior
     private fun String.removeLeadingFirebaseDomainInLinks() =
         remove(Regex("(?<=\")(https://firebase\\.google\\.com)(?=/docs/reference)"))
 }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/JavadocPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/JavadocPlugin.java
@@ -117,6 +117,7 @@ public class JavadocPlugin implements Plugin<Project> {
                 // This comes with the risks of Timestamp's javadoc and binary releases having
                 // disconnected timelines.
                 // Given the repeated tedium in dealing with javadoc, this risk seems worth taking
+                // b/243534168
                 if ("firebase-common".equals(project.getName())) {
                   Project firestoreProject = project.findProject(":firebase-firestore");
                   javadoc.setSource(

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/JavadocPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/JavadocPlugin.java
@@ -117,7 +117,7 @@ public class JavadocPlugin implements Plugin<Project> {
                 // This comes with the risks of Timestamp's javadoc and binary releases having
                 // disconnected timelines.
                 // Given the repeated tedium in dealing with javadoc, this risk seems worth taking
-                // b/243534168
+                // TODO(b/243534168): Move Timestamp class to firebase-common
                 if ("firebase-common".equals(project.getName())) {
                   Project firestoreProject = project.findProject(":firebase-firestore");
                   javadoc.setSource(

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/KotlinUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/KotlinUtils.kt
@@ -1,0 +1,11 @@
+package com.google.firebase.gradle.plugins
+
+/**
+ * Replaces all matching substrings with an empty string (nothing)
+ */
+fun String.remove(regex: Regex) = replace(regex, "")
+
+/**
+ * Replaces all matching substrings with an empty string (nothing)
+ */
+fun String.remove(str: String) = replace(str, "")

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
@@ -13,13 +13,9 @@
 // limitations under the License.
 package com.google.firebase.gradle.plugins
 
-import com.android.build.gradle.BaseExtension
-import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.plugins.ExtensionContainer
-import org.gradle.kotlin.dsl.getByType
 
 fun Project.isAndroid(): Boolean =
         listOf("com.android.application", "com.android.library", "com.android.test")
@@ -29,15 +25,6 @@ fun toBoolean(value: Any?): Boolean {
     val trimmed = value?.toString()?.trim()?.toLowerCase()
     return "true" == trimmed || "y" == trimmed || "1" == trimmed
 }
-
-/**
- * Shorthand for [BaseExtension.getBootClasspath]
- *
- * This method assumes your project has the [BaseExtension] extension,
- * as it uses [ExtensionContainer.getByType]
- */
-val Project.bootClasspath: List<File>
-    get() = extensions.getByType<BaseExtension>().bootClasspath
 
 /**
  * Finds or creates the javadocClasspath [Configuration].

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
@@ -59,15 +59,10 @@ val Project.dackkaConfig: Configuration
 
 /**
  * Fetches the jars of dependencies associated with this configuration through an artifact view.
- *
- * Excluding androidx.annotation:annotation artifacts.
  */
 fun Configuration.getJars() = incoming.artifactView {
     attributes {
         // replace value with android-class instead of jar after agp upgrade
         attribute(Attribute.of("artifactType", String::class.java), "jar")
-    }
-    componentFilter {
-        !it.displayName.startsWith("androidx.annotation:annotation:")
     }
 }.artifacts.artifactFiles

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
@@ -62,7 +62,7 @@ val Project.dackkaConfig: Configuration
  */
 fun Configuration.getJars() = incoming.artifactView {
     attributes {
-        // replace value with android-class instead of jar after agp upgrade
+        // TODO(b/241795594): replace value with android-class instead of jar after agp upgrade
         attribute(Attribute.of("artifactType", String::class.java), "jar")
     }
 }.artifacts.artifactFiles

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/PublishingPluginTests.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/PublishingPluginTests.kt
@@ -338,6 +338,9 @@ licenses {
                 jcenter()
                 maven {
                     url 'https://storage.googleapis.com/android-ci/mvn/'
+                    metadataSources {
+                        artifact()
+                    }
                 }
             }
         }
@@ -346,13 +349,16 @@ licenses {
         }
 
         configure(subprojects) {
-          repositories {
-              google()
-              jcenter()
-              maven {
-                  url 'https://storage.googleapis.com/android-ci/mvn/'
-              }
-          }
+            repositories {
+                google()
+                jcenter()
+                maven {
+                    url 'https://storage.googleapis.com/android-ci/mvn/'
+                    metadataSources {
+                          artifact()
+                    }
+                }
+            }
         }
         """
         private const val MANIFEST = """<?xml version="1.0" encoding="utf-8"?>

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentId.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentId.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
  * the POJO is created from a Cloud Firestore document (for example, via {@link
  * DocumentSnapshot#toObject(Class)}).
  *
+ * <p>Any of the following will throw a runtime exception:</p>
  * <ul>
- *   Any of the following will throw a runtime exception:
  *   <li>This annotation is applied to a property of a type other than String or {@link
  *       DocumentReference}.
  *   <li>This annotation is applied to a property that is not writable (for example, a Java Bean

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentId.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/DocumentId.java
@@ -24,7 +24,8 @@ import java.lang.annotation.Target;
  * the POJO is created from a Cloud Firestore document (for example, via {@link
  * DocumentSnapshot#toObject(Class)}).
  *
- * <p>Any of the following will throw a runtime exception:</p>
+ * <p>Any of the following will throw a runtime exception:
+ *
  * <ul>
  *   <li>This annotation is applied to a property of a type other than String or {@link
  *       DocumentReference}.

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/FirebaseInAppMessaging.java
@@ -92,9 +92,6 @@ public class FirebaseInAppMessaging {
   /**
    * Gets FirebaseInAppMessaging instance using the firebase app returned by {@link
    * FirebaseApp#getInstance()}
-   *
-   * @param
-   * @return
    */
   @NonNull
   public static FirebaseInAppMessaging getInstance() {

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/CampaignMetadata.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/CampaignMetadata.java
@@ -17,11 +17,12 @@ package com.google.firebase.inappmessaging.model;
 import androidx.annotation.NonNull;
 
 /**
- * <p>Provides the following about any message:</p>
+ * Provides the following about any message:
+ *
  * <ul>
- *    <li>Campaign ID
- *    <li>Campaign Name
- *    <li>Campaign Test Message State
+ *   <li>Campaign ID
+ *   <li>Campaign Name
+ *   <li>Campaign Test Message State
  * </ul>
  */
 public class CampaignMetadata {

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/CampaignMetadata.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/model/CampaignMetadata.java
@@ -17,10 +17,12 @@ package com.google.firebase.inappmessaging.model;
 import androidx.annotation.NonNull;
 
 /**
- * Provides the following about any message,
- * <li>Campaign ID
- * <li>Campaign Name
- * <li>Campaign Test Message State
+ * <p>Provides the following about any message:</p>
+ * <ul>
+ *    <li>Campaign ID
+ *    <li>Campaign Name
+ *    <li>Campaign Test Message State
+ * </ul>
  */
 public class CampaignMetadata {
   private final String campaignId;

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -22,7 +22,7 @@ firebase-config:ktx
 firebase-config:bandwagoner
 firebase-crashlytics
 firebase-crashlytics:ktx
-firebase-crashlytics-ndk
+#firebase-crashlytics-ndk
 firebase-database
 firebase-database:ktx
 firebase-database-collection

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -22,7 +22,7 @@ firebase-config:ktx
 firebase-config:bandwagoner
 firebase-crashlytics
 firebase-crashlytics:ktx
-#firebase-crashlytics-ndk
+firebase-crashlytics-ndk
 firebase-database
 firebase-database:ktx
 firebase-database-collection


### PR DESCRIPTION
Our current Dokka implementation is old and was due for an upgrade. Thankfully, the folks over at AndroidX have been working on new tooling that integrates directly with Dokka- and provides translations for DevSite. This PR does not include the removal of any old systems, only the addition of the new ones. The java variant of our ref doc generations will remain the same until we are comfortable with the DackkaPlugin.

This PR comes with:

- Various javadoc fixes
- Additional utility methods for buildSrc
- `DackkaGenerationTask` for creating ref docs with dackka
- `FiresiteTransformTask` for translating Devsite output from dackka to Firesite ready output
- `DackkaPlugin` for managing everything dackka related, and providing default configurations

All functionality provided in this PR is annotated, and follows standard practices with newer Gradle versions. There are minor differences that we can not implement until we upgrade our AGP version (per #3974), but I've left comments around them to revisit in the future.