### PR TITLE
Add Kotlin stdlib to the precompiled package-lists 

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
@@ -127,7 +127,8 @@ abstract class GenerateDocumentationTask @Inject constructor(
             "android" to "https://developer.android.com/reference/kotlin/",
             "google" to "https://developers.google.com/android/reference/",
             "firebase" to "https://firebase.google.com/docs/reference/kotlin/",
-            "coroutines" to "https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/"
+            "coroutines" to "https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/",
+            "kotlin" to "https://kotlinlang.org/api/latest/jvm/stdlib/"
         )
 
         return packageLists.get().map {

--- a/kotlindoc/package-lists/kotlin/package-list
+++ b/kotlindoc/package-lists/kotlin/package-list
@@ -1,0 +1,317 @@
+$dokka.format:kotlin-website-html
+$dokka.linkExtension:html
+$dokka.location:kotlin$and(java.math.BigInteger, java.math.BigInteger)kotlin/java.math.-big-integer/and.html
+$dokka.location:kotlin$dec(java.math.BigDecimal)kotlin/java.math.-big-decimal/dec.html
+$dokka.location:kotlin$dec(java.math.BigInteger)kotlin/java.math.-big-integer/dec.html
+$dokka.location:kotlin$div(java.math.BigDecimal, java.math.BigDecimal)kotlin/java.math.-big-decimal/div.html
+$dokka.location:kotlin$div(java.math.BigInteger, java.math.BigInteger)kotlin/java.math.-big-integer/div.html
+$dokka.location:kotlin$inc(java.math.BigDecimal)kotlin/java.math.-big-decimal/inc.html
+$dokka.location:kotlin$inc(java.math.BigInteger)kotlin/java.math.-big-integer/inc.html
+$dokka.location:kotlin$inv(java.math.BigInteger)kotlin/java.math.-big-integer/inv.html
+$dokka.location:kotlin$minus(java.math.BigDecimal, java.math.BigDecimal)kotlin/java.math.-big-decimal/minus.html
+$dokka.location:kotlin$minus(java.math.BigInteger, java.math.BigInteger)kotlin/java.math.-big-integer/minus.html
+$dokka.location:kotlin$or(java.math.BigInteger, java.math.BigInteger)kotlin/java.math.-big-integer/or.html
+$dokka.location:kotlin$plus(java.math.BigDecimal, java.math.BigDecimal)kotlin/java.math.-big-decimal/plus.html
+$dokka.location:kotlin$plus(java.math.BigInteger, java.math.BigInteger)kotlin/java.math.-big-integer/plus.html
+$dokka.location:kotlin$rem(java.math.BigDecimal, java.math.BigDecimal)kotlin/java.math.-big-decimal/rem.html
+$dokka.location:kotlin$rem(java.math.BigInteger, java.math.BigInteger)kotlin/java.math.-big-integer/rem.html
+$dokka.location:kotlin$shl(java.math.BigInteger, kotlin.Int)kotlin/java.math.-big-integer/shl.html
+$dokka.location:kotlin$shr(java.math.BigInteger, kotlin.Int)kotlin/java.math.-big-integer/shr.html
+$dokka.location:kotlin$times(java.math.BigDecimal, java.math.BigDecimal)kotlin/java.math.-big-decimal/times.html
+$dokka.location:kotlin$times(java.math.BigInteger, java.math.BigInteger)kotlin/java.math.-big-integer/times.html
+$dokka.location:kotlin$toBigDecimal(java.math.BigInteger)kotlin/java.math.-big-integer/to-big-decimal.html
+$dokka.location:kotlin$toBigDecimal(java.math.BigInteger, kotlin.Int, java.math.MathContext)kotlin/java.math.-big-integer/to-big-decimal.html
+$dokka.location:kotlin$unaryMinus(java.math.BigDecimal)kotlin/java.math.-big-decimal/unary-minus.html
+$dokka.location:kotlin$unaryMinus(java.math.BigInteger)kotlin/java.math.-big-integer/unary-minus.html
+$dokka.location:kotlin$xor(java.math.BigInteger, java.math.BigInteger)kotlin/java.math.-big-integer/xor.html
+$dokka.location:kotlin.ArithmeticExceptionkotlin/-arithmetic-exception/index.html
+$dokka.location:kotlin.AssertionErrorkotlin/-assertion-error/index.html
+$dokka.location:kotlin.ClassCastExceptionkotlin/-class-cast-exception/index.html
+$dokka.location:kotlin.Comparatorkotlin/-comparator/index.html
+$dokka.location:kotlin.ConcurrentModificationExceptionkotlin/-concurrent-modification-exception/index.html
+$dokka.location:kotlin.Errorkotlin/-error/index.html
+$dokka.location:kotlin.Exceptionkotlin/-exception/index.html
+$dokka.location:kotlin.IllegalArgumentExceptionkotlin/-illegal-argument-exception/index.html
+$dokka.location:kotlin.IllegalStateExceptionkotlin/-illegal-state-exception/index.html
+$dokka.location:kotlin.IndexOutOfBoundsExceptionkotlin/-index-out-of-bounds-exception/index.html
+$dokka.location:kotlin.NoSuchElementExceptionkotlin/-no-such-element-exception/index.html
+$dokka.location:kotlin.NullPointerExceptionkotlin/-null-pointer-exception/index.html
+$dokka.location:kotlin.NumberFormatExceptionkotlin/-number-format-exception/index.html
+$dokka.location:kotlin.RuntimeExceptionkotlin/-runtime-exception/index.html
+$dokka.location:kotlin.Throwskotlin/-throws/index.html
+$dokka.location:kotlin.UnsupportedOperationExceptionkotlin/-unsupported-operation-exception/index.html
+$dokka.location:kotlin.collections$getOrPut(java.util.concurrent.ConcurrentMap((kotlin.collections.getOrPut.K, kotlin.collections.getOrPut.V)), kotlin.collections.getOrPut.K, kotlin.Function0((kotlin.collections.getOrPut.V)))kotlin.collections/java.util.concurrent.-concurrent-map/get-or-put.html
+$dokka.location:kotlin.collections$iterator(java.util.Enumeration((kotlin.collections.iterator.T)))kotlin.collections/java.util.-enumeration/iterator.html
+$dokka.location:kotlin.collections$toList(java.util.Enumeration((kotlin.collections.toList.T)))kotlin.collections/java.util.-enumeration/to-list.html
+$dokka.location:kotlin.collections.ArrayListkotlin.collections/-array-list/index.html
+$dokka.location:kotlin.collections.HashMapkotlin.collections/-hash-map/index.html
+$dokka.location:kotlin.collections.HashSetkotlin.collections/-hash-set/index.html
+$dokka.location:kotlin.collections.LinkedHashMapkotlin.collections/-linked-hash-map/index.html
+$dokka.location:kotlin.collections.LinkedHashSetkotlin.collections/-linked-hash-set/index.html
+$dokka.location:kotlin.concurrent$getOrSet(java.lang.ThreadLocal((kotlin.concurrent.getOrSet.T)), kotlin.Function0((kotlin.concurrent.getOrSet.T)))kotlin.concurrent/java.lang.-thread-local/get-or-set.html
+$dokka.location:kotlin.concurrent$read(java.util.concurrent.locks.ReentrantReadWriteLock, kotlin.Function0((kotlin.concurrent.read.T)))kotlin.concurrent/java.util.concurrent.locks.-reentrant-read-write-lock/read.html
+$dokka.location:kotlin.concurrent$schedule(java.util.Timer, java.util.Date, kotlin.Function1((java.util.TimerTask, kotlin.Unit)))kotlin.concurrent/java.util.-timer/schedule.html
+$dokka.location:kotlin.concurrent$schedule(java.util.Timer, java.util.Date, kotlin.Long, kotlin.Function1((java.util.TimerTask, kotlin.Unit)))kotlin.concurrent/java.util.-timer/schedule.html
+$dokka.location:kotlin.concurrent$schedule(java.util.Timer, kotlin.Long, kotlin.Function1((java.util.TimerTask, kotlin.Unit)))kotlin.concurrent/java.util.-timer/schedule.html
+$dokka.location:kotlin.concurrent$schedule(java.util.Timer, kotlin.Long, kotlin.Long, kotlin.Function1((java.util.TimerTask, kotlin.Unit)))kotlin.concurrent/java.util.-timer/schedule.html
+$dokka.location:kotlin.concurrent$scheduleAtFixedRate(java.util.Timer, java.util.Date, kotlin.Long, kotlin.Function1((java.util.TimerTask, kotlin.Unit)))kotlin.concurrent/java.util.-timer/schedule-at-fixed-rate.html
+$dokka.location:kotlin.concurrent$scheduleAtFixedRate(java.util.Timer, kotlin.Long, kotlin.Long, kotlin.Function1((java.util.TimerTask, kotlin.Unit)))kotlin.concurrent/java.util.-timer/schedule-at-fixed-rate.html
+$dokka.location:kotlin.concurrent$withLock(java.util.concurrent.locks.Lock, kotlin.Function0((kotlin.concurrent.withLock.T)))kotlin.concurrent/java.util.concurrent.locks.-lock/with-lock.html
+$dokka.location:kotlin.concurrent$write(java.util.concurrent.locks.ReentrantReadWriteLock, kotlin.Function0((kotlin.concurrent.write.T)))kotlin.concurrent/java.util.concurrent.locks.-reentrant-read-write-lock/write.html
+$dokka.location:kotlin.coroutines.cancellation.CancellationExceptionkotlin.coroutines.cancellation/-cancellation-exception/index.html
+$dokka.location:kotlin.io$appendBytes(java.io.File, kotlin.ByteArray)kotlin.io/java.io.-file/append-bytes.html
+$dokka.location:kotlin.io$appendText(java.io.File, kotlin.String, java.nio.charset.Charset)kotlin.io/java.io.-file/append-text.html
+$dokka.location:kotlin.io$buffered(java.io.InputStream, kotlin.Int)kotlin.io/java.io.-input-stream/buffered.html
+$dokka.location:kotlin.io$buffered(java.io.OutputStream, kotlin.Int)kotlin.io/java.io.-output-stream/buffered.html
+$dokka.location:kotlin.io$buffered(java.io.Reader, kotlin.Int)kotlin.io/java.io.-reader/buffered.html
+$dokka.location:kotlin.io$buffered(java.io.Writer, kotlin.Int)kotlin.io/java.io.-writer/buffered.html
+$dokka.location:kotlin.io$bufferedReader(java.io.File, java.nio.charset.Charset, kotlin.Int)kotlin.io/java.io.-file/buffered-reader.html
+$dokka.location:kotlin.io$bufferedReader(java.io.InputStream, java.nio.charset.Charset)kotlin.io/java.io.-input-stream/buffered-reader.html
+$dokka.location:kotlin.io$bufferedWriter(java.io.File, java.nio.charset.Charset, kotlin.Int)kotlin.io/java.io.-file/buffered-writer.html
+$dokka.location:kotlin.io$bufferedWriter(java.io.OutputStream, java.nio.charset.Charset)kotlin.io/java.io.-output-stream/buffered-writer.html
+$dokka.location:kotlin.io$copyRecursively(java.io.File, java.io.File, kotlin.Boolean, kotlin.Function2((java.io.File, java.io.IOException, kotlin.io.OnErrorAction)))kotlin.io/java.io.-file/copy-recursively.html
+$dokka.location:kotlin.io$copyTo(java.io.File, java.io.File, kotlin.Boolean, kotlin.Int)kotlin.io/java.io.-file/copy-to.html
+$dokka.location:kotlin.io$copyTo(java.io.InputStream, java.io.OutputStream, kotlin.Int)kotlin.io/java.io.-input-stream/copy-to.html
+$dokka.location:kotlin.io$copyTo(java.io.Reader, java.io.Writer, kotlin.Int)kotlin.io/java.io.-reader/copy-to.html
+$dokka.location:kotlin.io$deleteRecursively(java.io.File)kotlin.io/java.io.-file/delete-recursively.html
+$dokka.location:kotlin.io$endsWith(java.io.File, java.io.File)kotlin.io/java.io.-file/ends-with.html
+$dokka.location:kotlin.io$endsWith(java.io.File, kotlin.String)kotlin.io/java.io.-file/ends-with.html
+$dokka.location:kotlin.io$extension#java.io.Filekotlin.io/java.io.-file/extension.html
+$dokka.location:kotlin.io$forEachBlock(java.io.File, kotlin.Function2((kotlin.ByteArray, kotlin.Int, kotlin.Unit)))kotlin.io/java.io.-file/for-each-block.html
+$dokka.location:kotlin.io$forEachBlock(java.io.File, kotlin.Int, kotlin.Function2((kotlin.ByteArray, kotlin.Int, kotlin.Unit)))kotlin.io/java.io.-file/for-each-block.html
+$dokka.location:kotlin.io$forEachLine(java.io.File, java.nio.charset.Charset, kotlin.Function1((kotlin.String, kotlin.Unit)))kotlin.io/java.io.-file/for-each-line.html
+$dokka.location:kotlin.io$forEachLine(java.io.Reader, kotlin.Function1((kotlin.String, kotlin.Unit)))kotlin.io/java.io.-reader/for-each-line.html
+$dokka.location:kotlin.io$inputStream(java.io.File)kotlin.io/java.io.-file/input-stream.html
+$dokka.location:kotlin.io$invariantSeparatorsPath#java.io.Filekotlin.io/java.io.-file/invariant-separators-path.html
+$dokka.location:kotlin.io$isRooted#java.io.Filekotlin.io/java.io.-file/is-rooted.html
+$dokka.location:kotlin.io$iterator(java.io.BufferedInputStream)kotlin.io/java.io.-buffered-input-stream/iterator.html
+$dokka.location:kotlin.io$lineSequence(java.io.BufferedReader)kotlin.io/java.io.-buffered-reader/line-sequence.html
+$dokka.location:kotlin.io$nameWithoutExtension#java.io.Filekotlin.io/java.io.-file/name-without-extension.html
+$dokka.location:kotlin.io$normalize(java.io.File)kotlin.io/java.io.-file/normalize.html
+$dokka.location:kotlin.io$outputStream(java.io.File)kotlin.io/java.io.-file/output-stream.html
+$dokka.location:kotlin.io$printWriter(java.io.File, java.nio.charset.Charset)kotlin.io/java.io.-file/print-writer.html
+$dokka.location:kotlin.io$readBytes(java.io.File)kotlin.io/java.io.-file/read-bytes.html
+$dokka.location:kotlin.io$readBytes(java.io.InputStream)kotlin.io/java.io.-input-stream/read-bytes.html
+$dokka.location:kotlin.io$readBytes(java.io.InputStream, kotlin.Int)kotlin.io/java.io.-input-stream/read-bytes.html
+$dokka.location:kotlin.io$readBytes(java.net.URL)kotlin.io/java.net.-u-r-l/read-bytes.html
+$dokka.location:kotlin.io$readLines(java.io.File, java.nio.charset.Charset)kotlin.io/java.io.-file/read-lines.html
+$dokka.location:kotlin.io$readLines(java.io.Reader)kotlin.io/java.io.-reader/read-lines.html
+$dokka.location:kotlin.io$readText(java.io.File, java.nio.charset.Charset)kotlin.io/java.io.-file/read-text.html
+$dokka.location:kotlin.io$readText(java.io.Reader)kotlin.io/java.io.-reader/read-text.html
+$dokka.location:kotlin.io$readText(java.net.URL, java.nio.charset.Charset)kotlin.io/java.net.-u-r-l/read-text.html
+$dokka.location:kotlin.io$reader(java.io.File, java.nio.charset.Charset)kotlin.io/java.io.-file/reader.html
+$dokka.location:kotlin.io$reader(java.io.InputStream, java.nio.charset.Charset)kotlin.io/java.io.-input-stream/reader.html
+$dokka.location:kotlin.io$relativeTo(java.io.File, java.io.File)kotlin.io/java.io.-file/relative-to.html
+$dokka.location:kotlin.io$relativeToOrNull(java.io.File, java.io.File)kotlin.io/java.io.-file/relative-to-or-null.html
+$dokka.location:kotlin.io$relativeToOrSelf(java.io.File, java.io.File)kotlin.io/java.io.-file/relative-to-or-self.html
+$dokka.location:kotlin.io$resolve(java.io.File, java.io.File)kotlin.io/java.io.-file/resolve.html
+$dokka.location:kotlin.io$resolve(java.io.File, kotlin.String)kotlin.io/java.io.-file/resolve.html
+$dokka.location:kotlin.io$resolveSibling(java.io.File, java.io.File)kotlin.io/java.io.-file/resolve-sibling.html
+$dokka.location:kotlin.io$resolveSibling(java.io.File, kotlin.String)kotlin.io/java.io.-file/resolve-sibling.html
+$dokka.location:kotlin.io$startsWith(java.io.File, java.io.File)kotlin.io/java.io.-file/starts-with.html
+$dokka.location:kotlin.io$startsWith(java.io.File, kotlin.String)kotlin.io/java.io.-file/starts-with.html
+$dokka.location:kotlin.io$toRelativeString(java.io.File, java.io.File)kotlin.io/java.io.-file/to-relative-string.html
+$dokka.location:kotlin.io$useLines(java.io.File, java.nio.charset.Charset, kotlin.Function1((kotlin.sequences.Sequence((kotlin.String)), kotlin.io.useLines.T)))kotlin.io/java.io.-file/use-lines.html
+$dokka.location:kotlin.io$useLines(java.io.Reader, kotlin.Function1((kotlin.sequences.Sequence((kotlin.String)), kotlin.io.useLines.T)))kotlin.io/java.io.-reader/use-lines.html
+$dokka.location:kotlin.io$walk(java.io.File, kotlin.io.FileWalkDirection)kotlin.io/java.io.-file/walk.html
+$dokka.location:kotlin.io$walkBottomUp(java.io.File)kotlin.io/java.io.-file/walk-bottom-up.html
+$dokka.location:kotlin.io$walkTopDown(java.io.File)kotlin.io/java.io.-file/walk-top-down.html
+$dokka.location:kotlin.io$writeBytes(java.io.File, kotlin.ByteArray)kotlin.io/java.io.-file/write-bytes.html
+$dokka.location:kotlin.io$writeText(java.io.File, kotlin.String, java.nio.charset.Charset)kotlin.io/java.io.-file/write-text.html
+$dokka.location:kotlin.io$writer(java.io.File, java.nio.charset.Charset)kotlin.io/java.io.-file/writer.html
+$dokka.location:kotlin.io$writer(java.io.OutputStream, java.nio.charset.Charset)kotlin.io/java.io.-output-stream/writer.html
+$dokka.location:kotlin.io.path$absolute(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/absolute.html
+$dokka.location:kotlin.io.path$absolutePathString(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/absolute-path-string.html
+$dokka.location:kotlin.io.path$appendBytes(java.nio.file.Path, kotlin.ByteArray)kotlin.io.path/java.nio.file.-path/append-bytes.html
+$dokka.location:kotlin.io.path$appendLines(java.nio.file.Path, kotlin.collections.Iterable((kotlin.CharSequence)), java.nio.charset.Charset)kotlin.io.path/java.nio.file.-path/append-lines.html
+$dokka.location:kotlin.io.path$appendLines(java.nio.file.Path, kotlin.sequences.Sequence((kotlin.CharSequence)), java.nio.charset.Charset)kotlin.io.path/java.nio.file.-path/append-lines.html
+$dokka.location:kotlin.io.path$appendText(java.nio.file.Path, kotlin.CharSequence, java.nio.charset.Charset)kotlin.io.path/java.nio.file.-path/append-text.html
+$dokka.location:kotlin.io.path$bufferedReader(java.nio.file.Path, java.nio.charset.Charset, kotlin.Int, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/buffered-reader.html
+$dokka.location:kotlin.io.path$bufferedWriter(java.nio.file.Path, java.nio.charset.Charset, kotlin.Int, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/buffered-writer.html
+$dokka.location:kotlin.io.path$copyTo(java.nio.file.Path, java.nio.file.Path, kotlin.Array((java.nio.file.CopyOption)))kotlin.io.path/java.nio.file.-path/copy-to.html
+$dokka.location:kotlin.io.path$copyTo(java.nio.file.Path, java.nio.file.Path, kotlin.Boolean)kotlin.io.path/java.nio.file.-path/copy-to.html
+$dokka.location:kotlin.io.path$createDirectories(java.nio.file.Path, kotlin.Array((java.nio.file.attribute.FileAttribute((kotlin.Any)))))kotlin.io.path/java.nio.file.-path/create-directories.html
+$dokka.location:kotlin.io.path$createDirectory(java.nio.file.Path, kotlin.Array((java.nio.file.attribute.FileAttribute((kotlin.Any)))))kotlin.io.path/java.nio.file.-path/create-directory.html
+$dokka.location:kotlin.io.path$createFile(java.nio.file.Path, kotlin.Array((java.nio.file.attribute.FileAttribute((kotlin.Any)))))kotlin.io.path/java.nio.file.-path/create-file.html
+$dokka.location:kotlin.io.path$createLinkPointingTo(java.nio.file.Path, java.nio.file.Path)kotlin.io.path/java.nio.file.-path/create-link-pointing-to.html
+$dokka.location:kotlin.io.path$createSymbolicLinkPointingTo(java.nio.file.Path, java.nio.file.Path, kotlin.Array((java.nio.file.attribute.FileAttribute((kotlin.Any)))))kotlin.io.path/java.nio.file.-path/create-symbolic-link-pointing-to.html
+$dokka.location:kotlin.io.path$deleteExisting(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/delete-existing.html
+$dokka.location:kotlin.io.path$deleteIfExists(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/delete-if-exists.html
+$dokka.location:kotlin.io.path$div(java.nio.file.Path, java.nio.file.Path)kotlin.io.path/java.nio.file.-path/div.html
+$dokka.location:kotlin.io.path$div(java.nio.file.Path, kotlin.String)kotlin.io.path/java.nio.file.-path/div.html
+$dokka.location:kotlin.io.path$exists(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/exists.html
+$dokka.location:kotlin.io.path$extension#java.nio.file.Pathkotlin.io.path/java.nio.file.-path/extension.html
+$dokka.location:kotlin.io.path$fileAttributesView(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/file-attributes-view.html
+$dokka.location:kotlin.io.path$fileAttributesViewOrNull(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/file-attributes-view-or-null.html
+$dokka.location:kotlin.io.path$fileSize(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/file-size.html
+$dokka.location:kotlin.io.path$fileStore(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/file-store.html
+$dokka.location:kotlin.io.path$forEachDirectoryEntry(java.nio.file.Path, kotlin.String, kotlin.Function1((java.nio.file.Path, kotlin.Unit)))kotlin.io.path/java.nio.file.-path/for-each-directory-entry.html
+$dokka.location:kotlin.io.path$forEachLine(java.nio.file.Path, java.nio.charset.Charset, kotlin.Function1((kotlin.String, kotlin.Unit)))kotlin.io.path/java.nio.file.-path/for-each-line.html
+$dokka.location:kotlin.io.path$getAttribute(java.nio.file.Path, kotlin.String, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/get-attribute.html
+$dokka.location:kotlin.io.path$getLastModifiedTime(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/get-last-modified-time.html
+$dokka.location:kotlin.io.path$getOwner(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/get-owner.html
+$dokka.location:kotlin.io.path$getPosixFilePermissions(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/get-posix-file-permissions.html
+$dokka.location:kotlin.io.path$inputStream(java.nio.file.Path, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/input-stream.html
+$dokka.location:kotlin.io.path$invariantSeparatorsPath#java.nio.file.Pathkotlin.io.path/java.nio.file.-path/invariant-separators-path.html
+$dokka.location:kotlin.io.path$invariantSeparatorsPathString#java.nio.file.Pathkotlin.io.path/java.nio.file.-path/invariant-separators-path-string.html
+$dokka.location:kotlin.io.path$isDirectory(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/is-directory.html
+$dokka.location:kotlin.io.path$isExecutable(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/is-executable.html
+$dokka.location:kotlin.io.path$isHidden(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/is-hidden.html
+$dokka.location:kotlin.io.path$isReadable(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/is-readable.html
+$dokka.location:kotlin.io.path$isRegularFile(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/is-regular-file.html
+$dokka.location:kotlin.io.path$isSameFileAs(java.nio.file.Path, java.nio.file.Path)kotlin.io.path/java.nio.file.-path/is-same-file-as.html
+$dokka.location:kotlin.io.path$isSymbolicLink(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/is-symbolic-link.html
+$dokka.location:kotlin.io.path$isWritable(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/is-writable.html
+$dokka.location:kotlin.io.path$listDirectoryEntries(java.nio.file.Path, kotlin.String)kotlin.io.path/java.nio.file.-path/list-directory-entries.html
+$dokka.location:kotlin.io.path$moveTo(java.nio.file.Path, java.nio.file.Path, kotlin.Array((java.nio.file.CopyOption)))kotlin.io.path/java.nio.file.-path/move-to.html
+$dokka.location:kotlin.io.path$moveTo(java.nio.file.Path, java.nio.file.Path, kotlin.Boolean)kotlin.io.path/java.nio.file.-path/move-to.html
+$dokka.location:kotlin.io.path$name#java.nio.file.Pathkotlin.io.path/java.nio.file.-path/name.html
+$dokka.location:kotlin.io.path$nameWithoutExtension#java.nio.file.Pathkotlin.io.path/java.nio.file.-path/name-without-extension.html
+$dokka.location:kotlin.io.path$notExists(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/not-exists.html
+$dokka.location:kotlin.io.path$outputStream(java.nio.file.Path, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/output-stream.html
+$dokka.location:kotlin.io.path$pathString#java.nio.file.Pathkotlin.io.path/java.nio.file.-path/path-string.html
+$dokka.location:kotlin.io.path$readAttributes(java.nio.file.Path, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/read-attributes.html
+$dokka.location:kotlin.io.path$readAttributes(java.nio.file.Path, kotlin.String, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/read-attributes.html
+$dokka.location:kotlin.io.path$readBytes(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/read-bytes.html
+$dokka.location:kotlin.io.path$readLines(java.nio.file.Path, java.nio.charset.Charset)kotlin.io.path/java.nio.file.-path/read-lines.html
+$dokka.location:kotlin.io.path$readSymbolicLink(java.nio.file.Path)kotlin.io.path/java.nio.file.-path/read-symbolic-link.html
+$dokka.location:kotlin.io.path$readText(java.nio.file.Path, java.nio.charset.Charset)kotlin.io.path/java.nio.file.-path/read-text.html
+$dokka.location:kotlin.io.path$reader(java.nio.file.Path, java.nio.charset.Charset, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/reader.html
+$dokka.location:kotlin.io.path$relativeTo(java.nio.file.Path, java.nio.file.Path)kotlin.io.path/java.nio.file.-path/relative-to.html
+$dokka.location:kotlin.io.path$relativeToOrNull(java.nio.file.Path, java.nio.file.Path)kotlin.io.path/java.nio.file.-path/relative-to-or-null.html
+$dokka.location:kotlin.io.path$relativeToOrSelf(java.nio.file.Path, java.nio.file.Path)kotlin.io.path/java.nio.file.-path/relative-to-or-self.html
+$dokka.location:kotlin.io.path$setAttribute(java.nio.file.Path, kotlin.String, kotlin.Any?, kotlin.Array((java.nio.file.LinkOption)))kotlin.io.path/java.nio.file.-path/set-attribute.html
+$dokka.location:kotlin.io.path$setLastModifiedTime(java.nio.file.Path, java.nio.file.attribute.FileTime)kotlin.io.path/java.nio.file.-path/set-last-modified-time.html
+$dokka.location:kotlin.io.path$setOwner(java.nio.file.Path, java.nio.file.attribute.UserPrincipal)kotlin.io.path/java.nio.file.-path/set-owner.html
+$dokka.location:kotlin.io.path$setPosixFilePermissions(java.nio.file.Path, kotlin.collections.Set((java.nio.file.attribute.PosixFilePermission)))kotlin.io.path/java.nio.file.-path/set-posix-file-permissions.html
+$dokka.location:kotlin.io.path$toPath(java.net.URI)kotlin.io.path/java.net.-u-r-i/to-path.html
+$dokka.location:kotlin.io.path$useDirectoryEntries(java.nio.file.Path, kotlin.String, kotlin.Function1((kotlin.sequences.Sequence((java.nio.file.Path)), kotlin.io.path.useDirectoryEntries.T)))kotlin.io.path/java.nio.file.-path/use-directory-entries.html
+$dokka.location:kotlin.io.path$useLines(java.nio.file.Path, java.nio.charset.Charset, kotlin.Function1((kotlin.sequences.Sequence((kotlin.String)), kotlin.io.path.useLines.T)))kotlin.io.path/java.nio.file.-path/use-lines.html
+$dokka.location:kotlin.io.path$writeBytes(java.nio.file.Path, kotlin.ByteArray, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/write-bytes.html
+$dokka.location:kotlin.io.path$writeLines(java.nio.file.Path, kotlin.collections.Iterable((kotlin.CharSequence)), java.nio.charset.Charset, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/write-lines.html
+$dokka.location:kotlin.io.path$writeLines(java.nio.file.Path, kotlin.sequences.Sequence((kotlin.CharSequence)), java.nio.charset.Charset, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/write-lines.html
+$dokka.location:kotlin.io.path$writeText(java.nio.file.Path, kotlin.CharSequence, java.nio.charset.Charset, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/write-text.html
+$dokka.location:kotlin.io.path$writer(java.nio.file.Path, java.nio.charset.Charset, kotlin.Array((java.nio.file.OpenOption)))kotlin.io.path/java.nio.file.-path/writer.html
+$dokka.location:kotlin.jvm$kotlin#java.lang.Class((kotlin.jvm.kotlin.T))kotlin.jvm/java.lang.-class/kotlin.html
+$dokka.location:kotlin.jvm.optionals$asSequence(java.util.Optional((kotlin.jvm.optionals.asSequence.T)))kotlin.jvm.optionals/java.util.-optional/as-sequence.html
+$dokka.location:kotlin.jvm.optionals$getOrNull(java.util.Optional((kotlin.jvm.optionals.getOrNull.T)))kotlin.jvm.optionals/java.util.-optional/get-or-null.html
+$dokka.location:kotlin.jvm.optionals$toCollection(java.util.Optional((kotlin.jvm.optionals.toCollection.T)), kotlin.jvm.optionals.toCollection.C)kotlin.jvm.optionals/java.util.-optional/to-collection.html
+$dokka.location:kotlin.jvm.optionals$toList(java.util.Optional((kotlin.jvm.optionals.toList.T)))kotlin.jvm.optionals/java.util.-optional/to-list.html
+$dokka.location:kotlin.jvm.optionals$toSet(java.util.Optional((kotlin.jvm.optionals.toSet.T)))kotlin.jvm.optionals/java.util.-optional/to-set.html
+$dokka.location:kotlin.random$asKotlinRandom(java.util.Random)kotlin.random/java.util.-random/as-kotlin-random.html
+$dokka.location:kotlin.reflect.KAnnotatedElementkotlin.reflect/-k-annotated-element/index.html
+$dokka.location:kotlin.reflect.KDeclarationContainerkotlin.reflect/-k-declaration-container/index.html
+$dokka.location:kotlin.reflect.KFunctionkotlin.reflect/-k-function/index.html
+$dokka.location:kotlin.reflect.KMutablePropertykotlin.reflect/-k-mutable-property/index.html
+$dokka.location:kotlin.reflect.KPropertykotlin.reflect/-k-property/index.html
+$dokka.location:kotlin.reflect.jvm$kotlinFunction#java.lang.reflect.Constructor((kotlin.reflect.jvm.kotlinFunction.T))kotlin.reflect.jvm/java.lang.reflect.-constructor/kotlin-function.html
+$dokka.location:kotlin.reflect.jvm$kotlinFunction#java.lang.reflect.Methodkotlin.reflect.jvm/java.lang.reflect.-method/kotlin-function.html
+$dokka.location:kotlin.reflect.jvm$kotlinProperty#java.lang.reflect.Fieldkotlin.reflect.jvm/java.lang.reflect.-field/kotlin-property.html
+$dokka.location:kotlin.sequences$asSequence(java.util.Enumeration((kotlin.sequences.asSequence.T)))kotlin.sequences/java.util.-enumeration/as-sequence.html
+$dokka.location:kotlin.streams$asSequence(java.util.stream.DoubleStream)kotlin.streams/java.util.stream.-double-stream/as-sequence.html
+$dokka.location:kotlin.streams$asSequence(java.util.stream.IntStream)kotlin.streams/java.util.stream.-int-stream/as-sequence.html
+$dokka.location:kotlin.streams$asSequence(java.util.stream.LongStream)kotlin.streams/java.util.stream.-long-stream/as-sequence.html
+$dokka.location:kotlin.streams$asSequence(java.util.stream.Stream((kotlin.streams.asSequence.T)))kotlin.streams/java.util.stream.-stream/as-sequence.html
+$dokka.location:kotlin.streams$asStream(kotlin.sequences.Sequence((kotlin.streams.asStream.T)))kotlin.streams/kotlin.sequences.-sequence/as-stream.html
+$dokka.location:kotlin.streams$toList(java.util.stream.DoubleStream)kotlin.streams/java.util.stream.-double-stream/to-list.html
+$dokka.location:kotlin.streams$toList(java.util.stream.IntStream)kotlin.streams/java.util.stream.-int-stream/to-list.html
+$dokka.location:kotlin.streams$toList(java.util.stream.LongStream)kotlin.streams/java.util.stream.-long-stream/to-list.html
+$dokka.location:kotlin.streams$toList(java.util.stream.Stream((kotlin.streams.toList.T)))kotlin.streams/java.util.stream.-stream/to-list.html
+$dokka.location:kotlin.text$appendLine(java.lang.StringBuilder, java.lang.StringBuffer?)kotlin.text/java.lang.-string-builder/append-line.html
+$dokka.location:kotlin.text$appendLine(java.lang.StringBuilder, java.lang.StringBuilder?)kotlin.text/java.lang.-string-builder/append-line.html
+$dokka.location:kotlin.text$appendLine(java.lang.StringBuilder, kotlin.Byte)kotlin.text/java.lang.-string-builder/append-line.html
+$dokka.location:kotlin.text$appendLine(java.lang.StringBuilder, kotlin.Double)kotlin.text/java.lang.-string-builder/append-line.html
+$dokka.location:kotlin.text$appendLine(java.lang.StringBuilder, kotlin.Float)kotlin.text/java.lang.-string-builder/append-line.html
+$dokka.location:kotlin.text$appendLine(java.lang.StringBuilder, kotlin.Int)kotlin.text/java.lang.-string-builder/append-line.html
+$dokka.location:kotlin.text$appendLine(java.lang.StringBuilder, kotlin.Long)kotlin.text/java.lang.-string-builder/append-line.html
+$dokka.location:kotlin.text$appendLine(java.lang.StringBuilder, kotlin.Short)kotlin.text/java.lang.-string-builder/append-line.html
+$dokka.location:kotlin.text$appendRange(java.lang.StringBuilder, kotlin.CharArray, kotlin.Int, kotlin.Int)kotlin.text/java.lang.-string-builder/append-range.html
+$dokka.location:kotlin.text$appendRange(java.lang.StringBuilder, kotlin.CharSequence, kotlin.Int, kotlin.Int)kotlin.text/java.lang.-string-builder/append-range.html
+$dokka.location:kotlin.text$appendln(java.lang.Appendable)kotlin.text/java.lang.-appendable/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.Appendable, kotlin.Char)kotlin.text/java.lang.-appendable/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.Appendable, kotlin.CharSequence?)kotlin.text/java.lang.-appendable/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, java.lang.StringBuffer?)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, java.lang.StringBuilder?)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Any?)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Boolean)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Byte)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Char)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.CharArray)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.CharSequence?)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Double)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Float)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Int)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Long)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.Short)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$appendln(java.lang.StringBuilder, kotlin.String?)kotlin.text/java.lang.-string-builder/appendln.html
+$dokka.location:kotlin.text$clear(java.lang.StringBuilder)kotlin.text/java.lang.-string-builder/clear.html
+$dokka.location:kotlin.text$deleteAt(java.lang.StringBuilder, kotlin.Int)kotlin.text/java.lang.-string-builder/delete-at.html
+$dokka.location:kotlin.text$deleteRange(java.lang.StringBuilder, kotlin.Int, kotlin.Int)kotlin.text/java.lang.-string-builder/delete-range.html
+$dokka.location:kotlin.text$insertRange(java.lang.StringBuilder, kotlin.Int, kotlin.CharArray, kotlin.Int, kotlin.Int)kotlin.text/java.lang.-string-builder/insert-range.html
+$dokka.location:kotlin.text$insertRange(java.lang.StringBuilder, kotlin.Int, kotlin.CharSequence, kotlin.Int, kotlin.Int)kotlin.text/java.lang.-string-builder/insert-range.html
+$dokka.location:kotlin.text$set(java.lang.StringBuilder, kotlin.Int, kotlin.Char)kotlin.text/java.lang.-string-builder/set.html
+$dokka.location:kotlin.text$setRange(java.lang.StringBuilder, kotlin.Int, kotlin.Int, kotlin.String)kotlin.text/java.lang.-string-builder/set-range.html
+$dokka.location:kotlin.text$toCharArray(java.lang.StringBuilder, kotlin.CharArray, kotlin.Int, kotlin.Int, kotlin.Int)kotlin.text/java.lang.-string-builder/to-char-array.html
+$dokka.location:kotlin.text$toRegex(java.util.regex.Pattern)kotlin.text/java.util.regex.-pattern/to-regex.html
+$dokka.location:kotlin.text.Appendablekotlin.text/-appendable/index.html
+$dokka.location:kotlin.text.CharacterCodingExceptionkotlin.text/-character-coding-exception/index.html
+$dokka.location:kotlin.text.StringBuilderkotlin.text/-string-builder/index.html
+$dokka.location:kotlin.time$toDurationUnit(java.util.concurrent.TimeUnit)kotlin.time/java.util.concurrent.-time-unit/to-duration-unit.html
+$dokka.location:kotlin.time$toKotlinDuration(java.time.Duration)kotlin.time/java.time.-duration/to-kotlin-duration.html
+kotlin
+kotlin.annotation
+kotlin.browser
+kotlin.collections
+kotlin.comparisons
+kotlin.concurrent
+kotlin.contracts
+kotlin.coroutines
+kotlin.coroutines.cancellation
+kotlin.coroutines.intrinsics
+kotlin.dom
+kotlin.experimental
+kotlin.io
+kotlin.io.path
+kotlin.js
+kotlin.jvm
+kotlin.jvm.optionals
+kotlin.math
+kotlin.native
+kotlin.native.concurrent
+kotlin.native.ref
+kotlin.properties
+kotlin.random
+kotlin.ranges
+kotlin.reflect
+kotlin.reflect.full
+kotlin.reflect.jvm
+kotlin.sequences
+kotlin.streams
+kotlin.system
+kotlin.text
+kotlin.time
+kotlinx.browser
+kotlinx.cinterop
+kotlinx.cinterop.internal
+kotlinx.dom
+kotlinx.wasm.jsinterop
+org.khronos.webgl
+org.w3c.css.masking
+org.w3c.dom
+org.w3c.dom.clipboard
+org.w3c.dom.css
+org.w3c.dom.encryptedmedia
+org.w3c.dom.events
+org.w3c.dom.mediacapture
+org.w3c.dom.mediasource
+org.w3c.dom.parsing
+org.w3c.dom.pointerevents
+org.w3c.dom.svg
+org.w3c.dom.url
+org.w3c.fetch
+org.w3c.files
+org.w3c.notifications
+org.w3c.performance
+org.w3c.workers
+org.w3c.xhr


### PR DESCRIPTION
Per [b/246812330](https://b.corp.google.com/issues/246812330), this adds the Kotlin standard library to our precompiled package lists. This also resolves [b/246794289](https://b.corp.google.com/issues/246794289).

Previously, it seems we fetched the package list for the Kotlin stdlib online at build time. With `offlineMode` enabled now, that process doesn't occur. Instead of disabling the setting, we can just add the Kotlin stdlib package-list to our list of precompiled package-lists.