### PR TITLE
Enable COUNT integration tests, now that backend support has rolled out

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
@@ -30,18 +30,11 @@ import static org.junit.Assert.assertTrue;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class CountTest {
-
-  @Before
-  public void setUp() {
-    // TODO(b/243368243): Remove this once backend is ready to support count.
-    org.junit.Assume.assumeTrue(BuildConfig.USE_EMULATOR_FOR_TESTS);
-  }
 
   @After
   public void tearDown() {


### PR DESCRIPTION
Enable the integration tests for COUNT that were added in https://github.com/firebase/firebase-android-sdk/pull/4130 now that the RunAggregationQuery RPC has been fully rolled out.