### PR TITLE
Only reset retries when the realtime connection successfully opens.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -318,9 +318,7 @@ public class ConfigRealtimeHttpClient {
       ConfigAutoFetch configAutoFetch = startAutoFetch(httpURLConnection);
       configAutoFetch.listenForNotifications();
     } catch (IOException e) {
-      propagateErrors(
-          new FirebaseRemoteConfigRealtimeUpdateStreamException(
-              "Exception connecting to realtime stream. Retrying..."));
+      Log.d(TAG, "Exception connecting to realtime stream. Retrying the connection...");
     } finally {
       closeRealtimeHttpStream();
       retryHTTPConnection();

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -331,6 +331,13 @@ public class ConfigRealtimeHttpClient {
   synchronized void closeRealtimeHttpStream() {
     if (httpURLConnection != null) {
       this.httpURLConnection.disconnect();
+
+      // Explicitly close the input stream due to a bug in the Android okhttp implementation.
+      // See github.com/firebase/firebase-android-sdk/pull/808.
+      try {
+        this.httpURLConnection.getInputStream().close();
+      } catch (IOException e) {
+      }
       this.httpURLConnection = null;
     }
   }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -298,9 +297,8 @@ public class ConfigRealtimeHttpClient {
    * Open the realtime connection, begin listening for updates, and auto-fetch when an update is
    * received.
    *
-   * <p>If the connection is successful, this method will block on its thread while it
-   * reads the chunk-encoded HTTP body. When the connection closes, it attempts to reestablish
-   * the stream.</p>
+   * <p>If the connection is successful, this method will block on its thread while it reads the
+   * chunk-encoded HTTP body. When the connection closes, it attempts to reestablish the stream.
    */
   @SuppressLint("VisibleForTests")
   synchronized void beginRealtimeHttpStream() {
@@ -321,8 +319,8 @@ public class ConfigRealtimeHttpClient {
       configAutoFetch.listenForNotifications();
     } catch (IOException e) {
       propagateErrors(
-              new FirebaseRemoteConfigRealtimeUpdateStreamException(
-                      "Exception connecting to realtime stream. Retrying..."));
+          new FirebaseRemoteConfigRealtimeUpdateStreamException(
+              "Exception connecting to realtime stream. Retrying..."));
     } finally {
       closeRealtimeHttpStream();
       retryHTTPConnection();


### PR DESCRIPTION
Since [`URL#openConnection()`](https://docs.oracle.com/javase/7/docs/api/java/net/URL.html#openConnection()) only creates the connection object and doesn't open the connection, we were optimistically resetting the retries remaining before checking if the connection actually succeeded. (`connect()` or any downstream method like `getResponseCode()` must be called to open the connection.)

This change
* updates `beginRealtimeHttpStream()` to call `connect()` before resetting the retries
* and propagates the `IOException` thrown by `openConnection()` rather than checking if the connection object is `null` so we can collapse the two into one user-visible error about the realtime connection

Comparable iOS change: https://github.com/firebase/firebase-ios-sdk/pull/10143