### PR TITLE
Add a screenshot-based trigger for in-app feedback

### DIFF
--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -21,6 +21,8 @@ package com.google.firebase.appdistribution {
     method public void signOutTester();
     method public void startFeedback(int);
     method public void startFeedback(@NonNull CharSequence);
+    method public void startFeedback(@NonNull int, @Nullable android.net.Uri);
+    method public void startFeedback(@NonNull CharSequence, @Nullable android.net.Uri);
     method @NonNull public com.google.firebase.appdistribution.UpdateTask updateApp();
     method @NonNull public com.google.firebase.appdistribution.UpdateTask updateIfNewReleaseAvailable();
   }

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -144,6 +144,7 @@ public interface FirebaseAppDistribution {
   void startFeedback(@NonNull CharSequence infoText);
 
 
+  // TODO: javadoc and infoTextResourceId version
   void startFeedback(@NonNull CharSequence infoText, @NonNull Uri screenshotUri);
 
   /** Gets the singleton {@link FirebaseAppDistribution} instance. */

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -15,8 +15,8 @@
 package com.google.firebase.appdistribution;
 
 import android.net.Uri;
-
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appdistribution.internal.FirebaseAppDistributionProxy;
@@ -143,9 +143,41 @@ public interface FirebaseAppDistribution {
    */
   void startFeedback(@NonNull CharSequence infoText);
 
+  /**
+   * Starts an activity to collect and submit feedback from the tester, along with the given
+   * screenshot.
+   *
+   * <p>Performs the following actions:
+   *
+   * <ol>
+   *   <li>If tester is not signed in, presents the tester with a Google Sign-in UI
+   *   <li>Starts a full screen activity for the tester to compose and submit the feedback
+   * </ol>
+   *
+   * @param infoTextResourceId string resource ID of text to display to the tester before collecting
+   *     feedback data (e.g. Terms and Conditions)
+   * @param screenshot URI to a bitmap containing a screenshot that will be included with the
+   *     report, or null to not include a screenshot
+   */
+  void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshot);
 
-  // TODO: javadoc and infoTextResourceId version
-  void startFeedback(@NonNull CharSequence infoText, @NonNull Uri screenshotUri);
+  /**
+   * Starts an activity to collect and submit feedback from the tester, along with the given
+   * screenshot.
+   *
+   * <p>Performs the following actions:
+   *
+   * <ol>
+   *   <li>If tester is not signed in, presents the tester with a Google Sign-in UI
+   *   <li>Starts a full screen activity for the tester to compose and submit the feedback
+   * </ol>
+   *
+   * @param infoText text to display to the tester before collecting feedback data (e.g. Terms and
+   *     Conditions)
+   * @param screenshot URI to a bitmap containing a screenshot that will be included with the
+   *     report, or null to not include a screenshot
+   */
+  void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri);
 
   /** Gets the singleton {@link FirebaseAppDistribution} instance. */
   @NonNull

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.appdistribution;
 
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
@@ -140,6 +142,9 @@ public interface FirebaseAppDistribution {
    *     Conditions)
    */
   void startFeedback(@NonNull CharSequence infoText);
+
+
+  void startFeedback(@NonNull CharSequence infoText, @NonNull Uri screenshotUri);
 
   /** Gets the singleton {@link FirebaseAppDistribution} instance. */
   @NonNull

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
@@ -15,8 +15,8 @@
 package com.google.firebase.appdistribution.internal;
 
 import android.net.Uri;
-
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.appdistribution.AppDistributionRelease;
 import com.google.firebase.appdistribution.FirebaseAppDistribution;
@@ -85,7 +85,12 @@ public class FirebaseAppDistributionProxy implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(@NonNull CharSequence infoText, @NonNull Uri screenshotUri) {
+  public void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshotUri) {
+    delegate.startFeedback(infoTextResourceId, screenshotUri);
+  }
+
+  @Override
+  public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {
     delegate.startFeedback(infoText, screenshotUri);
   }
 }

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
@@ -14,6 +14,8 @@
 
 package com.google.firebase.appdistribution.internal;
 
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.appdistribution.AppDistributionRelease;
@@ -80,5 +82,10 @@ public class FirebaseAppDistributionProxy implements FirebaseAppDistribution {
   @Override
   public void startFeedback(@NonNull CharSequence infoText) {
     delegate.startFeedback(infoText);
+  }
+
+  @Override
+  public void startFeedback(@NonNull CharSequence infoText, @NonNull Uri screenshotUri) {
+    delegate.startFeedback(infoText, screenshotUri);
   }
 }

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
@@ -16,7 +16,6 @@ package com.google.firebase.appdistribution.internal;
 
 import android.app.Activity;
 import android.net.Uri;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Continuation;
@@ -86,7 +85,12 @@ public class FirebaseAppDistributionStub implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(@NonNull CharSequence infoText, @NonNull Uri screenshotUri) {
+  public void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshotUri) {
+    return;
+  }
+
+  @Override
+  public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {
     return;
   }
 

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
@@ -15,6 +15,8 @@
 package com.google.firebase.appdistribution.internal;
 
 import android.app.Activity;
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Continuation;
@@ -80,6 +82,11 @@ public class FirebaseAppDistributionStub implements FirebaseAppDistribution {
 
   @Override
   public void startFeedback(@NonNull CharSequence infoText) {
+    return;
+  }
+
+  @Override
+  public void startFeedback(@NonNull CharSequence infoText, @NonNull Uri screenshotUri) {
     return;
   }
 

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
@@ -58,9 +58,7 @@ public class FirebaseAppDistributionStub implements FirebaseAppDistribution {
   }
 
   @Override
-  public void signOutTester() {
-    return;
-  }
+  public void signOutTester() {}
 
   @NonNull
   @Override
@@ -75,24 +73,16 @@ public class FirebaseAppDistributionStub implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(int infoTextResourceId) {
-    return;
-  }
+  public void startFeedback(int infoTextResourceId) {}
 
   @Override
-  public void startFeedback(@NonNull CharSequence infoText) {
-    return;
-  }
+  public void startFeedback(@NonNull CharSequence infoText) {}
 
   @Override
-  public void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshotUri) {
-    return;
-  }
+  public void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshotUri) {}
 
   @Override
