### PR TITLE
Add projectSpecificSources back to the DackkaPlugin

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -168,6 +168,7 @@ abstract class DackkaPlugin : Plugin<Project> {
                     val classpath = compileConfiguration.getJars() + project.javadocConfig.getJars() + project.files(bootClasspath)
 
                     val sourcesForJava = sourceSets.flatMap {
+                        // TODO(b/246984444): Investigate why kotlinDirectories includes javaDirectories
                         it.javaDirectories.map { it.absoluteFile }
                     }
 
@@ -177,13 +178,12 @@ abstract class DackkaPlugin : Plugin<Project> {
                     }
 
                     docsTask.configure {
-                        clientName.set(project.firebaseConfigValue { artifactId })
-                        // this will become useful with the agp upgrade, as they're separate in 7.x+
-                        val sourcesForKotlin = emptyList<File>()
+                        if (!isKotlin) dependsOnAndMustRunAfter(docStubs)
+
+                        val sourcesForKotlin = emptyList<File>() + projectSpecificSources(project)
                         val packageLists = fetchPackageLists(project)
 
-                        if (!isKotlin) dependsOn(docStubs)
-                        val excludedFiles = if (!isKotlin) projectSpecificSuppressedFiles(project) else emptyList()
+                        val excludedFiles = projectSpecificSuppressedFiles(project)
                         val fixedJavaSources = if (!isKotlin) listOf(project.docStubs) else sourcesForJava
 
                         javaSources.set(fixedJavaSources)
@@ -207,10 +207,19 @@ abstract class DackkaPlugin : Plugin<Project> {
         }.toList()
 
     // TODO(b/243534168): Remove when fixed
+    private fun projectSpecificSources(project: Project) =
+        when (project.name) {
+            "firebase-common" -> {
+                project.project(":firebase-firestore").files("src/main/java/com/google/firebase").toList()
+            }
+            else -> emptyList()
+        }
+
+    // TODO(b/243534168): Remove when fixed
     private fun projectSpecificSuppressedFiles(project: Project): List<File> =
         when (project.name) {
             "firebase-common" -> {
-                project.files("${project.docStubs}/com/google/firebase/firestore").toList()
+                project.project(":firebase-firestore").files("src/main/java/com/google/firebase/firestore").toList()
             }
             "firebase-firestore" -> {
                 project.files("${project.docStubs}/com/google/firebase/Timestamp.java").toList()
@@ -226,6 +235,7 @@ abstract class DackkaPlugin : Plugin<Project> {
 
         dackkaJarFile.set(dackkaFile)
         outputDirectory.set(dackkaOutputDirectory)
+        clientName.set(project.firebaseConfigValue { artifactId })
     }
 
     // TODO(b/243833009): Make task cacheable

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -178,7 +178,7 @@ abstract class DackkaPlugin : Plugin<Project> {
                     }
 
                     docsTask.configure {
-                        if (!isKotlin) dependsOnAndMustRunAfter(docStubs)
+                        if (!isKotlin) dependsOn(docStubs)
 
                         val sourcesForKotlin = emptyList<File>() + projectSpecificSources(project)
                         val packageLists = fetchPackageLists(project)

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
@@ -17,6 +17,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.provider.Provider
 
 fun Project.isAndroid(): Boolean =
         listOf("com.android.application", "com.android.library", "com.android.test")
@@ -59,6 +60,14 @@ fun Configuration.getJars() = incoming.artifactView {
  * Utility method to call [Task.mustRunAfter] and [Task.dependsOn] on the specified task
  */
 fun <T : Task, R : Task> T.dependsOnAndMustRunAfter(otherTask: R) {
+    mustRunAfter(otherTask)
+    dependsOn(otherTask)
+}
+
+/**
+ * Utility method to call [Task.mustRunAfter] and [Task.dependsOn] on the specified task
+ */
+fun <T : Task, R : Task> T.dependsOnAndMustRunAfter(otherTask: Provider<R>) {
     mustRunAfter(otherTask)
     dependsOn(otherTask)
 }


### PR DESCRIPTION
This fixes: [b/246972998](https://b.corp.google.com/issues/246972998)

Removing `projectSpecificSources` was an over-sight, and led to `com.google.firebase.Timestamp` not being generated during doc generation. Adding the method back fixes this.

Additionally, I removed the `isKotlin` check for `excludedFiles` as it was redundant (since the method checks for a specific project, it would be ignored when needed as a by-product).

I also added an additional util method for `dependsOnAndMustRunAfter` and changed our `dependsOn(docStubs)` as such. We need `docStubs` to run _before_ `generateDackkaDocumentation`, and not having `mustRunAfter` was leading to not-so-fun gradle "optimizations".

And some restructuring for readability and consistency :')