### PR TITLE
[Fireperf][AASA] change timebase to `elapsedRealtime`

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -18,7 +18,9 @@ import android.app.Activity;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.Process;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -120,6 +122,13 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
   @Keep
   public static void setLauncherActivityOnResumeTime(String activity) {
     // no-op, for backward compatibility with old version plugin.
+  }
+
+  public static Timer getProcessStartTimer() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      return Timer.of(TimeUnit.MILLISECONDS.toNanos(Process.getStartElapsedRealtime()));
+    }
+    return FirebasePerfProvider.getAppStartTime();
   }
 
   public static AppStartTrace getInstance() {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -126,7 +126,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
 
   public static Timer getProcessStartTimer() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      return Timer.of(TimeUnit.MILLISECONDS.toNanos(Process.getStartElapsedRealtime()));
+      return Timer.ofElapsedRealtime(Process.getStartElapsedRealtime());
     }
     return FirebasePerfProvider.getAppStartTime();
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -18,9 +18,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.Context;
-import android.os.Build;
 import android.os.Bundle;
-import android.os.Process;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -122,13 +120,6 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
   @Keep
   public static void setLauncherActivityOnResumeTime(String activity) {
     // no-op, for backward compatibility with old version plugin.
-  }
-
-  public static Timer getProcessStartTimer() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      return Timer.ofElapsedRealtime(Process.getStartElapsedRealtime());
-    }
-    return FirebasePerfProvider.getAppStartTime();
   }
 
   public static AppStartTrace getInstance() {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
@@ -46,13 +46,12 @@ public class Timer implements Parcelable {
    * Returns a new Timer object as if it was stamped at the given elapsedRealtime. Uses current
    * wall-clock as a reference to extrapolate the wall-clock at the given elapsedRealtime.
    *
-   * @param elapsedRealtime milliseconds timestamp in the {@link SystemClock#elapsedRealtime()}
-   *     timebase
+   * @param elapsedRealtimeMillis timestamp in the {@link SystemClock#elapsedRealtime()} timebase
    */
-  public static Timer ofElapsedRealtime(long elapsedRealtime) {
-    elapsedRealtime = MILLISECONDS.toMicros(elapsedRealtime);
-    long wallClock = wallClockMicros() + elapsedRealtime - elapsedRealtimeMicros();
-    return new Timer(wallClock, elapsedRealtime);
+  public static Timer ofElapsedRealtime(final long elapsedRealtimeMillis) {
+    long elapsedRealtimeMicros = MILLISECONDS.toMicros(elapsedRealtimeMillis);
+    long wallClockMicros = wallClockMicros() + (elapsedRealtimeMicros - elapsedRealtimeMicros());
+    return new Timer(wallClockMicros, elapsedRealtimeMicros);
   }
 
   /**
@@ -150,16 +149,6 @@ public class Timer implements Parcelable {
    */
   public long getCurrentTimestampMicros() {
     return wallClockMicros + getDurationMicros();
-  }
-
-  /**
-   * Return this Timer's timestamp in the {@link SystemClock#elapsedRealtime()} timebase.
-   *
-   * @return elapsedRealtime timestamp in microseconds.
-   */
-  @VisibleForTesting
-  public long getElapsedRealtimeMicros() {
-    return elapsedRealtimeMicros;
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
@@ -31,7 +31,7 @@ import com.google.android.gms.common.util.VisibleForTesting;
 public class Timer implements Parcelable {
 
   /**
-   * Wall-clock time or epoch time in milliseconds. Do NOT use for duration because wall-clock is
+   * Wall-clock time or epoch time in microseconds. Do NOT use for duration because wall-clock is
    * not guaranteed to be monotonic: it can be set by the user or the phone network, thus it may
    * jump forwards or backwards unpredictably. {@see SystemClock}
    */

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
@@ -15,7 +15,9 @@
 package com.google.firebase.perf.util;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.os.SystemClock;
@@ -69,6 +71,9 @@ public class Timer implements Parcelable {
    * @return wall-clock time in microseconds.
    */
   private static long elapsedRealtimeMicros() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      return NANOSECONDS.toMicros(SystemClock.elapsedRealtimeNanos());
+    }
     return MILLISECONDS.toMicros(SystemClock.elapsedRealtime());
   }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
@@ -24,54 +24,72 @@ import com.google.android.gms.common.util.VisibleForTesting;
 
 /**
  * A Timer class provides both wall-clock (epoch) time and monotonic time (elapsedRealtime).
- * Milliseconds is the time unit used in private fields and computations, because that's the time
- * unit most widely available in Android APIs. Public methods only return time in microseconds,
- * because Fireperf proto requires microseconds.
+ * Timestamps are captured with millisecond-precision, because that's the time unit most widely
+ * available in Android APIs. However, private fields and public method returns are in microseconds
+ * due to Fireperf proto requirements.
  */
 public class Timer implements Parcelable {
 
   /**
-   * Wall-clock time or epoch time in microseconds. Do NOT use for duration because wall-clock is
+   * Wall-clock time or epoch time in milliseconds. Do NOT use for duration because wall-clock is
    * not guaranteed to be monotonic: it can be set by the user or the phone network, thus it may
    * jump forwards or backwards unpredictably. {@see SystemClock}
    */
-  private long wallClock;
+  private long wallClockMicros;
   /**
    * Monotonic time measured in the {@link SystemClock#elapsedRealtime()} timebase. Only used to
    * compute duration between 2 timestamps in the same timebase. It is NOT wall-clock time.
    */
-  private long elapsedRealtime;
+  private long elapsedRealtimeMicros;
 
   /**
    * Returns a new Timer object as if it was stamped at the given elapsedRealtime. Uses current
    * wall-clock as a reference to extrapolate the wall-clock at the given elapsedRealtime.
    *
-   * @param elapsedRealtime timestamp in the {@link SystemClock#elapsedRealtime()} timebase
+   * @param elapsedRealtime milliseconds timestamp in the {@link SystemClock#elapsedRealtime()}
+   *     timebase
    */
   public static Timer ofElapsedRealtime(long elapsedRealtime) {
-    long wallClockNow = System.currentTimeMillis();
-    long elapsedRealtimeNow = SystemClock.elapsedRealtime();
-    long wallClock = wallClockNow + elapsedRealtime - elapsedRealtimeNow;
+    elapsedRealtime = MILLISECONDS.toMicros(elapsedRealtime);
+    long wallClock = wallClockMicros() + elapsedRealtime - elapsedRealtimeMicros();
     return new Timer(wallClock, elapsedRealtime);
+  }
+
+  /**
+   * Helper to get current wall-clock time from system API.
+   *
+   * @return wall-clock time in microseconds.
+   */
+  private static long wallClockMicros() {
+    return MILLISECONDS.toMicros(System.currentTimeMillis());
+  }
+
+  /**
+   * Helper to get current {@link SystemClock#elapsedRealtime()} from system API.
+   *
+   * @return wall-clock time in microseconds.
+   */
+  private static long elapsedRealtimeMicros() {
+    return MILLISECONDS.toMicros(SystemClock.elapsedRealtime());
   }
 
   // TODO: make all constructors private, use public static factory methods, per Effective Java
   /** Construct Timer object using System clock. */
   public Timer() {
-    this(System.currentTimeMillis(), SystemClock.elapsedRealtime());
+    this(wallClockMicros(), elapsedRealtimeMicros());
   }
 
   /**
    * Construct a Timer object with input wall-clock time and elapsedRealtime.
    *
-   * @param epochTime wall-clock time in milliseconds since epoch
-   * @param elapsedRealtime monotonic time in milliseconds in the {@link
+   * @param epochMicros wall-clock time in milliseconds since epoch
+   * @param elapsedRealtimeMicros monotonic time in microseconds in the {@link
    *     SystemClock#elapsedRealtime()} timebase
    */
   @VisibleForTesting
-  Timer(long epochTime, long elapsedRealtime) {
-    this.wallClock = epochTime;
-    this.elapsedRealtime = elapsedRealtime;
+  Timer(long epochMicros, long elapsedRealtimeMicros) {
+    this.wallClockMicros = epochMicros;
+    this.elapsedRealtimeMicros = elapsedRealtimeMicros;
   }
 
   /**
@@ -89,21 +107,16 @@ public class Timer implements Parcelable {
     this(in.readLong(), in.readLong());
   }
 
-  /** Returns milliseconds duration from this until end. */
-  private long durationUntil(Timer end) {
-    return end.elapsedRealtime - this.elapsedRealtime;
-  }
-
   /** resets the start time */
   public void reset() {
     // TODO: consider removing this method and make Timer immutable thus fully thread-safe
-    wallClock = System.currentTimeMillis();
-    elapsedRealtime = SystemClock.elapsedRealtime();
+    wallClockMicros = wallClockMicros();
+    elapsedRealtimeMicros = elapsedRealtimeMicros();
   }
 
   /** Return wall-clock time in microseconds. */
   public long getMicros() {
-    return MILLISECONDS.toMicros(wallClock);
+    return wallClockMicros;
   }
 
   /**
@@ -114,7 +127,7 @@ public class Timer implements Parcelable {
    * @return duration in microseconds.
    */
   public long getDurationMicros() {
-    return MILLISECONDS.toMicros(durationUntil(new Timer()));
+    return getDurationMicros(new Timer());
   }
 
   /**
@@ -124,7 +137,7 @@ public class Timer implements Parcelable {
    * @return duration in microseconds.
    */
   public long getDurationMicros(@NonNull final Timer end) {
-    return MILLISECONDS.toMicros(durationUntil(end));
+    return end.elapsedRealtimeMicros - this.elapsedRealtimeMicros;
   }
 
   /**
@@ -136,7 +149,7 @@ public class Timer implements Parcelable {
    *     was created.
    */
   public long getCurrentTimestampMicros() {
-    return MILLISECONDS.toMicros(wallClock + durationUntil(new Timer()));
+    return wallClockMicros + getDurationMicros();
   }
 
   /**
@@ -146,7 +159,7 @@ public class Timer implements Parcelable {
    */
   @VisibleForTesting
   public long getElapsedRealtimeMicros() {
-    return MILLISECONDS.toMicros(elapsedRealtime);
+    return elapsedRealtimeMicros;
   }
 
   /**
@@ -157,8 +170,8 @@ public class Timer implements Parcelable {
    * @param flags always will be the value 0.
    */
   public void writeToParcel(Parcel out, int flags) {
-    out.writeLong(wallClock);
-    out.writeLong(elapsedRealtime);
+    out.writeLong(wallClockMicros);
+    out.writeLong(elapsedRealtimeMicros);
   }
 
   /**

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
@@ -153,9 +153,9 @@ public class Timer implements Parcelable {
   }
 
   /**
-   * Return elapsedRealtime in microseconds, only useful for testing..
+   * Return this Timer's timestamp in the {@link SystemClock#elapsedRealtime()} timebase.
    *
-   * @return elapsedRealtime in microseconds.
+   * @return elapsedRealtime timestamp in microseconds.
    */
   @VisibleForTesting
   public long getElapsedRealtimeMicros() {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
@@ -49,8 +49,9 @@ public class Timer implements Parcelable {
    * @param elapsedRealtime timestamp in the {@link SystemClock#elapsedRealtime()} timebase
    */
   public static Timer ofElapsedRealtime(long elapsedRealtime) {
-    Timer now = new Timer();
-    long wallClock = now.wallClock + elapsedRealtime - now.elapsedRealtime;
+    long wallClockNow = System.currentTimeMillis();
+    long elapsedRealtimeNow = SystemClock.elapsedRealtime();
+    long wallClock = wallClockNow + elapsedRealtime - elapsedRealtimeNow;
     return new Timer(wallClock, elapsedRealtime);
   }
 
@@ -71,6 +72,17 @@ public class Timer implements Parcelable {
   Timer(long epochTime, long elapsedRealtime) {
     this.wallClock = epochTime;
     this.elapsedRealtime = elapsedRealtime;
+  }
+
+  /**
+   * TEST-ONLY constructor that sets both wall-clock time and elapsedRealtime to the same input
+   * value. Do NOT use this for any real logic because this is mixing 2 different time-bases.
+   *
+   * @param testTime value to set both wall-clock and elapsedRealtime to for testing purposes
+   */
+  @VisibleForTesting
+  public Timer(long testTime) {
+    this(testTime, testTime);
   }
 
   private Timer(Parcel in) {

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -84,7 +84,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     transportManager = mock(TransportManager.class);
     traceArgumentCaptor = ArgumentCaptor.forClass(TraceMetric.class);
     appStartTime = FirebasePerfProvider.getAppStartTime().getMicros();
-    appStartHRT = FirebasePerfProvider.getAppStartTime().getHighResTime();
+    appStartHRT = FirebasePerfProvider.getAppStartTime().getElapsedRealtimeMicros();
   }
 
   @After

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
@@ -55,7 +55,7 @@ public class TimerTest {
 
   @Test
   public void testGetCurrentTimestampMicros() {
-    Timer timer = new Timer(0);
+    Timer timer = new Timer(0, 0);
     long currentTimeSmallest = timer.getCurrentTimestampMicros();
 
     assertThat(timer.getMicros()).isEqualTo(0);
@@ -76,7 +76,7 @@ public class TimerTest {
 
     Timer timer2 = Timer.CREATOR.createFromParcel(p2);
     Assert.assertEquals(timer1.getMicros(), timer2.getMicros());
-    Assert.assertEquals(timer1.getHighResTime(), timer2.getHighResTime());
+    Assert.assertEquals(timer1.getElapsedRealtimeMicros(), timer2.getElapsedRealtimeMicros());
 
     p1.recycle();
     p2.recycle();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
@@ -63,18 +63,20 @@ public class TimerTest {
   @Test
   public void ofElapsedRealtime_extrapolatesWallTime() {
     // Robolectric shadows SystemClock, which is paused and can only change via specific methods.
+    // Advance SystemClock by a large amount to avoid negative time
     ShadowSystemClock.advanceBy(Duration.ofMillis(10000000));
-    long refElapsedRealtime = SystemClock.elapsedRealtime();
-    Timer ref = new Timer();
-    Timer past = Timer.ofElapsedRealtime(refElapsedRealtime - 500);
-    Timer morePast = Timer.ofElapsedRealtime(refElapsedRealtime - 500000);
-    Timer future = Timer.ofElapsedRealtime(refElapsedRealtime + 500);
-    Timer moreFuture = Timer.ofElapsedRealtime(refElapsedRealtime + 500000);
+    long nowElapsedRealtime = SystemClock.elapsedRealtime();
+    Timer now = new Timer();
+    Timer morePast = Timer.ofElapsedRealtime(nowElapsedRealtime - 2000);
+    Timer past = Timer.ofElapsedRealtime(nowElapsedRealtime - 1000);
+    Timer future = Timer.ofElapsedRealtime(nowElapsedRealtime + 1000);
+    Timer moreFuture = Timer.ofElapsedRealtime(nowElapsedRealtime + 2000);
 
-    assertThat(past.getMicros()).isLessThan(ref.getMicros());
+    // We cannot manipulate System.currentTimeMillis() so multiple comparisons are used to test
     assertThat(morePast.getMicros()).isLessThan(past.getMicros());
-    assertThat(future.getMicros()).isGreaterThan(ref.getMicros());
-    assertThat(moreFuture.getMicros()).isGreaterThan(future.getMicros());
+    assertThat(past.getMicros()).isLessThan(now.getMicros());
+    assertThat(now.getMicros()).isLessThan(future.getMicros());
+    assertThat(future.getMicros()).isLessThan(moreFuture.getMicros());
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
@@ -40,7 +40,7 @@ public class TimerTest {
   public void setUp() {}
 
   @Test
-  public void getDurationMicros_returnDifferenceBetweenElapsedRealtime() {
+  public void getDurationMicros_returnsDifferenceBetweenElapsedRealtime() {
     // Robolectric shadows SystemClock, which is paused and can only change via specific methods.
     Timer start = new Timer();
     ShadowSystemClock.advanceBy(Duration.ofMillis(100000));

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
@@ -55,7 +55,7 @@ public class TimerTest {
 
   @Test
   public void testGetCurrentTimestampMicros() {
-    Timer timer = new Timer(0);
+    Timer timer = new Timer(0, 0);
     long currentTimeSmallest = timer.getCurrentTimestampMicros();
 
     assertThat(timer.getMicros()).isEqualTo(0);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
@@ -17,6 +17,7 @@ package com.google.firebase.perf.util;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.os.Parcel;
+import android.os.Process;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,6 +31,25 @@ public class TimerTest {
 
   @Before
   public void setUp() {}
+
+  @Test
+  public void ofElapsedRealtime_extrapolatesWallClock() {
+    Timer processStart = Timer.ofElapsedRealtime(Process.getStartElapsedRealtime());
+    Timer reference = new Timer();
+
+    assertThat(processStart.getDurationMicros(reference))
+        .isEqualTo(reference.getMicros() - processStart.getMicros());
+  }
+
+  @Test
+  public void ofElapsedRealtime_createsNewTimerWithArgumentElapsedRealtime() {
+    Timer processStart = Timer.ofElapsedRealtime(Process.getStartElapsedRealtime());
+    Timer reference = new Timer();
+    long processStartERT = TimeUnit.MILLISECONDS.toMicros(Process.getStartElapsedRealtime());
+    long referenceERT = reference.getElapsedRealtimeMicros();
+
+    assertThat(processStart.getDurationMicros(reference)).isEqualTo(referenceERT - processStartERT);
+  }
 
   @Test
   public void testCreate() throws InterruptedException {

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
@@ -55,7 +55,7 @@ public class TimerTest {
 
   @Test
   public void testGetCurrentTimestampMicros() {
-    Timer timer = new Timer(0, 0);
+    Timer timer = new Timer(0);
     long currentTimeSmallest = timer.getCurrentTimestampMicros();
 
     assertThat(timer.getMicros()).isEqualTo(0);


### PR DESCRIPTION
b/243537606
Blocked by https://github.com/firebase/firebase-android-sdk/pull/4027

## Main change
Change `Timer.java`'s timebase to `elapsedRealtime` for consistency with Android platform API. Platform APIs like `Process.startElapsedRealtime()` are in that timebase, so if we want to find duration between our timestamps and Android API's, then they must be the same timebase. 

## Additional code health improvement
Changed variable names and some Javadoc, because the old ones are incorrect and misleading. We aren **not** using different APIs for wallclock time (`timeInMicros`) and duration-calculating-time (`highResTime`) because duration-calculating-time is high-resolution. _We are separating them because wall-clock is **not monotonic**_. See the top of this doc https://developer.android.com/reference/android/os/SystemClock to learn more. 