### PR TITLE
Clean up unused methods.

### DIFF
--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/CommonNotificationBuilder.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/CommonNotificationBuilder.java
@@ -110,30 +110,6 @@ public final class CommonNotificationBuilder {
   }
 
   /**
-   * Legacy method that creates a DisplayNotificationInfo from NotificationParams that allows
-   * specifying components so the calling Context can be different from the Context used for the
-   * notification (resources, etc.).
-   */
-  public static DisplayNotificationInfo createNotificationInfo(
-      Context context,
-      String pkgName,
-      NotificationParams params,
-      String channelId,
-      Resources appResources,
-      PackageManager appPackageManager,
-      Bundle manifestMetadata) {
-    return createNotificationInfo(
-        context,
-        context,
-        params,
-        channelId,
-        manifestMetadata,
-        pkgName,
-        appResources,
-        appPackageManager);
-  }
-
-  /**
    * Creates a DisplayNotificationInfo from NotificationParams that allows specifying a calling
    * Context to be used for creating PendingIntents and one Context that the notification is
    * intended for (resources, package name, manifest data, etc.)
@@ -147,27 +123,6 @@ public final class CommonNotificationBuilder {
     String pkgName = appContext.getPackageName();
     Resources appResources = appContext.getResources();
     PackageManager appPackageManager = appContext.getPackageManager();
-    return createNotificationInfo(
-        callingContext,
-        appContext,
-        params,
-        channelId,
-        manifestMetadata,
-        pkgName,
-        appResources,
-        appPackageManager);
-  }
-
-  public static DisplayNotificationInfo createNotificationInfo(
-      Context callingContext,
-      Context appContext,
-      NotificationParams params,
-      String channelId,
-      Bundle manifestMetadata,
-      String pkgName,
-      Resources appResources,
-      PackageManager appPackageManager) {
-
     NotificationCompat.Builder builder = new NotificationCompat.Builder(appContext, channelId);
 
     String title =

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmBroadcastProcessor.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmBroadcastProcessor.java
@@ -122,7 +122,9 @@ public class FcmBroadcastProcessor {
       WakeLockHolder.sendWakefulServiceIntent(
           context, getServiceConnection(context, ServiceStarter.ACTION_MESSAGING_EVENT), intent);
     } else {
-      getServiceConnection(context, ServiceStarter.ACTION_MESSAGING_EVENT).sendIntent(intent);
+      // Ignore result since we're no longer blocking on the service handling the intent.
+      Task<Void> unused =
+          getServiceConnection(context, ServiceStarter.ACTION_MESSAGING_EVENT).sendIntent(intent);
     }
 
     return Tasks.forResult(ServiceStarter.SUCCESS);


### PR DESCRIPTION
* Cleaned up some unused methods in CommonNotificationBuilder.
* Also changed to explicitly save the result of sendIntent() in FcmBroadcastProcessor but not use it since we're blocking on the result of the Task, and added a comment to that effect.