### PR TITLE
Add menu to test app for selecting feedback trigger

### DIFF
--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/AppDistroTestApplication.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/AppDistroTestApplication.kt
@@ -5,6 +5,8 @@ import android.app.Application
 class AppDistroTestApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        ShakeForFeedback.enable(this)
+
+        // Default feedback triggers can also be initialized here
+//        ShakeForFeedback.enable(this)
     }
 }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -17,8 +17,6 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
-import androidx.core.content.ContentProviderCompat.requireContext
-import androidx.core.widget.addTextChangedListener
 import androidx.core.widget.doOnTextChanged
 import com.google.android.gms.tasks.Task
 import com.google.android.material.textfield.TextInputLayout
@@ -84,19 +82,19 @@ class MainActivity : AppCompatActivity() {
 
         // Set up feedback trigger menu
         feedbackTriggerMenu = findViewById(R.id.feedbackTriggerMenu)
-        val items = listOf(TRIGGER_NONE, TRIGGER_SHAKE)
+        val items = listOf(FeedbackTrigger.NONE.label, FeedbackTrigger.SHAKE.label)
         val adapter = ArrayAdapter(this, R.layout.list_item, items)
         val autoCompleteTextView = feedbackTriggerMenu.editText!! as AutoCompleteTextView
         autoCompleteTextView.setAdapter(adapter)
-        autoCompleteTextView.setText(TRIGGER_NONE, false)
+        autoCompleteTextView.setText(FeedbackTrigger.NONE.label, false)
         autoCompleteTextView.doOnTextChanged { text, start, before, count ->
             // TODO: support enabling/disabling other triggers
             when(text.toString()) {
-                TRIGGER_NONE -> {
+                FeedbackTrigger.NONE.label -> {
                     Log.i(TAG, "Disabling shake")
                     ShakeForFeedback.disable(application)
                 }
-                TRIGGER_SHAKE -> {
+                FeedbackTrigger.SHAKE.label -> {
                     Log.i(TAG, "Enabling shake")
                     ShakeForFeedback.enable(application, this)
                 }
@@ -310,9 +308,12 @@ class MainActivity : AppCompatActivity() {
 
     companion object {
         const val TAG = "MainActivity"
-        const val TRIGGER_NONE = "None"
-        const val TRIGGER_SHAKE = "Shake the device"
-        const val TRIGGER_SCREENSHOT = "Take a screenshot"
-        const val TRIGGER_NOTIFICATION = "Click the notification"
+
+        enum class FeedbackTrigger(val label: String) {
+            NONE("None"),
+            SHAKE("Shake the device"),
+            SCREENSHOT("Take a screenshot"),
+            NOTIFICATION("Click the notification")
+        }
     }
 }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -7,12 +7,21 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
+import androidx.core.content.ContentProviderCompat.requireContext
+import androidx.core.widget.addTextChangedListener
+import androidx.core.widget.doOnTextChanged
 import com.google.android.gms.tasks.Task
+import com.google.android.material.textfield.TextInputLayout
 import com.google.firebase.appdistribution.AppDistributionRelease
 import com.google.firebase.appdistribution.UpdateProgress
 import com.google.firebase.appdistribution.ktx.appDistribution
@@ -36,11 +45,11 @@ class MainActivity : AppCompatActivity() {
     lateinit var signOutButtonBackground: AppCompatButton
     lateinit var checkForUpdateButtonBackground: AppCompatButton
     lateinit var updateAppButtonBackground: AppCompatButton
-    lateinit var feedbackButton: AppCompatButton
-    lateinit var progressPercentage: TextView
+    lateinit var secondActivityButton: AppCompatButton
     lateinit var signInStatus: TextView
     lateinit var progressPercent: TextView
     lateinit var progressBar: ProgressBar
+    lateinit var feedbackTriggerMenu: TextInputLayout
 
     private lateinit var screenshotTriggerThread: HandlerThread
     private lateinit var screenshotTrigger: ScreenshotDetectionFeedbackTrigger
@@ -48,22 +57,21 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        signInButton = findViewById<AppCompatButton>(R.id.sign_in_button)
-        signOutButton = findViewById<AppCompatButton>(R.id.sign_out)
-        checkForUpdateButton = findViewById<AppCompatButton>(R.id.check_for_update)
-        updateAppButton = findViewById<AppCompatButton>(R.id.update_app)
-        updateIfNewReleaseAvailableButton = findViewById<AppCompatButton>(R.id.basic_config)
+        signInButton = findViewById(R.id.sign_in_button)
+        signOutButton = findViewById(R.id.sign_out)
+        checkForUpdateButton = findViewById(R.id.check_for_update)
+        updateAppButton = findViewById(R.id.update_app)
+        updateIfNewReleaseAvailableButton = findViewById(R.id.basic_config)
         updateIfNewReleaseAvailableButtonBackground =
-            findViewById<AppCompatButton>(R.id.basic_config2)
-        signInButtonBackground = findViewById<AppCompatButton>(R.id.sign_in_button2)
-        signOutButtonBackground = findViewById<AppCompatButton>(R.id.sign_out2)
-        checkForUpdateButtonBackground = findViewById<AppCompatButton>(R.id.check_for_update2)
-        updateAppButtonBackground = findViewById<AppCompatButton>(R.id.update_app2)
-        feedbackButton = findViewById<AppCompatButton>(R.id.feedbackButton)
-        progressPercentage = findViewById<TextView>(R.id.progress_percentage)
-        signInStatus = findViewById<TextView>(R.id.sign_in_status)
-        progressPercent = findViewById<TextView>(R.id.progress_percentage)
-        progressBar = findViewById<ProgressBar>(R.id.progress_bar)
+            findViewById(R.id.basic_config2)
+        signInButtonBackground = findViewById(R.id.sign_in_button2)
+        signOutButtonBackground = findViewById(R.id.sign_out2)
+        checkForUpdateButtonBackground = findViewById(R.id.check_for_update2)
+        updateAppButtonBackground = findViewById(R.id.update_app2)
+        secondActivityButton = findViewById(R.id.secondActivityButton)
+        progressPercent = findViewById(R.id.progress_percentage)
+        signInStatus = findViewById(R.id.sign_in_status)
+        progressBar = findViewById(R.id.progress_bar)
 
         screenshotTriggerThread = HandlerThread("AppDistroFeedbackTrigger")
         screenshotTriggerThread.start()
@@ -73,6 +81,43 @@ class MainActivity : AppCompatActivity() {
                 R.string.terms_and_conditions,
                 Handler(screenshotTriggerThread.looper)
             )
+
+        // Set up feedback trigger menu
+        feedbackTriggerMenu = findViewById(R.id.feedbackTriggerMenu)
+        val items = listOf(TRIGGER_NONE, TRIGGER_SHAKE)
+        val adapter = ArrayAdapter(this, R.layout.list_item, items)
+        val autoCompleteTextView = feedbackTriggerMenu.editText!! as AutoCompleteTextView
+        autoCompleteTextView.setAdapter(adapter)
+        autoCompleteTextView.setText(TRIGGER_NONE, false)
+        autoCompleteTextView.doOnTextChanged { text, start, before, count ->
+            // TODO: support enabling/disabling other triggers
+            when(text.toString()) {
+                TRIGGER_NONE -> {
+                    Log.i(TAG, "Disabling shake")
+                    ShakeForFeedback.disable(application)
+                }
+                TRIGGER_SHAKE -> {
+                    Log.i(TAG, "Enabling shake")
+                    ShakeForFeedback.enable(application, this)
+                }
+            }
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        val inflater: MenuInflater = menuInflater
+        inflater.inflate(R.menu.action_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.startFeedbackMenuItem -> {
+                Firebase.appDistribution.startFeedback(R.string.terms_and_conditions)
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     override fun onDestroy() {
@@ -195,23 +240,21 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        feedbackButton.setOnClickListener {
-            firebaseAppDistribution.startFeedback(R.string.terms_and_conditions)
-        }
+        secondActivityButton.setOnClickListener { startSecondActivity() }
     }
 
-    fun startSecondActivity() {
+    private fun startSecondActivity() {
         val intent = Intent(this, SecondActivity::class.java)
         startActivity(intent)
     }
 
-    fun setProgressBar() {
+    private fun setProgressBar() {
         progressBar.visibility = View.VISIBLE
         progressPercent.visibility = View.VISIBLE
         progressBar.isIndeterminate = false
     }
 
-    fun failureListener(exception: Exception) {
+    private fun failureListener(exception: Exception) {
         val ex = exception as com.google.firebase.appdistribution.FirebaseAppDistributionException
         Log.d("FirebaseAppDistribution", "MAINACTIVITY:ERROR ERROR. CODE: " + exception.errorCode)
         AlertDialog.Builder(this)
@@ -221,7 +264,7 @@ class MainActivity : AppCompatActivity() {
             .show()
     }
 
-    fun progressListener(updateProgress: UpdateProgress) {
+    private fun progressListener(updateProgress: UpdateProgress) {
         val percentage =
             ((updateProgress.apkBytesDownloaded * 100) / updateProgress.apkFileTotalBytes).toInt()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -236,7 +279,7 @@ class MainActivity : AppCompatActivity() {
         release: AppDistributionRelease? = null
     ) {
         progressBar.visibility = View.GONE
-        progressPercentage.visibility = View.GONE
+        progressPercent.visibility = View.GONE
         if (isUpdateAvailable) {
             signInStatus.text =
                 "Release available - ${release?.displayVersion} (${release?.versionCode})"
@@ -263,5 +306,13 @@ class MainActivity : AppCompatActivity() {
         updateAppButtonBackground.visibility = if (isSignedIn) View.VISIBLE else View.GONE
         updateAppButton.visibility = View.GONE
         updateAppButtonBackground.visibility = View.GONE
+    }
+
+    companion object {
+        const val TAG = "MainActivity"
+        const val TRIGGER_NONE = "None"
+        const val TRIGGER_SHAKE = "Shake the device"
+        const val TRIGGER_SCREENSHOT = "Take a screenshot"
+        const val TRIGGER_NOTIFICATION = "Click the notification"
     }
 }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/SecondActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/SecondActivity.kt
@@ -2,8 +2,13 @@ package com.googletest.firebase.appdistribution.testapp
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
+import com.google.firebase.appdistribution.ktx.appDistribution
+import com.google.firebase.ktx.Firebase
 
 class SecondActivity : AppCompatActivity() {
 
@@ -17,6 +22,22 @@ class SecondActivity : AppCompatActivity() {
         val mainActivityButton = findViewById<AppCompatButton>(R.id.main_activity_button)
         mainActivityButton.setOnClickListener {
             startMainActivity()
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        val inflater: MenuInflater = menuInflater
+        inflater.inflate(R.menu.action_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.startFeedbackMenuItem -> {
+                Firebase.appDistribution.startFeedback(R.string.terms_and_conditions)
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
         }
     }
 

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ShakeForFeedback.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ShakeForFeedback.kt
@@ -9,9 +9,46 @@ import com.google.firebase.appdistribution.ktx.appDistribution
 import com.google.firebase.ktx.Firebase
 import com.squareup.seismic.ShakeDetector
 
-class ShakeForFeedback private constructor() : ShakeDetector.Listener,
-    Application.ActivityLifecycleCallbacks {
+object ShakeForFeedback : ShakeDetector.Listener, Application.ActivityLifecycleCallbacks {
+    const val TAG: String = "ShakeForFeedback"
+
     private val shakeDetector = ShakeDetector(this)
+    private var isEnabled = false
+
+    fun enable(application: Application) = enable(application, null)
+
+    fun enable(application: Application, currentActivity: Activity?) {
+        synchronized(this) {
+            if (!isEnabled) {
+                application.registerActivityLifecycleCallbacks(this)
+                Log.i(TAG, "Shake detector registered")
+                if (currentActivity != null) {
+                    listenForShakes(currentActivity)
+                }
+                isEnabled = true
+            }
+        }
+    }
+
+    fun disable(application: Application) {
+        synchronized(this) {
+            if (isEnabled) {
+                stopListeningForShakes()
+                application.unregisterActivityLifecycleCallbacks(this)
+                Log.i(TAG, "Shake detector unregistered")
+                isEnabled = false
+            }
+        }
+    }
+
+    private fun listenForShakes(activity: Activity) {
+        val sensorManager = activity.getSystemService(Activity.SENSOR_SERVICE) as SensorManager
+        shakeDetector.start(sensorManager, SensorManager.SENSOR_DELAY_NORMAL)
+    }
+
+    private fun stopListeningForShakes() {
+        shakeDetector.stop()
+    }
 
     override fun hearShake() {
         Log.i(TAG, "Shake detected")
@@ -20,13 +57,12 @@ class ShakeForFeedback private constructor() : ShakeDetector.Listener,
 
     override fun onActivityResumed(activity: Activity) {
         Log.i(TAG, "Shake detection started")
-        val sensorManager = activity.getSystemService(Activity.SENSOR_SERVICE) as SensorManager
-        shakeDetector.start(sensorManager, SensorManager.SENSOR_DELAY_NORMAL)
+        listenForShakes(activity)
     }
 
     override fun onActivityPaused(activity: Activity) {
         Log.i(TAG, "Shake detection stopped")
-        shakeDetector.stop()
+        stopListeningForShakes()
     }
 
     // Other lifecycle methods
@@ -35,13 +71,4 @@ class ShakeForFeedback private constructor() : ShakeDetector.Listener,
     override fun onActivityStopped(activity: Activity) {}
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
     override fun onActivityDestroyed(activity: Activity) {}
-
-    companion object {
-        const val TAG: String = "ShakeForFeedback"
-
-        fun enable(application: Application) {
-            application.registerActivityLifecycleCallbacks(ShakeForFeedback())
-            Log.i(TAG, "Shake detector registered")
-        }
-    }
 }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ShakeForFeedback.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ShakeForFeedback.kt
@@ -15,9 +15,7 @@ object ShakeForFeedback : ShakeDetector.Listener, Application.ActivityLifecycleC
     private val shakeDetector = ShakeDetector(this)
     private var isEnabled = false
 
-    fun enable(application: Application) = enable(application, null)
-
-    fun enable(application: Application, currentActivity: Activity?) {
+    fun enable(application: Application, currentActivity: Activity? = null) {
         synchronized(this) {
             if (!isEnabled) {
                 application.registerActivityLifecycleCallbacks(this)

--- a/firebase-appdistribution/test-app/src/main/res/layout/activity_main.xml
+++ b/firebase-appdistribution/test-app/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
         android:id="@+id/sign_out2"
         android:layout_width="156dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="24dp"
         android:background="@color/purple_500"
         android:text="Sign Out Background"
         android:textColor="@color/white"
@@ -23,7 +23,7 @@
         android:id="@+id/update_app2"
         android:layout_width="128dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="24dp"
         android:layout_marginEnd="24dp"
         android:background="@color/purple_500"
         android:text="Update App Background"
@@ -37,7 +37,7 @@
         android:id="@+id/check_for_update2"
         android:layout_width="156dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
+        android:layout_marginTop="24dp"
         android:background="@color/purple_500"
         android:text="Check For Update Background"
         android:textColor="@color/white"
@@ -49,7 +49,7 @@
         android:id="@+id/basic_config2"
         android:layout_width="128dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
+        android:layout_marginTop="24dp"
         android:background="@color/purple_500"
         android:text="Basic Config Background"
         android:textColor="@color/white"
@@ -61,7 +61,7 @@
         android:id="@+id/basic_config"
         android:layout_width="128dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
+        android:layout_marginTop="24dp"
         android:background="@color/purple_500"
         android:text="Basic Config"
         android:textColor="@color/white"
@@ -93,7 +93,7 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.14" />
+        app:layout_constraintVertical_bias="0.10" />
 
     <TextView
         android:id="@+id/sign_in_status"
@@ -124,7 +124,7 @@
         android:id="@+id/check_for_update"
         android:layout_width="156dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
+        android:layout_marginTop="24dp"
         android:background="@color/purple_500"
         android:text="Check For Update"
         android:textColor="@color/white"
@@ -136,7 +136,7 @@
         android:id="@+id/update_app"
         android:layout_width="128dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="24dp"
         android:background="@color/purple_500"
         android:text="Update App"
         android:textColor="@color/white"
@@ -152,7 +152,7 @@
         app:layout_constraintTop_toBottomOf="@id/update_app"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        android:layout_marginTop="40dp"
+        android:layout_marginTop="24dp"
         />
 
     <TextView
@@ -171,7 +171,7 @@
         android:id="@+id/sign_out"
         android:layout_width="156dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="24dp"
         android:background="@color/purple_500"
         android:text="Sign Out"
         android:textColor="@color/white"
@@ -179,14 +179,33 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/progress_percentage" />
-    <Button
-        android:id="@+id/feedbackButton"
-        android:layout_width="wrap_content"
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/secondActivityButton"
+        android:layout_width="156dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:text="Send feedback"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="24dp"
+        android:background="@color/purple_500"
+        android:text="Start new activity"
+        android:textColor="@color/white"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/sign_out" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/sign_out2" />
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/feedbackTriggerMenu"
+        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.ExposedDropdownMenu"
+        android:layout_width="match_parent"
+        android:layout_marginTop="24dp"
+        android:layout_marginHorizontal="60dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/feedbackTriggerMenuLabel"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/secondActivityButton">
+        <AutoCompleteTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="none"
+        />
+    </com.google.android.material.textfield.TextInputLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/firebase-appdistribution/test-app/src/main/res/layout/list_item.xml
+++ b/firebase-appdistribution/test-app/src/main/res/layout/list_item.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp"
+    android:ellipsize="end"
+    android:maxLines="1"
+    android:textAppearance="?attr/textAppearanceSubtitle1"
+    />

--- a/firebase-appdistribution/test-app/src/main/res/menu/action_menu.xml
+++ b/firebase-appdistribution/test-app/src/main/res/menu/action_menu.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/startFeedbackMenuItem"
+        android:title="@string/startFeedbackLabel"/>
+</menu>

--- a/firebase-appdistribution/test-app/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/test-app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="app_name">App Distro Sample</string>
     <string name="terms_and_conditions"><b>Before giving feedback</b> you might want to check out the <a href="http://google.com">Terms and Conditions</a></string>
+    <string name="feedbackTriggerMenuLabel">Choose a feedback trigger</string>
+    <string name="startFeedbackLabel">Start feedback</string>
 </resources>


### PR DESCRIPTION
Also:
- Move the regular feedback button trigger to an action bar menu
- Clean up some of the UX code (removing unnecessary type params, making padding uniform)
- Turn ShakeForFeedback from a singleton class into an object