### PR TITLE
update appcompat (1.3.0 -> 1.5.1) to fix lint

### DIFF
--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -61,7 +61,7 @@ dependencies {
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation "androidx.browser:browser:1.3.0"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
 }


### PR DESCRIPTION
`UsingOnClickInXml` did not work correctly when running with AGP 7.2.2,