### PR TITLE
Firestore: Fix COUNT APIs to match the API proposal

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
@@ -89,7 +89,7 @@ public class CountTest {
                 "c", map("k", "c")));
 
     AggregateQuerySnapshot snapshot = waitFor(collection.count().get(AggregateSource.SERVER));
-    assertEquals(Long.valueOf(3), snapshot.getCount());
+    assertEquals(3, snapshot.getCount());
   }
 
   @Test
@@ -103,7 +103,7 @@ public class CountTest {
 
     AggregateQuerySnapshot snapshot =
         waitFor(collection.whereEqualTo("k", "b").count().get(AggregateSource.SERVER));
-    assertEquals(Long.valueOf(1), snapshot.getCount());
+    assertEquals(1, snapshot.getCount());
   }
 
   @Test
@@ -119,7 +119,7 @@ public class CountTest {
     AggregateQuerySnapshot snapshot =
         waitFor(collection.orderBy("k").count().get(AggregateSource.SERVER));
     // "d" is filtered out because it is ordered by "k".
-    assertEquals(Long.valueOf(3), snapshot.getCount());
+    assertEquals(3, snapshot.getCount());
   }
 
   @Test
@@ -197,7 +197,7 @@ public class CountTest {
     AggregateQuerySnapshot snapshot =
         waitFor(db.collectionGroup(collectionGroup).count().get(AggregateSource.SERVER));
     assertEquals(
-        Long.valueOf(5), // "cg-doc1", "cg-doc2", "cg-doc3", "cg-doc4", "cg-doc5",
+        5, // "cg-doc1", "cg-doc2", "cg-doc3", "cg-doc4", "cg-doc5",
         snapshot.getCount());
   }
 
@@ -213,12 +213,12 @@ public class CountTest {
 
     AggregateQuerySnapshot snapshot =
         waitFor(collection.whereEqualTo("k", "a").limit(2).count().get(AggregateSource.SERVER));
-    assertEquals(Long.valueOf(2), snapshot.getCount());
+    assertEquals(2, snapshot.getCount());
 
     snapshot =
         waitFor(
             collection.whereEqualTo("k", "a").limitToLast(2).count().get(AggregateSource.SERVER));
-    assertEquals(Long.valueOf(2), snapshot.getCount());
+    assertEquals(2, snapshot.getCount());
 
     snapshot =
         waitFor(
@@ -227,7 +227,7 @@ public class CountTest {
                 .limitToLast(1000)
                 .count()
                 .get(AggregateSource.SERVER));
-    assertEquals(Long.valueOf(1), snapshot.getCount());
+    assertEquals(1, snapshot.getCount());
   }
 
   @Test
@@ -235,10 +235,10 @@ public class CountTest {
     CollectionReference collection = testFirestore().collection("random-coll");
 
     AggregateQuerySnapshot snapshot = waitFor(collection.count().get(AggregateSource.SERVER));
-    assertEquals(Long.valueOf(0), snapshot.getCount());
+    assertEquals(0, snapshot.getCount());
 
     snapshot = waitFor(collection.whereEqualTo("k", 100).count().get(AggregateSource.SERVER));
-    assertEquals(Long.valueOf(0), snapshot.getCount());
+    assertEquals(0, snapshot.getCount());
   }
 
   @Test
@@ -258,6 +258,6 @@ public class CountTest {
 
     waitFor(collection.getFirestore().enableNetwork());
     AggregateQuerySnapshot snapshot = waitFor(collection.count().get(AggregateSource.SERVER));
-    assertEquals(Long.valueOf(3), snapshot.getCount());
+    assertEquals(3, snapshot.getCount());
   }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
@@ -88,8 +88,7 @@ public class CountTest {
                 "b", map("k", "b"),
                 "c", map("k", "c")));
 
-    AggregateQuerySnapshot snapshot =
-        waitFor(collection.count().get(AggregateSource.SERVER_DIRECT));
+    AggregateQuerySnapshot snapshot = waitFor(collection.count().get(AggregateSource.SERVER));
     assertEquals(Long.valueOf(3), snapshot.getCount());
   }
 
@@ -103,7 +102,7 @@ public class CountTest {
                 "c", map("k", "c")));
 
     AggregateQuerySnapshot snapshot =
-        waitFor(collection.whereEqualTo("k", "b").count().get(AggregateSource.SERVER_DIRECT));
+        waitFor(collection.whereEqualTo("k", "b").count().get(AggregateSource.SERVER));
     assertEquals(Long.valueOf(1), snapshot.getCount());
   }
 
@@ -118,7 +117,7 @@ public class CountTest {
                 "d", map("absent", "d")));
 
     AggregateQuerySnapshot snapshot =
-        waitFor(collection.orderBy("k").count().get(AggregateSource.SERVER_DIRECT));
+        waitFor(collection.orderBy("k").count().get(AggregateSource.SERVER));
     // "d" is filtered out because it is ordered by "k".
     assertEquals(Long.valueOf(3), snapshot.getCount());
   }
@@ -132,7 +131,7 @@ public class CountTest {
                 "b", map("k", "b"),
                 "c", map("k", "c")));
 
-    collection.orderBy("k").count().get(AggregateSource.SERVER_DIRECT);
+    collection.orderBy("k").count().get(AggregateSource.SERVER);
     waitFor(collection.firestore.terminate());
   }
 
@@ -146,15 +145,15 @@ public class CountTest {
                 "c", map("k", "c")));
 
     AggregateQuerySnapshot snapshot1 =
