### PR TITLE
Implement Metalava with Dackka

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Metalava.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/Metalava.kt
@@ -37,6 +37,10 @@ val Project.metalavaConfig: Configuration
                 this.dependencies.add(this@metalavaConfig.dependencies.create("com.android.tools.metalava:metalava:1.0.0-alpha06"))
             }
 
+val Project.docStubs: File?
+    get() =
+        project.file("${buildDir.path}/doc-stubs")
+
 fun Project.runMetalavaWithArgs(
     arguments: List<String>,
     ignoreFailure: Boolean = false,

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
@@ -14,6 +14,7 @@
 package com.google.firebase.gradle.plugins
 
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
 
@@ -53,3 +54,19 @@ fun Configuration.getJars() = incoming.artifactView {
         attribute(Attribute.of("artifactType", String::class.java), "jar")
     }
 }.artifacts.artifactFiles
+
+/**
+ * Utility method to call [Task.mustRunAfter] and [Task.dependsOn] on the specified task
+ */
+fun <T : Task, R : Task> T.dependsOnAndMustRunAfter(otherTask: R) {
+    mustRunAfter(otherTask)
+    dependsOn(otherTask)
+}
+
+/**
+ * Utility method to call [Task.mustRunAfter] and [Task.dependsOn] on the specified task name
+ */
+fun <T : Task> T.dependsOnAndMustRunAfter(otherTask: String) {
+    mustRunAfter(otherTask)
+    dependsOn(otherTask)
+}


### PR DESCRIPTION
Per [b/243941807](b/243941807), this refactors the Dackka task to utilize Metalava generated stubs for Java sources, and use the standard sources for Kotlin.

This also adds a small extension method for Metalava, since we don't actually offer configuration of the output directory on stub generation.