### PR TITLE
Combine Java/Kotlin sources in Dackka Plugin

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
@@ -28,8 +28,7 @@ import org.json.JSONObject
  *
  * @property dackkaJarFile a [File] of the Dackka fat jar
  * @property dependencies a list of all dependent jars (the classpath)
- * @property kotlinSources a list of kotlin source roots
- * @property javaSources a list of java source roots
+ * @property sources a list of source roots
  * @property suppressedFiles a list of files to exclude from documentation
  * @property outputDirectory where to store the generated files
  */
@@ -43,11 +42,7 @@ abstract class GenerateDocumentationTaskExtension : DefaultTask() {
 
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val kotlinSources: ListProperty<File>
-
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val javaSources: ListProperty<File>
+    abstract val sources: ListProperty<File>
 
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -106,7 +101,7 @@ abstract class GenerateDocumentationTask @Inject constructor(
                     "scopeId" to "androidx",
                     "sourceSetName" to "main"
                 ),
-                "sourceRoots" to kotlinSources.get().map { it.path } + javaSources.get().map { it.path },
+                "sourceRoots" to sources.get().map { it.path },
                 "classpath" to dependencies.get().map { it.path },
                 "documentedVisibilities" to listOf("PUBLIC", "PROTECTED"),
                 "skipEmptyPackages" to "true",

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -183,32 +183,28 @@ abstract class DackkaPlugin : Plugin<Project> {
 
                     val classpath = compileConfiguration.getJars() + project.javadocConfig.getJars() + project.files(bootClasspath)
 
-                    val sourcesForJava = sourceSets.flatMap {
-                        // TODO(b/246984444): Investigate why kotlinDirectories includes javaDirectories
+                    val sourceDirectories = sourceSets.flatMap {
                         it.javaDirectories.map { it.absoluteFile }
                     }
 
                     docStubs.configure {
                         classPath = classpath
-                        sources.set(project.provider { sourcesForJava })
+                        sources.set(project.provider { sourceDirectories })
                     }
 
                     docsTask.configure {
                         if (!isKotlin) dependsOn(docStubs)
 
-                        val sourcesForKotlin = emptyList<File>() + projectSpecificSources(project)
                         val packageLists = fetchPackageLists(project)
 
                         val excludedFiles = projectSpecificSuppressedFiles(project)
-                        val fixedJavaSources = if (!isKotlin) listOf(project.docStubs) else sourcesForJava
+                        val fixedSourceDirectories = if (!isKotlin) listOf(project.docStubs) else sourceDirectories
 
-                        javaSources.set(fixedJavaSources)
+                        sources.set(fixedSourceDirectories + projectSpecificSources(project))
                         suppressedFiles.set(excludedFiles)
                         packageListFiles.set(packageLists)
 
-                        kotlinSources.set(sourcesForKotlin)
                         dependencies.set(classpath)
-
                         outputDirectory.set(targetDirectory)
 
                         applyCommonConfigurations()


### PR DESCRIPTION
After investigating why AGP's Kotlin directories shared the same sources as the Java variant ([b/46984444](https://b.corp.google.com/issues/246984444)), it has become apparent that this separation does not have any benefit to us- and is intended behavior. Because of this, I've removed all referenced of the bug- and combined Java and Kotlin source set variables during Dackka generation.