### PR TITLE
Fix appcheck-ktx doc generation

### DIFF
--- a/kotlindoc/package-lists/firebase/package-list
+++ b/kotlindoc/package-lists/firebase/package-list
@@ -2,6 +2,7 @@ com.google.firebase
 com.google.firebase.analytics
 com.google.firebase.analytics.ktx
 com.google.firebase.appcheck
+com.google.firebase.appcheck.ktx
 com.google.firebase.appcheck.debug
 com.google.firebase.appcheck.debug.testing
 com.google.firebase.appcheck.playintegrity


### PR DESCRIPTION
In accordance with [b/248593457](https://b.corp.google.com/issues/248593457), this fixes the incorrect output from running Dackka on `appcheck-ktx`. The `package-summary` url was missing the expected `firebase.google.com` prefix for translation. Since the artifact is new, it wasn't included in the previous package list. This PR adds it to the file, and the docs compile as expected.