### PR TITLE
Fix ApkUpdaterTest flake

### DIFF
--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
@@ -233,7 +233,6 @@ public class ApkUpdaterTest {
             ErrorMessages.APK_INSTALLATION_FAILED,
             FirebaseAppDistributionException.Status.INSTALLATION_FAILURE));
 
-    assertThat(updateTask.isComplete()).isFalse();
     FirebaseAppDistributionException e =
         assertThrows(FirebaseAppDistributionException.class, () -> onCompleteListener.await());
     assertThat(e.getErrorCode()).isEqualTo(Status.INSTALLATION_FAILURE);


### PR DESCRIPTION
The test was asserting that the task is not complete, and then awaiting completion. However it's totally possible that it would have already completed by that assertion, which is probably why it failed randomly during a presubmit test on https://github.com/firebase/firebase-android-sdk/pull/4152.