### PR TITLE
Removing getRunningAppProcesses since the process_name isn't used

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeManager.java
@@ -267,7 +267,6 @@ public class GaugeManager {
 
   private GaugeMetadata getGaugeMetadata() {
     return GaugeMetadata.newBuilder()
-        .setProcessName(gaugeMetadataManager.getProcessName())
         .setDeviceRamSizeKb(gaugeMetadataManager.getDeviceRamSizeKb())
         .setMaxAppJavaHeapMemoryKb(gaugeMetadataManager.getMaxAppJavaHeapMemoryKb())
         .setMaxEncouragedAppJavaHeapMemoryKb(

--- a/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeMetadataManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/session/gauges/GaugeMetadataManager.java
@@ -19,7 +19,6 @@ import android.app.ActivityManager.MemoryInfo;
 import android.content.Context;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
-import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.util.StorageUnit;
@@ -28,7 +27,6 @@ import com.google.firebase.perf.v1.GaugeMetadata;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,7 +41,6 @@ class GaugeMetadataManager {
   private final Runtime runtime;
   private final ActivityManager activityManager;
   private final MemoryInfo memoryInfo;
-  private final String currentProcessName;
   private final Context appContext;
 
   GaugeMetadataManager(Context appContext) {
@@ -57,15 +54,6 @@ class GaugeMetadataManager {
     this.activityManager = (ActivityManager) appContext.getSystemService(Context.ACTIVITY_SERVICE);
     memoryInfo = new ActivityManager.MemoryInfo();
     activityManager.getMemoryInfo(memoryInfo);
-
-    // Assign the current process name here to avoid iterating through all the running processes
-    // each time getCurrentProcessName() is called.
-    currentProcessName = getCurrentProcessName();
-  }
-
-  /** Returns the name of the process FirebaseApp is associated with. */
-  public String getProcessName() {
-    return currentProcessName;
   }
 
   /**
@@ -111,24 +99,5 @@ class GaugeMetadataManager {
     }
 
     return 0;
-  }
-
-  /** Returns the name of the process the Application is associated with. */
-  private String getCurrentProcessName() {
-    int myProcessPid = android.os.Process.myPid();
-
-    @Nullable
-    List<ActivityManager.RunningAppProcessInfo> runningAppProcessInfos =
-        activityManager.getRunningAppProcesses();
-
-    if (runningAppProcessInfos != null) {
-      for (ActivityManager.RunningAppProcessInfo processInfo : runningAppProcessInfos) {
-        if (processInfo.pid == myProcessPid) {
-          return processInfo.processName;
-        }
-      }
-    }
-
-    return appContext.getPackageName();
   }
 }

--- a/firebase-perf/src/main/proto/firebase/perf/v1/perf_metric.proto
+++ b/firebase-perf/src/main/proto/firebase/perf/v1/perf_metric.proto
@@ -266,11 +266,8 @@ message AndroidMemoryReading {
 //
 // Next tag: 7
 message GaugeMetadata {
-  // The process in which Firebase instance is initialized and collecting data.
-  // Fireperf sdk collects information in the context of a process (instead of
-  // the whole app). The process name helps developer identifies which process
-  // are the gauge data coming from.
-  optional string process_name = 1;
+  // Deprecated on 09/2022.
+  optional string process_name = 1 [deprecated = true];
 
   // Clock rate of the cpu of the device, in kHz.
   optional int32 cpu_clock_rate_khz = 2;

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfGaugeManagerValidatorTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/validator/FirebasePerfGaugeManagerValidatorTest.java
@@ -56,7 +56,6 @@ public final class FirebasePerfGaugeManagerValidatorTest {
     // Construct GaugeMetadata
     GaugeMetadata gaugeMetadata =
         createValidGaugeMetadata(
-            "processName",
             /* deviceRamSizeKb= */ 2000,
             /* maxAppJavaHeapMemoryKb= */ 1000,
             /* maxEncouragedAppJavaHeapMemoryKb= */ 800);
@@ -115,7 +114,6 @@ public final class FirebasePerfGaugeManagerValidatorTest {
   public void testGaugeMetricWithOnlyGaugeMetadataIsValid() {
     GaugeMetadata gaugeMetadata =
         createValidGaugeMetadata(
-            "processName",
             /* deviceRamSizeKb= */ 2000,
             /* maxAppJavaHeapMemoryKb= */ 1000,
             /* maxEncouragedAppJavaHeapMemoryKb= */ 800);
@@ -134,7 +132,6 @@ public final class FirebasePerfGaugeManagerValidatorTest {
   public void testGaugeMetadataWithoutMaxJavaHeapIsNotValid() {
     GaugeMetadata gaugeMetadata =
         GaugeMetadata.newBuilder()
-            .setProcessName("processName")
             .setDeviceRamSizeKb(2000)
             .setMaxEncouragedAppJavaHeapMemoryKb(800)
             .build();
@@ -202,12 +199,8 @@ public final class FirebasePerfGaugeManagerValidatorTest {
   }
 
   private GaugeMetadata createValidGaugeMetadata(
-      String processName,
-      int deviceRamSizeKb,
-      int maxAppJavaHeapMemoryKb,
-      int maxEncouragedAppJavaHeapMemoryKb) {
+      int deviceRamSizeKb, int maxAppJavaHeapMemoryKb, int maxEncouragedAppJavaHeapMemoryKb) {
     GaugeMetadata.Builder fakeGaugeMetadataBuilder = GaugeMetadata.newBuilder();
-    fakeGaugeMetadataBuilder.setProcessName(processName);
     fakeGaugeMetadataBuilder.setDeviceRamSizeKb(deviceRamSizeKb);
     fakeGaugeMetadataBuilder.setMaxAppJavaHeapMemoryKb(maxAppJavaHeapMemoryKb);
     fakeGaugeMetadataBuilder.setMaxEncouragedAppJavaHeapMemoryKb(maxEncouragedAppJavaHeapMemoryKb);

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeManagerTest.java
@@ -637,7 +637,6 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
 
   @Test
   public void testLogGaugeMetadataSendDataToTransport() {
-    when(fakeGaugeMetadataManager.getProcessName()).thenReturn("processName");
     when(fakeGaugeMetadataManager.getDeviceRamSizeKb()).thenReturn(2000);
     when(fakeGaugeMetadataManager.getMaxAppJavaHeapMemoryKb()).thenReturn(1000);
     when(fakeGaugeMetadataManager.getMaxEncouragedAppJavaHeapMemoryKb()).thenReturn(800);
@@ -649,7 +648,6 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
     GaugeMetadata recordedGaugeMetadata = recordedGaugeMetric.getGaugeMetadata();
 
     assertThat(recordedGaugeMetric.getSessionId()).isEqualTo("sessionId");
-    assertThat(recordedGaugeMetadata.getProcessName()).isEqualTo("processName");
 
     assertThat(recordedGaugeMetadata.getDeviceRamSizeKb())
         .isEqualTo(fakeGaugeMetadataManager.getDeviceRamSizeKb());
@@ -699,7 +697,6 @@ public final class GaugeManagerTest extends FirebasePerformanceTestBase {
     GaugeMetadata recordedGaugeMetadata = recordedGaugeMetric.getGaugeMetadata();
 
     assertThat(recordedGaugeMetric.getSessionId()).isEqualTo("sessionId");
-    assertThat(recordedGaugeMetadata.hasProcessName()).isTrue();
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeMetadataManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/gauges/GaugeMetadataManagerTest.java
@@ -16,13 +16,10 @@ package com.google.firebase.perf.session.gauges;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.ActivityManager;
-import android.app.ActivityManager.RunningAppProcessInfo;
 import android.content.Context;
 import android.os.Environment;
 import androidx.test.core.app.ApplicationProvider;
@@ -32,8 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,38 +74,6 @@ public class GaugeMetadataManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void testInitialization_getProcessNameReturnsNull_doesNotCrash() {
-    ActivityManager activityManagerPartialMock = spy(activityManager);
-    when(activityManagerPartialMock.getRunningAppProcesses()).thenReturn(null);
-
-    assertThat(new GaugeMetadataManager(runtime, appContext)).isNotNull();
-  }
-
-  @Test
-  public void testGetProcessName_noProcessInfoList_returnsPackageName() {
-    shadowOf(activityManager).setProcesses(new ArrayList<>());
-    assertThat(new GaugeMetadataManager(runtime, appContext).getProcessName())
-        .isEqualTo(appContext.getPackageName());
-  }
-
-  @Test
-  public void testGetProcessName_processListWithoutCurrentPid_returnsPackageName() {
-    shadowOf(activityManager)
-        .setProcesses(
-            generateFakeAppProcessInfoListThatContainsPid(android.os.Process.myPid() + 100));
-    assertThat(new GaugeMetadataManager(runtime, appContext).getProcessName())
-        .isEqualTo(appContext.getPackageName());
-  }
-
-  @Test
-  public void testGetProcessName_processListWithCurrentPid_returnsProcessName() {
-    shadowOf(activityManager)
-        .setProcesses(generateFakeAppProcessInfoListThatContainsPid(android.os.Process.myPid()));
-    assertThat(new GaugeMetadataManager(runtime, appContext).getProcessName())
-        .isEqualTo("fakeProcessName");
-  }
-
-  @Test
   public void testGetMaxAppJavaHeapMemory_returnsExpectedValue() {
     assertThat(testGaugeMetadataManager.getMaxAppJavaHeapMemoryKb()).isGreaterThan(0);
     //        .isEqualTo(StorageUnit.BYTES.toKilobytes(RUNTIME_MAX_MEMORY_BYTES));
@@ -144,17 +107,6 @@ public class GaugeMetadataManagerTest extends FirebasePerformanceTestBase {
     fileWriter.close();
 
     return file.getAbsolutePath();
-  }
-
-  private List<RunningAppProcessInfo> generateFakeAppProcessInfoListThatContainsPid(int pid) {
-    ActivityManager.RunningAppProcessInfo fakeProcessInfoList = new RunningAppProcessInfo();
-    fakeProcessInfoList.pid = pid;
-    fakeProcessInfoList.processName = "fakeProcessName";
-
-    List<RunningAppProcessInfo> processInfoList = new ArrayList<>();
-    processInfoList.add(fakeProcessInfoList);
-
-    return processInfoList;
   }
 
   private static final String MEM_INFO_CONTENTS =


### PR DESCRIPTION
getRunningAppProcesses() was also causing compliance issues with Tencent's appstore #4045 