### PR TITLE
Fix: Cannot mark as impressed more than one message almost same time

### DIFF
--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImpl.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImpl.java
@@ -73,7 +73,7 @@ public class DisplayCallbacksImpl implements FirebaseInAppMessagingDisplayCallba
   }
 
   @VisibleForTesting
-  boolean hasImpressed(){
+  boolean hasImpressed() {
     return wasImpressed;
   }
 

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImpl.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImpl.java
@@ -73,7 +73,7 @@ public class DisplayCallbacksImpl implements FirebaseInAppMessagingDisplayCallba
   }
 
   @VisibleForTesting
-  boolean hasImpressed() {
+  boolean wasImpressed() {
     return wasImpressed;
   }
 

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImpl.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImpl.java
@@ -72,6 +72,11 @@ public class DisplayCallbacksImpl implements FirebaseInAppMessagingDisplayCallba
     wasImpressed = false;
   }
 
+  @VisibleForTesting
+  boolean hasImpressed(){
+    return wasImpressed;
+  }
+
   @Override
   public Task<Void> impressionDetected() {
 

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImpl.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImpl.java
@@ -42,7 +42,7 @@ public class DisplayCallbacksImpl implements FirebaseInAppMessagingDisplayCallba
   private final InAppMessage inAppMessage;
   private final String triggeringEvent;
 
-  private static boolean wasImpressed;
+  private boolean wasImpressed;
   private static final String MESSAGE_CLICK = "message click to metrics logger";
 
   @VisibleForTesting

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ProtoStorageClient.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ProtoStorageClient.java
@@ -61,15 +61,17 @@ public class ProtoStorageClient {
    * @param messageLite
    * @throws IOException
    */
-  public synchronized Completable write(AbstractMessageLite messageLite) {
-      return Completable.fromCallable(
-              () -> {
-                  // reads / writes are synchronized per client instance
-                  try (FileOutputStream output = application.openFileOutput(fileName, MODE_PRIVATE)) {
-                      output.write(messageLite.toByteArray());
-                      return messageLite;
-                  }
-              });
+  public Completable write(AbstractMessageLite messageLite) {
+    return Completable.fromCallable(
+        () -> {
+          // reads / writes are synchronized per client instance
+          synchronized (this) {
+            try (FileOutputStream output = application.openFileOutput(fileName, MODE_PRIVATE)) {
+              output.write(messageLite.toByteArray());
+              return messageLite;
+            }
+          }
+        });
   }
 
   /**
@@ -87,17 +89,18 @@ public class ProtoStorageClient {
    * @param parser
    * @param <T>
    */
-  public synchronized  <T extends AbstractMessageLite> Maybe<T> read(Parser<T> parser) {
-      return Maybe.fromCallable(
-              () -> {
-                  // reads / writes are synchronized per client instance
-                  try (FileInputStream inputStream = application.openFileInput(fileName)) {
-                      return parser.parseFrom(inputStream);
-                  } catch (InvalidProtocolBufferException | FileNotFoundException e) {
-                      Logging.logi("Recoverable exception while reading cache: " + e.getMessage());
-                      return null;
-                  }
-
-              });
+  public <T extends AbstractMessageLite> Maybe<T> read(Parser<T> parser) {
+    return Maybe.fromCallable(
+        () -> {
+          // reads / writes are synchronized per client instance
+          synchronized (this) {
+            try (FileInputStream inputStream = application.openFileInput(fileName)) {
+              return parser.parseFrom(inputStream);
+            } catch (InvalidProtocolBufferException | FileNotFoundException e) {
+              Logging.logi("Recoverable exception while reading cache: " + e.getMessage());
+              return null;
+            }
+          }
+        });
   }
 }

--- a/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ProtoStorageClient.java
+++ b/firebase-inappmessaging/src/main/java/com/google/firebase/inappmessaging/internal/ProtoStorageClient.java
@@ -61,17 +61,15 @@ public class ProtoStorageClient {
    * @param messageLite
    * @throws IOException
    */
-  public Completable write(AbstractMessageLite messageLite) {
-    return Completable.fromCallable(
-        () -> {
-          // reads / writes are synchronized per client instance
-          synchronized (this) {
-            try (FileOutputStream output = application.openFileOutput(fileName, MODE_PRIVATE)) {
-              output.write(messageLite.toByteArray());
-              return messageLite;
-            }
-          }
-        });
+  public synchronized Completable write(AbstractMessageLite messageLite) {
+      return Completable.fromCallable(
+              () -> {
+                  // reads / writes are synchronized per client instance
+                  try (FileOutputStream output = application.openFileOutput(fileName, MODE_PRIVATE)) {
+                      output.write(messageLite.toByteArray());
+                      return messageLite;
+                  }
+              });
   }
 
   /**
@@ -89,18 +87,17 @@ public class ProtoStorageClient {
    * @param parser
    * @param <T>
    */
-  public <T extends AbstractMessageLite> Maybe<T> read(Parser<T> parser) {
-    return Maybe.fromCallable(
-        () -> {
-          // reads / writes are synchronized per client instance
-          synchronized (this) {
-            try (FileInputStream inputStream = application.openFileInput(fileName)) {
-              return parser.parseFrom(inputStream);
-            } catch (InvalidProtocolBufferException | FileNotFoundException e) {
-              Logging.logi("Recoverable exception while reading cache: " + e.getMessage());
-              return null;
-            }
-          }
-        });
+  public synchronized  <T extends AbstractMessageLite> Maybe<T> read(Parser<T> parser) {
+      return Maybe.fromCallable(
+              () -> {
+                  // reads / writes are synchronized per client instance
+                  try (FileInputStream inputStream = application.openFileInput(fileName)) {
+                      return parser.parseFrom(inputStream);
+                  } catch (InvalidProtocolBufferException | FileNotFoundException e) {
+                      Logging.logi("Recoverable exception while reading cache: " + e.getMessage());
+                      return null;
+                  }
+
+              });
   }
 }

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImplTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImplTest.java
@@ -259,6 +259,27 @@ public class DisplayCallbacksImplTest {
   }
 
   @Test
+  public void logImpression_forOneMessageShouldNotAffectOtherMessages() {
+    FirebaseInAppMessagingDisplayCallbacks displayCallbacksImplOne =
+            displayCallbacksFactory.generateDisplayCallback(
+                    BANNER_TEST_MESSAGE_MODEL, ANALYTICS_EVENT_NAME);
+
+    FirebaseInAppMessagingDisplayCallbacks displayCallbacksImplTwo =
+            displayCallbacksFactory.generateDisplayCallback(
+                    BANNER_TEST_MESSAGE_MODEL, ANALYTICS_EVENT_NAME);
+
+    displayCallbacksImplOne.impressionDetected();
+
+    assertThat(((DisplayCallbacksImpl)displayCallbacksImplOne).hasImpressed()).isTrue();
+    assertThat(((DisplayCallbacksImpl)displayCallbacksImplTwo).hasImpressed()).isFalse();
+
+    displayCallbacksImplTwo.impressionDetected();
+
+    assertThat(((DisplayCallbacksImpl)displayCallbacksImplOne).hasImpressed()).isTrue();
+    assertThat(((DisplayCallbacksImpl)displayCallbacksImplTwo).hasImpressed()).isTrue();
+  }
+
+  @Test
   public void logImpression_forTestCampaign_doesRecordImpression() {
     displayCallbacksImpl =
         displayCallbacksFactory.generateDisplayCallback(

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImplTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImplTest.java
@@ -270,13 +270,13 @@ public class DisplayCallbacksImplTest {
 
     displayCallbacksImplOne.impressionDetected();
 
-    assertThat(((DisplayCallbacksImpl) displayCallbacksImplOne).hasImpressed()).isTrue();
-    assertThat(((DisplayCallbacksImpl) displayCallbacksImplTwo).hasImpressed()).isFalse();
+    assertThat(((DisplayCallbacksImpl) displayCallbacksImplOne).wasImpressed()).isTrue();
+    assertThat(((DisplayCallbacksImpl) displayCallbacksImplTwo).wasImpressed()).isFalse();
 
     displayCallbacksImplTwo.impressionDetected();
 
-    assertThat(((DisplayCallbacksImpl) displayCallbacksImplOne).hasImpressed()).isTrue();
-    assertThat(((DisplayCallbacksImpl) displayCallbacksImplTwo).hasImpressed()).isTrue();
+    assertThat(((DisplayCallbacksImpl) displayCallbacksImplOne).wasImpressed()).isTrue();
+    assertThat(((DisplayCallbacksImpl) displayCallbacksImplTwo).wasImpressed()).isTrue();
   }
 
   @Test

--- a/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImplTest.java
+++ b/firebase-inappmessaging/src/test/java/com/google/firebase/inappmessaging/internal/DisplayCallbacksImplTest.java
@@ -261,22 +261,22 @@ public class DisplayCallbacksImplTest {
   @Test
   public void logImpression_forOneMessageShouldNotAffectOtherMessages() {
     FirebaseInAppMessagingDisplayCallbacks displayCallbacksImplOne =
-            displayCallbacksFactory.generateDisplayCallback(
-                    BANNER_TEST_MESSAGE_MODEL, ANALYTICS_EVENT_NAME);
+        displayCallbacksFactory.generateDisplayCallback(
+            BANNER_TEST_MESSAGE_MODEL, ANALYTICS_EVENT_NAME);
 
     FirebaseInAppMessagingDisplayCallbacks displayCallbacksImplTwo =
-            displayCallbacksFactory.generateDisplayCallback(
-                    BANNER_TEST_MESSAGE_MODEL, ANALYTICS_EVENT_NAME);
+        displayCallbacksFactory.generateDisplayCallback(
+            BANNER_TEST_MESSAGE_MODEL, ANALYTICS_EVENT_NAME);
 
     displayCallbacksImplOne.impressionDetected();
 
-    assertThat(((DisplayCallbacksImpl)displayCallbacksImplOne).hasImpressed()).isTrue();
-    assertThat(((DisplayCallbacksImpl)displayCallbacksImplTwo).hasImpressed()).isFalse();
+    assertThat(((DisplayCallbacksImpl) displayCallbacksImplOne).hasImpressed()).isTrue();
+    assertThat(((DisplayCallbacksImpl) displayCallbacksImplTwo).hasImpressed()).isFalse();
 
     displayCallbacksImplTwo.impressionDetected();
 
-    assertThat(((DisplayCallbacksImpl)displayCallbacksImplOne).hasImpressed()).isTrue();
-    assertThat(((DisplayCallbacksImpl)displayCallbacksImplTwo).hasImpressed()).isTrue();
+    assertThat(((DisplayCallbacksImpl) displayCallbacksImplOne).hasImpressed()).isTrue();
+    assertThat(((DisplayCallbacksImpl) displayCallbacksImplTwo).hasImpressed()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
https://github.com/firebase/firebase-android-sdk/issues/3774

The Flag variable to check whether impressed or not was a static one and because of which when one FIAM message is marked as impressed, it was affecting other messages until the app restarts.