### PR TITLE
Fix tests by downgrading AppCompat and fixing lint issue

### DIFF
--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation "androidx.browser:browser:1.3.0"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -18,6 +18,7 @@ import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -63,6 +64,8 @@ public class FeedbackActivity extends AppCompatActivity {
     TextView infoTextView = this.findViewById(R.id.infoText);
     infoTextView.setText(infoText);
     infoTextView.setMovementMethod(LinkMovementMethod.getInstance());
+    Button submitButton = this.findViewById(R.id.submitButton);
+    submitButton.setOnClickListener(this::submitFeedback);
 
     Bitmap thumbnail = readThumbnail();
     if (thumbnail != null) {

--- a/firebase-appdistribution/src/main/res/layout/activity_feedback.xml
+++ b/firebase-appdistribution/src/main/res/layout/activity_feedback.xml
@@ -36,7 +36,6 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_marginTop="24dp"
-      android:onClick="submitFeedback"
       android:text="Submit"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintHorizontal_bias="0.5"


### PR DESCRIPTION
AppCompat was updated in https://github.com/firebase/firebase-android-sdk/pull/4104

This requires a compileSdkVersion of 32. Without that the tests fail. Rather than increase compileSdkVersion, which requires our customers to do the same, let's just fix the lint error for now by removing the click handler.