### PR TITLE
[Fireperf][AASA] send `_experiment_app_start_ttid` trace, controlled by RC flag

### DIFF
--- a/firebase-perf/dev-app/dev-app.gradle
+++ b/firebase-perf/dev-app/dev-app.gradle
@@ -16,6 +16,7 @@ apply plugin: 'com.android.application'
 // Firebase performance plugin, the relevant dependency is specified in the "buildSrc/build-src.gradle"
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabPlugin
+apply plugin: 'com.google.gms.google-services'
 
 firebaseTestLab {
     device 'model=Pixel2,version=28,locale=en,orientation=portrait'

--- a/firebase-perf/dev-app/dev-app.gradle
+++ b/firebase-perf/dev-app/dev-app.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.application'
 // Firebase performance plugin, the relevant dependency is specified in the "buildSrc/build-src.gradle"
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabPlugin
-apply plugin: 'com.google.gms.google-services'
 
 firebaseTestLab {
     device 'model=Pixel2,version=28,locale=en,orientation=portrait'

--- a/firebase-perf/dev-app/src/main/AndroidManifest.xml
+++ b/firebase-perf/dev-app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
             android:name="fragment_sampling_percentage"
             android:value="100.0" />
         <meta-data
-            android:name="experiment_as_ttid"
+            android:name="experiment_app_start_ttid"
             android:value="true" />
 
         <receiver

--- a/firebase-perf/dev-app/src/main/AndroidManifest.xml
+++ b/firebase-perf/dev-app/src/main/AndroidManifest.xml
@@ -38,6 +38,9 @@
         <meta-data
             android:name="fragment_sampling_percentage"
             android:value="100.0" />
+        <meta-data
+            android:name="experiment_as_ttid"
+            android:value="true" />
 
         <receiver
             android:name=".FirebasePerfTestReceiver"

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -115,19 +115,9 @@ public class ConfigResolver {
 
   /** Default API to call for whether performance monitoring is currently silent. */
   public boolean isPerformanceMonitoringEnabled() {
-    saveExperimentFlagToDeviceCache();
     Boolean isPerformanceCollectionEnabled = getIsPerformanceCollectionEnabled();
     return (isPerformanceCollectionEnabled == null || isPerformanceCollectionEnabled == true)
         && getIsServiceCollectionEnabled();
-  }
-
-  // TODO: remove after _experiment_as_ttid is finished
-  private void saveExperimentFlagToDeviceCache() {
-    ExperimentTTID config = ExperimentTTID.getInstance();
-    Optional<Boolean> rcValue = getRemoteConfigBoolean(config);
-    if (rcValue.isAvailable()) {
-      deviceCacheManager.setValue(config.getDeviceCacheFlag(), rcValue.get());
-    }
   }
 
   /** Returns whether developers have enabled Firebase Performance event collection. */

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -772,7 +772,7 @@ public class ConfigResolver {
   public boolean getIsExperimentTTIDEnabled() {
     // Order of precedence is:
     // 1. If the value exists in Android Manifest, return this value.
-    // 2. Cannot read value from RC because it's not initalized yet
+    // 2. If the value exists through Firebase Remote Config, cache and return this value.
     // 3. If the value exists in device cache, return this value.
     // 4. Otherwise, return default value.
     ExperimentTTID config = ExperimentTTID.getInstance();
@@ -783,7 +783,13 @@ public class ConfigResolver {
       return metadataValue.get();
     }
 
-    // 2. Cannot read value from RC because it's not initialized yet.
+    // 2. Reads value from Firebase Remote Config, saves this value in cache layer if valid.
+    Optional<Boolean> rcValue = getRemoteConfigBoolean(config);
+    if (rcValue.isAvailable()) {
+      deviceCacheManager.setValue(config.getDeviceCacheFlag(), rcValue.get());
+      return rcValue.get();
+    }
+
     // 3. Reads value from cache layer.
     Optional<Boolean> deviceCacheValue = getDeviceCacheBoolean(config);
     if (deviceCacheValue.isAvailable()) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -768,7 +768,7 @@ public class ConfigResolver {
     return config.getDefault();
   }
 
-  /** Returns if _experiment_as_ttid should be captured. */
+  /** Returns if _experiment_app_start_ttid should be captured. */
   public boolean getIsExperimentTTIDEnabled() {
     // Order of precedence is:
     // 1. If the value exists in Android Manifest, return this value.

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
@@ -683,7 +683,7 @@ final class ConfigurationConstants {
 
     @Override
     protected String getRemoteConfigFlag() {
-      return "fpr_experiment_as_ttid";
+      return "fpr_experiment_app_start_ttid";
     }
 
     @Override
@@ -693,7 +693,7 @@ final class ConfigurationConstants {
 
     @Override
     protected String getMetadataFlag() {
-      return "experiment_as_ttid";
+      return "experiment_app_start_ttid";
     }
   }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
@@ -661,4 +661,39 @@ final class ConfigurationConstants {
       return "fragment_sampling_percentage";
     }
   }
+
+  protected static final class ExperimentTTID extends ConfigurationFlag<Boolean> {
+    private static ExperimentTTID instance;
+
+    private ExperimentTTID() {
+      super();
+    }
+
+    protected static synchronized ExperimentTTID getInstance() {
+      if (instance == null) {
+        instance = new ExperimentTTID();
+      }
+      return instance;
+    }
+
+    @Override
+    protected Boolean getDefault() {
+      return false;
+    }
+
+    @Override
+    protected String getRemoteConfigFlag() {
+      return "fpr_experiment_as_ttid";
+    }
+
+    @Override
+    protected String getDeviceCacheFlag() {
+      return "com.google.firebase.perf.ExperimentTTID";
+    }
+
+    @Override
+    protected String getMetadataFlag() {
+      return "experiment_as_ttid";
+    }
+  }
 }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -342,7 +342,9 @@ public class RemoteConfigManager {
       }
     }
 
-    // Save to device cache upon successful RC fetchAndActivate
+    // TODO: remove after experiment is over and experiment RC flag is no longer needed
+    // Save ExperimentTTID flag to device cache upon successful RC fetchAndActivate, because reading
+    // is done quite early and it is possible that RC isn't initialized yet.
     ExperimentTTID flag = ExperimentTTID.getInstance();
     FirebaseRemoteConfigValue rcValue = allRcConfigMap.get(flag.getRemoteConfigFlag());
     if (rcValue != null) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -18,11 +18,16 @@ import android.app.Activity;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.Process;
+import android.view.View;
+
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.common.util.VisibleForTesting;
+import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.logging.AndroidLogger;
 import com.google.firebase.perf.provider.FirebasePerfProvider;
 import com.google.firebase.perf.session.PerfSession;
@@ -30,11 +35,14 @@ import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
 import com.google.firebase.perf.util.Clock;
 import com.google.firebase.perf.util.Constants;
+import com.google.firebase.perf.util.FirstDrawDoneListener;
 import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.TraceMetric;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -89,6 +97,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
   private Timer onCreateTime = null;
   private Timer onStartTime = null;
   private Timer onResumeTime = null;
+  private Timer firstDrawDone = null;
 
   private PerfSession startSession;
   private boolean isStartedFromBackground = false;
@@ -139,7 +148,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
                       MAX_POOL_SIZE,
                       /* keepAliveTime= */ MAX_LATENCY_BEFORE_UI_INIT + 10,
                       TimeUnit.SECONDS,
-                      new LinkedBlockingQueue<>(1)));
+                      new LinkedBlockingQueue<>()));
         }
       }
     }
