### PR TITLE
Hook screenshot trigger to test app menu

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -332,10 +332,10 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
             taskExecutor,
             e -> {
               LogWrapper.getInstance().w("Failed to take screenshot for feedback", e);
-              startFeedback(infoText, null);
+              doStartFeedback(infoText, null);
             })
         .addOnSuccessListener(
-            taskExecutor, screenshotUri -> startFeedback(infoText, screenshotUri));
+            taskExecutor, screenshotUri -> doStartFeedback(infoText, screenshotUri));
   }
 
   @Override
@@ -345,6 +345,15 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
 
   @Override
   public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {
+    if (!feedbackInProgress.compareAndSet(/* expect= */ false, /* update= */ true)) {
+      LogWrapper.getInstance()
+          .i("Ignoring startFeedback() call because feedback is already in progress");
+      return;
+    }
+    doStartFeedback(infoText, screenshotUri);
+  }
+
+  private void doStartFeedback(CharSequence infoText, @Nullable Uri screenshotUri) {
     testerSignInManager
         .signInTester()
         .addOnFailureListener(

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -668,11 +669,42 @@ public class FirebaseAppDistributionServiceImplTest {
   }
 
   @Test
-  public void startFeedback_calledMultipleTimes_onlyStartsOnce() throws InterruptedException {
+  public void startFeedback_withoutUri_onlyStartsOnce() throws InterruptedException {
     when(mockReleaseIdentifier.identifyRelease()).thenReturn(Tasks.forResult("release-name"));
 
     firebaseAppDistribution.startFeedback("Some terms and conditions");
     firebaseAppDistribution.startFeedback("Some other terms and conditions");
+    TestUtils.awaitAsyncOperations(taskExecutor);
+
+    verify(activity, times(1)).startActivity(any());
+  }
+
+  @Test
+  public void startFeedback_withUri_doesNotTakeScreenshot() throws InterruptedException {
+    when(mockReleaseIdentifier.identifyRelease()).thenReturn(Tasks.forResult("release-name"));
+    Uri providedUri = Uri.parse("file:/provided/uri");
+    firebaseAppDistribution.startFeedback("Some terms and conditions", providedUri);
+    TestUtils.awaitAsyncOperations(taskExecutor);
+
+    verifyNoInteractions(mockScreenshotTaker);
+    verify(mockTesterSignInManager).signInTester();
+    Intent expectedIntent = new Intent(activity, FeedbackActivity.class);
+    Intent actualIntent = shadowOf(RuntimeEnvironment.getApplication()).getNextStartedActivity();
+    assertEquals(expectedIntent.getComponent(), actualIntent.getComponent());
+    assertThat(actualIntent.getStringExtra(RELEASE_NAME_EXTRA_KEY)).isEqualTo("release-name");
+    assertThat(actualIntent.getStringExtra(SCREENSHOT_URI_EXTRA_KEY))
+        .isEqualTo(providedUri.toString());
+    assertThat(actualIntent.getStringExtra(INFO_TEXT_EXTRA_KEY))
+        .isEqualTo("Some terms and conditions");
+    assertThat(firebaseAppDistribution.isFeedbackInProgress()).isTrue();
+  }
+
+  @Test
+  public void startFeedback_withUri_onlyStartsOnce() throws InterruptedException {
+    when(mockReleaseIdentifier.identifyRelease()).thenReturn(Tasks.forResult("release-name"));
+
+    firebaseAppDistribution.startFeedback("Some terms and conditions", TEST_SCREENSHOT_URI);
+    firebaseAppDistribution.startFeedback("Some other terms and conditions", TEST_SCREENSHOT_URI);
     TestUtils.awaitAsyncOperations(taskExecutor);
 
     verify(activity, times(1)).startActivity(any());

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/AppDistroTestApplication.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/AppDistroTestApplication.kt
@@ -6,7 +6,11 @@ class AppDistroTestApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        // Default feedback triggers can also be initialized here
+        // Perform any required trigger initialization here
+        ScreenshotDetectionFeedbackTrigger.initialize(this, R.string.terms_and_conditions);
+
+        // Default feedback triggers can optionally be enabled application-wide here
 //        ShakeForFeedback.enable(this)
+//        ScreenshotDetectionFeedbackTrigger.enable()
     }
 }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -4,8 +4,6 @@ import android.app.AlertDialog
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.HandlerThread
 import android.util.Log
 import android.view.Menu
 import android.view.MenuInflater
@@ -49,9 +47,6 @@ class MainActivity : AppCompatActivity() {
     lateinit var progressBar: ProgressBar
     lateinit var feedbackTriggerMenu: TextInputLayout
 
-    private lateinit var screenshotTriggerThread: HandlerThread
-    private lateinit var screenshotTrigger: ScreenshotDetectionFeedbackTrigger
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -71,18 +66,13 @@ class MainActivity : AppCompatActivity() {
         signInStatus = findViewById(R.id.sign_in_status)
         progressBar = findViewById(R.id.progress_bar)
 
-        screenshotTriggerThread = HandlerThread("AppDistroFeedbackTrigger")
-        screenshotTriggerThread.start()
-        screenshotTrigger =
-            ScreenshotDetectionFeedbackTrigger(
-                this,
-                R.string.terms_and_conditions,
-                Handler(screenshotTriggerThread.looper)
-            )
-
         // Set up feedback trigger menu
         feedbackTriggerMenu = findViewById(R.id.feedbackTriggerMenu)
-        val items = listOf(FeedbackTrigger.NONE.label, FeedbackTrigger.SHAKE.label)
+        val items = listOf(
+            FeedbackTrigger.NONE.label,
+            FeedbackTrigger.SHAKE.label,
+            FeedbackTrigger.SCREENSHOT.label
+        )
         val adapter = ArrayAdapter(this, R.layout.list_item, items)
         val autoCompleteTextView = feedbackTriggerMenu.editText!! as AutoCompleteTextView
         autoCompleteTextView.setAdapter(adapter)
@@ -91,15 +81,26 @@ class MainActivity : AppCompatActivity() {
             // TODO: support enabling/disabling other triggers
             when(text.toString()) {
                 FeedbackTrigger.NONE.label -> {
-                    Log.i(TAG, "Disabling shake")
-                    ShakeForFeedback.disable(application)
+                    disableAllFeedbackTriggers()
                 }
                 FeedbackTrigger.SHAKE.label -> {
-                    Log.i(TAG, "Enabling shake")
+                    disableAllFeedbackTriggers()
+                    Log.i(TAG, "Enabling shake for feedback trigger")
                     ShakeForFeedback.enable(application, this)
+                }
+                FeedbackTrigger.SCREENSHOT.label -> {
+                    disableAllFeedbackTriggers()
+                    Log.i(TAG, "Enabling screenshot detection trigger")
+                    ScreenshotDetectionFeedbackTrigger.enable()
                 }
             }
         }
+    }
+
+    private fun disableAllFeedbackTriggers() {
+        Log.i(TAG, "Disabling all feedback triggers")
+        ShakeForFeedback.disable(application)
+        ScreenshotDetectionFeedbackTrigger.disable()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -118,19 +119,8 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        screenshotTriggerThread.quitSafely()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        screenshotTrigger.unRegisterScreenshotObserver()
-    }
-
     override fun onResume() {
         super.onResume()
-        screenshotTrigger.registerScreenshotObserver()
 
         findViewById<TextView>(R.id.app_name).text =
             "Sample App v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ScreenshotDetectionFeedbackTrigger.java
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ScreenshotDetectionFeedbackTrigger.java
@@ -18,26 +18,32 @@ import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
 import static android.Manifest.permission.READ_MEDIA_IMAGES;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
+import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.Application;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images.Media;
 import android.util.Log;
+import androidx.activity.result.ActivityResultCaller;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.appcompat.app.AppCompatActivity;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import com.google.firebase.appdistribution.FirebaseAppDistribution;
 import java.util.HashSet;
 import java.util.Set;
 
-class ScreenshotDetectionFeedbackTrigger extends ContentObserver {
+class ScreenshotDetectionFeedbackTrigger extends ContentObserver
+    implements Application.ActivityLifecycleCallbacks {
   private static final String TAG = "ScreenshotDetectionFeedbackTrigger";
-
   private static final String PERMISSION_TO_REQUEST =
       Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
           ? READ_MEDIA_IMAGES
@@ -47,66 +53,90 @@ class ScreenshotDetectionFeedbackTrigger extends ContentObserver {
       SHOULD_CHECK_IF_PENDING
           ? new String[] {MediaStore.Images.Media.DATA, MediaStore.MediaColumns.IS_PENDING}
           : new String[] {MediaStore.Images.Media.DATA};
-  private final Set<Uri> seenImages = new HashSet<>();
 
-  private final AppCompatActivity activity;
+  private final Set<Uri> seenImages = new HashSet<>();
   private final int infoTextResourceId;
 
-  private final ActivityResultLauncher<String> requestPermissionLauncher;
-
+  private ActivityResultLauncher<String> requestPermissionLauncher;
+  private Activity currentActivity;
   private Uri currentUri;
-
+  private boolean isEnabled = false;
   private boolean hasRequestedPermission = false;
 
+  private static ScreenshotDetectionFeedbackTrigger instance;
+
   /**
-   * Creates a FeedbackTriggers instance for an activity.
+   * Initialize the screenshot detection trigger for this application.
    *
-   * <p>This must be called during activity initialization.
+   * <p>This should be called during {@link Application#onCreate()}. {@link #enable()} should then
+   * be called when you want to actually start detecting screenshots.
    *
-   * @param activity The host activity
-   * @param handler The handler to run {@link #onChange} on, or null if none.
+   * @param application the {@link Application} object
+   * @param infoTextResourceId resource ID of info text to show to testers before giving feedback
    */
-  public ScreenshotDetectionFeedbackTrigger(
-      AppCompatActivity activity, int infoTextResourceId, Handler handler) {
+  public static void initialize(Application application, int infoTextResourceId) {
+    if (instance == null) {
+      HandlerThread handlerThread = new HandlerThread("AppDistroFeedbackTrigger");
+      handlerThread.start();
+      instance =
+          new ScreenshotDetectionFeedbackTrigger(
+              application, infoTextResourceId, new Handler(handlerThread.getLooper()));
+    }
+  }
+
+  /**
+   * Start listening for screenshots, and start feedback when a new screenshot is detected.
+   *
+   * @throws IllegalStateException if {@link #initialize} has not been called yet
+   */
+  public static void enable() {
+    if (instance == null) {
+      throw new IllegalStateException(
+          "You must call initialize() in your Application.onCreate() before enabling screenshot detection");
+    }
+    if (!instance.isEnabled) {
+      instance.isEnabled = true;
+      instance.listenForScreenshots();
+    }
+  }
+
+  /**
+   * Stop listening for screenshots.
+   *
+   * @throws IllegalStateException if {@link #initialize} has not been called yet
+   */
+  public static void disable() {
+    if (instance == null) {
+      throw new IllegalStateException(
+          "You must call initialize() in your Application.onCreate() before enabling screenshot detection");
+    }
+    if (instance.isEnabled) {
+      instance.isEnabled = false;
+      instance.stopListeningForScreenshots();
+    }
+  }
+
+  private ScreenshotDetectionFeedbackTrigger(
+      Application application, int infoTextResourceId, Handler handler) {
     super(handler);
-    this.activity = activity;
     this.infoTextResourceId = infoTextResourceId;
-
-    // Register the permissions launcher
-    requestPermissionLauncher =
-        activity.registerForActivityResult(
-            new ActivityResultContracts.RequestPermission(),
-            isGranted -> {
-              if (isGranted) {
-                maybeStartFeedbackForScreenshot(currentUri);
-              } else {
-                Log.i(TAG, "Permission not granted");
-                // TODO: Ideally we would show a message indicating the impact of not enabling the
-                // permission, but there's no way to know if they've permanently denied the
-                // permission, and we don't want to show them a message on every screenshot.
-              }
-            });
-  }
-
-  void registerScreenshotObserver() {
-    activity
-        .getContentResolver()
-        .registerContentObserver(
-            Media.EXTERNAL_CONTENT_URI, /* notifyForDescendants= */ true, this);
-  }
-
-  void unRegisterScreenshotObserver() {
-    activity.getContentResolver().unregisterContentObserver(this);
+    application.registerActivityLifecycleCallbacks(this);
   }
 
   @Override
   public void onChange(boolean selfChange, Uri uri) {
+    if (currentActivity == null) {
+      Log.w(TAG, "There is no current activity. Ignoring change to external media.");
+      return;
+    }
+
     if (!uri.toString().matches(String.format("%s/[0-9]+", Media.EXTERNAL_CONTENT_URI))
         || seenImages.contains(uri)) {
       return;
     }
 
-    if (ContextCompat.checkSelfPermission(activity, PERMISSION_TO_REQUEST) == PERMISSION_GRANTED) {
+    if (ContextCompat.checkSelfPermission(currentActivity, PERMISSION_TO_REQUEST)
+        == PERMISSION_GRANTED) {
       maybeStartFeedbackForScreenshot(uri);
     } else if (hasRequestedPermission) {
       Log.i(
@@ -119,10 +149,60 @@ class ScreenshotDetectionFeedbackTrigger extends ContentObserver {
     }
   }
 
+  @Override
+  public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
+    if (activity instanceof ActivityResultCaller) {
+      requestPermissionLauncher =
+          ((ActivityResultCaller) activity)
+              .registerForActivityResult(
+                  new ActivityResultContracts.RequestPermission(),
+                  isGranted -> {
+                    if (!isEnabled) {
+                      Log.w(
+                          TAG,
+                          "Trigger disabled after permission check. Abandoning screenshot detection.");
+                    } else if (currentActivity == null) {
+                      Log.w(
+                          TAG,
+                          "There is no current activity after permission check. Abandoning screenshot detection.");
+                    } else if (isGranted) {
+                      maybeStartFeedbackForScreenshot(currentUri);
+                    } else {
+                      Log.i(TAG, "Permission not granted");
+                      // TODO: Ideally we would show a message indicating the impact of not enabling
+                      // the
+                      // permission, but there's no way to know if they've permanently denied the
+                      // permission, and we don't want to show them a message on every screenshot.
+                    }
+                  });
+    } else {
+      Log.w(
+          TAG,
+          "Not listening for screenshots because this activity can't register for permission request results: "
+              + activity);
+    }
+  }
+
+  @Override
+  public void onActivityResumed(@NonNull Activity activity) {
+    currentActivity = activity;
+    if (isEnabled) {
+      listenForScreenshots();
+    }
+  }
+
+  @Override
+  public void onActivityPaused(@NonNull Activity activity) {
+    if (isEnabled) {
+      stopListeningForScreenshots();
+    }
+    currentActivity = null;
+  }
+
   private void requestReadPermission(Uri uri) {
-    if (activity.shouldShowRequestPermissionRationale(PERMISSION_TO_REQUEST)) {
+    if (currentActivity.shouldShowRequestPermissionRationale(PERMISSION_TO_REQUEST)) {
       Log.i(TAG, "Showing customer rationale for requesting permission.");
-      new AlertDialog.Builder(activity)
+      new AlertDialog.Builder(currentActivity)
           .setMessage(
               "Taking a screenshot of the app can initiate feedback to the developer. To enable this feature, allow the app access to device storage.")
           .setPositiveButton(
@@ -143,7 +223,7 @@ class ScreenshotDetectionFeedbackTrigger extends ContentObserver {
   private void maybeStartFeedbackForScreenshot(Uri uri) {
     Cursor cursor = null;
     try {
-      cursor = activity.getContentResolver().query(uri, PROJECTION, null, null, null);
+      cursor = currentActivity.getContentResolver().query(uri, PROJECTION, null, null, null);
       if (cursor != null && cursor.moveToFirst()) {
         if (SHOULD_CHECK_IF_PENDING
             && cursor.getInt(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.IS_PENDING))
@@ -164,4 +244,32 @@ class ScreenshotDetectionFeedbackTrigger extends ContentObserver {
       if (cursor != null) cursor.close();
     }
   }
+
+  private void listenForScreenshots() {
+    if (currentActivity != null) {
+      currentActivity
+          .getContentResolver()
+          .registerContentObserver(
+              Media.EXTERNAL_CONTENT_URI, /* notifyForDescendants= */ true, this);
+    }
+  }
+
+  private void stopListeningForScreenshots() {
+    if (currentActivity != null) {
+      currentActivity.getContentResolver().unregisterContentObserver(this);
+    }
+  }
+
+  // Other lifecycle methods
+  @Override
+  public void onActivityDestroyed(@NonNull Activity activity) {}
+
+  @Override
+  public void onActivityStarted(@NonNull Activity activity) {}
+
+  @Override
+  public void onActivityStopped(@NonNull Activity activity) {}
+
+  @Override
+  public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {}
 }


### PR DESCRIPTION
Also:
- Refactor screenshot trigger so it can be enabled application-wide, instead of per activity
- Put a guard in place on URI-based startActivity() methods to prevent callers from starting feedback multiple times simultaneously