### PR TITLE
Resolve StrictMode violation in App Check.

### DIFF
--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -85,6 +85,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
           if (token != null) {
             setCachedToken(token);
           }
+          taskCompletionSource.setResult(null);
         });
     return taskCompletionSource.getTask();
   }
@@ -191,8 +192,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
                                   task.getResult()));
                         }
                         // If the token exchange failed, return a dummy token for integrators to
-                        // attach in
-                        // their headers.
+                        // attach in their headers.
                         return Tasks.forResult(
                             DefaultAppCheckTokenResult.constructFromError(
                                 new FirebaseException(

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -235,7 +235,6 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
     return appCheckProvider
         .getToken()
         .continueWithTask(
-            backgroundExecutor,
             new Continuation<AppCheckToken, Task<AppCheckToken>>() {
               @Override
               public Task<AppCheckToken> then(@NonNull Task<AppCheckToken> task) {
@@ -270,11 +269,9 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
   /**
    * Updates the {@link AppCheckToken} persisted in {@link android.content.SharedPreferences} as
    * well as the in-memory cached {@link AppCheckToken}.
-   *
-   * <p>This method performs a disk write, and should therefore be called on a background thread.
    */
   private void updateStoredToken(@NonNull AppCheckToken token) {
-    storageHelper.saveAppCheckToken(token);
+    backgroundExecutor.execute(() -> storageHelper.saveAppCheckToken(token));
     setCachedToken(token);
 
     tokenRefreshManager.maybeScheduleTokenRefresh(token);

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -86,9 +86,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
     this.clock = new Clock.DefaultClock();
   }
 
-  @VisibleForTesting
-  @NonNull
-  Task<Void> retrieveStoredAppCheckTokenInBackground(@NonNull ExecutorService executor) {
+  private Task<Void> retrieveStoredAppCheckTokenInBackground(@NonNull ExecutorService executor) {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
     executor.execute(
         () -> {

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
@@ -14,12 +14,14 @@
 
 package com.google.firebase.appcheck.internal;
 
+import static android.os.Looper.getMainLooper;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
 
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
@@ -75,6 +77,7 @@ public class DefaultFirebaseAppCheckTest {
 
     defaultFirebaseAppCheck =
         new DefaultFirebaseAppCheck(mockFirebaseApp, () -> mockHeartBeatController);
+    shadowOf(getMainLooper()).idle();
   }
 
   @Test

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
@@ -14,18 +14,17 @@
 
 package com.google.firebase.appcheck.internal;
 
-import static android.os.Looper.getMainLooper;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.robolectric.Shadows.shadowOf;
 
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.AppCheckProvider;
 import com.google.firebase.appcheck.AppCheckProviderFactory;
@@ -76,8 +75,10 @@ public class DefaultFirebaseAppCheckTest {
     when(mockAppCheckProvider.getToken()).thenReturn(Tasks.forResult(validDefaultAppCheckToken));
 
     defaultFirebaseAppCheck =
-        new DefaultFirebaseAppCheck(mockFirebaseApp, () -> mockHeartBeatController);
-    shadowOf(getMainLooper()).idle();
+        new DefaultFirebaseAppCheck(
+            mockFirebaseApp,
+            () -> mockHeartBeatController,
+            MoreExecutors.newDirectExecutorService());
   }
 
   @Test


### PR DESCRIPTION
Resolve a StrictMode violation in App Check by moving the retrieval of the stored App Check token out of the initialization path.