### PR TITLE
Fix links in FeedbackActivity info text

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -310,6 +310,8 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
 
   @Override
   public void startFeedback(int infoTextResourceId) {
+    // TODO(lkellogg): Once we have the real FeedbackActivity view implemented, we should write a
+    // test that checks that <a> tags are preserved
     startFeedback(firebaseApp.getApplicationContext().getText(infoTextResourceId));
   }
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -310,7 +310,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
 
   @Override
   public void startFeedback(int infoTextResourceId) {
-    startFeedback(firebaseApp.getApplicationContext().getString(infoTextResourceId));
+    startFeedback(firebaseApp.getApplicationContext().getText(infoTextResourceId));
   }
 
   @VisibleForTesting


### PR DESCRIPTION
`getText()` preserves styles, unlike `getString()`

After: 
![image](https://user-images.githubusercontent.com/10420620/191807026-fa251b21-f573-4885-a175-e8cd2ba08e14.png)

Before:
![image](https://user-images.githubusercontent.com/10420620/191807335-dfc70cd9-bde7-4979-bdd8-7d5547bd81f3.png)