-  public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {
-    return;
-  }
+  public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {}
 
   private static <TResult> Task<TResult> getNotImplementedTask() {
     return Tasks.forException(

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import java.io.IOException;
 
 /** Activity for tester to compose and submit feedback. */
 public class FeedbackActivity extends AppCompatActivity {
@@ -67,7 +68,7 @@ public class FeedbackActivity extends AppCompatActivity {
     Button submitButton = this.findViewById(R.id.submitButton);
     submitButton.setOnClickListener(this::submitFeedback);
 
-    Bitmap thumbnail = readThumbnail();
+    Bitmap thumbnail = screenshotUri == null ? null : readThumbnail();
     if (thumbnail != null) {
       ImageView screenshotImageView = this.findViewById(R.id.thumbnail);
       screenshotImageView.setImageBitmap(thumbnail);
@@ -80,11 +81,20 @@ public class FeedbackActivity extends AppCompatActivity {
 
   @Nullable
   private Bitmap readThumbnail() {
-    if (screenshotUri == null) {
+    Bitmap thumbnail;
+    try {
+      thumbnail =
+          ImageUtils.readScaledImage(
+              getContentResolver(), screenshotUri, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+    } catch (IOException e) {
+      LogWrapper.getInstance()
+          .e(TAG, "Could not read screenshot image from URI: " + screenshotUri, e);
       return null;
     }
-    return ImageUtils.readScaledImage(
-        getContentResolver(), screenshotUri, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+    if (thumbnail == null) {
+      LogWrapper.getInstance().e(TAG, "Could not decode screenshot image: " + screenshotUri);
+    }
+    return thumbnail;
   }
 
   public void submitFeedback(View view) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -72,7 +72,6 @@ public class FeedbackActivity extends AppCompatActivity {
     submitButton.setOnClickListener(this::submitFeedback);
 
     try {
-      // TODO: set up loading state and wait for screenshot in the background
       Bitmap thumbnail = readThumbnail();
       ImageView screenshotImageView = this.findViewById(R.id.thumbnail);
       screenshotImageView.setImageBitmap(thumbnail);

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -74,6 +74,7 @@ public class FeedbackActivity extends AppCompatActivity {
       ImageView screenshotImageView = this.findViewById(R.id.thumbnail);
       screenshotImageView.setImageBitmap(thumbnail);
     } else {
+      LogWrapper.getInstance().i(TAG, "Rendering missing screenshot error");
       View screenshotErrorLabel = this.findViewById(R.id.screenshotErrorLabel);
       screenshotErrorLabel.setVisibility(View.VISIBLE);
     }
@@ -81,11 +82,12 @@ public class FeedbackActivity extends AppCompatActivity {
 
   @Nullable
   private Bitmap readThumbnail() {
-    InputStream inputStream = getScreenshotInputStream();
-    if (inputStream == null) {
+    Bitmap image = ImageUtils.readScaledImage(getContentResolver(), screenshotUri, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+    if (image == null) {
+      LogWrapper.getInstance().e(TAG, "Could not decode image.");
       return null;
     }
-    return ImageUtils.readScaledImage(inputStream, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+    return image;
   }
 
   public void submitFeedback(View view) {
@@ -109,8 +111,10 @@ public class FeedbackActivity extends AppCompatActivity {
 
   private @Nullable InputStream getScreenshotInputStream() {
     if (screenshotUri == null) {
+      LogWrapper.getInstance().i(TAG, "No screenshot URI provided.");
       return null;
     }
+    LogWrapper.getInstance().i(TAG, "Trying to read screenshot from URI: " + screenshotUri);
     try {
       return this.getContentResolver().openInputStream(screenshotUri);
     } catch (FileNotFoundException e) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -14,12 +14,10 @@
 
 package com.google.firebase.appdistribution.impl;
 
-import android.content.ContentResolver;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -28,12 +26,9 @@ import android.widget.TextView;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
-
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 
 /** Activity for tester to compose and submit feedback. */
@@ -48,7 +43,7 @@ public class FeedbackActivity extends AppCompatActivity {
   public static final String INFO_TEXT_EXTRA_KEY =
       "com.google.firebase.appdistribution.FeedbackActivity.INFO_TEXT";
   public static final String SCREENSHOT_URI_EXTRA_KEY =
-          "com.google.firebase.appdistribution.FeedbackActivity.SCREENSHOT_URI";
+      "com.google.firebase.appdistribution.FeedbackActivity.SCREENSHOT_URI";
 
   private FeedbackSender feedbackSender;
   private String releaseName;
@@ -92,7 +87,8 @@ public class FeedbackActivity extends AppCompatActivity {
     if (screenshotUri == null) {
       throw new FirebaseAppDistributionException("No screenshot provided.", Status.UNKNOWN);
     }
-    return ImageUtils.readScaledImage(getContentResolver(), screenshotUri, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+    return ImageUtils.readScaledImage(
+        getContentResolver(), screenshotUri, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
   }
 
   public void submitFeedback(View view) {
@@ -123,7 +119,8 @@ public class FeedbackActivity extends AppCompatActivity {
     try {
       return this.getContentResolver().openInputStream(screenshotUri);
     } catch (FileNotFoundException e) {
-      LogWrapper.getInstance().e(TAG, String.format("Could not read screenshot from URI %s", screenshotUri), e);
+      LogWrapper.getInstance()
+          .e(TAG, String.format("Could not read screenshot from URI %s", screenshotUri), e);
       return null;
     }
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
@@ -18,7 +18,7 @@ import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
-import java.io.File;
+import java.io.InputStream;
 
 /** Sends tester feedback to the Tester API. */
 class FeedbackSender {
@@ -35,17 +35,17 @@ class FeedbackSender {
   }
 
   /** Send feedback text and optionally a screenshot to the Tester API for the given release. */
-  Task<Void> sendFeedback(String releaseName, String feedbackText, @Nullable File screenshotFile) {
+  Task<Void> sendFeedback(String releaseName, String feedbackText, @Nullable InputStream screenshotInputStream) {
     return testerApiClient
         .createFeedback(releaseName, feedbackText)
-        .onSuccessTask(feedbackName -> attachScreenshot(feedbackName, screenshotFile))
+        .onSuccessTask(feedbackName -> attachScreenshot(feedbackName, screenshotInputStream))
         .onSuccessTask(testerApiClient::commitFeedback);
   }
 
-  private Task<String> attachScreenshot(String feedbackName, @Nullable File screenshotFile) {
-    if (screenshotFile == null) {
+  private Task<String> attachScreenshot(String feedbackName, @Nullable InputStream screenshotInputStream) {
+    if (screenshotInputStream == null) {
       return Tasks.forResult(feedbackName);
     }
-    return testerApiClient.attachScreenshot(feedbackName, screenshotFile);
+    return testerApiClient.attachScreenshot(feedbackName, screenshotInputStream);
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
@@ -14,11 +14,11 @@
 
 package com.google.firebase.appdistribution.impl;
 
+import android.net.Uri;
 import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
-import java.io.InputStream;
 
 /** Sends tester feedback to the Tester API. */
 class FeedbackSender {
@@ -35,19 +35,17 @@ class FeedbackSender {
   }
 
   /** Send feedback text and optionally a screenshot to the Tester API for the given release. */
-  Task<Void> sendFeedback(
-      String releaseName, String feedbackText, @Nullable InputStream screenshotInputStream) {
+  Task<Void> sendFeedback(String releaseName, String feedbackText, @Nullable Uri screenshotUri) {
     return testerApiClient
         .createFeedback(releaseName, feedbackText)
-        .onSuccessTask(feedbackName -> attachScreenshot(feedbackName, screenshotInputStream))
+        .onSuccessTask(feedbackName -> attachScreenshot(feedbackName, screenshotUri))
         .onSuccessTask(testerApiClient::commitFeedback);
   }
 
-  private Task<String> attachScreenshot(
-      String feedbackName, @Nullable InputStream screenshotInputStream) {
-    if (screenshotInputStream == null) {
+  private Task<String> attachScreenshot(String feedbackName, @Nullable Uri screenshotUri) {
+    if (screenshotUri == null) {
       return Tasks.forResult(feedbackName);
     }
-    return testerApiClient.attachScreenshot(feedbackName, screenshotInputStream);
+    return testerApiClient.attachScreenshot(feedbackName, screenshotUri);
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
@@ -35,14 +35,16 @@ class FeedbackSender {
   }
 
   /** Send feedback text and optionally a screenshot to the Tester API for the given release. */
-  Task<Void> sendFeedback(String releaseName, String feedbackText, @Nullable InputStream screenshotInputStream) {
+  Task<Void> sendFeedback(
+      String releaseName, String feedbackText, @Nullable InputStream screenshotInputStream) {
     return testerApiClient
         .createFeedback(releaseName, feedbackText)
         .onSuccessTask(feedbackName -> attachScreenshot(feedbackName, screenshotInputStream))
         .onSuccessTask(testerApiClient::commitFeedback);
   }
 
-  private Task<String> attachScreenshot(String feedbackName, @Nullable InputStream screenshotInputStream) {
+  private Task<String> attachScreenshot(
+      String feedbackName, @Nullable InputStream screenshotInputStream) {
     if (screenshotInputStream == null) {
       return Tasks.forResult(feedbackName);
     }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -20,7 +20,7 @@ import static com.google.firebase.appdistribution.FirebaseAppDistributionExcepti
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE;
 import static com.google.firebase.appdistribution.impl.FeedbackActivity.INFO_TEXT_EXTRA_KEY;
 import static com.google.firebase.appdistribution.impl.FeedbackActivity.RELEASE_NAME_EXTRA_KEY;
-import static com.google.firebase.appdistribution.impl.FeedbackActivity.SCREENSHOT_FILENAME_EXTRA_KEY;
+import static com.google.firebase.appdistribution.impl.FeedbackActivity.SCREENSHOT_URI_EXTRA_KEY;
 import static com.google.firebase.appdistribution.impl.TaskUtils.safeSetTaskException;
 import static com.google.firebase.appdistribution.impl.TaskUtils.safeSetTaskResult;
 
@@ -28,6 +28,8 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -321,7 +323,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
         .takeScreenshot()
         .onSuccessTask(
             taskExecutor,
-            screenshotFilename ->
+            screenshotUri ->
                 testerSignInManager
                     .signInTester()
                     .addOnFailureListener(
@@ -333,19 +335,19 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
                     .onSuccessTask(
                         taskExecutor,
                         releaseName ->
-                            launchFeedbackActivity(releaseName, infoText, screenshotFilename)))
+                            launchFeedbackActivity(releaseName, infoText, screenshotUri)))
         .addOnFailureListener(
             taskExecutor, e -> LogWrapper.getInstance().e("Failed to launch feedback flow", e));
   }
 
   private Task<Void> launchFeedbackActivity(
-      String releaseName, CharSequence infoText, String screenshotFilename) {
+      String releaseName, CharSequence infoText, Uri screenshotFilename) {
     return lifecycleNotifier.consumeForegroundActivity(
         activity -> {
           Intent intent = new Intent(activity, FeedbackActivity.class);
           intent.putExtra(RELEASE_NAME_EXTRA_KEY, releaseName);
           intent.putExtra(INFO_TEXT_EXTRA_KEY, infoText);
-          intent.putExtra(SCREENSHOT_FILENAME_EXTRA_KEY, screenshotFilename);
+          intent.putExtra(SCREENSHOT_URI_EXTRA_KEY, screenshotFilename);
           activity.startActivity(intent);
         });
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -29,7 +29,6 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -326,9 +325,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
         .addOnFailureListener(
             taskExecutor, e -> LogWrapper.getInstance().e("Failed to take screenshot", e))
         .addOnSuccessListener(
-            taskExecutor,
-            screenshotUri ->
-                    startFeedback(infoText, screenshotUri));
+            taskExecutor, screenshotUri -> startFeedback(infoText, screenshotUri));
   }
 
   @Override
@@ -336,17 +333,16 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
     testerSignInManager
         .signInTester()
         .addOnFailureListener(
-                taskExecutor,
-                e ->
-                        LogWrapper.getInstance()
-                                .e("Failed to sign in tester. Could not collect feedback.", e))
+            taskExecutor,
+            e ->
+                LogWrapper.getInstance()
+                    .e("Failed to sign in tester. Could not collect feedback.", e))
         .onSuccessTask(taskExecutor, unused -> releaseIdentifier.identifyRelease())
         .onSuccessTask(
-                taskExecutor,
-                releaseName ->
-                        launchFeedbackActivity(releaseName, infoText, screenshotUri))
+            taskExecutor,
+            releaseName -> launchFeedbackActivity(releaseName, infoText, screenshotUri))
         .addOnFailureListener(
-                taskExecutor, e -> LogWrapper.getInstance().e("Failed to launch feedback flow", e));
+            taskExecutor, e -> LogWrapper.getInstance().e("Failed to launch feedback flow", e));
   }
 
   private Task<Void> launchFeedbackActivity(

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
@@ -26,7 +26,6 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException.Stat
 import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
-import java.io.File;
 import java.io.InputStream;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -157,7 +156,8 @@ class FirebaseAppDistributionTesterApiClient {
           LogWrapper.getInstance().i("Uploading screenshot for feedback: " + feedbackName);
           String path =
               String.format("upload/v1alpha/%s:uploadArtifact?type=SCREENSHOT", feedbackName);
-          testerApiHttpClient.makeUploadRequest(UPLOAD_SCREENSHOT_TAG, path, token, screenshotInputStream);
+          testerApiHttpClient.makeUploadRequest(
+              UPLOAD_SCREENSHOT_TAG, path, token, screenshotInputStream);
           return feedbackName;
         });
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
@@ -27,6 +27,7 @@ import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
 import java.io.File;
+import java.io.InputStream;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.json.JSONArray;
@@ -150,13 +151,13 @@ class FirebaseAppDistributionTesterApiClient {
    * @return a {@link Task} containing the feedback name, for convenience when chaining subsequent
    *     requests off of this task
    */
-  Task<String> attachScreenshot(String feedbackName, File screenshotFile) {
+  Task<String> attachScreenshot(String feedbackName, InputStream screenshotInputStream) {
     return runWithFidAndToken(
         (unused, token) -> {
           LogWrapper.getInstance().i("Uploading screenshot for feedback: " + feedbackName);
           String path =
               String.format("upload/v1alpha/%s:uploadArtifact?type=SCREENSHOT", feedbackName);
-          testerApiHttpClient.makeUploadRequest(UPLOAD_SCREENSHOT_TAG, path, token, screenshotFile);
+          testerApiHttpClient.makeUploadRequest(UPLOAD_SCREENSHOT_TAG, path, token, screenshotInputStream);
           return feedbackName;
         });
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
@@ -16,6 +16,7 @@ package com.google.firebase.appdistribution.impl;
 
 import static com.google.firebase.appdistribution.impl.TaskUtils.runAsyncInTask;
 
+import android.net.Uri;
 import androidx.annotation.NonNull;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -26,7 +27,6 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException.Stat
 import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
-import java.io.InputStream;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.json.JSONArray;
@@ -150,14 +150,13 @@ class FirebaseAppDistributionTesterApiClient {
    * @return a {@link Task} containing the feedback name, for convenience when chaining subsequent
    *     requests off of this task
    */
-  Task<String> attachScreenshot(String feedbackName, InputStream screenshotInputStream) {
+  Task<String> attachScreenshot(String feedbackName, Uri screenshotUri) {
     return runWithFidAndToken(
         (unused, token) -> {
           LogWrapper.getInstance().i("Uploading screenshot for feedback: " + feedbackName);
           String path =
               String.format("upload/v1alpha/%s:uploadArtifact?type=SCREENSHOT", feedbackName);
-          testerApiHttpClient.makeUploadRequest(
-              UPLOAD_SCREENSHOT_TAG, path, token, screenshotInputStream);
+          testerApiHttpClient.makeUploadRequest(UPLOAD_SCREENSHOT_TAG, path, token, screenshotUri);
           return feedbackName;
         });
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
@@ -14,11 +14,15 @@
 
 package com.google.firebase.appdistribution.impl;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.net.Uri;
 import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 
 public class ImageUtils {
 
@@ -28,16 +32,16 @@ public class ImageUtils {
 
     abstract int height();
 
-    static ImageSize read(File file) {
+    static ImageSize read(InputStream inputStream) {
       final BitmapFactory.Options options = new BitmapFactory.Options();
       options.inJustDecodeBounds = true;
-      BitmapFactory.decodeFile(file.getAbsolutePath(), options);
+      BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
       return new AutoValue_ImageUtils_ImageSize(options.outWidth, options.outHeight);
     }
   }
 
   /**
-   * Read an image from a file, scaled as small as possible according to the target size.
+   * Read an image, scaled as small as possible according to the target size.
    *
    * <p>The returned bitmap will be scaled down, preserving the aspect ratio, by the largest power
    * of 2 that results in the width and height still being larger than the target.
@@ -48,17 +52,17 @@ public class ImageUtils {
    * @throws IllegalArgumentException if target height or width are less than or equal to zero
    */
   @Nullable
-  public static Bitmap readScaledImage(File file, int targetWidth, int targetHeight) {
+  public static Bitmap readScaledImage(InputStream inputStream, int targetWidth, int targetHeight) {
     if (targetWidth <= 0 || targetHeight <= 0) {
       throw new IllegalArgumentException(
           String.format(
               "Tried to read image with bad dimensions: %dx%d", targetWidth, targetHeight));
     }
-    ImageSize imageSize = ImageSize.read(file);
+    ImageSize imageSize = ImageSize.read(inputStream);
     final BitmapFactory.Options options = new BitmapFactory.Options();
     options.inSampleSize =
         calculateInSampleSize(imageSize.width(), imageSize.height(), targetWidth, targetHeight);
-    return BitmapFactory.decodeFile(file.getAbsolutePath(), options);
+    return BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
   }
 
   private static int calculateInSampleSize(

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
@@ -56,7 +56,8 @@ public class ImageUtils {
    */
   @Nullable
   public static Bitmap readScaledImage(
-      ContentResolver contentResolver, Uri uri, int targetWidth, int targetHeight) {
+      ContentResolver contentResolver, Uri uri, int targetWidth, int targetHeight)
+      throws IOException {
     if (targetWidth <= 0 || targetHeight <= 0) {
       throw new IllegalArgumentException(
           String.format(
@@ -67,12 +68,8 @@ public class ImageUtils {
     ImageSize imageSize;
     try (InputStream inputStream = contentResolver.openInputStream(uri)) {
       imageSize = ImageSize.read(inputStream);
-      LogWrapper.getInstance().d("Read screenshot image size: " + imageSize);
-    } catch (IOException e) {
-      LogWrapper.getInstance()
-          .e(TAG, String.format("Could not read image size from URI %s", uri), e);
-      return null;
     }
+    LogWrapper.getInstance().d("Read screenshot image size: " + imageSize);
 
     // Read the actual image, scaled using the actual and target dimensions
     final BitmapFactory.Options options = new BitmapFactory.Options();
@@ -81,9 +78,6 @@ public class ImageUtils {
     // Get a fresh input stream because we've exhausted the last one
     try (InputStream inputStream = contentResolver.openInputStream(uri)) {
       return BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
-    } catch (IOException e) {
-      LogWrapper.getInstance().e(TAG, String.format("Could not read image from URI %s", uri), e);
-      return null;
     }
   }
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
@@ -19,11 +19,9 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.util.Log;
-
 import com.google.auto.value.AutoValue;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
-
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
@@ -58,7 +56,9 @@ public class ImageUtils {
    * @return the image
    * @throws FirebaseAppDistributionException if the image could not be read
    */
-  public static Bitmap readScaledImage(ContentResolver contentResolver, Uri uri, int targetWidth, int targetHeight) throws FirebaseAppDistributionException {
+  public static Bitmap readScaledImage(
+      ContentResolver contentResolver, Uri uri, int targetWidth, int targetHeight)
+      throws FirebaseAppDistributionException {
     if (targetWidth <= 0 || targetHeight <= 0) {
       throw new FirebaseAppDistributionException(
           String.format(
@@ -72,10 +72,12 @@ public class ImageUtils {
     options.inSampleSize =
         calculateInSampleSize(imageSize.width(), imageSize.height(), targetWidth, targetHeight);
     // Get a fresh input stream because we've exhausted the last one
-    return BitmapFactory.decodeStream(waitForInputStream(contentResolver, uri), /* outPadding= */ null, options);
+    return BitmapFactory.decodeStream(
+        waitForInputStream(contentResolver, uri), /* outPadding= */ null, options);
   }
 
-  private static InputStream waitForInputStream(ContentResolver contentResolver, Uri uri) throws FirebaseAppDistributionException {
+  private static InputStream waitForInputStream(ContentResolver contentResolver, Uri uri)
+      throws FirebaseAppDistributionException {
     LogWrapper.getInstance().d(TAG, "Trying to read screenshot from URI: " + uri);
     for (int i = 0; i < MAX_IMAGE_READ_RETRIES; i++) {
       try {
@@ -85,18 +87,22 @@ public class ImageUtils {
         try {
           Thread.sleep(IMAGE_READ_RETRY_SLEEP_MS);
         } catch (InterruptedException ex) {
-          throw new FirebaseAppDistributionException("Interrupted while waiting for screenshot to become available", Status.UNKNOWN);
+          throw new FirebaseAppDistributionException(
+              "Interrupted while waiting for screenshot to become available", Status.UNKNOWN);
         }
       }
     }
-    throw new FirebaseAppDistributionException("Timed out waiting for screenshot to be readable.", Status.UNKNOWN);
+    throw new FirebaseAppDistributionException(
+        "Timed out waiting for screenshot to be readable.", Status.UNKNOWN);
   }
 
-  private static InputStream getInputStream(ContentResolver contentResolver, Uri uri) throws FirebaseAppDistributionException {
+  private static InputStream getInputStream(ContentResolver contentResolver, Uri uri)
+      throws FirebaseAppDistributionException {
     try {
       return contentResolver.openInputStream(uri);
     } catch (FileNotFoundException e) {
-      throw new FirebaseAppDistributionException(String.format("Could not read screenshot from URI %s", uri), Status.UNKNOWN, e);
+      throw new FirebaseAppDistributionException(
+          String.format("Could not read screenshot from URI %s", uri), Status.UNKNOWN, e);
     }
   }
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/LogWrapper.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/LogWrapper.java
@@ -76,6 +76,10 @@ class LogWrapper {
     Log.e(LOG_TAG, msg);
   }
 
+  void e(@NonNull String additionalTag, @NonNull String msg) {
+    Log.e(LOG_TAG, prependTag(additionalTag, msg));
+  }
+
   void e(@NonNull String msg, @NonNull Throwable tr) {
     Log.e(LOG_TAG, msg, tr);
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -72,7 +72,6 @@ class ScreenshotTaker {
     return TaskUtils.runAsyncInTask(
         taskExecutor,
         () -> {
-          // throw new IllegalStateException("We got this far");
           firebaseApp.getApplicationContext().deleteFile(SCREENSHOT_FILE_NAME);
           return null;
         });

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -109,8 +109,8 @@ class ScreenshotTaker {
             throw new FirebaseAppDistributionException(
                 "Failed to write screenshot to storage", Status.UNKNOWN, e);
           }
-          return Uri.fromFile(firebaseApp.getApplicationContext()
-                  .getFileStreamPath(SCREENSHOT_FILE_NAME));
+          return Uri.fromFile(
+              firebaseApp.getApplicationContext().getFileStreamPath(SCREENSHOT_FILE_NAME));
         });
   }
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -17,6 +17,7 @@ package com.google.firebase.appdistribution.impl;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.net.Uri;
 import android.view.View;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.Task;
@@ -57,10 +58,10 @@ class ScreenshotTaker {
   /**
    * Take a screenshot of the running host app and write it to a file.
    *
-   * @return a {@link Task} that will complete with the filename in app-level storage where the
+   * @return a {@link Task} that will complete with the file URI in app-level storage where the
    *     screenshot was written.
    */
-  Task<String> takeScreenshot() {
+  Task<Uri> takeScreenshot() {
     return deleteScreenshot()
         .onSuccessTask(unused -> captureScreenshot())
         .onSuccessTask(this::writeToFile);
@@ -97,7 +98,7 @@ class ScreenshotTaker {
         });
   }
 
-  private Task<String> writeToFile(Bitmap bitmap) {
+  private Task<Uri> writeToFile(Bitmap bitmap) {
     return TaskUtils.runAsyncInTask(
         taskExecutor,
         () -> {
@@ -108,7 +109,8 @@ class ScreenshotTaker {
             throw new FirebaseAppDistributionException(
                 "Failed to write screenshot to storage", Status.UNKNOWN, e);
           }
-          return SCREENSHOT_FILE_NAME;
+          return Uri.fromFile(firebaseApp.getApplicationContext()
+                  .getFileStreamPath(SCREENSHOT_FILE_NAME));
         });
   }
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterApiHttpClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterApiHttpClient.java
@@ -16,8 +16,6 @@ package com.google.firebase.appdistribution.impl;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.net.Uri;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.util.AndroidUtilsLight;
@@ -26,8 +24,6 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterApiHttpClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterApiHttpClient.java
@@ -16,6 +16,7 @@ package com.google.firebase.appdistribution.impl;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.util.AndroidUtilsLight;
@@ -123,13 +124,15 @@ class TesterApiHttpClient {
    *
    * @return the response body
    */
-  JSONObject makeUploadRequest(String tag, String path, String token, InputStream inputStream)
+  JSONObject makeUploadRequest(String tag, String path, String token, Uri contentUri)
       throws FirebaseAppDistributionException {
     Map<String, String> extraHeaders = new HashMap<>();
     extraHeaders.put(X_GOOG_UPLOAD_PROTOCOL_HEADER, X_GOOG_UPLOAD_PROTOCOL_RAW);
     extraHeaders.put(X_GOOG_UPLOAD_FILE_NAME_HEADER, X_GOOG_UPLOAD_FILE_NAME);
     RequestBodyWriter requestBodyWriter =
         outputStream -> {
+          InputStream inputStream =
+              firebaseApp.getApplicationContext().getContentResolver().openInputStream(contentUri);
           writeInputStreamToOutputStream(inputStream, outputStream);
         };
     return makePostRequest(tag, path, token, extraHeaders, requestBodyWriter);

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterApiHttpClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterApiHttpClient.java
@@ -16,6 +16,8 @@ package com.google.firebase.appdistribution.impl;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.util.AndroidUtilsLight;
@@ -119,20 +121,19 @@ class TesterApiHttpClient {
   }
 
   /**
-   * Make a raw file upload request to the tester API at the given path using a FIS token for auth.
+   * Make an upload request to the tester API at the given path using a FIS token for auth.
    *
-   * <p>Uploads the file with gzip encoding.
+   * <p>Uploads the content with gzip encoding.
    *
    * @return the response body
    */
-  JSONObject makeUploadRequest(String tag, String path, String token, File file)
+  JSONObject makeUploadRequest(String tag, String path, String token, InputStream inputStream)
       throws FirebaseAppDistributionException {
     Map<String, String> extraHeaders = new HashMap<>();
     extraHeaders.put(X_GOOG_UPLOAD_PROTOCOL_HEADER, X_GOOG_UPLOAD_PROTOCOL_RAW);
     extraHeaders.put(X_GOOG_UPLOAD_FILE_NAME_HEADER, X_GOOG_UPLOAD_FILE_NAME);
     RequestBodyWriter requestBodyWriter =
         outputStream -> {
-          FileInputStream inputStream = new FileInputStream(file);
           writeInputStreamToOutputStream(inputStream, outputStream);
         };
     return makePostRequest(tag, path, token, extraHeaders, requestBodyWriter);

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FeedbackSenderTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FeedbackSenderTest.java
@@ -19,12 +19,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.net.Uri;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
-import java.io.File;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,8 +37,8 @@ public class FeedbackSenderTest {
   private static final String TEST_RELEASE_NAME = "release-name";
   private static final String TEST_FEEDBACK_NAME = "feedback-name";
   private static final String TEST_FEEDBACK_TEXT = "Feedback text";
-  private static final File TEST_SCREENSHOT_FILE =
-      ApplicationProvider.getApplicationContext().getFileStreamPath("test.png");
+  private static final Uri TEST_SCREENSHOT_URI =
+      Uri.fromFile(ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
   @Mock private FirebaseAppDistributionTesterApiClient mockTesterApiClient;
 
@@ -54,16 +54,16 @@ public class FeedbackSenderTest {
   public void sendFeedback_success() throws Exception {
     when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
-    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_FILE))
+    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_URI))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
     when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME)).thenReturn(Tasks.forResult(null));
 
     Task<Void> task =
-        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_FILE);
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_URI);
     TestUtils.awaitTask(task);
 
     verify(mockTesterApiClient).createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT);
-    verify(mockTesterApiClient).attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_FILE);
+    verify(mockTesterApiClient).attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_URI);
     verify(mockTesterApiClient).commitFeedback(TEST_FEEDBACK_NAME);
   }
 
@@ -90,7 +90,7 @@ public class FeedbackSenderTest {
         .thenReturn(Tasks.forException(cause));
 
     Task<Void> task =
-        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_FILE);
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_URI);
 
     TestUtils.awaitTaskFailure(task, Status.AUTHENTICATION_FAILURE, "test ex");
   }
@@ -101,11 +101,11 @@ public class FeedbackSenderTest {
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
     FirebaseAppDistributionException cause =
         new FirebaseAppDistributionException("test ex", Status.AUTHENTICATION_FAILURE);
-    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_FILE))
+    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_URI))
         .thenReturn(Tasks.forException(cause));
 
     Task<Void> task =
-        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_FILE);
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_URI);
 
     TestUtils.awaitTaskFailure(task, Status.AUTHENTICATION_FAILURE, "test ex");
   }
@@ -114,7 +114,7 @@ public class FeedbackSenderTest {
   public void sendFeedback_commitFeedbackFails_failsTask() {
     when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
-    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_FILE))
+    when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_URI))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
     FirebaseAppDistributionException cause =
         new FirebaseAppDistributionException("test ex", Status.AUTHENTICATION_FAILURE);
@@ -122,7 +122,7 @@ public class FeedbackSenderTest {
         .thenReturn(Tasks.forException(cause));
 
     Task<Void> task =
-        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_FILE);
+        feedbackSender.sendFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_URI);
 
     TestUtils.awaitTaskFailure(task, Status.AUTHENTICATION_FAILURE, "test ex");
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -645,7 +645,7 @@ public class FirebaseAppDistributionServiceImplTest {
     assertThat(argument.getValue().getStringExtra(RELEASE_NAME_EXTRA_KEY))
         .isEqualTo("release-name");
     assertThat(argument.getValue().getStringExtra(SCREENSHOT_URI_EXTRA_KEY))
-        .isEqualTo(TEST_SCREENSHOT_URI);
+        .isEqualTo(TEST_SCREENSHOT_URI.toString());
     assertThat(argument.getValue().getStringExtra(INFO_TEXT_EXTRA_KEY))
         .isEqualTo("Some terms and conditions");
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -192,8 +192,7 @@ public class FirebaseAppDistributionServiceImplTest {
 
     activity = spy(Robolectric.buildActivity(TestActivity.class).create().get());
     TestUtils.mockForegroundActivity(mockLifecycleNotifier, activity);
-    when(mockScreenshotTaker.takeScreenshot())
-        .thenReturn(Tasks.forResult(TEST_SCREENSHOT_URI));
+    when(mockScreenshotTaker.takeScreenshot()).thenReturn(Tasks.forResult(TEST_SCREENSHOT_URI));
   }
 
   @Test

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -29,7 +29,7 @@ import static com.google.firebase.appdistribution.impl.ErrorMessages.RELEASE_NOT
 import static com.google.firebase.appdistribution.impl.ErrorMessages.UPDATE_CANCELED;
 import static com.google.firebase.appdistribution.impl.FeedbackActivity.INFO_TEXT_EXTRA_KEY;
 import static com.google.firebase.appdistribution.impl.FeedbackActivity.RELEASE_NAME_EXTRA_KEY;
-import static com.google.firebase.appdistribution.impl.FeedbackActivity.SCREENSHOT_FILENAME_EXTRA_KEY;
+import static com.google.firebase.appdistribution.impl.FeedbackActivity.SCREENSHOT_URI_EXTRA_KEY;
 import static com.google.firebase.appdistribution.impl.TestUtils.assertTaskFailure;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -51,6 +51,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
+import android.net.Uri;
 import android.os.Bundle;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.core.content.pm.ApplicationInfoBuilder;
@@ -94,7 +95,7 @@ public class FirebaseAppDistributionServiceImplTest {
   private static final String IAS_ARTIFACT_ID_KEY = "com.android.vending.internal.apk.id";
   private static final String TEST_URL = "https://test-url";
   private static final long INSTALLED_VERSION_CODE = 2;
-  private static final String TEST_SCREENSHOT_FILE_NAME = "screenshot.png";
+  private static final Uri TEST_SCREENSHOT_URI = Uri.parse("file:/path/to/screenshot.png");
 
   private static final AppDistributionReleaseInternal.Builder TEST_RELEASE_NEWER_AAB_INTERNAL =
       AppDistributionReleaseInternal.builder()
@@ -191,9 +192,8 @@ public class FirebaseAppDistributionServiceImplTest {
 
     activity = spy(Robolectric.buildActivity(TestActivity.class).create().get());
     TestUtils.mockForegroundActivity(mockLifecycleNotifier, activity);
-
     when(mockScreenshotTaker.takeScreenshot())
-        .thenReturn(Tasks.forResult(TEST_SCREENSHOT_FILE_NAME));
+        .thenReturn(Tasks.forResult(TEST_SCREENSHOT_URI));
   }
 
   @Test
@@ -644,8 +644,8 @@ public class FirebaseAppDistributionServiceImplTest {
     verify(mockTesterSignInManager).signInTester();
     assertThat(argument.getValue().getStringExtra(RELEASE_NAME_EXTRA_KEY))
         .isEqualTo("release-name");
-    assertThat(argument.getValue().getStringExtra(SCREENSHOT_FILENAME_EXTRA_KEY))
-        .isEqualTo(TEST_SCREENSHOT_FILE_NAME);
+    assertThat(argument.getValue().getStringExtra(SCREENSHOT_URI_EXTRA_KEY))
+        .isEqualTo(TEST_SCREENSHOT_URI);
     assertThat(argument.getValue().getStringExtra(INFO_TEXT_EXTRA_KEY))
         .isEqualTo("Some terms and conditions");
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -648,4 +648,24 @@ public class FirebaseAppDistributionServiceImplTest {
     assertThat(argument.getValue().getStringExtra(INFO_TEXT_EXTRA_KEY))
         .isEqualTo("Some terms and conditions");
   }
+
+  @Test
+  public void startFeedback_screenshotFails_startActivityWithNoScreenshot()
+      throws InterruptedException {
+    when(mockScreenshotTaker.takeScreenshot())
+        .thenReturn(
+            Tasks.forException(new FirebaseAppDistributionException("Error", Status.UNKNOWN)));
+    when(mockReleaseIdentifier.identifyRelease()).thenReturn(Tasks.forResult("release-name"));
+    firebaseAppDistribution.startFeedback("Some terms and conditions");
+    TestUtils.awaitAsyncOperations(taskExecutor);
+
+    ArgumentCaptor<Intent> argument = ArgumentCaptor.forClass(Intent.class);
+    verify(activity).startActivity(argument.capture());
+    verify(mockTesterSignInManager).signInTester();
+    assertThat(argument.getValue().getStringExtra(RELEASE_NAME_EXTRA_KEY))
+        .isEqualTo("release-name");
+    assertThat(argument.getValue().hasExtra(SCREENSHOT_URI_EXTRA_KEY)).isFalse();
+    assertThat(argument.getValue().getStringExtra(INFO_TEXT_EXTRA_KEY))
+        .isEqualTo("Some terms and conditions");
+  }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
@@ -35,6 +35,10 @@ import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -389,42 +393,45 @@ public class FirebaseAppDistributionTesterApiClientTest {
   @Test
   public void attachScreenshot_whenResponseSuccessful_makesPostRequestAndReturnsFeedbackName()
       throws Exception {
-    File testScreenshotFile =
-        ApplicationProvider.getApplicationContext().getFileStreamPath("test.png");
+    InputStream inputStream =
+        new FileInputStream(
+                ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
     Task<String> task =
-        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, testScreenshotFile);
+        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
     String result = awaitTask(task);
 
     assertThat(result).isEqualTo(FEEDBACK_NAME);
     verify(mockTesterApiHttpClient)
         .makeUploadRequest(
-            any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), eq(testScreenshotFile));
+            any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), eq(inputStream));
   }
 
   @Test
-  public void attachScreenshot_getFidError_throwsError() {
+  public void attachScreenshot_getFidError_throwsError() throws FileNotFoundException {
     Exception expectedException = new Exception("test ex");
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forException(expectedException));
-    File testScreenshotFile =
-        ApplicationProvider.getApplicationContext().getFileStreamPath("test.png");
+    InputStream inputStream =
+            new FileInputStream(
+                    ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
     Task<String> task =
-        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, testScreenshotFile);
+        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex", expectedException);
   }
 
   @Test
-  public void attachScreenshot_getFisAuthTokenError_throwsError() {
+  public void attachScreenshot_getFisAuthTokenError_throwsError() throws FileNotFoundException {
     Exception expectedException = new Exception("test ex");
     when(mockFirebaseInstallations.getToken(false))
         .thenReturn(Tasks.forException(expectedException));
-    File testScreenshotFile =
-        ApplicationProvider.getApplicationContext().getFileStreamPath("test.png");
+    InputStream inputStream =
+            new FileInputStream(
+                    ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
     Task<String> task =
-        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, testScreenshotFile);
+        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex", expectedException);
   }
@@ -434,11 +441,12 @@ public class FirebaseAppDistributionTesterApiClientTest {
     when(mockTesterApiHttpClient.makeUploadRequest(
             any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), any()))
         .thenThrow(new FirebaseAppDistributionException("test ex", Status.UNKNOWN));
-    File testScreenshotFile =
-        ApplicationProvider.getApplicationContext().getFileStreamPath("test.png");
+    InputStream inputStream =
+            new FileInputStream(
+                    ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
     Task<String> task =
-        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, testScreenshotFile);
+        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex");
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.net.Uri;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -34,9 +35,7 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException.Stat
 import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.InputStream;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -391,29 +390,25 @@ public class FirebaseAppDistributionTesterApiClientTest {
   @Test
   public void attachScreenshot_whenResponseSuccessful_makesPostRequestAndReturnsFeedbackName()
       throws Exception {
-    InputStream inputStream =
-        new FileInputStream(
-            ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
+    Uri uri =
+        Uri.fromFile(ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
-    Task<String> task =
-        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
+    Task<String> task = firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, uri);
     String result = awaitTask(task);
 
     assertThat(result).isEqualTo(FEEDBACK_NAME);
     verify(mockTesterApiHttpClient)
-        .makeUploadRequest(any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), eq(inputStream));
+        .makeUploadRequest(any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), eq(uri));
   }
 
   @Test
   public void attachScreenshot_getFidError_throwsError() throws FileNotFoundException {
     Exception expectedException = new Exception("test ex");
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forException(expectedException));
-    InputStream inputStream =
-        new FileInputStream(
-            ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
+    Uri uri =
+        Uri.fromFile(ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
-    Task<String> task =
-        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
+    Task<String> task = firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, uri);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex", expectedException);
   }
@@ -423,12 +418,10 @@ public class FirebaseAppDistributionTesterApiClientTest {
     Exception expectedException = new Exception("test ex");
     when(mockFirebaseInstallations.getToken(false))
         .thenReturn(Tasks.forException(expectedException));
-    InputStream inputStream =
-        new FileInputStream(
-            ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
+    Uri uri =
+        Uri.fromFile(ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
-    Task<String> task =
-        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
+    Task<String> task = firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, uri);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex", expectedException);
   }
@@ -438,12 +431,10 @@ public class FirebaseAppDistributionTesterApiClientTest {
     when(mockTesterApiHttpClient.makeUploadRequest(
             any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), any()))
         .thenThrow(new FirebaseAppDistributionException("test ex", Status.UNKNOWN));
-    InputStream inputStream =
-        new FileInputStream(
-            ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
+    Uri uri =
+        Uri.fromFile(ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
-    Task<String> task =
-        firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
+    Task<String> task = firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, uri);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex");
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
@@ -34,11 +34,9 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException.Stat
 import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -395,7 +393,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
       throws Exception {
     InputStream inputStream =
         new FileInputStream(
-                ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
+            ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
     Task<String> task =
         firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
@@ -403,8 +401,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
 
     assertThat(result).isEqualTo(FEEDBACK_NAME);
     verify(mockTesterApiHttpClient)
-        .makeUploadRequest(
-            any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), eq(inputStream));
+        .makeUploadRequest(any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), eq(inputStream));
   }
 
   @Test
@@ -412,8 +409,8 @@ public class FirebaseAppDistributionTesterApiClientTest {
     Exception expectedException = new Exception("test ex");
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forException(expectedException));
     InputStream inputStream =
-            new FileInputStream(
-                    ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
+        new FileInputStream(
+            ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
     Task<String> task =
         firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
@@ -427,8 +424,8 @@ public class FirebaseAppDistributionTesterApiClientTest {
     when(mockFirebaseInstallations.getToken(false))
         .thenReturn(Tasks.forException(expectedException));
     InputStream inputStream =
-            new FileInputStream(
-                    ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
+        new FileInputStream(
+            ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
     Task<String> task =
         firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);
@@ -442,8 +439,8 @@ public class FirebaseAppDistributionTesterApiClientTest {
             any(), eq(ATTACH_SCREENSHOT_PATH), eq(TEST_AUTH_TOKEN), any()))
         .thenThrow(new FirebaseAppDistributionException("test ex", Status.UNKNOWN));
     InputStream inputStream =
-            new FileInputStream(
-                    ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
+        new FileInputStream(
+            ApplicationProvider.getApplicationContext().getFileStreamPath("test.png"));
 
     Task<String> task =
         firebaseAppDistributionTesterApiClient.attachScreenshot(FEEDBACK_NAME, inputStream);

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
@@ -17,13 +17,18 @@ package com.google.firebase.appdistribution.impl;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.Bitmap.Config;
+import android.net.Uri;
+
 import androidx.test.core.app.ApplicationProvider;
+
+import com.google.firebase.appdistribution.FirebaseAppDistributionException;
+
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowBitmapFactory;
 
 @RunWith(RobolectricTestRunner.class)
@@ -42,75 +48,77 @@ public class ImageUtilsTest {
   private static final Bitmap TEST_SCREENSHOT =
       Bitmap.createBitmap(TEST_SCREENSHOT_WIDTH, TEST_SCREENSHOT_HEIGHT, Config.RGB_565);
 
+  private ContentResolver contentResolver;
+
   @Before
   public void setUp() {
     // Makes the shadow behave like the real BitmapFactory, for example returning null for
     // nonexistent files
     ShadowBitmapFactory.setAllowInvalidImageData(false);
+    contentResolver = RuntimeEnvironment.getApplication().getContentResolver();
   }
 
   @Test
-  public void readScaledImage_targetIsLessThanHalf_scalesDown() throws IOException {
-    InputStream inputStream = writeBitmapToTmpFile();
-
+  public void readScaledImage_targetIsLessThanHalf_scalesDown() throws IOException, FirebaseAppDistributionException {
+    Uri uri = writeBitmapToTmpFile();
     Bitmap result =
         ImageUtils.readScaledImage(
-                inputStream, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
+                contentResolver, uri, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
   }
 
   @Test
-  public void readScaledImage_targetExactlyPowerOfTwoSmaller_scalesDown() throws IOException {
-    InputStream inputStream = writeBitmapToTmpFile();
-
+  public void readScaledImage_targetExactlyPowerOfTwoSmaller_scalesDown() throws IOException, FirebaseAppDistributionException {
+    Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-        ImageUtils.readScaledImage(inputStream, TEST_SCREENSHOT_WIDTH / 4, TEST_SCREENSHOT_HEIGHT / 4);
+            ImageUtils.readScaledImage(
+                    contentResolver, uri, TEST_SCREENSHOT_WIDTH / 4, TEST_SCREENSHOT_HEIGHT / 4);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 4);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 4);
   }
 
   @Test
-  public void readScaledImage_targetWidthIsSmaller_scalesDownToFitHeight() throws IOException {
-    InputStream inputStream = writeBitmapToTmpFile();
-
+  public void readScaledImage_targetWidthIsSmaller_scalesDownToFitHeight() throws IOException, FirebaseAppDistributionException {
+    Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-        ImageUtils.readScaledImage(
-            inputStream, TEST_SCREENSHOT_WIDTH / 4 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
+            ImageUtils.readScaledImage(
+                    contentResolver, uri, TEST_SCREENSHOT_WIDTH / 4 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
   }
 
   @Test
-  public void readScaledImage_targetHeightIsSmaller_scalesDownToFitWidth() throws IOException {
-    InputStream inputStream = writeBitmapToTmpFile();
-
+  public void readScaledImage_targetHeightIsSmaller_scalesDownToFitWidth() throws IOException, FirebaseAppDistributionException {
+    Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-        ImageUtils.readScaledImage(
-                inputStream, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 4 - 100);
+            ImageUtils.readScaledImage(
+                    contentResolver, uri, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 4 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
   }
 
   @Test
-  public void readScaledImage_targetIsGreaterThanHalf_returnsOriginal() throws IOException {
-    InputStream inputStream = writeBitmapToTmpFile();
+  public void readScaledImage_targetIsGreaterThanHalf_returnsOriginal() throws IOException, FirebaseAppDistributionException {
+    Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-        ImageUtils.readScaledImage(inputStream, TEST_SCREENSHOT_WIDTH - 100, TEST_SCREENSHOT_HEIGHT - 100);
+            ImageUtils.readScaledImage(
+                    contentResolver, uri, TEST_SCREENSHOT_WIDTH - 100, TEST_SCREENSHOT_HEIGHT - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
   }
 
   @Test
-  public void readScaledImage_targetIsGreater_returnsOriginal() throws IOException {
-    InputStream inputStream = writeBitmapToTmpFile();
+  public void readScaledImage_targetIsGreater_returnsOriginal() throws IOException, FirebaseAppDistributionException {
+    Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-        ImageUtils.readScaledImage(inputStream, TEST_SCREENSHOT_WIDTH * 2, TEST_SCREENSHOT_HEIGHT * 2);
+            ImageUtils.readScaledImage(
+                    contentResolver, uri, TEST_SCREENSHOT_WIDTH * 2, TEST_SCREENSHOT_HEIGHT * 2);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
@@ -118,18 +126,18 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_zeroDimension_throws() throws IOException {
-    InputStream inputStream = writeBitmapToTmpFile();
-    assertThrows(IllegalArgumentException.class, () -> ImageUtils.readScaledImage(inputStream, 500, 0));
+    Uri uri = writeBitmapToTmpFile();
+    assertThrows(IllegalArgumentException.class, () -> ImageUtils.readScaledImage(contentResolver, uri, 500, 0));
   }
 
   @Test
   public void readScaledImage_doesntExist_throws() throws IOException {
     assertThrows(
         IllegalArgumentException.class,
-        () -> ImageUtils.readScaledImage(Files.newInputStream(new File("nonexistent.png").toPath()), 500, 0));
+        () -> ImageUtils.readScaledImage(contentResolver, Uri.fromFile(new File("nonexistent.png")), 500, 0));
   }
 
-  private static InputStream writeBitmapToTmpFile() throws IOException {
+  private static Uri writeBitmapToTmpFile() throws IOException {
     // Write bitmap to file
     try (FileOutputStream outputStream =
         ApplicationProvider.getApplicationContext()
@@ -137,6 +145,6 @@ public class ImageUtilsTest {
       TEST_SCREENSHOT.compress(CompressFormat.PNG, 100, outputStream);
     }
     File file = ApplicationProvider.getApplicationContext().getFileStreamPath(TEST_FILENAME);
-    return new FileInputStream(file);
+    return Uri.fromFile(file);
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
@@ -23,8 +23,11 @@ import android.graphics.Bitmap.CompressFormat;
 import android.graphics.Bitmap.Config;
 import androidx.test.core.app.ApplicationProvider;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,11 +51,11 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetIsLessThanHalf_scalesDown() throws IOException {
-    File file = writeBitmapToTmpFile();
+    InputStream inputStream = writeBitmapToTmpFile();
 
     Bitmap result =
         ImageUtils.readScaledImage(
-            file, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
+                inputStream, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
@@ -60,10 +63,10 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetExactlyPowerOfTwoSmaller_scalesDown() throws IOException {
-    File file = writeBitmapToTmpFile();
+    InputStream inputStream = writeBitmapToTmpFile();
 
     Bitmap result =
-        ImageUtils.readScaledImage(file, TEST_SCREENSHOT_WIDTH / 4, TEST_SCREENSHOT_HEIGHT / 4);
+        ImageUtils.readScaledImage(inputStream, TEST_SCREENSHOT_WIDTH / 4, TEST_SCREENSHOT_HEIGHT / 4);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 4);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 4);
@@ -71,11 +74,11 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetWidthIsSmaller_scalesDownToFitHeight() throws IOException {
-    File file = writeBitmapToTmpFile();
+    InputStream inputStream = writeBitmapToTmpFile();
 
     Bitmap result =
         ImageUtils.readScaledImage(
-            file, TEST_SCREENSHOT_WIDTH / 4 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
+            inputStream, TEST_SCREENSHOT_WIDTH / 4 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
@@ -83,11 +86,11 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetHeightIsSmaller_scalesDownToFitWidth() throws IOException {
-    File file = writeBitmapToTmpFile();
+    InputStream inputStream = writeBitmapToTmpFile();
 
     Bitmap result =
         ImageUtils.readScaledImage(
-            file, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 4 - 100);
+                inputStream, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 4 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
@@ -95,9 +98,9 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetIsGreaterThanHalf_returnsOriginal() throws IOException {
-    File file = writeBitmapToTmpFile();
+    InputStream inputStream = writeBitmapToTmpFile();
     Bitmap result =
-        ImageUtils.readScaledImage(file, TEST_SCREENSHOT_WIDTH - 100, TEST_SCREENSHOT_HEIGHT - 100);
+        ImageUtils.readScaledImage(inputStream, TEST_SCREENSHOT_WIDTH - 100, TEST_SCREENSHOT_HEIGHT - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
@@ -105,9 +108,9 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetIsGreater_returnsOriginal() throws IOException {
-    File file = writeBitmapToTmpFile();
+    InputStream inputStream = writeBitmapToTmpFile();
     Bitmap result =
-        ImageUtils.readScaledImage(file, TEST_SCREENSHOT_WIDTH * 2, TEST_SCREENSHOT_HEIGHT * 2);
+        ImageUtils.readScaledImage(inputStream, TEST_SCREENSHOT_WIDTH * 2, TEST_SCREENSHOT_HEIGHT * 2);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
@@ -115,24 +118,25 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_zeroDimension_throws() throws IOException {
-    File file = writeBitmapToTmpFile();
-    assertThrows(IllegalArgumentException.class, () -> ImageUtils.readScaledImage(file, 500, 0));
+    InputStream inputStream = writeBitmapToTmpFile();
+    assertThrows(IllegalArgumentException.class, () -> ImageUtils.readScaledImage(inputStream, 500, 0));
   }
 
   @Test
   public void readScaledImage_doesntExist_throws() throws IOException {
     assertThrows(
         IllegalArgumentException.class,
-        () -> ImageUtils.readScaledImage(new File("nonexistent.png"), 500, 0));
+        () -> ImageUtils.readScaledImage(Files.newInputStream(new File("nonexistent.png").toPath()), 500, 0));
   }
 
-  private static File writeBitmapToTmpFile() throws IOException {
+  private static InputStream writeBitmapToTmpFile() throws IOException {
     // Write bitmap to file
     try (FileOutputStream outputStream =
         ApplicationProvider.getApplicationContext()
             .openFileOutput(TEST_FILENAME, Context.MODE_PRIVATE)) {
       TEST_SCREENSHOT.compress(CompressFormat.PNG, 100, outputStream);
     }
-    return ApplicationProvider.getApplicationContext().getFileStreamPath(TEST_FILENAME);
+    File file = ApplicationProvider.getApplicationContext().getFileStreamPath(TEST_FILENAME);
+    return new FileInputStream(file);
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
@@ -60,7 +60,7 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetIsLessThanHalf_scalesDown()
-      throws FirebaseAppDistributionException {
+      throws FirebaseAppDistributionException, IOException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
@@ -74,7 +74,7 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetExactlyPowerOfTwoSmaller_scalesDown()
-      throws FirebaseAppDistributionException {
+      throws FirebaseAppDistributionException, IOException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
@@ -88,7 +88,7 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetWidthIsSmaller_scalesDownToFitHeight()
-      throws FirebaseAppDistributionException {
+      throws FirebaseAppDistributionException, IOException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
@@ -102,7 +102,7 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetHeightIsSmaller_scalesDownToFitWidth()
-      throws FirebaseAppDistributionException {
+      throws FirebaseAppDistributionException, IOException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
@@ -116,7 +116,7 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetIsGreaterThanHalf_returnsOriginal()
-      throws FirebaseAppDistributionException {
+      throws FirebaseAppDistributionException, IOException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
@@ -130,7 +130,7 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetIsGreater_returnsOriginal()
-      throws FirebaseAppDistributionException {
+      throws FirebaseAppDistributionException, IOException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
@@ -150,7 +150,7 @@ public class ImageUtilsTest {
   }
 
   @Test
-  public void readScaledImage_doesntExist_returnsNull() {
+  public void readScaledImage_doesntExist_returnsNull() throws IOException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
@@ -16,17 +16,17 @@ package com.google.firebase.appdistribution.impl;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.content.ContentResolver;
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.Bitmap.Config;
 import android.net.Uri;
-import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,33 +34,37 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowBitmapFactory;
+import org.robolectric.shadows.ShadowContentResolver;
 
 @RunWith(RobolectricTestRunner.class)
 public class ImageUtilsTest {
-  private static final String TEST_FILENAME = "test.png";
   private static final int TEST_SCREENSHOT_WIDTH = 1080;
   private static final int TEST_SCREENSHOT_HEIGHT = 2280;
   private static final Bitmap TEST_SCREENSHOT =
       Bitmap.createBitmap(TEST_SCREENSHOT_WIDTH, TEST_SCREENSHOT_HEIGHT, Config.RGB_565);
+  private static final Uri TEST_SCREENSHOT_URI = Uri.parse("file:///path/to/screenshot.png");
 
   private ContentResolver contentResolver;
+  private ShadowContentResolver shadowContentResolver;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
     // Makes the shadow behave like the real BitmapFactory, for example returning null for
     // nonexistent files
     ShadowBitmapFactory.setAllowInvalidImageData(false);
     contentResolver = RuntimeEnvironment.getApplication().getContentResolver();
+    shadowContentResolver = shadowOf(contentResolver);
+    shadowContentResolver.registerInputStream(
+        TEST_SCREENSHOT_URI, new ByteArrayInputStream(writeBitmapToByteArray()));
   }
 
   @Test
   public void readScaledImage_targetIsLessThanHalf_scalesDown()
-      throws IOException, FirebaseAppDistributionException {
-    Uri uri = writeBitmapToTmpFile();
+      throws FirebaseAppDistributionException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
-            uri,
+            TEST_SCREENSHOT_URI,
             TEST_SCREENSHOT_WIDTH / 2 - 100,
             TEST_SCREENSHOT_HEIGHT / 2 - 100);
 
@@ -70,11 +74,13 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetExactlyPowerOfTwoSmaller_scalesDown()
-      throws IOException, FirebaseAppDistributionException {
-    Uri uri = writeBitmapToTmpFile();
+      throws FirebaseAppDistributionException {
     Bitmap result =
         ImageUtils.readScaledImage(
-            contentResolver, uri, TEST_SCREENSHOT_WIDTH / 4, TEST_SCREENSHOT_HEIGHT / 4);
+            contentResolver,
+            TEST_SCREENSHOT_URI,
+            TEST_SCREENSHOT_WIDTH / 4,
+            TEST_SCREENSHOT_HEIGHT / 4);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 4);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 4);
@@ -82,12 +88,11 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetWidthIsSmaller_scalesDownToFitHeight()
-      throws IOException, FirebaseAppDistributionException {
-    Uri uri = writeBitmapToTmpFile();
+      throws FirebaseAppDistributionException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
-            uri,
+            TEST_SCREENSHOT_URI,
             TEST_SCREENSHOT_WIDTH / 4 - 100,
             TEST_SCREENSHOT_HEIGHT / 2 - 100);
 
@@ -97,12 +102,11 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetHeightIsSmaller_scalesDownToFitWidth()
-      throws IOException, FirebaseAppDistributionException {
-    Uri uri = writeBitmapToTmpFile();
+      throws FirebaseAppDistributionException {
     Bitmap result =
         ImageUtils.readScaledImage(
             contentResolver,
-            uri,
+            TEST_SCREENSHOT_URI,
             TEST_SCREENSHOT_WIDTH / 2 - 100,
             TEST_SCREENSHOT_HEIGHT / 4 - 100);
 
@@ -112,11 +116,13 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetIsGreaterThanHalf_returnsOriginal()
-      throws IOException, FirebaseAppDistributionException {
-    Uri uri = writeBitmapToTmpFile();
+      throws FirebaseAppDistributionException {
     Bitmap result =
         ImageUtils.readScaledImage(
-            contentResolver, uri, TEST_SCREENSHOT_WIDTH - 100, TEST_SCREENSHOT_HEIGHT - 100);
+            contentResolver,
+            TEST_SCREENSHOT_URI,
+            TEST_SCREENSHOT_WIDTH - 100,
+            TEST_SCREENSHOT_HEIGHT - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
@@ -124,41 +130,40 @@ public class ImageUtilsTest {
 
   @Test
   public void readScaledImage_targetIsGreater_returnsOriginal()
-      throws IOException, FirebaseAppDistributionException {
-    Uri uri = writeBitmapToTmpFile();
+      throws FirebaseAppDistributionException {
     Bitmap result =
         ImageUtils.readScaledImage(
-            contentResolver, uri, TEST_SCREENSHOT_WIDTH * 2, TEST_SCREENSHOT_HEIGHT * 2);
+            contentResolver,
+            TEST_SCREENSHOT_URI,
+            TEST_SCREENSHOT_WIDTH * 2,
+            TEST_SCREENSHOT_HEIGHT * 2);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
   }
 
   @Test
-  public void readScaledImage_zeroDimension_throws() throws IOException {
-    Uri uri = writeBitmapToTmpFile();
+  public void readScaledImage_zeroDimension_throws() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> ImageUtils.readScaledImage(contentResolver, uri, 500, 0));
+        () -> ImageUtils.readScaledImage(contentResolver, TEST_SCREENSHOT_URI, 500, 0));
   }
 
   @Test
-  public void readScaledImage_doesntExist_throws() throws IOException {
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            ImageUtils.readScaledImage(
-                contentResolver, Uri.fromFile(new File("nonexistent.png")), 500, 0));
+  public void readScaledImage_doesntExist_returnsNull() {
+    Bitmap result =
+        ImageUtils.readScaledImage(
+            contentResolver,
+            Uri.fromFile(new File("nonexistent.png")),
+            TEST_SCREENSHOT_WIDTH / 4,
+            TEST_SCREENSHOT_HEIGHT / 4);
+    assertThat(result).isNull();
   }
 
-  private static Uri writeBitmapToTmpFile() throws IOException {
-    // Write bitmap to file
-    try (FileOutputStream outputStream =
-        ApplicationProvider.getApplicationContext()
-            .openFileOutput(TEST_FILENAME, Context.MODE_PRIVATE)) {
+  private static byte[] writeBitmapToByteArray() throws IOException {
+    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
       TEST_SCREENSHOT.compress(CompressFormat.PNG, 100, outputStream);
+      return outputStream.toByteArray();
     }
-    File file = ApplicationProvider.getApplicationContext().getFileStreamPath(TEST_FILENAME);
-    return Uri.fromFile(file);
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ImageUtilsTest.java
@@ -23,16 +23,11 @@ import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.Bitmap.Config;
 import android.net.Uri;
-
 import androidx.test.core.app.ApplicationProvider;
-
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,66 +54,81 @@ public class ImageUtilsTest {
   }
 
   @Test
-  public void readScaledImage_targetIsLessThanHalf_scalesDown() throws IOException, FirebaseAppDistributionException {
+  public void readScaledImage_targetIsLessThanHalf_scalesDown()
+      throws IOException, FirebaseAppDistributionException {
     Uri uri = writeBitmapToTmpFile();
     Bitmap result =
         ImageUtils.readScaledImage(
-                contentResolver, uri, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
+            contentResolver,
+            uri,
+            TEST_SCREENSHOT_WIDTH / 2 - 100,
+            TEST_SCREENSHOT_HEIGHT / 2 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
   }
 
   @Test
-  public void readScaledImage_targetExactlyPowerOfTwoSmaller_scalesDown() throws IOException, FirebaseAppDistributionException {
+  public void readScaledImage_targetExactlyPowerOfTwoSmaller_scalesDown()
+      throws IOException, FirebaseAppDistributionException {
     Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-            ImageUtils.readScaledImage(
-                    contentResolver, uri, TEST_SCREENSHOT_WIDTH / 4, TEST_SCREENSHOT_HEIGHT / 4);
+        ImageUtils.readScaledImage(
+            contentResolver, uri, TEST_SCREENSHOT_WIDTH / 4, TEST_SCREENSHOT_HEIGHT / 4);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 4);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 4);
   }
 
   @Test
-  public void readScaledImage_targetWidthIsSmaller_scalesDownToFitHeight() throws IOException, FirebaseAppDistributionException {
+  public void readScaledImage_targetWidthIsSmaller_scalesDownToFitHeight()
+      throws IOException, FirebaseAppDistributionException {
     Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-            ImageUtils.readScaledImage(
-                    contentResolver, uri, TEST_SCREENSHOT_WIDTH / 4 - 100, TEST_SCREENSHOT_HEIGHT / 2 - 100);
+        ImageUtils.readScaledImage(
+            contentResolver,
+            uri,
+            TEST_SCREENSHOT_WIDTH / 4 - 100,
+            TEST_SCREENSHOT_HEIGHT / 2 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
   }
 
   @Test
-  public void readScaledImage_targetHeightIsSmaller_scalesDownToFitWidth() throws IOException, FirebaseAppDistributionException {
+  public void readScaledImage_targetHeightIsSmaller_scalesDownToFitWidth()
+      throws IOException, FirebaseAppDistributionException {
     Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-            ImageUtils.readScaledImage(
-                    contentResolver, uri, TEST_SCREENSHOT_WIDTH / 2 - 100, TEST_SCREENSHOT_HEIGHT / 4 - 100);
+        ImageUtils.readScaledImage(
+            contentResolver,
+            uri,
+            TEST_SCREENSHOT_WIDTH / 2 - 100,
+            TEST_SCREENSHOT_HEIGHT / 4 - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH / 2);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT / 2);
   }
 
   @Test
-  public void readScaledImage_targetIsGreaterThanHalf_returnsOriginal() throws IOException, FirebaseAppDistributionException {
+  public void readScaledImage_targetIsGreaterThanHalf_returnsOriginal()
+      throws IOException, FirebaseAppDistributionException {
     Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-            ImageUtils.readScaledImage(
-                    contentResolver, uri, TEST_SCREENSHOT_WIDTH - 100, TEST_SCREENSHOT_HEIGHT - 100);
+        ImageUtils.readScaledImage(
+            contentResolver, uri, TEST_SCREENSHOT_WIDTH - 100, TEST_SCREENSHOT_HEIGHT - 100);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
   }
 
   @Test
-  public void readScaledImage_targetIsGreater_returnsOriginal() throws IOException, FirebaseAppDistributionException {
+  public void readScaledImage_targetIsGreater_returnsOriginal()
+      throws IOException, FirebaseAppDistributionException {
     Uri uri = writeBitmapToTmpFile();
     Bitmap result =
-            ImageUtils.readScaledImage(
-                    contentResolver, uri, TEST_SCREENSHOT_WIDTH * 2, TEST_SCREENSHOT_HEIGHT * 2);
+        ImageUtils.readScaledImage(
+            contentResolver, uri, TEST_SCREENSHOT_WIDTH * 2, TEST_SCREENSHOT_HEIGHT * 2);
 
     assertThat(result.getWidth()).isEqualTo(TEST_SCREENSHOT_WIDTH);
     assertThat(result.getHeight()).isEqualTo(TEST_SCREENSHOT_HEIGHT);
@@ -127,14 +137,18 @@ public class ImageUtilsTest {
   @Test
   public void readScaledImage_zeroDimension_throws() throws IOException {
     Uri uri = writeBitmapToTmpFile();
-    assertThrows(IllegalArgumentException.class, () -> ImageUtils.readScaledImage(contentResolver, uri, 500, 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ImageUtils.readScaledImage(contentResolver, uri, 500, 0));
   }
 
   @Test
   public void readScaledImage_doesntExist_throws() throws IOException {
     assertThrows(
         IllegalArgumentException.class,
-        () -> ImageUtils.readScaledImage(contentResolver, Uri.fromFile(new File("nonexistent.png")), 500, 0));
+        () ->
+            ImageUtils.readScaledImage(
+                contentResolver, Uri.fromFile(new File("nonexistent.png")), 500, 0));
   }
 
   private static Uri writeBitmapToTmpFile() throws IOException {

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ScreenshotTakerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ScreenshotTakerTest.java
@@ -23,11 +23,13 @@ import static org.robolectric.Shadows.shadowOf;
 
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
+import android.net.Uri;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import java.io.File;
 import java.util.concurrent.Executor;
 import org.junit.After;
 import org.junit.Before;
@@ -80,16 +82,14 @@ public class ScreenshotTakerTest {
   @Test
   public void takeAndDeleteScreenshot_success() throws Exception {
     // Take a screenshot
-    Task<String> task = screenshotTaker.takeScreenshot();
+    Task<Uri> task = screenshotTaker.takeScreenshot();
     shadowOf(getMainLooper()).idle();
-    String screenshotFilename = TestUtils.awaitTask(task);
+    Uri screenshotUri = TestUtils.awaitTask(task);
 
-    assertThat(screenshotFilename).isEqualTo(SCREENSHOT_FILE_NAME);
-    assertThat(
-            ApplicationProvider.getApplicationContext()
-                .getFileStreamPath(SCREENSHOT_FILE_NAME)
-                .length())
-        .isGreaterThan(0);
+    File expectedFile =
+        ApplicationProvider.getApplicationContext().getFileStreamPath(SCREENSHOT_FILE_NAME);
+    assertThat(screenshotUri).isEqualTo(Uri.fromFile(expectedFile));
+    assertThat(expectedFile.length()).isGreaterThan(0);
 
     // Delete the screenshot
     Task<Void> deleteScreenshot = screenshotTaker.deleteScreenshot();

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterApiHttpClientTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterApiHttpClientTest.java
@@ -252,7 +252,6 @@ public class TesterApiHttpClientTest {
   public void makeUploadRequest_writesRequestBodyAndSetsCorrectHeaders() throws Exception {
     String responseJson = readTestFile("testSimpleResponse.json");
 
-    // Setup test streams. They should be closed but close them anyway just to be safe.
     try (InputStream postBodyInputStream =
             new ByteArrayInputStream("Test post body".getBytes(UTF_8));
         ByteArrayOutputStream requestBodyOutputStream = new ByteArrayOutputStream();

--- a/firebase-appdistribution/test-app/src/main/AndroidManifest.xml
+++ b/firebase-appdistribution/test-app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.googletest.firebase.appdistribution.testapp">
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
   <application
       android:allowBackup="true"

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/FeedbackTriggers.java
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/FeedbackTriggers.java
@@ -11,13 +11,20 @@ import android.util.Log;
 
 import com.google.firebase.appdistribution.FirebaseAppDistribution;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
 class FeedbackTriggers extends ContentObserver {
 
     private static final String TAG = "FeedbackTriggers";
     private static final String[] PROJECTION =
             new String[] {
                     MediaStore.Images.Media.DATA,
+                    MediaStore.Images.Media._ID
             };
+    private final Set<String> seenImages = new HashSet<>();
 
     private final Context context;
     private final CharSequence infoText;
@@ -40,6 +47,12 @@ class FeedbackTriggers extends ContentObserver {
         Log.i(TAG, "Screenshot observer successfully registered.");
     }
 
+    void unRegisterScreenshotObserver() {
+        context.getContentResolver()
+                .unregisterContentObserver(this);
+        Log.i(TAG, "Screenshot observer successfully unregistered.");
+    }
+
     @Override
     public void onChange(boolean selfChange) {
         Log.i(TAG, "Detected content written to external media but no URI present");
@@ -53,25 +66,52 @@ class FeedbackTriggers extends ContentObserver {
             return;
         }
 
+        if (!seenImages.add(uri.toString())) {
+            Log.i(TAG, "Ignoring redundant URI");
+            return;
+        }
+
         Cursor cursor = null;
         try {
-//            cursor = context.getContentResolver().query(uri, PROJECTION, null, null, null);
-            cursor = context.getContentResolver().query(uri, null, null, null, null);
-            Log.i(TAG, "Cursor: " + cursor);
-            Log.i(TAG, "Cursor has count: " + cursor.getCount());
+            cursor = context.getContentResolver().query(uri, PROJECTION, null, null, null);
             if (cursor != null && cursor.moveToFirst()) {
                 String path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA));
+                Long id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID));
                 Log.i(TAG, "Path: " + path);
-                if (path.toLowerCase().contains("images") || path.toLowerCase().contains("screenshot")) {
-                    Log.i(TAG, "Detected screenshot. Starting feedback flow.");
-                    FirebaseAppDistribution.getInstance().startFeedback(infoText);
+                if (!path.toLowerCase().contains("screenshot")) {
+                    return;
                 }
+                Log.i(TAG, "Detected screenshot.");
+                // TODO: since we have a file path here, should we just use File or path everywhere instead of content URI?
+                try {
+                    waitUntilImageIsAvailable(uri);
+                } catch (InterruptedException e) {
+                    Log.e(TAG, "Interrupted while waiting for screenshot to be readable.", e);
+                } catch (IOException e) {
+                    Log.e(TAG, "Failed to read screenshot.", e);
+                }
+                FirebaseAppDistribution.getInstance().startFeedback(infoText, uri);
             }
         } catch (Exception e) {
             Log.e(TAG, "Could not determine if media change was due to taking a screenshot", e);
         } finally {
             if (cursor != null) {
                 cursor.close();
+            }
+        }
+    }
+
+    // TODO: wait until image is available in the FeedbackActivity instead of here
+    private void waitUntilImageIsAvailable(Uri uri) throws InterruptedException, IOException {
+        for (int i = 0; i < 10; i++) {
+            try {
+                InputStream is = context.getContentResolver().openInputStream(uri);
+                Log.i(TAG, "Screenshot is readable. Starting feedback flow.");
+                is.close();
+                return;
+            } catch (IllegalStateException e) {
+                Log.e(TAG, "Screenshot in URI is still pending. Sleeping.", e);
+                Thread.sleep(300);
             }
         }
     }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/FeedbackTriggers.java
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/FeedbackTriggers.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.googletest.firebase.appdistribution.testapp;
 
 import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
@@ -12,104 +26,108 @@ import android.os.Handler;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images.Media;
 import android.util.Log;
-
 import androidx.activity.ComponentActivity;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.core.content.ContextCompat;
-
 import com.google.firebase.appdistribution.FirebaseAppDistribution;
-
 import java.util.HashSet;
 import java.util.Set;
 
 class FeedbackTriggers extends ContentObserver {
 
-    private static final String TAG = "FeedbackTriggers";
-    private static final String[] PROJECTION =
-            new String[] {
-                    MediaStore.Images.Media.DATA,
-                    MediaStore.Images.Media._ID
-            };
-    private final Set<String> seenImages = new HashSet<>();
+  private static final String TAG = "FeedbackTriggers";
+  private static final String[] PROJECTION =
+      new String[] {MediaStore.Images.Media.DATA, MediaStore.Images.Media._ID};
+  private final Set<String> seenImages = new HashSet<>();
 
-    private final Context context;
-    private final CharSequence infoText;
+  private final Context context;
+  private final CharSequence infoText;
 
-    private final ActivityResultLauncher<String> requestPermissionLauncher;
+  private final ActivityResultLauncher<String> requestPermissionLauncher;
 
-    private Uri currentUri;
+  private Uri currentUri;
 
-    /**
-     * Creates a FeedbackTriggers instance for an activity.
-     *
-     * This must be called during activity initialization.
-     *
-     * @param activity The host activity
-     * @param handler The handler to run {@link #onChange} on, or null if none.
-     */
-    public FeedbackTriggers(ComponentActivity activity, CharSequence infoText, Handler handler) {
-        super(handler);
-        this.context = activity;
-        this.infoText = infoText;
+  /**
+   * Creates a FeedbackTriggers instance for an activity.
+   *
+   * <p>This must be called during activity initialization.
+   *
+   * @param activity The host activity
+   * @param handler The handler to run {@link #onChange} on, or null if none.
+   */
+  public FeedbackTriggers(ComponentActivity activity, CharSequence infoText, Handler handler) {
+    super(handler);
+    this.context = activity;
+    this.infoText = infoText;
 
-        // Register the permissions launcher
-        requestPermissionLauncher = activity.registerForActivityResult(
-                new ActivityResultContracts.RequestPermission(), isGranted -> {
-            if (isGranted) {
+    // Register the permissions launcher
+    requestPermissionLauncher =
+        activity.registerForActivityResult(
+            new ActivityResultContracts.RequestPermission(),
+            isGranted -> {
+              if (isGranted) {
                 maybeStartFeedbackForScreenshot(currentUri);
-            } else {
+              } else {
                 new AlertDialog.Builder(context)
-                    .setMessage("Without storage access, screenshots taken while in the app will not be able to automatically start the feedback flow. To enable this feature, grant the app storage access in Settings.")
-                    .setPositiveButton("OK", (a, b) -> { /* do nothing */ })
+                    .setMessage(
+                        "Without storage access, screenshots taken while in the app will not be able to automatically start the feedback flow. To enable this feature, grant the app storage access in Settings.")
+                    .setPositiveButton(
+                        "OK",
+                        (a, b) -> {
+                          /* do nothing */
+                        })
                     .show();
-            }
-        });
+              }
+            });
+  }
+
+  void registerScreenshotObserver() {
+    context
+        .getContentResolver()
+        .registerContentObserver(Media.EXTERNAL_CONTENT_URI, true /*notifyForDescendants*/, this);
+  }
+
+  void unRegisterScreenshotObserver() {
+    context.getContentResolver().unregisterContentObserver(this);
+  }
+
+  @Override
+  public void onChange(boolean selfChange, Uri uri) {
+    if (!uri.toString().matches(String.format("%s/[0-9]+", Media.EXTERNAL_CONTENT_URI))
+        || !seenImages.add(uri.toString())) {
+      return;
     }
 
-    void registerScreenshotObserver() {
-        context.getContentResolver().registerContentObserver(
-                Media.EXTERNAL_CONTENT_URI, true /*notifyForDescendants*/, this);
+    if (ContextCompat.checkSelfPermission(context, WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED) {
+      maybeStartFeedbackForScreenshot(uri);
+    } else {
+      // Ideally we'd give the user some context here, but we have no way of knowing if they
+      // have previously "Deny & don't ask again" in which case we wouldn't want to show them
+      // anything here.
+      currentUri = uri;
+      requestPermissionLauncher.launch(WRITE_EXTERNAL_STORAGE);
     }
+  }
 
-    void unRegisterScreenshotObserver() {
-        context.getContentResolver().unregisterContentObserver(this);
-    }
-
-    @Override
-    public void onChange(boolean selfChange, Uri uri) {
-        if (!uri.toString().matches(String.format("%s/[0-9]+", Media.EXTERNAL_CONTENT_URI)) || !seenImages.add(uri.toString())) {
-            return;
+  private void maybeStartFeedbackForScreenshot(Uri uri) {
+    Cursor cursor = null;
+    try {
+      cursor = context.getContentResolver().query(uri, PROJECTION, null, null, null);
+      if (cursor != null && cursor.moveToFirst()) {
+        String path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA));
+        Long id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID));
+        Log.i(TAG, "Path: " + path);
+        if (path.toLowerCase().contains("screenshot")) {
+          // TODO: since we have a file path here, should we just use File or path everywhere
+          // instead of content URI?
+          FirebaseAppDistribution.getInstance().startFeedback(infoText, uri);
         }
-
-        if (ContextCompat.checkSelfPermission(context, WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED) {
-            maybeStartFeedbackForScreenshot(uri);
-        } else {
-            // Ideally we'd give the user some context here, but we have no way of knowing if they
-            // have previously "Deny & don't ask again" in which case we wouldn't want to show them
-            // anything here.
-            currentUri = uri;
-            requestPermissionLauncher.launch(WRITE_EXTERNAL_STORAGE);
-        }
+      }
+    } catch (Exception e) {
+      Log.e(TAG, "Could not determine if media change was due to taking a screenshot", e);
+    } finally {
+      if (cursor != null) cursor.close();
     }
-
-    private void maybeStartFeedbackForScreenshot(Uri uri) {
-        Cursor cursor = null;
-        try {
-            cursor = context.getContentResolver().query(uri, PROJECTION, null, null, null);
-            if (cursor != null && cursor.moveToFirst()) {
-                String path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA));
-                Long id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID));
-                Log.i(TAG, "Path: " + path);
-                if (path.toLowerCase().contains("screenshot")) {
-                    // TODO: since we have a file path here, should we just use File or path everywhere instead of content URI?
-                    FirebaseAppDistribution.getInstance().startFeedback(infoText, uri);
-                }
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "Could not determine if media change was due to taking a screenshot", e);
-        } finally {
-            if (cursor != null) cursor.close();
-        }
-    }
+  }
 }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/FeedbackTriggers.java
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/FeedbackTriggers.java
@@ -1,0 +1,78 @@
+package com.googletest.firebase.appdistribution.testapp;
+
+import android.content.Context;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Handler;
+import android.provider.MediaStore;
+import android.provider.MediaStore.Images.Media;
+import android.util.Log;
+
+import com.google.firebase.appdistribution.FirebaseAppDistribution;
+
+class FeedbackTriggers extends ContentObserver {
+
+    private static final String TAG = "FeedbackTriggers";
+    private static final String[] PROJECTION =
+            new String[] {
+                    MediaStore.Images.Media.DATA,
+            };
+
+    private final Context context;
+    private final CharSequence infoText;
+
+    /**
+     * Creates a FeedbackTriggers instance.
+     *
+     * @param handler The handler to run {@link #onChange} on, or null if none.
+     */
+    public FeedbackTriggers(Context context, CharSequence infoText, Handler handler) {
+        super(handler);
+        this.context = context;
+        this.infoText = infoText;
+    }
+
+    void registerScreenshotObserver() {
+        context.getContentResolver()
+                .registerContentObserver(
+                        Media.EXTERNAL_CONTENT_URI, true /*notifyForDescendants*/, this);
+        Log.i(TAG, "Screenshot observer successfully registered.");
+    }
+
+    @Override
+    public void onChange(boolean selfChange) {
+        Log.i(TAG, "Detected content written to external media but no URI present");
+    }
+
+    @Override
+    public void onChange(boolean selfChange, Uri uri) {
+        Log.i(TAG, "Detected content written to external media: " + uri);
+        if (!uri.toString().matches(String.format("%s/[0-9]+", Media.EXTERNAL_CONTENT_URI))) {
+            Log.i(TAG, "Detected non-screenshot content written to external media");
+            return;
+        }
+
+        Cursor cursor = null;
+        try {
+//            cursor = context.getContentResolver().query(uri, PROJECTION, null, null, null);
+            cursor = context.getContentResolver().query(uri, null, null, null, null);
+            Log.i(TAG, "Cursor: " + cursor);
+            Log.i(TAG, "Cursor has count: " + cursor.getCount());
+            if (cursor != null && cursor.moveToFirst()) {
+                String path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA));
+                Log.i(TAG, "Path: " + path);
+                if (path.toLowerCase().contains("images") || path.toLowerCase().contains("screenshot")) {
+                    Log.i(TAG, "Detected screenshot. Starting feedback flow.");
+                    FirebaseAppDistribution.getInstance().startFeedback(infoText);
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Could not determine if media change was due to taking a screenshot", e);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+}

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.googletest.firebase.appdistribution.testapp
 
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.AlertDialog
 import android.content.Intent
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -10,8 +12,11 @@ import android.util.Log
 import android.view.View
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
+import androidx.core.content.ContextCompat
 import com.google.android.gms.tasks.Task
 import com.google.firebase.appdistribution.AppDistributionRelease
 import com.google.firebase.appdistribution.UpdateProgress
@@ -21,6 +26,8 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 class MainActivity : AppCompatActivity() {
+    val TAG = "MainActivity"
+
     var firebaseAppDistribution = Firebase.appDistribution
     var updateTask: Task<Void>? = null
     var release: AppDistributionRelease? = null
@@ -40,6 +47,8 @@ class MainActivity : AppCompatActivity() {
     lateinit var signInStatus: TextView
     lateinit var progressPercent: TextView
     lateinit var progressBar: ProgressBar
+    private lateinit var feedbackTriggers: FeedbackTriggers
+    private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -61,10 +70,28 @@ class MainActivity : AppCompatActivity() {
         progressPercent = findViewById<TextView>(R.id.progress_percentage)
         progressBar = findViewById<ProgressBar>(R.id.progress_bar)
 
+
         val thread = HandlerThread("AppDistroFeedbackTrigger")
         thread.start()
-        FeedbackTriggers(this, "Here's some terms and conditions", Handler(thread.looper))
-            .registerScreenshotObserver()
+        feedbackTriggers = FeedbackTriggers(this, "Here's some terms and conditions", Handler(thread.looper))
+
+        requestPermissionLauncher = registerForActivityResult(
+            ActivityResultContracts.RequestPermission()
+        ) { isGranted: Boolean ->
+            if (isGranted) {
+                Log.i(TAG, "Permission granted")
+                // Permission is granted. Continue the action or workflow in your
+                // app.
+                feedbackTriggers.registerScreenshotObserver()
+            } else {
+                Log.i(TAG, "Permission not granted")
+                // Explain to the user that the feature is unavailable because the
+                // features requires a permission that the user has denied. At the
+                // same time, respect the user's decision. Don't link to system
+                // settings in an effort to convince the user to change their
+                // decision.
+            }
+        }
     }
 
     override fun onResume() {
@@ -178,6 +205,20 @@ class MainActivity : AppCompatActivity() {
         feedbackButton.setOnClickListener {
             firebaseAppDistribution.startFeedback(R.string.terms_and_conditions)
         }
+
+        if (ContextCompat.checkSelfPermission(this, WRITE_EXTERNAL_STORAGE) == PERMISSION_GRANTED) {
+            Log.i(TAG, "Registering screenshot trigger")
+            feedbackTriggers.registerScreenshotObserver()
+        } else {
+            Log.i(TAG, "Permission needs to be granted")
+            // TODO: explain to tester why we want this permission
+            requestPermissionLauncher.launch(WRITE_EXTERNAL_STORAGE)
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        feedbackTriggers.unRegisterScreenshotObserver()
     }
 
     fun startSecondActivity() {

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -4,6 +4,8 @@ import android.app.AlertDialog
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.HandlerThread
 import android.util.Log
 import android.view.View
 import android.widget.ProgressBar
@@ -58,6 +60,11 @@ class MainActivity : AppCompatActivity() {
         signInStatus = findViewById<TextView>(R.id.sign_in_status)
         progressPercent = findViewById<TextView>(R.id.progress_percentage)
         progressBar = findViewById<ProgressBar>(R.id.progress_bar)
+
+        val thread = HandlerThread("AppDistroFeedbackTrigger")
+        thread.start()
+        FeedbackTriggers(this, "Here's some terms and conditions", Handler(thread.looper))
+            .registerScreenshotObserver()
     }
 
     override fun onResume() {

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -70,7 +70,7 @@ class MainActivity : AppCompatActivity() {
         screenshotTrigger =
             ScreenshotDetectionFeedbackTrigger(
                 this,
-                "Here's some terms and conditions",
+                R.string.terms_and_conditions,
                 Handler(screenshotTriggerThread.looper)
             )
     }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -41,7 +41,9 @@ class MainActivity : AppCompatActivity() {
     lateinit var signInStatus: TextView
     lateinit var progressPercent: TextView
     lateinit var progressBar: ProgressBar
-    private lateinit var feedbackTriggers: FeedbackTriggers
+
+    private lateinit var screenshotTriggerThread: HandlerThread
+    private lateinit var screenshotTrigger: ScreenshotDetectionFeedbackTrigger
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -63,20 +65,29 @@ class MainActivity : AppCompatActivity() {
         progressPercent = findViewById<TextView>(R.id.progress_percentage)
         progressBar = findViewById<ProgressBar>(R.id.progress_bar)
 
+        screenshotTriggerThread = HandlerThread("AppDistroFeedbackTrigger")
+        screenshotTriggerThread.start()
+        screenshotTrigger =
+            ScreenshotDetectionFeedbackTrigger(
+                this,
+                "Here's some terms and conditions",
+                Handler(screenshotTriggerThread.looper)
+            )
+    }
 
-        val thread = HandlerThread("AppDistroFeedbackTrigger")
-        thread.start()
-        feedbackTriggers = FeedbackTriggers(this, "Here's some terms and conditions", Handler(thread.looper))
+    override fun onDestroy() {
+        super.onDestroy()
+        screenshotTriggerThread.quitSafely()
     }
 
     override fun onPause() {
         super.onPause()
-        feedbackTriggers.unRegisterScreenshotObserver()
+        screenshotTrigger.unRegisterScreenshotObserver()
     }
 
     override fun onResume() {
         super.onResume()
-        feedbackTriggers.registerScreenshotObserver()
+        screenshotTrigger.registerScreenshotObserver()
 
         findViewById<TextView>(R.id.app_name).text =
             "Sample App v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ScreenshotDetectionFeedbackTrigger.java
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ScreenshotDetectionFeedbackTrigger.java
@@ -35,8 +35,7 @@ import com.google.firebase.appdistribution.FirebaseAppDistribution;
 import java.util.HashSet;
 import java.util.Set;
 
-class FeedbackTriggers extends ContentObserver {
-
+class ScreenshotDetectionFeedbackTrigger extends ContentObserver {
   private static final String TAG = "FeedbackTriggers";
   private static final boolean SHOULD_CHECK_IF_PENDING = Build.VERSION.SDK_INT == 29;
   private static final String[] PROJECTION =
@@ -45,7 +44,7 @@ class FeedbackTriggers extends ContentObserver {
           : new String[] {
             MediaStore.Images.Media.DATA, android.provider.MediaStore.MediaColumns.IS_PENDING
           };
-  private final Set<String> seenImages = new HashSet<>();
+  private final Set<Uri> seenImages = new HashSet<>();
 
   private final Context context;
   private final CharSequence infoText;
@@ -62,7 +61,8 @@ class FeedbackTriggers extends ContentObserver {
    * @param activity The host activity
    * @param handler The handler to run {@link #onChange} on, or null if none.
    */
-  public FeedbackTriggers(ComponentActivity activity, CharSequence infoText, Handler handler) {
+  public ScreenshotDetectionFeedbackTrigger(
+      ComponentActivity activity, CharSequence infoText, Handler handler) {
     super(handler);
     this.context = activity;
     this.infoText = infoText;
@@ -91,7 +91,8 @@ class FeedbackTriggers extends ContentObserver {
   void registerScreenshotObserver() {
     context
         .getContentResolver()
-        .registerContentObserver(Media.EXTERNAL_CONTENT_URI, true /*notifyForDescendants*/, this);
+        .registerContentObserver(
+            Media.EXTERNAL_CONTENT_URI, /* notifyForDescendants= */ true, this);
   }
 
   void unRegisterScreenshotObserver() {
@@ -101,7 +102,7 @@ class FeedbackTriggers extends ContentObserver {
   @Override
   public void onChange(boolean selfChange, Uri uri) {
     if (!uri.toString().matches(String.format("%s/[0-9]+", Media.EXTERNAL_CONTENT_URI))
-        || !seenImages.add(uri.toString())) {
+        || !seenImages.add(uri)) {
       return;
     }
 

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         applicationId "com.googletest.firebase.appdistribution.testapp"
-        minSdkVersion 19
+        minSdkVersion 23
         targetSdkVersion 33
         versionName "1.0"
         versionCode 1
@@ -72,6 +72,8 @@ dependencies {
 
     // Other dependencies
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "androidx.activity:activity-ktx:1.5.1"
+    implementation "androidx.fragment:fragment-ktx:1.5.2"
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation "androidx.core:core:1.9.0"
     implementation 'androidx.appcompat:appcompat:1.5.1'

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+
     testImplementation 'junit:junit:4.+'
 }
 


### PR DESCRIPTION
Also has some refactoring to, among other things, allow the passing of a screenshot URI to the `startFeedback()` API.