### PR TITLE
Specify unique ref tags in Dackka output

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -92,8 +92,9 @@ tasks above). While we do not currently offer any configuration for the Dackka
 plugin, this could change in the future as needed. Currently, the DackkaPlugin
 provides sensible defaults to output directories, package lists, and so forth.
 
-The DackkaPlugin also provides three extra tasks:
+The DackkaPlugin also provides four extra tasks:
 [cleanDackkaDocumentation][registerCleanDackkaDocumentation],
+[separateJavadocAndKotlinDoc][registerSeparateJavadocAndKotlinDoc]
 [copyJavaDocToCommonDirectory][registerCopyJavaDocToCommonDirectoryTask] and
 [copyKotlinDocToCommonDirectory][registerCopyKotlinDocToCommonDirectoryTask].
 
@@ -101,6 +102,9 @@ _cleanDackkaDocumentation_ is exactly what it sounds like, a task to clean up (d
 the output of Dackka. This is useful when testing Dackka outputs itself- and
 shouldn't be apart of the normal flow. The reasoning is that it would otherwise
 invalidate the gradle cache.
+
+_separateJavadocAndKotlinDoc_ copies the Javadoc and Kotlindoc directories from Dackka into
+their own subdirectories- for easy and consistent differentiation.
 
 _copyJavaDocToCommonDirectory_ copies the JavaDoc variant of the Dackka output for each sdk,
 and pastes it in a common directory under the root project's build directory. This makes it easier

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -298,7 +298,7 @@ abstract class DackkaPlugin : Plugin<Project> {
         val transformJavadoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformJavadoc") {
             dependsOnAndMustRunAfter("separateJavadoc")
 
-            referenceHeadTagsPath.set("google3/third_party/devsite/firebase/en/docs/reference/android")
+            referenceHeadTagsPath.set("en/docs/reference/android")
             dackkaFiles.set(project.childFile(separatedFilesDirectory, "android"))
             outputDirectory.set(project.childFile(targetDirectory, "android"))
         }
@@ -306,7 +306,7 @@ abstract class DackkaPlugin : Plugin<Project> {
         val transformKotlindoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformKotlindoc") {
             dependsOnAndMustRunAfter("separateKotlindoc")
 
-            referenceHeadTagsPath.set("google3/third_party/devsite/firebase/en/docs/reference/kotlin")
+            referenceHeadTagsPath.set("en/docs/reference/kotlin")
             dackkaFiles.set(project.childFile(separatedFilesDirectory, "kotlin"))
             outputDirectory.set(project.childFile(targetDirectory, "kotlin"))
         }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -5,9 +5,11 @@ import com.android.build.gradle.LibraryExtension
 import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 
@@ -119,24 +121,30 @@ abstract class DackkaPlugin : Plugin<Project> {
         registerCleanDackkaDocumentation(project)
         project.afterEvaluate {
             if (shouldWePublish(project)) {
-                val generateDocumentation = registerGenerateDackkaDocumentationTask(project)
-                val dackkaFilesDirectory = generateDocumentation.flatMap { it.outputDirectory }
-                val firesiteTransform = registerFiresiteTransformTask(project, dackkaFilesDirectory)
-                val transformedFilesDirectory = firesiteTransform.flatMap { it.outputDirectory }
-                val copyJavaDocToCommonDirectory = registerCopyJavaDocToCommonDirectoryTask(project, transformedFilesDirectory)
-                val copyKotlinDocToCommonDirectory = registerCopyKotlinDocToCommonDirectoryTask(project, transformedFilesDirectory)
+                val dackkaOutputDirectory = project.provider { fileFromBuildDir("dackkaRawOutput") }
+                val separatedFilesDirectory = project.provider { fileFromBuildDir("dackkaSeparatedFiles") }
+                val transformedDackkaFilesDirectory = project.provider { fileFromBuildDir("dackkaTransformedFiles") }
+
+                val generateDocumentation = registerGenerateDackkaDocumentationTask(project, dackkaOutputDirectory)
+                val separateJavadocAndKotlinDoc = registerSeparateJavadocAndKotlinDoc(project, dackkaOutputDirectory, separatedFilesDirectory)
+                val firesiteTransform = registerFiresiteTransformTask(project, separatedFilesDirectory, transformedDackkaFilesDirectory)
+                val copyJavaDocToCommonDirectory = registerCopyJavaDocToCommonDirectoryTask(project, transformedDackkaFilesDirectory)
+                val copyKotlinDocToCommonDirectory = registerCopyKotlinDocToCommonDirectoryTask(project, transformedDackkaFilesDirectory)
 
                 project.tasks.register("kotlindoc") {
                     group = "documentation"
                     dependsOn(
                         generateDocumentation,
+                        separateJavadocAndKotlinDoc,
                         firesiteTransform,
                         copyJavaDocToCommonDirectory,
                         copyKotlinDocToCommonDirectory
                     )
                 }
             } else {
-                project.tasks.register("kotlindoc")
+                project.tasks.register("kotlindoc") {
+                    group = "documentation"
+                }
             }
         }
     }
@@ -158,7 +166,10 @@ abstract class DackkaPlugin : Plugin<Project> {
     }
 
     // TODO(b/243324828): Refactor when fixed, so we no longer need stubs
-    private fun registerGenerateDackkaDocumentationTask(project: Project): Provider<GenerateDocumentationTask> {
+    private fun registerGenerateDackkaDocumentationTask(
+        project: Project,
+        targetDirectory: Provider<File>
+    ): Provider<GenerateDocumentationTask> {
         val docStubs = project.tasks.register<GenerateStubsTask>("docStubsForDackkaInput")
         val docsTask = project.tasks.register<GenerateDocumentationTask>("generateDackkaDocumentation")
         with(project.extensions.getByType<LibraryExtension>()) {
@@ -193,6 +204,8 @@ abstract class DackkaPlugin : Plugin<Project> {
 
                         kotlinSources.set(sourcesForKotlin)
                         dependencies.set(classpath)
+
+                        outputDirectory.set(targetDirectory)
 
                         applyCommonConfigurations()
                     }
@@ -232,20 +245,72 @@ abstract class DackkaPlugin : Plugin<Project> {
         dependsOnAndMustRunAfter("createFullJarRelease")
 
         val dackkaFile = project.provider { project.dackkaConfig.singleFile }
-        val dackkaOutputDirectory = File(project.buildDir, "dackkaDocumentation")
 
         dackkaJarFile.set(dackkaFile)
-        outputDirectory.set(dackkaOutputDirectory)
         clientName.set(project.firebaseConfigValue { artifactId })
     }
 
-    private fun registerFiresiteTransformTask(project: Project, dackkaFilesDirectory: Provider<File>) =
-        project.tasks.register<FiresiteTransformTask>("firesiteTransform") {
-            mustRunAfter("generateDackkaDocumentation")
+    // TODO(b/248302613): Remove when dackka exposes configuration for this
+    private fun registerSeparateJavadocAndKotlinDoc(
+        project: Project,
+        dackkaOutputDirectory: Provider<File>,
+        outputDirectory: Provider<File>
+    ): TaskProvider<Task> {
+        val outputJavadocFolder = project.childFile(outputDirectory, "android")
+        val outputKotlindocFolder = project.childFile(outputDirectory, "kotlin")
 
-            dackkaFiles.set(dackkaFilesDirectory)
-            outputDirectory.set(project.file("${project.buildDir}/dackkaTransformedFiles"))
+        val separateJavadoc = project.tasks.register<Copy>("separateJavadoc") {
+            dependsOn("generateDackkaDocumentation")
+
+            val javadocClientFolder = project.childFile(dackkaOutputDirectory, "reference/client")
+            val javadocComFolder = project.childFile(dackkaOutputDirectory, "reference/com")
+
+            fromDirectory(javadocClientFolder)
+            fromDirectory(javadocComFolder)
+
+            into(outputJavadocFolder)
         }
+
+        val separateKotlindoc = project.tasks.register<Copy>("separateKotlindoc") {
+            dependsOn("generateDackkaDocumentation")
+
+            val kotlindocFolder = project.childFile(dackkaOutputDirectory, "reference/kotlin")
+
+            from(kotlindocFolder)
+
+            into(outputKotlindocFolder)
+        }
+
+        return project.tasks.register("separateJavadocAndKotlinDoc") {
+            dependsOn(separateJavadoc, separateKotlindoc)
+        }
+    }
+
+    private fun registerFiresiteTransformTask(
+        project: Project,
+        separatedFilesDirectory: Provider<File>,
+        targetDirectory: Provider<File>
+    ): TaskProvider<Task> {
+        val transformJavadoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformJavadoc") {
+            dependsOnAndMustRunAfter("separateJavadoc")
+
+            referenceHeadTagsPath.set("google3/third_party/devsite/firebase/en/docs/reference/android")
+            dackkaFiles.set(project.childFile(separatedFilesDirectory, "android"))
+            outputDirectory.set(project.childFile(targetDirectory, "android"))
+        }
+
+        val transformKotlindoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformKotlindoc") {
+            dependsOnAndMustRunAfter("separateKotlindoc")
+
+            referenceHeadTagsPath.set("google3/third_party/devsite/firebase/en/docs/reference/kotlin")
+            dackkaFiles.set(project.childFile(separatedFilesDirectory, "kotlin"))
+            outputDirectory.set(project.childFile(targetDirectory, "kotlin"))
+        }
+
+        return project.tasks.register("firesiteTransform") {
+            dependsOn(transformJavadoc, transformKotlindoc)
+        }
+    }
 
     // TODO(b/246593212): Migrate doc files to single directory
     private fun registerCopyJavaDocToCommonDirectoryTask(project: Project, outputDirectory: Provider<File>) =
@@ -258,12 +323,10 @@ abstract class DackkaPlugin : Plugin<Project> {
             if (project.rootProject.findProperty("dackkaJavadoc") == "true") {
                 mustRunAfter("firesiteTransform")
 
-                val outputFolder = project.file("${project.rootProject.buildDir}/firebase-kotlindoc/android")
-                val clientFolder = outputDirectory.map { project.file("${it.path}/reference/client") }
-                val comFolder = outputDirectory.map { project.file("${it.path}/reference/com") }
+                val outputFolder = project.rootProject.fileFromBuildDir("firebase-kotlindoc/android")
+                val javaFolder = project.childFile(outputDirectory, "android")
 
-                fromDirectory(clientFolder)
-                fromDirectory(comFolder)
+                fromDirectory(javaFolder)
 
                 into(outputFolder)
             }
@@ -274,8 +337,8 @@ abstract class DackkaPlugin : Plugin<Project> {
         project.tasks.register<Copy>("copyKotlinDocToCommonDirectory") {
             mustRunAfter("firesiteTransform")
 
-            val outputFolder = project.file("${project.rootProject.buildDir}/firebase-kotlindoc")
-            val kotlinFolder = outputDirectory.map { project.file("${it.path}/reference/kotlin") }
+            val outputFolder = project.rootProject.fileFromBuildDir("firebase-kotlindoc")
+            val kotlinFolder = project.childFile(outputDirectory, "kotlin")
 
             fromDirectory(kotlinFolder)
 
@@ -287,8 +350,9 @@ abstract class DackkaPlugin : Plugin<Project> {
         project.tasks.register<Delete>("cleanDackkaDocumentation") {
             group = "cleanup"
 
-            delete("${project.buildDir}/dackkaDocumentation")
-            delete("${project.buildDir}/dackkaTransformedFiles")
-            delete("${project.rootProject.buildDir}/firebase-kotlindoc")
+            val outputDirs = listOf("dackkaRawOutput", "dackkaSeparatedFiles", "dackkaTransformedFiles")
+
+            delete(outputDirs.map { project.fileFromBuildDir(it) })
+            delete(project.rootProject.fileFromBuildDir("firebase-kotlindoc"))
         }
 }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -298,7 +298,7 @@ abstract class DackkaPlugin : Plugin<Project> {
         val transformJavadoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformJavadoc") {
             dependsOnAndMustRunAfter("separateJavadoc")
 
-            referenceHeadTagsPath.set("/android")
+            referenceHeadTagsPath.set("docs/reference/android")
             dackkaFiles.set(project.childFile(separatedFilesDirectory, "android"))
             outputDirectory.set(project.childFile(targetDirectory, "android"))
         }
@@ -306,7 +306,7 @@ abstract class DackkaPlugin : Plugin<Project> {
         val transformKotlindoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformKotlindoc") {
             dependsOnAndMustRunAfter("separateKotlindoc")
 
-            referenceHeadTagsPath.set("/kotlin")
+            referenceHeadTagsPath.set("docs/reference/kotlin")
             dackkaFiles.set(project.childFile(separatedFilesDirectory, "kotlin"))
             outputDirectory.set(project.childFile(targetDirectory, "kotlin"))
         }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -298,7 +298,7 @@ abstract class DackkaPlugin : Plugin<Project> {
         val transformJavadoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformJavadoc") {
             dependsOnAndMustRunAfter("separateJavadoc")
 
-            referenceHeadTagsPath.set("en/docs/reference/android")
+            referenceHeadTagsPath.set("/android")
             dackkaFiles.set(project.childFile(separatedFilesDirectory, "android"))
             outputDirectory.set(project.childFile(targetDirectory, "android"))
         }
@@ -306,7 +306,7 @@ abstract class DackkaPlugin : Plugin<Project> {
         val transformKotlindoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformKotlindoc") {
             dependsOnAndMustRunAfter("separateKotlindoc")
 
-            referenceHeadTagsPath.set("en/docs/reference/kotlin")
+            referenceHeadTagsPath.set("/kotlin")
             dackkaFiles.set(project.childFile(separatedFilesDirectory, "kotlin"))
             outputDirectory.set(project.childFile(targetDirectory, "kotlin"))
         }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -4,6 +4,7 @@ import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
@@ -21,6 +22,7 @@ import org.gradle.api.tasks.TaskAction
  *  - Appends /docs/ to hyperlinks in html files
  *  - Removes the prefix path from book_path
  *  - Removes the firebase prefix from all links
+ *  - Changes the path for _reference-head-tags at the top of html files
  *
  *  **Please note:**
  *  This task is idempotent- meaning it can safely be ran multiple times on the same set of files.
@@ -30,6 +32,9 @@ abstract class FiresiteTransformTask : DefaultTask() {
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val dackkaFiles: Property<File>
+
+    @get:Input
+    abstract val referenceHeadTagsPath: Property<String>
 
     @get:OutputDirectory
     abstract val outputDirectory: Property<File>
@@ -60,7 +65,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
     }
 
     private fun File.fixHTMLFile() {
-        val fixedContent = readText().fixBookPath().fixHyperlinks().removeLeadingFirebaseDomainInLinks()
+        val fixedContent = readText().fixBookPath().fixHyperlinks().removeLeadingFirebaseDomainInLinks().fixReferenceHeadTagsPath()
         writeText(fixedContent)
     }
 
@@ -69,28 +74,33 @@ abstract class FiresiteTransformTask : DefaultTask() {
         writeText(fixedContent)
     }
 
+    // We utilize difference reference head tags between Kotlin and Java docs
+    // TODO(b/248316730): Remove when dackka exposes configuration for this
+    private fun String.fixReferenceHeadTagsPath() =
+        replace(Regex("(?<=include \").*(?=/_reference-head-tags.html\" %})"), referenceHeadTagsPath.get())
+
     // We don't actually upload class or index files,
     // so these headers will throw not found errors if not removed.
-    // TODO(b/243674302): Remove when dackka supports this behavior
+    // TODO(b/243674302): Remove when dackka exposes configuration for this
     private fun String.removeClassHeader() =
         remove(Regex("- title: \"Class Index\"\n {2}path: \".+\"\n\n"))
     private fun String.removeIndexHeader() =
         remove(Regex("- title: \"Package Index\"\n {2}path: \".+\"\n\n"))
 
     // We use a common book for all sdks, wheres dackka expects each sdk to have its own book.
-    // TODO(b/243674303): Remove when dackka supports this behavior
+    // TODO(b/243674303): Remove when dackka exposes configuration for this
     private fun String.fixBookPath() =
         remove(Regex("(?<=setvar book_path ?%})(.+)(?=/_book.yaml\\{% ?endsetvar)"))
 
     // Our documentation lives under /docs/reference/ versus the expected /reference/
-    // TODO(b/243674305): Remove when dackka supports this behavior
+    // TODO(b/243674305): Remove when dackka exposes configuration for this
     private fun String.fixHyperlinks() =
         replace(Regex("(?<=href=\")(/)(?=reference/.*\\.html)"), "/docs/")
 
     // The documentation will work fine without this. This is primarily to make sure that links
     // resolve to their local counter part. Meaning when the docs are staged, they will resolve to
     // staged docs instead of prod docs- and vise versa.
-    // TODO(b/243673063): Remove when dackka supports this behavior
+    // TODO(b/243673063): Remove when dackka exposes configuration for this
     private fun String.removeLeadingFirebaseDomainInLinks() =
         remove(Regex("(?<=\")(https://firebase\\.google\\.com)(?=/docs/reference)"))
 }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
@@ -1,6 +1,7 @@
 package com.google.firebase.gradle.plugins
 
 import java.io.File
+import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 
@@ -8,3 +9,9 @@ fun Copy.fromDirectory(directory: Provider<File>) =
     from(directory) {
         into(directory.map { it.name })
     }
+
+fun Project.fileFromBuildDir(path: String) = file("$buildDir/$path")
+
+fun Project.childFile(provider: Provider<File>, childPath: String) = provider.map {
+    file("${it.path}/$childPath")
+}

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
@@ -10,8 +10,26 @@ fun Copy.fromDirectory(directory: Provider<File>) =
         into(directory.map { it.name })
     }
 
+/**
+ * Creates a file at the buildDir for the given [Project].
+ *
+ * Syntax sugar for:
+ *
+ * ```
+ * project.file("${project.buildDir}/$path)
+ * ```
+ */
 fun Project.fileFromBuildDir(path: String) = file("$buildDir/$path")
 
+/**
+ * Maps a file provider to another file provider as a sub directory.
+ *
+ * Syntax sugar for:
+ *
+ * ```
+ * fileProvider.map { project.file("${it.path}/$path") }
+ * ```
+ */
 fun Project.childFile(provider: Provider<File>, childPath: String) = provider.map {
     file("${it.path}/$childPath")
 }

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/publishing.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/publishing.kt
@@ -29,6 +29,7 @@ data class Project(
     val externalDependencies: Set<Artifact> = setOf(),
     val releaseWith: Project? = null,
     val customizePom: String? = null,
+    val publishJavadoc: Boolean = false,
     val libraryType: LibraryType = LibraryType.ANDROID
 ) {
     fun generateBuildFile(): String {
@@ -42,6 +43,7 @@ data class Project(
             firebaseLibrary {
                 ${if (releaseWith != null) "releaseWith project(':${releaseWith.name}')" else ""}
                 ${if (customizePom != null) "customizePom {$customizePom}" else ""}
+                ${"publishJavadoc = $publishJavadoc"}
             }
             ${if (libraryType == LibraryType.ANDROID) "android.compileSdkVersion = 26" else ""}
 

--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -19,6 +19,7 @@ plugins {
 firebaseLibrary {
     testLab.enabled = false
     publishSources = true
+    publishJavadoc = false
 }
 
 android {

--- a/firebase-components/firebase-components.gradle
+++ b/firebase-components/firebase-components.gradle
@@ -18,6 +18,7 @@ plugins {
 
 firebaseLibrary {
     publishSources = true
+    publishJavadoc = false
 }
 
 android {

--- a/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle
+++ b/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle
@@ -21,6 +21,7 @@ group = 'com.google.firebase'
 firebaseLibrary {
     testLab.enabled = false
     publishSources = true
+    publishJavadoc = false
 }
 
 android {

--- a/firebase-database-collection/firebase-database-collection.gradle
+++ b/firebase-database-collection/firebase-database-collection.gradle
@@ -18,6 +18,7 @@ plugins {
 
 firebaseLibrary {
     publishSources = true
+    publishJavadoc = false
 }
 
 android {


### PR DESCRIPTION
In accordance with [b/247570655](https://b.corp.google.com/issues/247570655), this PR extends `FiresiteTransform` to offer configuration for the generated `_reference-head-tags.html` at the top of html files.

We would like to offer a unique ref html file for each set of docs (Java & Kotlin), for SEO purposes etc.,

To accomplish this, without drastically changing the behavior of `FiresiteTransform` - we now expose a task to separate the Java and Kotlin generated sets before transformation- and then combine them after the fact. This required a bit of overhead to accomplish, but will pay off in the long run whenever we decide to combine the output directory of Java and Kotlin generated sets.

To keep things as idiomatic as possible, I started defining the desired output directories at the root of `kotlindoc`'s configuration, and offer them as inputs to the relevant tasks.

There was also a lot of repeat in the creation of sub directories and files- which I split off into extension methods;

`project.fileFromBuildDir()` -> creates a `File` at the project's builddir

`project.childFile()` -> maps a file provider to another file provider as a sub directory

Furthermore, I found some artifacts that don't actually generate any documentation (everything is either `@hidden` or private), and marked them as such as to avoid needing an empty dir check on `DackkaPlugin` tasks- as that could mask potential edge cases that we'd otherwise like to pay attention to.