### PR TITLE
Resolve strict mode violations in firebase-appdistribution

### DIFF
--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -54,7 +54,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.8.1"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-inline:3.4.0'
-    androidTestImplementation "org.mockito:mockito-android:3.4.0"
     testImplementation 'androidx.test:core:1.2.0'
 
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
@@ -64,4 +63,13 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation "androidx.browser:browser:1.3.0"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+
+    androidTestImplementation project(':integ-testing')
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation "androidx.annotation:annotation:1.0.0"
+    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
 }

--- a/firebase-appdistribution/src/androidTest/AndroidManifest.xml
+++ b/firebase-appdistribution/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2022 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.installations">
+
+    <application>
+        <uses-library android:name="android.test.runner"/>
+    </application>
+
+    <instrumentation
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:targetPackage="com.google.firebase.appdistribution" />
+</manifest>

--- a/firebase-appdistribution/src/androidTest/java/com/google/firebase/appdistribution/StrictModeTest.java
+++ b/firebase-appdistribution/src/androidTest/java/com/google/firebase/appdistribution/StrictModeTest.java
@@ -1,0 +1,48 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.firebase.appdistribution;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.appdistribution.internal.FirebaseAppDistributionProxy;
+import com.google.firebase.testing.integ.StrictModeRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class StrictModeTest {
+
+  @Rule public StrictModeRule strictMode = new StrictModeRule();
+
+  @Test
+  public void initializingFirebaseAppdistribution_shouldNotViolateStrictMode() {
+    strictMode.runOnMainThread(
+        () -> {
+          FirebaseApp app =
+              FirebaseApp.initializeApp(
+                  ApplicationProvider.getApplicationContext(),
+                  new FirebaseOptions.Builder()
+                      .setApiKey("api")
+                      .setProjectId("123")
+                      .setApplicationId("appId")
+                      .build(),
+                  "hello");
+          app.get(FirebaseAppDistribution.class);
+          app.get(FirebaseAppDistributionProxy.class);
+        });
+  }
+}

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
@@ -16,6 +16,7 @@ package com.google.firebase.appdistribution.impl;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import com.google.firebase.components.Lazy;
 
 /** Class that handles storage for App Distribution SignIn persistence. */
 class SignInStorage {
@@ -23,18 +24,21 @@ class SignInStorage {
   private static final String SIGNIN_PREFERENCES_NAME = "FirebaseAppDistributionSignInStorage";
   private static final String SIGNIN_TAG = "firebase_app_distribution_signin";
 
-  private final SharedPreferences signInSharedPreferences;
+  private final Lazy<SharedPreferences> signInSharedPreferences;
 
   SignInStorage(Context applicationContext) {
     this.signInSharedPreferences =
-        applicationContext.getSharedPreferences(SIGNIN_PREFERENCES_NAME, Context.MODE_PRIVATE);
+        new Lazy(
+            () ->
+                applicationContext.getSharedPreferences(
+                    SIGNIN_PREFERENCES_NAME, Context.MODE_PRIVATE));
   }
 
   void setSignInStatus(boolean testerSignedIn) {
-    this.signInSharedPreferences.edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
+    this.signInSharedPreferences.get().edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
   }
 
   boolean getSignInStatus() {
-    return signInSharedPreferences.getBoolean(SIGNIN_TAG, false);
+    return signInSharedPreferences.get().getBoolean(SIGNIN_TAG, false);
   }
 }


### PR DESCRIPTION
* Adds integration tests in appdistribution for testing strict mode violations
* Defers access of shared preferences off of component initialization to not block during init
