### PR TITLE
Upgrade Dackka to 1.0.3

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ProjectUtils.kt
@@ -43,7 +43,7 @@ val Project.javadocConfig: Configuration
 val Project.dackkaConfig: Configuration
     get() =
         configurations.findByName("dackkaArtifacts") ?: configurations.create("dackkaArtifacts") {
-            dependencies.add(this@dackkaConfig.dependencies.create("com.google.devsite:dackka-fat:1.0.1"))
+            dependencies.add(this@dackkaConfig.dependencies.create("com.google.devsite:dackka-fat:1.0.3"))
         }
 
 /**


### PR DESCRIPTION
Per [b/248582256](https://b.corp.google.com/issues/248582256), this PR upgrades Dackka to 1.0.3

For the sake of keeping our dry run up-to-date, and since the Dackka team is constantly fixing bugs- an effort to keep the artifact up-to-date should be made.

Note: I've also added the 1.0.3 artifact to our maven bucket, so the DackkaPlugin can be ran successfully.