-        waitFor(collection.whereEqualTo("k", "b").count().get(AggregateSource.SERVER_DIRECT));
+        waitFor(collection.whereEqualTo("k", "b").count().get(AggregateSource.SERVER));
     AggregateQuerySnapshot snapshot1_same =
-        waitFor(collection.whereEqualTo("k", "b").count().get(AggregateSource.SERVER_DIRECT));
+        waitFor(collection.whereEqualTo("k", "b").count().get(AggregateSource.SERVER));
 
     AggregateQuerySnapshot snapshot2 =
-        waitFor(collection.whereEqualTo("k", "a").count().get(AggregateSource.SERVER_DIRECT));
+        waitFor(collection.whereEqualTo("k", "a").count().get(AggregateSource.SERVER));
     waitFor(collection.document("d").set(map("k", "a")));
     AggregateQuerySnapshot snapshot2_different =
-        waitFor(collection.whereEqualTo("k", "a").count().get(AggregateSource.SERVER_DIRECT));
+        waitFor(collection.whereEqualTo("k", "a").count().get(AggregateSource.SERVER));
 
     assertTrue(snapshot1.equals(snapshot1_same));
     assertEquals(snapshot1.hashCode(), snapshot1_same.hashCode());
@@ -196,7 +195,7 @@ public class CountTest {
     waitFor(batch.commit());
 
     AggregateQuerySnapshot snapshot =
-        waitFor(db.collectionGroup(collectionGroup).count().get(AggregateSource.SERVER_DIRECT));
+        waitFor(db.collectionGroup(collectionGroup).count().get(AggregateSource.SERVER));
     assertEquals(
         Long.valueOf(5), // "cg-doc1", "cg-doc2", "cg-doc3", "cg-doc4", "cg-doc5",
         snapshot.getCount());
@@ -213,17 +212,12 @@ public class CountTest {
                 "d", map("k", "d")));
 
     AggregateQuerySnapshot snapshot =
-        waitFor(
-            collection.whereEqualTo("k", "a").limit(2).count().get(AggregateSource.SERVER_DIRECT));
+        waitFor(collection.whereEqualTo("k", "a").limit(2).count().get(AggregateSource.SERVER));
     assertEquals(Long.valueOf(2), snapshot.getCount());
 
     snapshot =
         waitFor(
-            collection
-                .whereEqualTo("k", "a")
-                .limitToLast(2)
-                .count()
-                .get(AggregateSource.SERVER_DIRECT));
+            collection.whereEqualTo("k", "a").limitToLast(2).count().get(AggregateSource.SERVER));
     assertEquals(Long.valueOf(2), snapshot.getCount());
 
     snapshot =
@@ -232,7 +226,7 @@ public class CountTest {
                 .whereEqualTo("k", "d")
                 .limitToLast(1000)
                 .count()
-                .get(AggregateSource.SERVER_DIRECT));
+                .get(AggregateSource.SERVER));
     assertEquals(Long.valueOf(1), snapshot.getCount());
   }
 
@@ -240,12 +234,10 @@ public class CountTest {
   public void testCanRunCountOnNonExistentCollection() {
     CollectionReference collection = testFirestore().collection("random-coll");
 
-    AggregateQuerySnapshot snapshot =
-        waitFor(collection.count().get(AggregateSource.SERVER_DIRECT));
+    AggregateQuerySnapshot snapshot = waitFor(collection.count().get(AggregateSource.SERVER));
     assertEquals(Long.valueOf(0), snapshot.getCount());
 
-    snapshot =
-        waitFor(collection.whereEqualTo("k", 100).count().get(AggregateSource.SERVER_DIRECT));
+    snapshot = waitFor(collection.whereEqualTo("k", 100).count().get(AggregateSource.SERVER));
     assertEquals(Long.valueOf(0), snapshot.getCount());
   }
 
@@ -259,14 +251,13 @@ public class CountTest {
                 "c", map("k", "c")));
     waitFor(collection.getFirestore().disableNetwork());
 
-    Exception e = waitForException(collection.count().get(AggregateSource.SERVER_DIRECT));
+    Exception e = waitForException(collection.count().get(AggregateSource.SERVER));
     assertThat(e, instanceOf(FirebaseFirestoreException.class));
     assertEquals(
         FirebaseFirestoreException.Code.UNAVAILABLE, ((FirebaseFirestoreException) e).getCode());
 
     waitFor(collection.getFirestore().enableNetwork());
-    AggregateQuerySnapshot snapshot =
-        waitFor(collection.count().get(AggregateSource.SERVER_DIRECT));
+    AggregateQuerySnapshot snapshot = waitFor(collection.count().get(AggregateSource.SERVER));
     assertEquals(Long.valueOf(3), snapshot.getCount());
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateQuerySnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateQuerySnapshot.java
@@ -17,7 +17,6 @@ package com.google.firebase.firestore;
 import static com.google.firebase.firestore.util.Preconditions.checkNotNull;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -44,12 +43,8 @@ class AggregateQuerySnapshot {
     return query;
   }
 
-  /**
-   * @return The result of a document count aggregation. Returns null if no count aggregation is
-   *     available in the result.
-   */
-  @Nullable
-  public Long getCount() {
+  /** @return The result of a document count aggregation. */
+  public long getCount() {
     return count;
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateSource.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateSource.java
@@ -22,5 +22,5 @@ enum AggregateSource {
    *
    * <p>Requires client to be online.
    */
-  SERVER_DIRECT,
+  SERVER,
 }


### PR DESCRIPTION
This is a follow-up to #3847 to modify the API surface of the new Query.count() feature to match the API proposal go/firestore-count-api-client-proposal.