@@ -178,6 +187,32 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
     isRegisteredForLifecycleCallbacks = false;
   }
 
+  /**
+   * Gets the timetamp that marks the beginning of app start, currently defined as the beginning of
+   * BIND_APPLICATION. Fallback to class-load time of {@link FirebasePerfProvider} when API < 24.
+   *
+   * @return {@link Timer} at the beginning of app start by Fireperf definition.
+   */
+  private static Timer getStartTimer() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      return Timer.ofElapsedRealtime(Process.getStartElapsedRealtime());
+    }
+    return FirebasePerfProvider.getAppStartTime();
+  }
+
+  private void recordFirstDrawDone() {
+    if (firstDrawDone != null) {
+      return;
+    }
+    this.firstDrawDone = clock.getTime();
+    executorService.execute(() -> this.logColdStart(getStartTimer(), this.firstDrawDone, this.startSession));
+
+    if (isRegisteredForLifecycleCallbacks) {
+      // After AppStart trace is queued to be logged, we can unregister this callback.
+      unregisterActivityLifecycleCallbacks();
+    }
+  }
+
   @Override
   public synchronized void onActivityCreated(Activity activity, Bundle savedInstanceState) {
     if (isStartedFromBackground || onCreateTime != null // An activity already called onCreate()
@@ -207,8 +242,17 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
   @Override
   public synchronized void onActivityResumed(Activity activity) {
     if (isStartedFromBackground
-        || onResumeTime != null // An activity already called onResume()
         || isTooLateToInitUI) {
+      return;
+    }
+
+    // Shadow-launch experiment of new app start time
+    if (ConfigResolver.getInstance().getIsExperimentTTIDEnabled()) {
+      View rootView = activity.findViewById(android.R.id.content);
+      FirstDrawDoneListener.registerForNextDraw(rootView, this::recordFirstDrawDone);
+    }
+
+    if (onResumeTime != null) { // An activity already called onResume()
       return;
     }
 
@@ -227,11 +271,24 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
 
     // Log the app start trace in a non-main thread.
     executorService.execute(this::logAppStartTrace);
+  }
 
-    if (isRegisteredForLifecycleCallbacks) {
-      // After AppStart trace is logged, we can unregister this callback.
-      unregisterActivityLifecycleCallbacks();
-    }
+  private void logColdStart(Timer start, Timer end, PerfSession session) {
+    TraceMetric.Builder metric =
+        TraceMetric.newBuilder()
+            .setName("_experiment_as_ttid")
+            .setClientStartTimeUs(start.getMicros())
+            .setDurationUs(start.getDurationMicros(end));
+
+    TraceMetric.Builder subtrace =
+            TraceMetric.newBuilder()
+                    .setName("_experiment_classLoadTime")
+                    .setClientStartTimeUs(FirebasePerfProvider.getAppStartTime().getMicros())
+                    .setDurationUs(FirebasePerfProvider.getAppStartTime().getDurationMicros(end));
+
+    metric.addSubtraces(subtrace).addPerfSessions(this.startSession.build());
+
+    transportManager.log(metric.build(), ApplicationProcessState.FOREGROUND_BACKGROUND);
   }
 
   private void logAppStartTrace() {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -74,6 +74,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
   private boolean isRegisteredForLifecycleCallbacks = false;
   private final TransportManager transportManager;
   private final Clock clock;
+  private final ConfigResolver configResolver;
   private Context appContext;
   /**
    * The first time onCreate() of any activity is called, the activity is saved as launchActivity.
@@ -140,6 +141,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
               new AppStartTrace(
                   transportManager,
                   clock,
+                  ConfigResolver.getInstance(),
                   new ThreadPoolExecutor(
                       CORE_POOL_SIZE,
                       MAX_POOL_SIZE,
@@ -155,9 +157,11 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
   AppStartTrace(
       @NonNull TransportManager transportManager,
       @NonNull Clock clock,
+      @NonNull ConfigResolver configResolver,
       @NonNull ExecutorService executorService) {
     this.transportManager = transportManager;
     this.clock = clock;
+    this.configResolver = configResolver;
     this.executorService = executorService;
   }
 
@@ -244,7 +248,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
     }
 
     // Shadow-launch experiment of new app start time
-    if (ConfigResolver.getInstance().getIsExperimentTTIDEnabled()) {
+    if (configResolver.getIsExperimentTTIDEnabled()) {
       View rootView = activity.findViewById(android.R.id.content);
       FirstDrawDoneListener.registerForNextDraw(rootView, this::recordFirstDrawDone);
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -22,7 +22,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Process;
 import android.view.View;
-
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -41,8 +40,6 @@ import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.TraceMetric;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -205,7 +202,8 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
       return;
     }
     this.firstDrawDone = clock.getTime();
-    executorService.execute(() -> this.logColdStart(getStartTimer(), this.firstDrawDone, this.startSession));
+    executorService.execute(
+        () -> this.logColdStart(getStartTimer(), this.firstDrawDone, this.startSession));
 
     if (isRegisteredForLifecycleCallbacks) {
       // After AppStart trace is queued to be logged, we can unregister this callback.
@@ -241,8 +239,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
 
   @Override
   public synchronized void onActivityResumed(Activity activity) {
-    if (isStartedFromBackground
-        || isTooLateToInitUI) {
+    if (isStartedFromBackground || isTooLateToInitUI) {
       return;
     }
 
@@ -281,10 +278,10 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
             .setDurationUs(start.getDurationMicros(end));
 
     TraceMetric.Builder subtrace =
-            TraceMetric.newBuilder()
-                    .setName("_experiment_classLoadTime")
-                    .setClientStartTimeUs(FirebasePerfProvider.getAppStartTime().getMicros())
-                    .setDurationUs(FirebasePerfProvider.getAppStartTime().getDurationMicros(end));
+        TraceMetric.newBuilder()
+            .setName("_experiment_classLoadTime")
+            .setClientStartTimeUs(FirebasePerfProvider.getAppStartTime().getMicros())
+            .setDurationUs(FirebasePerfProvider.getAppStartTime().getDurationMicros(end));
 
     metric.addSubtraces(subtrace).addPerfSessions(this.startSession.build());
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
@@ -37,7 +37,6 @@ import com.google.firebase.remoteconfig.RemoteConfigComponent;
 import com.google.testing.timing.FakeScheduledExecutorService;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +59,6 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   @Mock private Provider<RemoteConfigComponent> mockFirebaseRemoteConfigProvider;
 
   private DeviceCacheManager cacheManager;
-  private ExecutorService directExecutor;
   private FakeScheduledExecutorService fakeExecutor;
 
   @Before
@@ -68,8 +66,8 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
     initMocks(this);
 
     fakeExecutor = new FakeScheduledExecutorService();
-    directExecutor = MoreExecutors.newDirectExecutorService();
-    cacheManager = new DeviceCacheManager(directExecutor);
+    // DeviceCacheManager initialization requires immediate blocking task execution in its executor
+    cacheManager = new DeviceCacheManager(MoreExecutors.newDirectExecutorService());
 
     when(mockFirebaseRemoteConfigProvider.get()).thenReturn(mockFirebaseRemoteConfigComponent);
     when(mockFirebaseRemoteConfigComponent.get(FIREPERF_FRC_NAMESPACE_NAME))

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
@@ -52,6 +52,7 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   @Mock private FirebaseRemoteConfig mockFirebaseRemoteConfig;
   @Mock private RemoteConfigComponent mockFirebaseRemoteConfigComponent;
   @Mock private Provider<RemoteConfigComponent> mockFirebaseRemoteConfigProvider;
+  @Mock private DeviceCacheManager mockCacheManager;
 
   private FakeScheduledExecutorService fakeExecutor;
 
@@ -889,10 +890,13 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
     when(mockFirebaseRemoteConfig.getAll()).thenReturn(configs);
     if (initializeFrc) {
       return new RemoteConfigManager(
-          fakeExecutor, mockFirebaseRemoteConfig, appStartConfigFetchDelayInMs);
+          mockCacheManager, fakeExecutor, mockFirebaseRemoteConfig, appStartConfigFetchDelayInMs);
     } else {
       return new RemoteConfigManager(
-          fakeExecutor, /* firebaseRemoteConfig= */ null, appStartConfigFetchDelayInMs);
+          mockCacheManager,
+          fakeExecutor,
+          /* firebaseRemoteConfig= */ null,
+          appStartConfigFetchDelayInMs);
     }
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -14,19 +14,27 @@
 
 package com.google.firebase.perf.metrics;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.perf.util.TimerTest.getElapsedRealtimeMicros;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
 import android.content.pm.ProviderInfo;
 import android.os.Bundle;
