### PR TITLE
lintVersion: 30.2.2 -> 30.3.0-rc01 

### DIFF
--- a/tools/lint/lint.gradle
+++ b/tools/lint/lint.gradle
@@ -16,7 +16,7 @@ plugins {
   id 'org.jetbrains.kotlin.jvm'
 }
 
-def lintVersion = '30.2.2'
+def lintVersion = '30.3.0-rc01'
 
 dependencies {
   compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"


### PR DESCRIPTION
fix `UsingOnClickInXml` which did not work correctly when running in AGP 7.2.2.