### PR TITLE
Resolved strict mode violations in firebase-installations

### DIFF
--- a/firebase-installations/src/androidTest/java/com/google/firebase/installations/StrictModeTest.java
+++ b/firebase-installations/src/androidTest/java/com/google/firebase/installations/StrictModeTest.java
@@ -19,7 +19,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions.Builder;
 import com.google.firebase.testing.integ.StrictModeRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +29,6 @@ public class StrictModeTest {
   @Rule public StrictModeRule strictMode = new StrictModeRule();
 
   @Test
-  @Ignore("enable once strict mode violations are addressed")
   public void initializingFirebaseInstallations_shouldNotViolateStrictMode() {
     strictMode.runOnMainThread(
         () -> {

--- a/firebase-installations/src/main/java/com/google/firebase/installations/FirebaseInstallations.java
+++ b/firebase-installations/src/main/java/com/google/firebase/installations/FirebaseInstallations.java
@@ -25,6 +25,7 @@ import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.components.Lazy;
 import com.google.firebase.heartbeatinfo.HeartBeatController;
 import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsException.Status;
@@ -65,7 +66,7 @@ public class FirebaseInstallations implements FirebaseInstallationsApi {
   private final FirebaseInstallationServiceClient serviceClient;
   private final PersistedInstallation persistedInstallation;
   private final Utils utils;
-  private final IidStore iidStore;
+  private final Lazy<IidStore> iidStore;
   private final RandomFidGenerator fidGenerator;
   private final Object lock = new Object();
   private final ExecutorService backgroundExecutor;
@@ -137,7 +138,7 @@ public class FirebaseInstallations implements FirebaseInstallationsApi {
             firebaseApp.getApplicationContext(), heartBeatProvider),
         new PersistedInstallation(firebaseApp),
         Utils.getInstance(),
-        new IidStore(firebaseApp),
+        new Lazy<>(() -> new IidStore(firebaseApp)),
         new RandomFidGenerator());
   }
 
@@ -147,7 +148,7 @@ public class FirebaseInstallations implements FirebaseInstallationsApi {
       FirebaseInstallationServiceClient serviceClient,
       PersistedInstallation persistedInstallation,
       Utils utils,
-      IidStore iidStore,
+      Lazy<IidStore> iidStore,
       RandomFidGenerator fidGenerator) {
     this.firebaseApp = firebaseApp;
     this.serviceClient = serviceClient;
@@ -374,6 +375,10 @@ public class FirebaseInstallations implements FirebaseInstallationsApi {
     networkExecutor.execute(() -> doNetworkCallIfNecessary(forceRefresh));
   }
 
+  private IidStore getIidStore() {
+    return iidStore.get();
+  }
+
   private void doNetworkCallIfNecessary(boolean forceRefresh) {
     PersistedInstallationEntry prefs = getMultiProcessSafePrefs();
     // There are two possible cleanup steps to perform at this stage: the FID may need to
@@ -506,7 +511,7 @@ public class FirebaseInstallations implements FirebaseInstallationsApi {
       return fidGenerator.createRandomFid();
     }
     // For a default/chime firebase installation, read the existing iid from shared prefs
-    String fid = iidStore.readIid();
+    String fid = getIidStore().readIid();
     if (TextUtils.isEmpty(fid)) {
       fid = fidGenerator.createRandomFid();
     }
@@ -524,7 +529,7 @@ public class FirebaseInstallations implements FirebaseInstallationsApi {
         && prefs.getFirebaseInstallationId().length() == 11) {
       // For a default firebase installation, read the stored star scoped iid token. This token
       // will be used for authenticating Instance-ID when migrating to FIS.
-      iidToken = iidStore.readToken();
+      iidToken = getIidStore().readToken();
     }
 
     InstallationResponse response =

--- a/firebase-installations/src/test/java/com/google/firebase/installations/FirebaseInstallationsTest.java
+++ b/firebase-installations/src/test/java/com/google/firebase/installations/FirebaseInstallationsTest.java
@@ -38,6 +38,7 @@ import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.components.Lazy;
 import com.google.firebase.installations.FirebaseInstallationsException.Status;
 import com.google.firebase.installations.internal.FidListenerHandle;
 import com.google.firebase.installations.local.IidStore;
@@ -162,7 +163,7 @@ public class FirebaseInstallationsTest {
             mockBackend,
             persistedInstallation,
             utils,
-            mockIidStore,
+            new Lazy(() -> mockIidStore),
             mockFidGenerator);
 
     when(mockFidGenerator.createRandomFid()).thenReturn(TEST_FID_1);


### PR DESCRIPTION
This fix defers initialization of `IidStore` (which performs a disk read) with a `Lazy`, resolving strict mode violations, and re-enables the strict mode test.