### PR TITLE
Realtime RC - Check HTTP status before listening and retrying

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -97,16 +97,9 @@ public class ConfigAutoFetch {
   public void listenForNotifications() {
     if (httpURLConnection != null) {
       try {
-        int responseCode = httpURLConnection.getResponseCode();
-        if (responseCode == 200) {
-          InputStream inputStream = httpURLConnection.getInputStream();
-          handleNotifications(inputStream);
-          inputStream.close();
-        } else {
-          propagateErrors(
-              new FirebaseRemoteConfigRealtimeUpdateStreamException(
-                  "Http connection responded with error: " + responseCode));
-        }
+        InputStream inputStream = httpURLConnection.getInputStream();
+        handleNotifications(inputStream);
+        inputStream.close();
       } catch (IOException ex) {
         propagateErrors(
             new FirebaseRemoteConfigRealtimeUpdateFetchException(

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -313,8 +313,7 @@ public class ConfigRealtimeHttpClient {
         || statusCode == HTTP_TOO_MANY_REQUESTS
         || statusCode == HttpURLConnection.HTTP_BAD_GATEWAY
         || statusCode == HttpURLConnection.HTTP_UNAVAILABLE
-        || statusCode == HttpURLConnection.HTTP_GATEWAY_TIMEOUT
-        || statusCode == HttpURLConnection.HTTP_OK;
+        || statusCode == HttpURLConnection.HTTP_GATEWAY_TIMEOUT;
   }
 
   /**
@@ -330,7 +329,7 @@ public class ConfigRealtimeHttpClient {
       return;
     }
 
-    int responseCode = 200;
+    int responseCode = 0;
     try {
       // Create the open the connection.
       httpURLConnection = createRealtimeConnection();
@@ -349,7 +348,11 @@ public class ConfigRealtimeHttpClient {
       Log.d(TAG, "Exception connecting to realtime stream. Retrying the connection...");
     } finally {
       closeRealtimeHttpStream();
-      if (isStatusCodeRetryable(responseCode)) {
+
+      // If responseCode is 0 then no connection was made to server and the SDK should still retry.
+      if (responseCode == 0
+          || responseCode == HttpURLConnection.HTTP_OK
+          || isStatusCodeRetryable(responseCode)) {
         retryHTTPConnection();
       } else {
         propagateErrors(

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -310,11 +310,11 @@ public class ConfigRealtimeHttpClient {
   // HTTP status code that the Realtime client should retry on.
   private boolean isStatusCodeRetryable(int statusCode) {
     return statusCode == HttpURLConnection.HTTP_CLIENT_TIMEOUT
-            || statusCode == HTTP_TOO_MANY_REQUESTS
-            || statusCode == HttpURLConnection.HTTP_BAD_GATEWAY
-            || statusCode == HttpURLConnection.HTTP_UNAVAILABLE
-            || statusCode == HttpURLConnection.HTTP_GATEWAY_TIMEOUT
-            || statusCode == HttpURLConnection.HTTP_OK;
+        || statusCode == HTTP_TOO_MANY_REQUESTS
+        || statusCode == HttpURLConnection.HTTP_BAD_GATEWAY
+        || statusCode == HttpURLConnection.HTTP_UNAVAILABLE
+        || statusCode == HttpURLConnection.HTTP_GATEWAY_TIMEOUT
+        || statusCode == HttpURLConnection.HTTP_OK;
   }
 
   /**
@@ -353,8 +353,8 @@ public class ConfigRealtimeHttpClient {
         retryHTTPConnection();
       } else {
         propagateErrors(
-                new FirebaseRemoteConfigRealtimeUpdateStreamException(
-                        "The server returned a status code that is not retryable. Realtime is shutting down."));
+            new FirebaseRemoteConfigRealtimeUpdateStreamException(
+                "The server returned a status code that is not retryable. Realtime is shutting down."));
       }
     }
   }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -368,6 +368,7 @@ public class ConfigRealtimeHttpClient {
       // See github.com/firebase/firebase-android-sdk/pull/808.
       try {
         this.httpURLConnection.getInputStream().close();
+        this.httpURLConnection.getErrorStream().close();
       } catch (IOException e) {
       }
       this.httpURLConnection = null;

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -329,7 +329,7 @@ public class ConfigRealtimeHttpClient {
       return;
     }
 
-    int responseCode = 0;
+    Integer responseCode = null;
     try {
       // Create the open the connection.
       httpURLConnection = createRealtimeConnection();
@@ -349,8 +349,9 @@ public class ConfigRealtimeHttpClient {
     } finally {
       closeRealtimeHttpStream();
 
-      // If responseCode is 0 then no connection was made to server and the SDK should still retry.
-      if (responseCode == 0
+      // If responseCode is null then no connection was made to server and the SDK should still
+      // retry.
+      if (responseCode == null
           || responseCode == HttpURLConnection.HTTP_OK
           || isStatusCodeRetryable(responseCode)) {
         retryHTTPConnection();

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -276,13 +276,13 @@ public final class FirebaseRemoteConfigTest {
     configAutoFetch =
         new ConfigAutoFetch(mockHttpURLConnection, mockFetchHandler, listeners, mockRetryListener);
     configRealtimeHttpClient =
-            new ConfigRealtimeHttpClient(
-                    firebaseApp,
-                    mockFirebaseInstallations,
-                    mockFetchHandler,
-                    context,
-                    "firebase",
-                    listeners);
+        new ConfigRealtimeHttpClient(
+            firebaseApp,
+            mockFirebaseInstallations,
+            mockFetchHandler,
+            context,
+            "firebase",
+            listeners);
   }
 
   @Test


### PR DESCRIPTION
- Check http response status code before retrying. Http status codes being used to retry are:
Ok 200
Client Timeout 408
Bad Gateway 502
Unavailable 503
Gateway timeout 504
Similar to what Fetch uses to throttle requests:
[firebase-android-sdk/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java](https://github.com/firebase/firebase-android-sdk/blob/523730a3b4463160490170d9348818a5c403a2eb/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandler.java#L390)

- Close error stream