### PR TITLE
Some fixes to the test app's screenshot detection trigger

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -86,7 +86,7 @@ public class FeedbackActivity extends AppCompatActivity {
       thumbnail =
           ImageUtils.readScaledImage(
               getContentResolver(), screenshotUri, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
-    } catch (IOException e) {
+    } catch (IOException | SecurityException e) {
       LogWrapper.getInstance()
           .e(TAG, "Could not read screenshot image from URI: " + screenshotUri, e);
       return null;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ImageUtils.java
@@ -53,6 +53,8 @@ public class ImageUtils {
    *
    * @return the image, or null if it could not be decoded
    * @throws IllegalArgumentException if target height or width are less than or equal to zero
+   * @throws SecurityException if the app does not have access to the image
+   * @throws IOException if the image can't be read
    */
   @Nullable
   public static Bitmap readScaledImage(


### PR DESCRIPTION
- Catch `SecurityException` for when we don't have access to the screenshot anymore
- Don't crash when trying to read images in the "pending" state
- Prevent us from requesting permissions multiple times in a row