### PR TITLE
Make count queries publicly available for use

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -4,6 +4,8 @@ by opting into a release at
 
 # Unreleased
 - [fixed] Fixed an issue `waitForPendingWrites()` could lead to NullPointerException.
+- [feature] Added Query.count(), which fetches the number of documents in the
+  result set without actually downloading the documents (#NNNN).
 
 # 24.2.0
 - [feature] Added `TransactionOptions` to control how many times a transaction

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -5,7 +5,7 @@ by opting into a release at
 # Unreleased
 - [fixed] Fixed an issue `waitForPendingWrites()` could lead to NullPointerException.
 - [feature] Added Query.count(), which fetches the number of documents in the
-  result set without actually downloading the documents (#NNNN).
+  result set without actually downloading the documents (#4126).
 
 # 24.2.0
 - [feature] Added `TransactionOptions` to control how many times a transaction

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateQuery.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateQuery.java
@@ -28,7 +28,7 @@ import com.google.firebase.firestore.util.Preconditions;
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
  * code that does so.
  */
-class AggregateQuery {
+public class AggregateQuery {
   // The base query.
   private final Query query;
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateQuerySnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateQuerySnapshot.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * in test mocks. Subclassing is not supported in production code and new SDK releases may break
  * code that does so.
  */
-class AggregateQuerySnapshot {
+public class AggregateQuerySnapshot {
 
   private final long count;
   private final AggregateQuery query;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateSource.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateSource.java
@@ -15,7 +15,7 @@
 package com.google.firebase.firestore;
 
 /** Configures the behavior of {@link AggregateQuery#get}. */
-enum AggregateSource {
+public enum AggregateSource {
   /**
    * Reach to the Firestore backend and surface the result verbatim, that is no local documents or
    * mutations in the SDK cache will be included in the surfaced result.

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/Query.java
@@ -1230,7 +1230,7 @@ public class Query {
    *     the result set of this query.
    */
   @NonNull
-  AggregateQuery count() {
+  public AggregateQuery count() {
     return new AggregateQuery(this);
   }
 


### PR DESCRIPTION
This PR changes the visibility of classes and methods that provide "count" queries from default to public, making them available for anyone to use. See #3847 for the implementation of COUNT queries.