### PR TITLE
Add Javadoc support to the DackkaPlugin

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -239,6 +239,11 @@ abstract class DackkaPlugin : Plugin<Project> {
     // TODO(b/246593212): Migrate doc files to single directory
     private fun registerCopyJavaDocToCommonDirectoryTask(project: Project, outputDirectory: Provider<File>) =
         project.tasks.register<Copy>("copyJavaDocToCommonDirectory") {
+            /**
+             * This is not currently cache compliant. The need for this property is
+             * temporary while we test it alongside the current javaDoc task. Since it's such a
+             * temporary behavior, losing cache compliance is fine for now.
+             */
             if (project.rootProject.findProperty("dackkaJavadoc") == "true") {
                 mustRunAfter("firesiteTransform")
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
@@ -1,0 +1,10 @@
+package com.google.firebase.gradle.plugins
+
+import java.io.File
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Copy
+
+fun Copy.fromDirectory(directory: Provider<File>) =
+    from(directory) {
+        into(directory.map { it.nameWithoutExtension })
+    }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
@@ -6,5 +6,5 @@ import org.gradle.api.tasks.Copy
 
 fun Copy.fromDirectory(directory: Provider<File>) =
     from(directory) {
-        into(directory.map { it.nameWithoutExtension })
+        into(directory.map { it.name })
     }


### PR DESCRIPTION
In accordance with [b/245753889](https://b.corp.google.com/issues/245753889), this adds support to the DackkaPlugin to generate Javadoc variants.

More specifically this:
- Removes the `deleteDackkaGeneratedJavaReferences` task
- Refactors `copyOutputToCommonDirectory` to two separate task
- Adds a new task to copy the Javadoc output via `copyJavaDocToCommonDirectory`
- Adds a new task to copy the Kotlindoc output via `copyKotlinDocToCommonDirectory`
- Adds an extension method to the `Copy` task in gradle for copying individual directories
- Fixes the `DackkaPlugin` documentation to reflect the new changes

Keep in mind that the current implementation in this pr requires the project setting `dackkaJavadoc` to be equal to `true`, otherwise Dackka won't copy the Javadoc output to the root directory.

For example, running `./gradlew :firebase-common:kotlindoc` will yield this at the root build directory
```
firebase-kotlindoc/
  kotlin/
```
Wheres running this `./gradlew -PdackkaJavadoc=true :firebase-common:kotlindoc` will yield this at the root build directory
```
firebase-kotlindoc/
  kotlin/
  android/
```

Android contains the Firesite ready Javadoc files for staging.