+import android.os.Looper;
+import android.os.Process;
+import android.os.SystemClock;
+import android.view.View;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.config.ConfigResolver;
 import com.google.firebase.perf.provider.FirebasePerfProvider;
 import com.google.firebase.perf.session.SessionManager;
 import com.google.firebase.perf.transport.TransportManager;
@@ -36,6 +44,7 @@ import com.google.firebase.perf.util.Timer;
 import com.google.firebase.perf.v1.ApplicationProcessState;
 import com.google.firebase.perf.v1.TraceMetric;
 import com.google.testing.timing.FakeScheduledExecutorService;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
@@ -48,13 +57,18 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
+import org.robolectric.shadows.ShadowSystemClock;
 
 /** Unit tests for {@link AppStartTrace}. */
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.PAUSED)
 public class AppStartTraceTest extends FirebasePerformanceTestBase {
 
   @Mock private Clock clock;
   @Mock private TransportManager transportManager;
+  @Mock private ConfigResolver configResolver;
   @Mock private Activity activity1;
   @Mock private Activity activity2;
   @Mock private Bundle bundle;
@@ -94,7 +108,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   @Test
   public void testLaunchActivity() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
-    AppStartTrace trace = new AppStartTrace(transportManager, clock, fakeExecutorService);
+    AppStartTrace trace =
+        new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
     // first activity goes through onCreate()->onStart()->onResume() state change.
     currentTime = 1;
     trace.onActivityCreated(activity1, bundle);
@@ -171,7 +186,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   @Test
   public void testInterleavedActivity() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
-    AppStartTrace trace = new AppStartTrace(transportManager, clock, fakeExecutorService);
+    AppStartTrace trace =
+        new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
     // first activity onCreate()
     currentTime = 1;
     trace.onActivityCreated(activity1, bundle);
@@ -206,7 +222,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   @Test
   public void testDelayedAppStart() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
-    AppStartTrace trace = new AppStartTrace(transportManager, clock, fakeExecutorService);
+    AppStartTrace trace =
+        new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
     // Delays activity creation after 1 minute from app start time.
     currentTime = appStart.getMicros() + TimeUnit.MINUTES.toMicros(1) + 1;
     trace.onActivityCreated(activity1, bundle);
@@ -227,7 +244,8 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   @Test
   public void testStartFromBackground() {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
-    AppStartTrace trace = new AppStartTrace(transportManager, clock, fakeExecutorService);
+    AppStartTrace trace =
+        new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
     trace.setIsStartFromBackground();
     trace.onActivityCreated(activity1, bundle);
     Assert.assertNull(trace.getOnCreateTime());
@@ -260,5 +278,39 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
 
     Assert.assertEquals(oldSessionId, SessionManager.getInstance().perfSession().sessionId());
     verify(mockPerfSession, times(2)).isGaugeAndEventCollectionEnabled();
+  }
+
+  @Test
+  @Config(sdk = 26)
+  public void timeToInitialDisplay_isLogged() {
+    when(clock.getTime()).thenCallRealMethod(); // Use robolectric shadows to manipulate time
+    long appStartTime = TimeUnit.MILLISECONDS.toMicros(Process.getStartElapsedRealtime());
+    View testView = new View(ApplicationProvider.getApplicationContext());
+    when(activity1.findViewById(android.R.id.content)).thenReturn(testView);
+    when(configResolver.getIsExperimentTTIDEnabled()).thenReturn(true);
+    FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
+    AppStartTrace trace =
+        new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+
+    ShadowSystemClock.advanceBy(Duration.ofMillis(1000));
+    long resumeTime = TimeUnit.NANOSECONDS.toMicros(SystemClock.elapsedRealtimeNanos());
+    trace.onActivityCreated(activity1, bundle);
+    trace.onActivityStarted(activity1);
+    trace.onActivityResumed(activity1);
+    fakeExecutorService.runAll();
+    verify(transportManager, times(1))
+        .log(isA(TraceMetric.class), isA(ApplicationProcessState.class));
+    ShadowSystemClock.advanceBy(Duration.ofMillis(1000));
+    long drawTime = TimeUnit.NANOSECONDS.toMicros(SystemClock.elapsedRealtimeNanos());
+    testView.getViewTreeObserver().dispatchOnDraw();
+    shadowOf(Looper.getMainLooper()).idle();
+    fakeExecutorService.runNext();
+    verify(transportManager, times(2))
+        .log(traceArgumentCaptor.capture(), isA(ApplicationProcessState.class));
+
+    TraceMetric ttid = traceArgumentCaptor.getValue();
+    assertThat(ttid.getName()).isEqualTo("_experiment_as_ttid");
+    assertThat(ttid.getDurationUs()).isNotEqualTo(resumeTime - appStartTime);
+    assertThat(ttid.getDurationUs()).isEqualTo(drawTime - appStartTime);
   }
 }


### PR DESCRIPTION
b/245947422
b/243540978

During startup, when we want to decide to record this trace or not, we only check disk cache for RC flag because RC is not initialized yet. 

This RC flag will be saved to disk ONLY upon successful RC `fetchAndActivate()`. There's a problem with all other flags in that they are being saved to disk every time they are queried.