### PR TITLE
Add strict mode testing in firebase-messaging

### DIFF
--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -133,4 +133,13 @@ dependencies {
     testImplementation 'androidx.test.ext:truth:1.4.0'
     testImplementation 'androidx.test.services:test-services:1.2.0'
     testImplementation 'androidx.core:core:1.6.0'
+
+    androidTestImplementation project(':integ-testing')
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation "androidx.annotation:annotation:1.0.0"
+    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
 }

--- a/firebase-messaging/src/androidTest/AndroidManifest.xml
+++ b/firebase-messaging/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.installations">
+
+    <application>
+        <uses-library android:name="android.test.runner"/>
+    </application>
+
+    <instrumentation
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:targetPackage="com.google.firebase.messaging" />
+</manifest>

--- a/firebase-messaging/src/androidTest/java/com/google/firebase/messaging/StrictModeTest.java
+++ b/firebase-messaging/src/androidTest/java/com/google/firebase/messaging/StrictModeTest.java
@@ -1,0 +1,47 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.messaging;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions.Builder;
+import com.google.firebase.testing.integ.StrictModeRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class StrictModeTest {
+
+  @Rule public StrictModeRule strictMode = new StrictModeRule();
+
+  @Test
+  public void initializingFirebaseMessaging_shouldNotViolateStrictMode() {
+    strictMode.runOnMainThread(
+        () -> {
+          FirebaseApp app =
+              FirebaseApp.initializeApp(
+                  ApplicationProvider.getApplicationContext(),
+                  new Builder()
+                      .setApiKey("api")
+                      .setProjectId("123")
+                      .setApplicationId("appId")
+                      .build(),
+                  "hello");
+          app.get(FirebaseMessaging.class);
+        });
+  }
+}


### PR DESCRIPTION
Part of a larger effort to resolve and prevent strict mode violations for eager components.