### PR TITLE
Notification trigger API

### DIFF
--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -16,7 +16,10 @@ package com.google.firebase.appdistribution {
   public interface FirebaseAppDistribution {
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.appdistribution.AppDistributionRelease> checkForNewRelease();
     method @NonNull public static com.google.firebase.appdistribution.FirebaseAppDistribution getInstance();
+    method public void cancelFeedbackNotification();
     method public boolean isTesterSignedIn();
+    method public void showFeedbackNotification(@NonNull int, int);
+    method public void showFeedbackNotification(@NonNull CharSequence, int);
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();
     method public void signOutTester();
     method public void startFeedback(int);

--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -18,13 +18,13 @@ package com.google.firebase.appdistribution {
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.appdistribution.AppDistributionRelease> checkForNewRelease();
     method @NonNull public static com.google.firebase.appdistribution.FirebaseAppDistribution getInstance();
     method public boolean isTesterSignedIn();
-    method public void showFeedbackNotification(int, @NonNull com.google.firebase.appdistribution.InterruptionLevel);
+    method public void showFeedbackNotification(@StringRes int, @NonNull com.google.firebase.appdistribution.InterruptionLevel);
     method public void showFeedbackNotification(@NonNull CharSequence, @NonNull com.google.firebase.appdistribution.InterruptionLevel);
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();
     method public void signOutTester();
-    method public void startFeedback(int);
+    method public void startFeedback(@StringRes int);
     method public void startFeedback(@NonNull CharSequence);
-    method public void startFeedback(int, @Nullable android.net.Uri);
+    method public void startFeedback(@StringRes int, @Nullable android.net.Uri);
     method public void startFeedback(@NonNull CharSequence, @Nullable android.net.Uri);
     method @NonNull public com.google.firebase.appdistribution.UpdateTask updateApp();
     method @NonNull public com.google.firebase.appdistribution.UpdateTask updateIfNewReleaseAvailable();

--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -14,17 +14,17 @@ package com.google.firebase.appdistribution {
   }
 
   public interface FirebaseAppDistribution {
+    method public void cancelFeedbackNotification();
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.appdistribution.AppDistributionRelease> checkForNewRelease();
     method @NonNull public static com.google.firebase.appdistribution.FirebaseAppDistribution getInstance();
-    method public void cancelFeedbackNotification();
     method public boolean isTesterSignedIn();
-    method public void showFeedbackNotification(@NonNull int, int);
+    method public void showFeedbackNotification(int, int);
     method public void showFeedbackNotification(@NonNull CharSequence, int);
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();
     method public void signOutTester();
     method public void startFeedback(int);
     method public void startFeedback(@NonNull CharSequence);
-    method public void startFeedback(@NonNull int, @Nullable android.net.Uri);
+    method public void startFeedback(int, @Nullable android.net.Uri);
     method public void startFeedback(@NonNull CharSequence, @Nullable android.net.Uri);
     method @NonNull public com.google.firebase.appdistribution.UpdateTask updateApp();
     method @NonNull public com.google.firebase.appdistribution.UpdateTask updateIfNewReleaseAvailable();

--- a/firebase-appdistribution-api/api.txt
+++ b/firebase-appdistribution-api/api.txt
@@ -18,8 +18,8 @@ package com.google.firebase.appdistribution {
     method @NonNull public com.google.android.gms.tasks.Task<com.google.firebase.appdistribution.AppDistributionRelease> checkForNewRelease();
     method @NonNull public static com.google.firebase.appdistribution.FirebaseAppDistribution getInstance();
     method public boolean isTesterSignedIn();
-    method public void showFeedbackNotification(int, int);
-    method public void showFeedbackNotification(@NonNull CharSequence, int);
+    method public void showFeedbackNotification(int, @NonNull com.google.firebase.appdistribution.InterruptionLevel);
+    method public void showFeedbackNotification(@NonNull CharSequence, @NonNull com.google.firebase.appdistribution.InterruptionLevel);
     method @NonNull public com.google.android.gms.tasks.Task<java.lang.Void> signInTester();
     method public void signOutTester();
     method public void startFeedback(int);
@@ -47,6 +47,14 @@ package com.google.firebase.appdistribution {
     enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status NOT_IMPLEMENTED;
     enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status UNKNOWN;
     enum_constant public static final com.google.firebase.appdistribution.FirebaseAppDistributionException.Status UPDATE_NOT_AVAILABLE;
+  }
+
+  public enum InterruptionLevel {
+    enum_constant public static final com.google.firebase.appdistribution.InterruptionLevel DEFAULT;
+    enum_constant public static final com.google.firebase.appdistribution.InterruptionLevel HIGH;
+    enum_constant public static final com.google.firebase.appdistribution.InterruptionLevel LOW;
+    enum_constant public static final com.google.firebase.appdistribution.InterruptionLevel MAX;
+    enum_constant public static final com.google.firebase.appdistribution.InterruptionLevel MIN;
   }
 
   public interface OnProgressListener {

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -205,10 +205,10 @@ public interface FirebaseAppDistribution {
    *
    * @param infoTextResourceId string resource ID of text to display to the tester before collecting
    *     feedback data (e.g. Terms and Conditions)
-   * @param importance the amount the user should be interrupted by notifications from the feedback
-   *     notification channel. Once the channel's importance is set it cannot be changed except by
-   *     the user. See {@link NotificationChannel#setImportance}. On platforms below Android 8, the
-   *     importance will be translated into a comparable notification priority (see {@link
+   * @param importance the level of interruption for the feedback notification channel. Once the
+   *     channel's importance is set it cannot be changed except by the user. See {@link
+   *     NotificationChannel#setImportance}. On platforms below Android 8, the importance will be
+   *     translated into a comparable notification priority (see {@link
    *     NotificationCompat.Builder#setPriority}).
    */
   void showFeedbackNotification(int infoTextResourceId, int importance);
@@ -236,10 +236,10 @@ public interface FirebaseAppDistribution {
    *
    * @param infoText text to display to the tester before collecting feedback data (e.g. Terms and
    *     Conditions)
-   * @param importance the amount the user should be interrupted by notifications from the feedback
-   *     notification channel. Once the channel's importance is set it cannot be changed except by
-   *     the user. See {@link NotificationChannel#setImportance}. On platforms below Android 8, the
-   *     importance will be translated into a comparable notification priority (see {@link
+   * @param importance the level of interruption for the feedback notification channel. Once the
+   *     channel's importance is set it cannot be changed except by the user. See {@link
+   *     NotificationChannel#setImportance}. On platforms below Android 8, the importance will be
+   *     translated into a comparable notification priority (see {@link
    *     NotificationCompat.Builder#setPriority}).
    */
   void showFeedbackNotification(@NonNull CharSequence infoText, int importance);

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -15,11 +15,9 @@
 package com.google.firebase.appdistribution;
 
 import android.app.Activity;
-import android.app.NotificationChannel;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.app.NotificationCompat;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appdistribution.internal.FirebaseAppDistributionProxy;
@@ -202,17 +200,14 @@ public interface FirebaseAppDistribution {
    *   <li>Starts a full screen activity for the tester to compose and submit the feedback
    * </ol>
    *
-   * <p>On Android 8 and above, the notification will be created in its own notification channel.
-   *
    * @param infoTextResourceId string resource ID of text to display to the tester before collecting
    *     feedback data (e.g. Terms and Conditions)
-   * @param importance the level of interruption for the feedback notification channel. Once the
-   *     channel's importance is set it cannot be changed except by the user. See {@link
-   *     NotificationChannel#setImportance}. On platforms below Android 8, the importance will be
-   *     translated into a comparable notification priority (see {@link
-   *     NotificationCompat.Builder#setPriority}).
+   * @param interruptionLevel the level of interruption for the feedback notification. On platforms
+   *     below Android 8, this corresponds to a notification channel importance and once set cannot
+   *     be changed except by the user.
    */
-  void showFeedbackNotification(int infoTextResourceId, int importance);
+  void showFeedbackNotification(
+      int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel);
 
   /**
    * Displays a notification that, when tapped, will take a screenshot of the current activity, then
@@ -233,17 +228,14 @@ public interface FirebaseAppDistribution {
    *   <li>Starts a full screen activity for the tester to compose and submit the feedback
    * </ol>
    *
-   * <p>On Android 8 and above, the notification will be created in its own notification channel.
-   *
    * @param infoText text to display to the tester before collecting feedback data (e.g. Terms and
    *     Conditions)
-   * @param importance the level of interruption for the feedback notification channel. Once the
-   *     channel's importance is set it cannot be changed except by the user. See {@link
-   *     NotificationChannel#setImportance}. On platforms below Android 8, the importance will be
-   *     translated into a comparable notification priority (see {@link
-   *     NotificationCompat.Builder#setPriority}).
+   * @param interruptionLevel the level of interruption for the feedback notification. On platforms
+   *     below Android 8, this corresponds to a notification channel importance and once set cannot
+   *     be changed except by the user.
    */
-  void showFeedbackNotification(@NonNull CharSequence infoText, int importance);
+  void showFeedbackNotification(
+      @NonNull CharSequence infoText, @NonNull InterruptionLevel interruptionLevel);
 
   /**
    * Hides the notification shown with {@link #showFeedbackNotification}.

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -37,6 +37,7 @@ import com.google.firebase.appdistribution.internal.FirebaseAppDistributionProxy
  * <p>Call {@link #getInstance()} to get the singleton instance of {@link FirebaseAppDistribution}.
  */
 public interface FirebaseAppDistribution {
+
   /**
    * Updates the app to the newest release, if one is available.
    *

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -18,6 +18,7 @@ import android.app.Activity;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appdistribution.internal.FirebaseAppDistributionProxy;
@@ -127,7 +128,7 @@ public interface FirebaseAppDistribution {
    * @param infoTextResourceId string resource ID of text to display to the tester before collecting
    *     feedback data (e.g. Terms and Conditions)
    */
-  void startFeedback(int infoTextResourceId);
+  void startFeedback(@StringRes int infoTextResourceId);
 
   /**
    * Takes a screenshot, and starts an activity to collect and submit feedback from the tester.
@@ -161,7 +162,7 @@ public interface FirebaseAppDistribution {
    * @param screenshot URI to a bitmap containing a screenshot that will be included with the
    *     report, or null to not include a screenshot
    */
-  void startFeedback(int infoTextResourceId, @Nullable Uri screenshot);
+  void startFeedback(@StringRes int infoTextResourceId, @Nullable Uri screenshot);
 
   /**
    * Starts an activity to collect and submit feedback from the tester, along with the given
@@ -207,7 +208,7 @@ public interface FirebaseAppDistribution {
    *     be changed except by the user.
    */
   void showFeedbackNotification(
-      int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel);
+      @StringRes int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel);
 
   /**
    * Displays a notification that, when tapped, will take a screenshot of the current activity, then

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/FirebaseAppDistribution.java
@@ -14,9 +14,12 @@
 
 package com.google.firebase.appdistribution;
 
+import android.app.Activity;
+import android.app.NotificationChannel;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appdistribution.internal.FirebaseAppDistributionProxy;
@@ -159,7 +162,7 @@ public interface FirebaseAppDistribution {
    * @param screenshot URI to a bitmap containing a screenshot that will be included with the
    *     report, or null to not include a screenshot
    */
-  void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshot);
+  void startFeedback(int infoTextResourceId, @Nullable Uri screenshot);
 
   /**
    * Starts an activity to collect and submit feedback from the tester, along with the given
@@ -178,6 +181,76 @@ public interface FirebaseAppDistribution {
    *     report, or null to not include a screenshot
    */
   void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshot);
+
+  /**
+   * Displays a notification that, when tapped, will take a screenshot of the current activity, then
+   * start a new activity to collect and submit feedback from the tester along with the screenshot.
+   *
+   * <p>On Android 13 and above, this method requires the <a
+   * href="https://developer.android.com/develop/ui/views/notifications/notification-permission">runtime
+   * permission for sending notifications</a>: {@code POST_NOTIFICATIONS}. If your app targets
+   * Android 13 (API level 33) or above, you should <a
+   * href="https://developer.android.com/training/permissions/requesting">request the
+   * permission</a>.
+   *
+   * <p>When the notification is tapped:
+   *
+   * <ol>
+   *   <li>If the app is open, take a screenshot of the current activity
+   *   <li>If tester is not signed in, presents the tester with a Google Sign-in UI
+   *   <li>Starts a full screen activity for the tester to compose and submit the feedback
+   * </ol>
+   *
+   * <p>On Android 8 and above, the notification will be created in its own notification channel.
+   *
+   * @param infoTextResourceId string resource ID of text to display to the tester before collecting
+   *     feedback data (e.g. Terms and Conditions)
+   * @param importance the amount the user should be interrupted by notifications from the feedback
+   *     notification channel. Once the channel's importance is set it cannot be changed except by
+   *     the user. See {@link NotificationChannel#setImportance}. On platforms below Android 8, the
+   *     importance will be translated into a comparable notification priority (see {@link
+   *     NotificationCompat.Builder#setPriority}).
+   */
+  void showFeedbackNotification(int infoTextResourceId, int importance);
+
+  /**
+   * Displays a notification that, when tapped, will take a screenshot of the current activity, then
+   * start a new activity to collect and submit feedback from the tester along with the screenshot.
+   *
+   * <p>On Android 13 and above, this method requires the <a
+   * href="https://developer.android.com/develop/ui/views/notifications/notification-permission">runtime
+   * permission for sending notifications</a>: {@code POST_NOTIFICATIONS}. If your app targets
+   * Android 13 (API level 33) or above, you should <a
+   * href="https://developer.android.com/training/permissions/requesting">request the
+   * permission</a>.
+   *
+   * <p>When the notification is tapped:
+   *
+   * <ol>
+   *   <li>If the app is open, take a screenshot of the current activity
+   *   <li>If tester is not signed in, presents the tester with a Google Sign-in UI
+   *   <li>Starts a full screen activity for the tester to compose and submit the feedback
+   * </ol>
+   *
+   * <p>On Android 8 and above, the notification will be created in its own notification channel.
+   *
+   * @param infoText text to display to the tester before collecting feedback data (e.g. Terms and
+   *     Conditions)
+   * @param importance the amount the user should be interrupted by notifications from the feedback
+   *     notification channel. Once the channel's importance is set it cannot be changed except by
+   *     the user. See {@link NotificationChannel#setImportance}. On platforms below Android 8, the
+   *     importance will be translated into a comparable notification priority (see {@link
+   *     NotificationCompat.Builder#setPriority}).
+   */
+  void showFeedbackNotification(@NonNull CharSequence infoText, int importance);
+
+  /**
+   * Hides the notification shown with {@link #showFeedbackNotification}.
+   *
+   * <p>This should be called in the {@link Activity#onDestroy} of the activity that showed the
+   * notification.
+   */
+  void cancelFeedbackNotification();
 
   /** Gets the singleton {@link FirebaseAppDistribution} instance. */
   @NonNull

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/InterruptionLevel.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/InterruptionLevel.java
@@ -1,0 +1,81 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution;
+
+import android.app.NotificationManager;
+import androidx.core.app.NotificationCompat;
+
+/** An enum specifying the level of interruption of a notification when it is created. */
+public enum InterruptionLevel {
+
+  /**
+   * Minimum interruption level.
+   *
+   * <p>Translates to {@link NotificationManager#IMPORTANCE_MIN} on Android O+ and {@link
+   * NotificationCompat#PRIORITY_MIN} on older platforms.
+   */
+  MIN(NotificationManager.IMPORTANCE_MIN, NotificationCompat.PRIORITY_MIN),
+
+  /**
+   * Low interruption level.
+   *
+   * <p>Translates to {@link NotificationManager#IMPORTANCE_LOW} on Android O+ and {@link
+   * NotificationCompat#PRIORITY_LOW} on older platforms.
+   */
+  LOW(NotificationManager.IMPORTANCE_LOW, NotificationCompat.PRIORITY_LOW),
+
+  /**
+   * Default interruption level.
+   *
+   * <p>Translates to {@link NotificationManager#IMPORTANCE_DEFAULT} on Android O+ and {@link
+   * NotificationCompat#PRIORITY_DEFAULT} on older platforms.
+   */
+  DEFAULT(NotificationManager.IMPORTANCE_DEFAULT, NotificationCompat.PRIORITY_DEFAULT),
+
+  /**
+   * High interruption level.
+   *
+   * <p>Translates to {@link NotificationManager#IMPORTANCE_HIGH} on Android O+ and {@link
+   * NotificationCompat#PRIORITY_HIGH} on older platforms.
+   */
+  HIGH(NotificationManager.IMPORTANCE_HIGH, NotificationCompat.PRIORITY_HIGH),
+
+  /**
+   * Maximum interruption level.
+   *
+   * <p>Translates to {@link NotificationManager#IMPORTANCE_HIGH} on Android O+ and {@link
+   * NotificationCompat#PRIORITY_MAX} on older platforms.
+   */
+  MAX(NotificationManager.IMPORTANCE_HIGH, NotificationCompat.PRIORITY_MAX);
+
+  /**
+   * The notification channel importance corresponding to this interruption level on Android O+.
+   *
+   * @hide
+   */
+  public final int channelImportance;
+
+  /**
+   * The notification priority corresponding to this interruption level on older platforms.
+   *
+   * @hide
+   */
+  public final int notificationPriority;
+
+  InterruptionLevel(int channelImportance, int notificationPriority) {
+    this.channelImportance = channelImportance;
+    this.notificationPriority = notificationPriority;
+  }
+}

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
@@ -17,6 +17,7 @@ package com.google.firebase.appdistribution.internal;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.appdistribution.AppDistributionRelease;
 import com.google.firebase.appdistribution.FirebaseAppDistribution;
@@ -76,7 +77,7 @@ public class FirebaseAppDistributionProxy implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(int infoTextResourceId) {
+  public void startFeedback(@StringRes int infoTextResourceId) {
     delegate.startFeedback(infoTextResourceId);
   }
 
@@ -86,7 +87,7 @@ public class FirebaseAppDistributionProxy implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(int infoTextResourceId, @Nullable Uri screenshotUri) {
+  public void startFeedback(@StringRes int infoTextResourceId, @Nullable Uri screenshotUri) {
     delegate.startFeedback(infoTextResourceId, screenshotUri);
   }
 
@@ -97,7 +98,7 @@ public class FirebaseAppDistributionProxy implements FirebaseAppDistribution {
 
   @Override
   public void showFeedbackNotification(
-      int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {
+      @StringRes int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {
     delegate.showFeedbackNotification(infoTextResourceId, interruptionLevel);
   }
 

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
@@ -85,12 +85,27 @@ public class FirebaseAppDistributionProxy implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshotUri) {
+  public void startFeedback(int infoTextResourceId, @Nullable Uri screenshotUri) {
     delegate.startFeedback(infoTextResourceId, screenshotUri);
   }
 
   @Override
   public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {
     delegate.startFeedback(infoText, screenshotUri);
+  }
+
+  @Override
+  public void showFeedbackNotification(int infoTextResourceId, int importance) {
+    delegate.showFeedbackNotification(infoTextResourceId, importance);
+  }
+
+  @Override
+  public void showFeedbackNotification(@NonNull CharSequence infoText, int importance) {
+    delegate.showFeedbackNotification(infoText, importance);
+  }
+
+  @Override
+  public void cancelFeedbackNotification() {
+    delegate.cancelFeedbackNotification();
   }
 }

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionProxy.java
@@ -21,6 +21,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.appdistribution.AppDistributionRelease;
 import com.google.firebase.appdistribution.FirebaseAppDistribution;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
+import com.google.firebase.appdistribution.InterruptionLevel;
 import com.google.firebase.appdistribution.UpdateTask;
 import com.google.firebase.inject.Provider;
 
@@ -95,13 +96,15 @@ public class FirebaseAppDistributionProxy implements FirebaseAppDistribution {
   }
 
   @Override
-  public void showFeedbackNotification(int infoTextResourceId, int importance) {
-    delegate.showFeedbackNotification(infoTextResourceId, importance);
+  public void showFeedbackNotification(
+      int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {
+    delegate.showFeedbackNotification(infoTextResourceId, interruptionLevel);
   }
 
   @Override
-  public void showFeedbackNotification(@NonNull CharSequence infoText, int importance) {
-    delegate.showFeedbackNotification(infoText, importance);
+  public void showFeedbackNotification(
+      @NonNull CharSequence infoText, @NonNull InterruptionLevel interruptionLevel) {
+    delegate.showFeedbackNotification(infoText, interruptionLevel);
   }
 
   @Override

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
@@ -18,6 +18,7 @@ import android.app.Activity;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.OnCanceledListener;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -74,20 +75,20 @@ public class FirebaseAppDistributionStub implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(int infoTextResourceId) {}
+  public void startFeedback(@StringRes int infoTextResourceId) {}
 
   @Override
   public void startFeedback(@NonNull CharSequence infoText) {}
 
   @Override
-  public void startFeedback(int infoTextResourceId, @Nullable Uri screenshotUri) {}
+  public void startFeedback(@StringRes int infoTextResourceId, @Nullable Uri screenshotUri) {}
 
   @Override
   public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {}
 
   @Override
   public void showFeedbackNotification(
-      int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {}
+      @StringRes int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {}
 
   @Override
   public void showFeedbackNotification(

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
@@ -30,6 +30,7 @@ import com.google.firebase.appdistribution.AppDistributionRelease;
 import com.google.firebase.appdistribution.FirebaseAppDistribution;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
+import com.google.firebase.appdistribution.InterruptionLevel;
 import com.google.firebase.appdistribution.OnProgressListener;
 import com.google.firebase.appdistribution.UpdateTask;
 import java.util.concurrent.Executor;
@@ -85,10 +86,12 @@ public class FirebaseAppDistributionStub implements FirebaseAppDistribution {
   public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {}
 
   @Override
-  public void showFeedbackNotification(int infoTextResourceId, int importance) {}
+  public void showFeedbackNotification(
+      int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {}
 
   @Override
-  public void showFeedbackNotification(@NonNull CharSequence infoText, int importance) {}
+  public void showFeedbackNotification(
+      @NonNull CharSequence infoText, @NonNull InterruptionLevel interruptionLevel) {}
 
   @Override
   public void cancelFeedbackNotification() {}

--- a/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
+++ b/firebase-appdistribution-api/src/main/java/com/google/firebase/appdistribution/internal/FirebaseAppDistributionStub.java
@@ -79,10 +79,19 @@ public class FirebaseAppDistributionStub implements FirebaseAppDistribution {
   public void startFeedback(@NonNull CharSequence infoText) {}
 
   @Override
-  public void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshotUri) {}
+  public void startFeedback(int infoTextResourceId, @Nullable Uri screenshotUri) {}
 
   @Override
   public void startFeedback(@NonNull CharSequence infoText, @Nullable Uri screenshotUri) {}
+
+  @Override
+  public void showFeedbackNotification(int infoTextResourceId, int importance) {}
+
+  @Override
+  public void showFeedbackNotification(@NonNull CharSequence infoText, int importance) {}
+
+  @Override
+  public void cancelFeedbackNotification() {}
 
   private static <TResult> Task<TResult> getNotImplementedTask() {
     return Tasks.forException(

--- a/firebase-appdistribution/src/main/AndroidManifest.xml
+++ b/firebase-appdistribution/src/main/AndroidManifest.xml
@@ -17,8 +17,9 @@
     package="com.google.firebase.appdistribution.impl">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application>
@@ -50,6 +51,10 @@
             android:name=".FeedbackActivity"
             android:exported="false"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+
+        <activity
+            android:name=".TakeScreenshotAndStartFeedbackActivity"
+            android:exported="false" />
 
         <provider
             android:name="com.google.firebase.appdistribution.impl.FirebaseAppDistributionFileProvider"

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
@@ -307,7 +307,7 @@ class ApkUpdater {
               .build());
     }
     if (showNotification) {
-      appDistributionNotificationsManager.updateNotification(
+      appDistributionNotificationsManager.showAppUpdateNotification(
           totalBytes, downloadedBytes, stringResourceId);
     }
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -18,9 +18,6 @@ import static com.google.firebase.appdistribution.FirebaseAppDistributionExcepti
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.AUTHENTICATION_FAILURE;
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.HOST_ACTIVITY_INTERRUPTED;
 import static com.google.firebase.appdistribution.FirebaseAppDistributionException.Status.UPDATE_NOT_AVAILABLE;
-import static com.google.firebase.appdistribution.impl.FeedbackActivity.INFO_TEXT_EXTRA_KEY;
-import static com.google.firebase.appdistribution.impl.FeedbackActivity.RELEASE_NAME_EXTRA_KEY;
-import static com.google.firebase.appdistribution.impl.FeedbackActivity.SCREENSHOT_URI_EXTRA_KEY;
 import static com.google.firebase.appdistribution.impl.TaskUtils.safeSetTaskException;
 import static com.google.firebase.appdistribution.impl.TaskUtils.safeSetTaskResult;
 
@@ -66,6 +63,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   private final ReleaseIdentifier releaseIdentifier;
   private final ScreenshotTaker screenshotTaker;
   private final Executor taskExecutor;
+  private final FirebaseAppDistributionNotificationsManager notificationsManager;
 
   private final Object updateIfNewReleaseTaskLock = new Object();
 
@@ -81,13 +79,11 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   private AlertDialog updateConfirmationDialog;
   private AlertDialog signInConfirmationDialog;
   @Nullable private Activity dialogHostActivity = null;
-
   private boolean remakeSignInConfirmationDialog = false;
   private boolean remakeUpdateConfirmationDialog = false;
-
   private TaskCompletionSource<Void> showSignInDialogTask = null;
   private TaskCompletionSource<Void> showUpdateDialogTask = null;
-  private AtomicBoolean feedbackInProgress = new AtomicBoolean(false);
+  private final AtomicBoolean feedbackInProgress = new AtomicBoolean(false);
 
   @VisibleForTesting
   FirebaseAppDistributionImpl(
@@ -111,6 +107,8 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
     this.lifecycleNotifier = lifecycleNotifier;
     this.screenshotTaker = screenshotTaker;
     this.taskExecutor = taskExecutor;
+    this.notificationsManager =
+        new FirebaseAppDistributionNotificationsManager(firebaseApp.getApplicationContext());
     lifecycleNotifier.addOnActivityDestroyedListener(this::onActivityDestroyed);
     lifecycleNotifier.addOnActivityPausedListener(this::onActivityPaused);
     lifecycleNotifier.addOnActivityResumedListener(this::onActivityResumed);
@@ -339,8 +337,8 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(@NonNull int infoTextResourceId, @Nullable Uri screenshotUri) {
-    startFeedback(firebaseApp.getApplicationContext().getText(infoTextResourceId), screenshotUri);
+  public void startFeedback(int infoTextResourceId, @Nullable Uri screenshotUri) {
+    startFeedback(getText(infoTextResourceId), screenshotUri);
   }
 
   @Override
@@ -351,6 +349,21 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
       return;
     }
     doStartFeedback(infoText, screenshotUri);
+  }
+
+  @Override
+  public void showFeedbackNotification(int infoTextResourceId, int importance) {
+    showFeedbackNotification(getText(infoTextResourceId), importance);
+  }
+
+  @Override
+  public void showFeedbackNotification(@NonNull CharSequence infoText, int importance) {
+    notificationsManager.showFeedbackNotification(infoText, importance);
+  }
+
+  @Override
+  public void cancelFeedbackNotification() {
+    notificationsManager.cancelFeedbackNotification();
   }
 
   private void doStartFeedback(CharSequence infoText, @Nullable Uri screenshotUri) {
@@ -378,10 +391,10 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
         activity -> {
           LogWrapper.getInstance().i("Launching feedback activity");
           Intent intent = new Intent(activity, FeedbackActivity.class);
-          intent.putExtra(RELEASE_NAME_EXTRA_KEY, releaseName);
-          intent.putExtra(INFO_TEXT_EXTRA_KEY, infoText);
+          intent.putExtra(FeedbackActivity.RELEASE_NAME_EXTRA_KEY, releaseName);
+          intent.putExtra(FeedbackActivity.INFO_TEXT_EXTRA_KEY, infoText);
           if (screenshotUri != null) {
-            intent.putExtra(SCREENSHOT_URI_EXTRA_KEY, screenshotUri.toString());
+            intent.putExtra(FeedbackActivity.SCREENSHOT_URI_EXTRA_KEY, screenshotUri.toString());
           }
           activity.startActivity(intent);
         });
@@ -568,5 +581,9 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
     return (showUpdateDialogTask != null
         && !showUpdateDialogTask.getTask().isComplete()
         && remakeUpdateConfirmationDialog);
+  }
+
+  private CharSequence getText(int resourceId) {
+    return firebaseApp.getApplicationContext().getText(resourceId);
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -39,6 +39,7 @@ import com.google.firebase.appdistribution.BinaryType;
 import com.google.firebase.appdistribution.FirebaseAppDistribution;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
+import com.google.firebase.appdistribution.InterruptionLevel;
 import com.google.firebase.appdistribution.UpdateProgress;
 import com.google.firebase.appdistribution.UpdateStatus;
 import com.google.firebase.appdistribution.UpdateTask;
@@ -352,13 +353,15 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   }
 
   @Override
-  public void showFeedbackNotification(int infoTextResourceId, int importance) {
-    showFeedbackNotification(getText(infoTextResourceId), importance);
+  public void showFeedbackNotification(
+      int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {
+    showFeedbackNotification(getText(infoTextResourceId), interruptionLevel);
   }
 
   @Override
-  public void showFeedbackNotification(@NonNull CharSequence infoText, int importance) {
-    notificationsManager.showFeedbackNotification(infoText, importance);
+  public void showFeedbackNotification(
+      @NonNull CharSequence infoText, @NonNull InterruptionLevel interruptionLevel) {
+    notificationsManager.showFeedbackNotification(infoText, interruptionLevel);
   }
 
   @Override

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -29,6 +29,7 @@ import android.net.Uri;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
@@ -311,7 +312,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(int infoTextResourceId) {
+  public void startFeedback(@StringRes int infoTextResourceId) {
     // TODO(lkellogg): Once we have the real FeedbackActivity view implemented, we should write a
     // test that checks that <a> tags are preserved
     startFeedback(firebaseApp.getApplicationContext().getText(infoTextResourceId));
@@ -338,7 +339,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   }
 
   @Override
-  public void startFeedback(int infoTextResourceId, @Nullable Uri screenshotUri) {
+  public void startFeedback(@StringRes int infoTextResourceId, @Nullable Uri screenshotUri) {
     startFeedback(getText(infoTextResourceId), screenshotUri);
   }
 
@@ -354,7 +355,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
 
   @Override
   public void showFeedbackNotification(
-      int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {
+      @StringRes int infoTextResourceId, @NonNull InterruptionLevel interruptionLevel) {
     showFeedbackNotification(getText(infoTextResourceId), interruptionLevel);
   }
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
@@ -240,6 +240,7 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
       if (currentActivity != activity) {
         if (currentActivity != null) {
           // Store a reference to the previous activity in case the current activity is ignored
+          // later in call to applyToNullableForegroundActivity()
           previousActivity = currentActivity;
         }
         currentActivity = activity;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
@@ -42,7 +42,14 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
 
   /** A functional interface for a function that takes an activity and produces a new value. */
   interface ActivityFunction<T> {
-    T apply(Activity activity) throws FirebaseAppDistributionException;
+    T apply(@NonNull Activity activity) throws FirebaseAppDistributionException;
+  }
+
+  /**
+   * A functional interface for a function that takes a nullable activity and produces a new value.
+   */
+  interface NullableActivityFunction<T> {
+    T apply(@Nullable Activity activity) throws FirebaseAppDistributionException;
   }
 
   private static FirebaseAppDistributionLifecycleNotifier instance;
@@ -50,6 +57,9 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
 
   @GuardedBy("lock")
   private Activity currentActivity;
+
+  @GuardedBy("lock")
+  private Activity previousActivity;
 
   /** A queue of listeners that trigger when the activity is foregrounded. */
   @GuardedBy("lock")
@@ -110,7 +120,34 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
    * activity available when this method is called.
    */
   <T> Task<T> applyToForegroundActivity(ActivityFunction<T> function) {
-    return getForegroundActivity()
+    return getForegroundActivity(null)
+        .onSuccessTask(
+            // Use direct executor to ensure the consumer is called while Activity is in foreground
+            DIRECT_EXECUTOR,
+            activity -> {
+              try {
+                return Tasks.forResult(function.apply(activity));
+              } catch (Throwable t) {
+                return Tasks.forException(FirebaseAppDistributionExceptions.wrap(t));
+              }
+            });
+  }
+
+  /**
+   * Apply a function to a foreground activity, when one is available, returning a {@link Task} that
+   * will complete immediately after the function is applied.
+   *
+   * <p>If the foreground activity is of type {@code classToIgnore}, the previously active activity
+   * will be passed to the function, which may be null if there was no previously active activity or
+   * the activity has been destroyed.
+   *
+   * <p>The function will be called immediately once the activity is available. This may be main
+   * thread or the calling thread, depending on whether or not there is already a foreground
+   * activity available when this method is called.
+   */
+  <T, A extends Activity> Task<T> applyToNullableForegroundActivity(
+      Class<A> classToIgnore, NullableActivityFunction<T> function) {
+    return getForegroundActivity(classToIgnore)
         .onSuccessTask(
             // Use direct executor to ensure the consumer is called while Activity is in foreground
             DIRECT_EXECUTOR,
@@ -162,22 +199,51 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
   }
 
   Task<Activity> getForegroundActivity() {
+    return getForegroundActivity(null);
+  }
+
+  <A extends Activity> Task<Activity> getForegroundActivity(@Nullable Class<A> classToIgnore) {
     synchronized (lock) {
       if (currentActivity != null) {
-        return Tasks.forResult(currentActivity);
+        return Tasks.forResult(
+            getActivityWithIgnoredClass(currentActivity, previousActivity, classToIgnore));
       }
+
       TaskCompletionSource<Activity> task = new TaskCompletionSource<>();
 
       addOnActivityResumedListener(
           new OnActivityResumedListener() {
             @Override
             public void onResumed(Activity activity) {
-              task.setResult(activity);
+              task.setResult(
+                  getActivityWithIgnoredClass(activity, previousActivity, classToIgnore));
               removeOnActivityResumedListener(this);
             }
           });
 
       return task.getTask();
+    }
+  }
+
+  @Nullable
+  private static <A extends Activity> Activity getActivityWithIgnoredClass(
+      Activity activity, @Nullable Activity fallbackActivity, @Nullable Class<A> classToIgnore) {
+    if (classToIgnore != null && classToIgnore.isInstance(activity)) {
+      return fallbackActivity;
+    } else {
+      return activity;
+    }
+  }
+
+  private void updateCurrentActivity(@Nullable Activity activity) {
+    synchronized (lock) {
+      if (currentActivity != activity) {
+        if (currentActivity != null) {
+          // Store a reference to the previous activity in case the current activity is ignored
+          previousActivity = currentActivity;
+        }
+        currentActivity = activity;
+      }
     }
   }
 
@@ -220,7 +286,7 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
   @Override
   public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle bundle) {
     synchronized (lock) {
-      currentActivity = activity;
+      updateCurrentActivity(activity);
       for (OnActivityCreatedListener listener : onActivityCreatedListeners) {
         listener.onCreated(activity);
       }
@@ -230,7 +296,7 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
   @Override
   public void onActivityStarted(@NonNull Activity activity) {
     synchronized (lock) {
-      currentActivity = activity;
+      updateCurrentActivity(activity);
       for (OnActivityStartedListener listener : onActivityStartedListeners) {
         listener.onStarted(activity);
       }
@@ -240,7 +306,7 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
   @Override
   public void onActivityResumed(@NonNull Activity activity) {
     synchronized (lock) {
-      currentActivity = activity;
+      updateCurrentActivity(activity);
       for (OnActivityResumedListener listener : onActivityResumedListeners) {
         listener.onResumed(activity);
       }
@@ -250,8 +316,8 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
   @Override
   public void onActivityPaused(@NonNull Activity activity) {
     synchronized (lock) {
-      if (this.currentActivity == activity) {
-        this.currentActivity = null;
+      if (currentActivity == activity) {
+        updateCurrentActivity(null);
       }
       for (OnActivityPausedListener listener : onActivityPausedListeners) {
         listener.onPaused(activity);
@@ -268,8 +334,13 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
   @Override
   public void onActivityDestroyed(@NonNull Activity activity) {
     synchronized (lock) {
-      if (this.currentActivity == activity) {
-        this.currentActivity = null;
+      if (currentActivity == activity) {
+        updateCurrentActivity(null);
+      }
+
+      // If an activity is destroyed, delete all references to it, including the previous activity
+      if (previousActivity == activity) {
+        previousActivity = null;
       }
 
       for (OnActivityDestroyedListener listener : onDestroyedListeners) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
@@ -334,11 +334,10 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
   @Override
   public void onActivityDestroyed(@NonNull Activity activity) {
     synchronized (lock) {
+      // If an activity is destroyed, delete all references to it, including the previous activity
       if (currentActivity == activity) {
         updateCurrentActivity(null);
       }
-
-      // If an activity is destroyed, delete all references to it, including the previous activity
       if (previousActivity == activity) {
         previousActivity = null;
       }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManager.java
@@ -33,29 +33,24 @@ import androidx.core.app.NotificationManagerCompat;
 class FirebaseAppDistributionNotificationsManager {
   private static final String TAG = "FirebaseAppDistributionNotificationsManager";
 
+  private static final String PACKAGE_PREFIX = "com.google.firebase.appdistribution";
+
   @VisibleForTesting
-  static final String CHANNEL_GROUP_ID =
-      "com.google.firebase.appdistribution.notification_channel_group_id";
+  static final String CHANNEL_GROUP_ID = prependPackage("notification_channel_group_id");
 
   @VisibleForTesting
   enum Notification {
-    APP_UPDATE(
-        "com.google.firebase.appdistribution.notification_channel_id",
-        "com.google.firebase.appdistribution.app_update_notification_tag",
-        0),
-    FEEDBACK(
-        "com.google.firebase.appdistribution.feedback_notification_channel_id",
-        "com.google.firebase.appdistribution.feedback_notification_tag",
-        1);
+    APP_UPDATE("notification_channel_id", "app_update_notification_tag"),
+    FEEDBACK("feedback_notification_channel_id", "feedback_notification_tag");
 
     final String channelId;
     final String tag;
     final int id;
 
-    Notification(String channelId, String tag, int id) {
-      this.channelId = channelId;
-      this.tag = tag;
-      this.id = id;
+    Notification(String channelId, String tag) {
+      this.channelId = prependPackage(channelId);
+      this.tag = prependPackage(tag);
+      this.id = ordinal();
     }
   }
 
@@ -212,5 +207,9 @@ class FirebaseAppDistributionNotificationsManager {
     // Register the channel with the system; you can't change the importance
     // or other notification behaviors after this
     notificationManager.createNotificationChannel(channel);
+  }
+
+  private static String prependPackage(String id) {
+    return String.format("%s.%s", PACKAGE_PREFIX, id);
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManager.java
@@ -15,25 +15,53 @@
 package com.google.firebase.appdistribution.impl;
 
 import android.app.NotificationChannel;
+import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 
 class FirebaseAppDistributionNotificationsManager {
-  private static final String TAG = "NotificationsManager:";
-  private static final String NOTIFICATION_CHANNEL_ID =
-      "com.google.firebase.appdistribution.notification_channel_id";
+  private static final String TAG = "FirebaseAppDistributionNotificationsManager";
 
   @VisibleForTesting
-  static final String NOTIFICATION_TAG = "com.google.firebase.appdistribution.tag";
+  static final String CHANNEL_GROUP_ID =
+      "com.google.firebase.appdistribution.notification_channel_group_id";
+
+  @VisibleForTesting
+  enum Notification {
+    APP_UPDATE(
+        "com.google.firebase.appdistribution.notification_channel_id",
+        "com.google.firebase.appdistribution.app_update_notification_tag",
+        0),
+    FEEDBACK(
+        "com.google.firebase.appdistribution.feedback_notification_channel_id",
+        "com.google.firebase.appdistribution.feedback_notification_tag",
+        1);
+
+    final String channelId;
+    final String tag;
+    final int id;
+
+    Notification(String channelId, String tag, int id) {
+      this.channelId = channelId;
+      this.tag = tag;
+      this.id = id;
+    }
+  }
 
   private final Context context;
   private final AppIconSource appIconSource;
+  private final NotificationManagerCompat notificationManager;
 
   FirebaseAppDistributionNotificationsManager(Context context) {
     this(context, new AppIconSource());
@@ -43,43 +71,42 @@ class FirebaseAppDistributionNotificationsManager {
   FirebaseAppDistributionNotificationsManager(Context context, AppIconSource appIconSource) {
     this.context = context;
     this.appIconSource = appIconSource;
+    this.notificationManager = NotificationManagerCompat.from(context);
   }
 
-  void updateNotification(long totalBytes, long downloadedBytes, int stringResourceId) {
-    NotificationManager notificationManager = createNotificationManager(context);
+  void showAppUpdateNotification(long totalBytes, long downloadedBytes, int stringResourceId) {
+    // Create the NotificationChannel, but only on API 26+ because
+    // the NotificationChannel class is new and not in the support library
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      LogWrapper.getInstance().i(TAG, "Creating app update notification channel group");
+      createChannel(
+          Notification.APP_UPDATE,
+          R.string.app_update_notification_channel_name,
+          R.string.app_update_notification_channel_description,
+          NotificationManager.IMPORTANCE_DEFAULT);
+    }
+
+    if (!notificationManager.areNotificationsEnabled()) {
+      LogWrapper.getInstance()
+          .w("Not showing app update notifications because app notifications are disabled");
+      return;
+    }
+
     NotificationCompat.Builder notificationBuilder =
-        new NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+        new NotificationCompat.Builder(context, Notification.APP_UPDATE.channelId)
             .setOnlyAlertOnce(true)
             .setSmallIcon(appIconSource.getNonAdaptiveIconOrDefault(context))
             .setContentTitle(context.getString(stringResourceId))
             .setProgress(
-                100,
-                (int) (((float) downloadedBytes / (float) totalBytes) * 100),
-                /*indeterminate = */ false);
+                /* max= */ 100,
+                /* progress= */ (int) (((float) downloadedBytes / (float) totalBytes) * 100),
+                /* indeterminate= */ false);
     PendingIntent appLaunchIntent = createAppLaunchIntent();
     if (appLaunchIntent != null) {
       notificationBuilder.setContentIntent(appLaunchIntent);
     }
-    notificationManager.notify(NOTIFICATION_TAG, /*id =*/ 0, notificationBuilder.build());
-  }
-
-  private NotificationManager createNotificationManager(Context context) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      NotificationChannel channel =
-          new NotificationChannel(
-              NOTIFICATION_CHANNEL_ID,
-              context.getString(R.string.notifications_channel_name),
-              NotificationManager.IMPORTANCE_DEFAULT);
-      channel.setDescription(context.getString(R.string.notifications_channel_description));
-      // Register the channel with the system; you can't change the importance
-      // or other notification behaviors after this
-      NotificationManager notificationManager =
-          (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-      notificationManager.createNotificationChannel(channel);
-      return notificationManager;
-    } else {
-      return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-    }
+    notificationManager.notify(
+        Notification.APP_UPDATE.tag, Notification.APP_UPDATE.id, notificationBuilder.build());
   }
 
   @Nullable
@@ -87,7 +114,7 @@ class FirebaseAppDistributionNotificationsManager {
     // Query the package manager for the best launch intent for the app
     Intent intent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
     if (intent == null) {
-      LogWrapper.getInstance().w(TAG + "No activity found to launch app");
+      LogWrapper.getInstance().w(TAG, "No activity found to launch app");
       return null;
     }
     return PendingIntent.getActivity(
@@ -105,5 +132,85 @@ class FirebaseAppDistributionNotificationsManager {
     return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
         ? baseFlags | PendingIntent.FLAG_IMMUTABLE
         : baseFlags;
+  }
+
+  public void showFeedbackNotification(@NonNull CharSequence infoText, int importance) {
+    // Create the NotificationChannel, but only on API 26+ because
+    // the NotificationChannel class is new and not in the support library
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      LogWrapper.getInstance().i(TAG, "Creating feedback notification channel group");
+      createChannel(
+          Notification.FEEDBACK,
+          R.string.feedback_notification_channel_name,
+          R.string.feedback_notification_channel_description,
+          importance);
+    }
+
+    if (!notificationManager.areNotificationsEnabled()) {
+      LogWrapper.getInstance()
+          .w(TAG, "Not showing notification because app notifications are disabled");
+      return;
+    }
+
+    Intent intent = new Intent(context, TakeScreenshotAndStartFeedbackActivity.class);
+    intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+    intent.putExtra(TakeScreenshotAndStartFeedbackActivity.INFO_TEXT_EXTRA_KEY, infoText);
+    PendingIntent pendingIntent =
+        PendingIntent.getActivity(
+            context, /* requestCode = */ 0, intent, PendingIntent.FLAG_IMMUTABLE);
+    ApplicationInfo applicationInfo = context.getApplicationInfo();
+    PackageManager packageManager = context.getPackageManager();
+    CharSequence appLabel = packageManager.getApplicationLabel(applicationInfo);
+    NotificationCompat.Builder builder =
+        new NotificationCompat.Builder(context, Notification.FEEDBACK.channelId)
+            .setSmallIcon(appIconSource.getNonAdaptiveIconOrDefault(context))
+            .setContentTitle(context.getString(R.string.feedback_notification_title))
+            .setContentText(context.getString(R.string.feedback_notification_text, appLabel))
+            .setPriority(convertImportanceToPriority(importance))
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setAutoCancel(false)
+            .setContentIntent(pendingIntent);
+    LogWrapper.getInstance().i(TAG, "Showing feedback notification");
+    notificationManager.notify(
+        Notification.FEEDBACK.tag, Notification.FEEDBACK.id, builder.build());
+  }
+
+  public void cancelFeedbackNotification() {
+    LogWrapper.getInstance().i(TAG, "Cancelling feedback notification");
+    NotificationManagerCompat.from(context)
+        .cancel(Notification.FEEDBACK.tag, Notification.FEEDBACK.id);
+  }
+
+  private int convertImportanceToPriority(int importance) {
+    switch (importance) {
+      case NotificationManagerCompat.IMPORTANCE_MIN:
+        return NotificationCompat.PRIORITY_MIN;
+      case NotificationManagerCompat.IMPORTANCE_LOW:
+        return NotificationCompat.PRIORITY_LOW;
+      case NotificationManagerCompat.IMPORTANCE_HIGH:
+        return NotificationCompat.PRIORITY_HIGH;
+      case NotificationManagerCompat.IMPORTANCE_MAX:
+        return NotificationCompat.PRIORITY_MAX;
+      case NotificationManagerCompat.IMPORTANCE_UNSPECIFIED:
+      case NotificationManagerCompat.IMPORTANCE_NONE:
+      case NotificationManagerCompat.IMPORTANCE_DEFAULT:
+      default:
+        return NotificationCompat.PRIORITY_DEFAULT;
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.O)
+  private void createChannel(Notification notification, int name, int description, int importance) {
+    notificationManager.createNotificationChannelGroup(
+        new NotificationChannelGroup(
+            CHANNEL_GROUP_ID, context.getString(R.string.notifications_group_name)));
+    NotificationChannel channel =
+        new NotificationChannel(notification.channelId, context.getString(name), importance);
+    channel.setDescription(context.getString(description));
+    channel.setGroup(CHANNEL_GROUP_ID);
+    // Register the channel with the system; you can't change the importance
+    // or other notification behaviors after this
+    notificationManager.createNotificationChannel(channel);
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManager.java
@@ -16,7 +16,6 @@ package com.google.firebase.appdistribution.impl;
 
 import android.app.NotificationChannel;
 import android.app.NotificationChannelGroup;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -29,6 +28,7 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
+import com.google.firebase.appdistribution.InterruptionLevel;
 
 class FirebaseAppDistributionNotificationsManager {
   private static final String TAG = "FirebaseAppDistributionNotificationsManager";
@@ -78,7 +78,7 @@ class FirebaseAppDistributionNotificationsManager {
           Notification.APP_UPDATE,
           R.string.app_update_notification_channel_name,
           R.string.app_update_notification_channel_description,
-          NotificationManager.IMPORTANCE_DEFAULT);
+          InterruptionLevel.DEFAULT);
     }
 
     if (!notificationManager.areNotificationsEnabled()) {
@@ -129,7 +129,8 @@ class FirebaseAppDistributionNotificationsManager {
         : baseFlags;
   }
 
-  public void showFeedbackNotification(@NonNull CharSequence infoText, int importance) {
+  public void showFeedbackNotification(
+      @NonNull CharSequence infoText, @NonNull InterruptionLevel interruptionLevel) {
     // Create the NotificationChannel, but only on API 26+ because
     // the NotificationChannel class is new and not in the support library
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -138,7 +139,7 @@ class FirebaseAppDistributionNotificationsManager {
           Notification.FEEDBACK,
           R.string.feedback_notification_channel_name,
           R.string.feedback_notification_channel_description,
-          importance);
+          interruptionLevel);
     }
 
     if (!notificationManager.areNotificationsEnabled()) {
@@ -161,7 +162,7 @@ class FirebaseAppDistributionNotificationsManager {
             .setSmallIcon(appIconSource.getNonAdaptiveIconOrDefault(context))
             .setContentTitle(context.getString(R.string.feedback_notification_title))
             .setContentText(context.getString(R.string.feedback_notification_text, appLabel))
-            .setPriority(convertImportanceToPriority(importance))
+            .setPriority(interruptionLevel.notificationPriority)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setAutoCancel(false)
@@ -177,31 +178,15 @@ class FirebaseAppDistributionNotificationsManager {
         .cancel(Notification.FEEDBACK.tag, Notification.FEEDBACK.id);
   }
 
-  private int convertImportanceToPriority(int importance) {
-    switch (importance) {
-      case NotificationManagerCompat.IMPORTANCE_MIN:
-        return NotificationCompat.PRIORITY_MIN;
-      case NotificationManagerCompat.IMPORTANCE_LOW:
-        return NotificationCompat.PRIORITY_LOW;
-      case NotificationManagerCompat.IMPORTANCE_HIGH:
-        return NotificationCompat.PRIORITY_HIGH;
-      case NotificationManagerCompat.IMPORTANCE_MAX:
-        return NotificationCompat.PRIORITY_MAX;
-      case NotificationManagerCompat.IMPORTANCE_UNSPECIFIED:
-      case NotificationManagerCompat.IMPORTANCE_NONE:
-      case NotificationManagerCompat.IMPORTANCE_DEFAULT:
-      default:
-        return NotificationCompat.PRIORITY_DEFAULT;
-    }
-  }
-
   @RequiresApi(Build.VERSION_CODES.O)
-  private void createChannel(Notification notification, int name, int description, int importance) {
+  private void createChannel(
+      Notification notification, int name, int description, InterruptionLevel interruptionLevel) {
     notificationManager.createNotificationChannelGroup(
         new NotificationChannelGroup(
             CHANNEL_GROUP_ID, context.getString(R.string.notifications_group_name)));
     NotificationChannel channel =
-        new NotificationChannel(notification.channelId, context.getString(name), importance);
+        new NotificationChannel(
+            notification.channelId, context.getString(name), interruptionLevel.channelImportance);
     channel.setDescription(context.getString(description));
     channel.setGroup(CHANNEL_GROUP_ID);
     // Register the channel with the system; you can't change the importance

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TakeScreenshotAndStartFeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TakeScreenshotAndStartFeedbackActivity.java
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import android.app.Activity;
+import android.os.Bundle;
+import com.google.firebase.appdistribution.FirebaseAppDistribution;
+
+public class TakeScreenshotAndStartFeedbackActivity extends Activity {
+
+  private static final String TAG = "TakeScreenshotAndStartFeedbackActivity";
+
+  public static final String INFO_TEXT_EXTRA_KEY =
+      "com.google.firebase.appdistribution.TakeScreenshotAndStartFeedbackActivity.INFO_TEXT";
+
+  private CharSequence infoText;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    infoText = getIntent().getCharSequenceExtra(INFO_TEXT_EXTRA_KEY);
+    LogWrapper.getInstance().i(TAG, "Capturing screenshot and starting feedback");
+    FirebaseAppDistribution.getInstance().startFeedback(infoText);
+    finish();
+  }
+}

--- a/firebase-appdistribution/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/src/main/res/values/strings.xml
@@ -29,8 +29,13 @@
   <string name="install_failed">Install failed</string>
   <string name="install_canceled">Install canceled</string>
   <string name="update_canceled">Update canceled </string>
-  <string name="notifications_channel_name">App Distribution App Update Downloads</string>
-  <string name="notifications_channel_description">Shows download progress of in-app updates from App Distribution SDK</string>
+  <string name="notifications_group_name">Firebase App Distribution</string>
+  <string name="app_update_notification_channel_name">App updates</string>
+  <string name="app_update_notification_channel_description">Shows progress of in-app updates</string>
+  <string name="feedback_notification_channel_name">Feedback</string>
+  <string name="feedback_notification_channel_description">Tap to leave feedback</string>
+  <string name="feedback_notification_title">We want your feedback!</string>
+  <string name="feedback_notification_text">Tap to leave feedback for %1$s</string>
   <string name="unknown_sources_dialog_title">Enable Unknown Sources</string>
   <string name="unknown_sources_dialog_description">To install the update enable unknown sources</string>
   <string name="unknown_sources_yes_button">Settings</string>

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
@@ -167,7 +167,7 @@ public class ApkUpdaterTest {
     assertThat(e.getErrorCode()).isEqualTo(Status.DOWNLOAD_FAILURE);
     assertThat(e).hasMessageThat().contains("Failed to download APK");
     assertThat(e).hasCauseThat().isEqualTo(caughtException);
-    verify(mockNotificationsManager).updateNotification(0, 0, R.string.download_failed);
+    verify(mockNotificationsManager).showAppUpdateNotification(0, 0, R.string.download_failed);
   }
 
   @Test
@@ -211,7 +211,7 @@ public class ApkUpdaterTest {
 
     // Verify that the notification in validateJarFile is set.
     verify(mockNotificationsManager)
-        .updateNotification(0, TEST_FILE.length(), R.string.download_failed);
+        .showAppUpdateNotification(0, TEST_FILE.length(), R.string.download_failed);
   }
 
   @Test
@@ -239,7 +239,7 @@ public class ApkUpdaterTest {
     assertThat(progressEvents).hasSize(1);
     assertThat(progressEvents.get(0).getUpdateStatus()).isEqualTo(UpdateStatus.INSTALL_FAILED);
     assertThat(updateTask.isSuccessful()).isFalse();
-    verify(mockNotificationsManager).updateNotification(1000, 1000, R.string.install_failed);
+    verify(mockNotificationsManager).showAppUpdateNotification(1000, 1000, R.string.install_failed);
   }
 
   @Test

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManagerTest.java
@@ -28,6 +28,7 @@ import android.app.NotificationManager;
 import android.content.Intent;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.appdistribution.InterruptionLevel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -110,7 +111,7 @@ public class FirebaseAppDistributionNotificationsManagerTest {
   @Test
   public void showFeedbackNotification_createsGroupAndChannel() {
     firebaseAppDistributionNotificationsManager.showFeedbackNotification(
-        "Terms and conditions", IMPORTANCE_HIGH);
+        "Terms and conditions", InterruptionLevel.HIGH);
     assertThat(shadowOf(notificationManager).getNotificationChannelGroup(CHANNEL_GROUP_ID))
         .isNotNull();
     assertThat(shadowOf(notificationManager).getNotificationChannels()).hasSize(1);
@@ -123,7 +124,7 @@ public class FirebaseAppDistributionNotificationsManagerTest {
   @Test
   public void showFeedbackNotification_setsIntentToScreenshotActivity() {
     firebaseAppDistributionNotificationsManager.showFeedbackNotification(
-        "Terms and conditions", IMPORTANCE_HIGH);
+        "Terms and conditions", InterruptionLevel.HIGH);
     assertThat(shadowOf(notificationManager).size()).isEqualTo(1);
     Notification notification =
         shadowOf(notificationManager).getNotification(FEEDBACK.tag, FEEDBACK.id);
@@ -141,7 +142,7 @@ public class FirebaseAppDistributionNotificationsManagerTest {
   @Test
   public void showFeedbackNotification_convertsImportanceToPriority() {
     firebaseAppDistributionNotificationsManager.showFeedbackNotification(
-        "Terms and conditions", IMPORTANCE_HIGH);
+        "Terms and conditions", InterruptionLevel.HIGH);
     assertThat(shadowOf(notificationManager).size()).isEqualTo(1);
     Notification notification =
         shadowOf(notificationManager).getNotification(FEEDBACK.tag, FEEDBACK.id);

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManagerTest.java
@@ -14,13 +14,18 @@
 
 package com.google.firebase.appdistribution.impl;
 
+import static android.app.NotificationManager.IMPORTANCE_HIGH;
 import static android.content.Context.NOTIFICATION_SERVICE;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.firebase.appdistribution.impl.FirebaseAppDistributionNotificationsManager.NOTIFICATION_TAG;
+import static com.google.firebase.appdistribution.impl.FirebaseAppDistributionNotificationsManager.CHANNEL_GROUP_ID;
+import static com.google.firebase.appdistribution.impl.FirebaseAppDistributionNotificationsManager.Notification.APP_UPDATE;
+import static com.google.firebase.appdistribution.impl.FirebaseAppDistributionNotificationsManager.Notification.FEEDBACK;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.content.Intent;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.firebase.FirebaseApp;
 import org.junit.Before;
@@ -48,41 +53,98 @@ public class FirebaseAppDistributionNotificationsManagerTest {
   }
 
   @Test
-  public void updateNotification_withProgress() {
-    firebaseAppDistributionNotificationsManager.updateNotification(
+  public void showAppUpdateNotification_createsGroupAndChannel() {
+    firebaseAppDistributionNotificationsManager.showAppUpdateNotification(
+        1000, 900, R.string.downloading_app_update);
+    assertThat(shadowOf(notificationManager).getNotificationChannelGroup(CHANNEL_GROUP_ID))
+        .isNotNull();
+    assertThat(shadowOf(notificationManager).getNotificationChannels()).hasSize(1);
+    NotificationChannel channel =
+        (NotificationChannel) shadowOf(notificationManager).getNotificationChannels().get(0);
+    assertThat(channel.getId()).isEqualTo(APP_UPDATE.channelId);
+  }
+
+  @Test
+  public void showAppUpdateNotification_withProgress() {
+    firebaseAppDistributionNotificationsManager.showAppUpdateNotification(
         1000, 900, R.string.downloading_app_update);
     assertThat(shadowOf(notificationManager).size()).isEqualTo(1);
-    Notification notification = shadowOf(notificationManager).getNotification(NOTIFICATION_TAG, 0);
+    Notification notification =
+        shadowOf(notificationManager).getNotification(APP_UPDATE.tag, APP_UPDATE.id);
     assertThat(shadowOf(notification).getProgress()).isEqualTo(90);
     assertThat(shadowOf(notification).getContentTitle().toString()).contains("Downloading");
   }
 
   @Test
-  public void updateNotification_withError() {
-    firebaseAppDistributionNotificationsManager.updateNotification(
+  public void showAppUpdateNotification_withError() {
+    firebaseAppDistributionNotificationsManager.showAppUpdateNotification(
         1000, 1000, R.string.download_failed);
     assertThat(shadowOf(notificationManager).size()).isEqualTo(1);
-    Notification notification = shadowOf(notificationManager).getNotification(NOTIFICATION_TAG, 0);
+    Notification notification =
+        shadowOf(notificationManager).getNotification(APP_UPDATE.tag, APP_UPDATE.id);
     assertThat(shadowOf(notification).getProgress()).isEqualTo(100);
     assertThat(shadowOf(notification).getContentTitle().toString()).contains("Download failed");
   }
 
   @Test
-  public void updateNotification_withSuccess() {
-    firebaseAppDistributionNotificationsManager.updateNotification(
+  public void showAppUpdateNotification_withSuccess() {
+    firebaseAppDistributionNotificationsManager.showAppUpdateNotification(
         1000, 1000, R.string.download_completed);
     assertThat(shadowOf(notificationManager).size()).isEqualTo(1);
-    Notification notification = shadowOf(notificationManager).getNotification(NOTIFICATION_TAG, 0);
+    Notification notification =
+        shadowOf(notificationManager).getNotification(APP_UPDATE.tag, APP_UPDATE.id);
     assertThat(shadowOf(notification).getProgress()).isEqualTo(100);
     assertThat(shadowOf(notification).getContentTitle().toString()).contains("Download completed");
   }
 
   @Test
-  public void updateNotification_withZeroTotalBytes_shows0Percent() {
-    firebaseAppDistributionNotificationsManager.updateNotification(
+  public void showAppUpdateNotification_withZeroTotalBytes_shows0Percent() {
+    firebaseAppDistributionNotificationsManager.showAppUpdateNotification(
         0, 0, R.string.downloading_app_update);
     assertThat(shadowOf(notificationManager).size()).isEqualTo(1);
-    Notification notification = shadowOf(notificationManager).getNotification(NOTIFICATION_TAG, 0);
+    Notification notification =
+        shadowOf(notificationManager).getNotification(APP_UPDATE.tag, APP_UPDATE.id);
     assertThat(shadowOf(notification).getProgress()).isEqualTo(0);
+  }
+
+  @Test
+  public void showFeedbackNotification_createsGroupAndChannel() {
+    firebaseAppDistributionNotificationsManager.showFeedbackNotification(
+        "Terms and conditions", IMPORTANCE_HIGH);
+    assertThat(shadowOf(notificationManager).getNotificationChannelGroup(CHANNEL_GROUP_ID))
+        .isNotNull();
+    assertThat(shadowOf(notificationManager).getNotificationChannels()).hasSize(1);
+    NotificationChannel channel =
+        (NotificationChannel) shadowOf(notificationManager).getNotificationChannels().get(0);
+    assertThat(channel.getImportance()).isEqualTo(IMPORTANCE_HIGH);
+    assertThat(channel.getId()).isEqualTo(FEEDBACK.channelId);
+  }
+
+  @Test
+  public void showFeedbackNotification_setsIntentToScreenshotActivity() {
+    firebaseAppDistributionNotificationsManager.showFeedbackNotification(
+        "Terms and conditions", IMPORTANCE_HIGH);
+    assertThat(shadowOf(notificationManager).size()).isEqualTo(1);
+    Notification notification =
+        shadowOf(notificationManager).getNotification(FEEDBACK.tag, FEEDBACK.id);
+    Intent expectedIntent =
+        new Intent(
+            ApplicationProvider.getApplicationContext(),
+            TakeScreenshotAndStartFeedbackActivity.class);
+    Intent actualIntent = shadowOf(notification.contentIntent).getSavedIntent();
+    assertThat(actualIntent.getComponent()).isEqualTo(expectedIntent.getComponent());
+    assertThat(
+            actualIntent.getStringExtra(TakeScreenshotAndStartFeedbackActivity.INFO_TEXT_EXTRA_KEY))
+        .isEqualTo("Terms and conditions");
+  }
+
+  @Test
+  public void showFeedbackNotification_convertsImportanceToPriority() {
+    firebaseAppDistributionNotificationsManager.showFeedbackNotification(
+        "Terms and conditions", IMPORTANCE_HIGH);
+    assertThat(shadowOf(notificationManager).size()).isEqualTo(1);
+    Notification notification =
+        shadowOf(notificationManager).getNotification(FEEDBACK.tag, FEEDBACK.id);
+    assertThat(notification.priority).isEqualTo(Notification.PRIORITY_HIGH);
   }
 }

--- a/firebase-appdistribution/test-app/src/main/AndroidManifest.xml
+++ b/firebase-appdistribution/test-app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
   <application
       android:allowBackup="true"
       android:icon="@mipmap/ic_launcher"
-      android:label="@string/app_name"
+      android:label="@string/appName"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:supportsRtl="true"
       android:theme="@style/Theme.AppDistributionTestAppSample"

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/AppDistroTestApplication.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/AppDistroTestApplication.kt
@@ -7,8 +7,8 @@ class AppDistroTestApplication : Application() {
         super.onCreate()
 
         // Perform any required trigger initialization here
-        ScreenshotDetectionFeedbackTrigger.initialize(this, R.string.terms_and_conditions)
-//        NotificationFeedbackTrigger.initialize(this);
+        ScreenshotDetectionFeedbackTrigger.initialize(this, R.string.termsAndConditions)
+        CustomNotificationFeedbackTrigger.initialize(this);
 
         // Default feedback triggers can optionally be enabled application-wide here
 //        ShakeForFeedback.enable(this)

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/AppDistroTestApplication.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/AppDistroTestApplication.kt
@@ -7,8 +7,8 @@ class AppDistroTestApplication : Application() {
         super.onCreate()
 
         // Perform any required trigger initialization here
-        ScreenshotDetectionFeedbackTrigger.initialize(this, R.string.terms_and_conditions);
-        NotificationFeedbackTrigger.initialize(this);
+        ScreenshotDetectionFeedbackTrigger.initialize(this, R.string.terms_and_conditions)
+//        NotificationFeedbackTrigger.initialize(this);
 
         // Default feedback triggers can optionally be enabled application-wide here
 //        ShakeForFeedback.enable(this)

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/CustomNotificationFeedbackTrigger.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/CustomNotificationFeedbackTrigger.kt
@@ -24,7 +24,7 @@ import com.google.firebase.ktx.Firebase
 import java.io.IOException
 
 @SuppressLint("StaticFieldLeak") // Reference to Activity is set to null in onActivityDestroyed
-object NotificationFeedbackTrigger : Application.ActivityLifecycleCallbacks {
+object CustomNotificationFeedbackTrigger : Application.ActivityLifecycleCallbacks {
   private const val TAG: String = "NotificationFeedbackTrigger"
   private const val FEEBACK_NOTIFICATION_CHANNEL_ID = "InAppFeedbackNotification"
   private const val FEEDBACK_NOTIFICATION_ID = 1
@@ -49,11 +49,11 @@ object NotificationFeedbackTrigger : Application.ActivityLifecycleCallbacks {
       val channel =
         NotificationChannel(
           FEEBACK_NOTIFICATION_CHANNEL_ID,
-          application.getString(R.string.feedback_trigger_notification_channel_name),
+          application.getString(R.string.feedbackTriggerNotificationChannelName),
           NotificationManager.IMPORTANCE_HIGH
         )
       channel.description =
-        application.getString(R.string.feedback_trigger_notification_channel_description)
+        application.getString(R.string.feedbackTriggerNotificationChannelDescription)
       application
         .getSystemService(NotificationManager::class.java)
         .createNotificationChannel(channel)
@@ -156,8 +156,8 @@ object NotificationFeedbackTrigger : Application.ActivityLifecycleCallbacks {
     val builder =
       NotificationCompat.Builder(context, FEEBACK_NOTIFICATION_CHANNEL_ID)
         .setSmallIcon(R.mipmap.ic_launcher)
-        .setContentTitle(context.getText(R.string.feedback_trigger_notification_title))
-        .setContentText(context.getText(R.string.feedback_trigger_notification_text))
+        .setContentTitle(context.getText(R.string.feedbackTriggerNotificationTitle))
+        .setContentText(context.getText(R.string.feedbackTriggerNotificationText))
         .setPriority(NotificationCompat.PRIORITY_HIGH)
         .setContentIntent(pendingIntent)
     val notificationManager = NotificationManagerCompat.from(context)
@@ -198,7 +198,7 @@ object NotificationFeedbackTrigger : Application.ActivityLifecycleCallbacks {
 class TakeScreenshotAndTriggerFeedbackActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    val activity = NotificationFeedbackTrigger.activityToScreenshot
+    val activity = CustomNotificationFeedbackTrigger.activityToScreenshot
     if (activity == null) {
       Log.e(TAG, "Can't take screenshot because activity is unknown")
       return
@@ -209,7 +209,8 @@ class TakeScreenshotAndTriggerFeedbackActivity : Activity() {
   override fun onResume() {
     super.onResume()
     val screenshotUri = Uri.fromFile(getFileStreamPath(SCREENSHOT_FILE_NAME))
-    Firebase.appDistribution.startFeedback(R.string.terms_and_conditions, screenshotUri)
+    Firebase.appDistribution.startFeedback(R.string.termsAndConditions, screenshotUri)
+    finish()
   }
 
   fun takeScreenshot(activity: Activity) {

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -15,7 +15,6 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
-import androidx.core.app.NotificationManagerCompat
 import androidx.core.widget.doOnTextChanged
 import com.google.android.gms.tasks.Task
 import com.google.android.material.textfield.TextInputLayout

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.core.widget.doOnTextChanged
 import com.google.android.gms.tasks.Task
 import com.google.android.material.textfield.TextInputLayout
 import com.google.firebase.appdistribution.AppDistributionRelease
+import com.google.firebase.appdistribution.InterruptionLevel
 import com.google.firebase.appdistribution.UpdateProgress
 import com.google.firebase.appdistribution.ktx.appDistribution
 import com.google.firebase.ktx.Firebase
@@ -94,7 +95,7 @@ class MainActivity : AppCompatActivity() {
                     disableAllFeedbackTriggers()
                     Log.i(TAG, "Enabling notification trigger (SDK)")
                     firebaseAppDistribution.showFeedbackNotification(
-                        R.string.termsAndConditions, NotificationManagerCompat.IMPORTANCE_HIGH)
+                        R.string.termsAndConditions, InterruptionLevel.HIGH)
                 }
                 FeedbackTrigger.CUSTOM_NOTIFICATION.label -> {
                     disableAllFeedbackTriggers()

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/NotificationFeedbackTrigger.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/NotificationFeedbackTrigger.kt
@@ -49,11 +49,11 @@ object NotificationFeedbackTrigger : Application.ActivityLifecycleCallbacks {
       val channel =
         NotificationChannel(
           FEEBACK_NOTIFICATION_CHANNEL_ID,
-          application.getString(R.string.feedback_notification_channel_name),
+          application.getString(R.string.feedback_trigger_notification_channel_name),
           NotificationManager.IMPORTANCE_HIGH
         )
       channel.description =
-        application.getString(R.string.feedback_notification_channel_description)
+        application.getString(R.string.feedback_trigger_notification_channel_description)
       application
         .getSystemService(NotificationManager::class.java)
         .createNotificationChannel(channel)
@@ -156,8 +156,8 @@ object NotificationFeedbackTrigger : Application.ActivityLifecycleCallbacks {
     val builder =
       NotificationCompat.Builder(context, FEEBACK_NOTIFICATION_CHANNEL_ID)
         .setSmallIcon(R.mipmap.ic_launcher)
-        .setContentTitle(context.getText(R.string.feedback_notification_title))
-        .setContentText(context.getText(R.string.feedback_notification_text))
+        .setContentTitle(context.getText(R.string.feedback_trigger_notification_title))
+        .setContentText(context.getText(R.string.feedback_trigger_notification_text))
         .setPriority(NotificationCompat.PRIORITY_HIGH)
         .setContentIntent(pendingIntent)
     val notificationManager = NotificationManagerCompat.from(context)
@@ -221,9 +221,9 @@ class TakeScreenshotAndTriggerFeedbackActivity : Activity() {
       activity.openFileOutput(SCREENSHOT_FILE_NAME, Context.MODE_PRIVATE).use { outputStream ->
         bitmap.compress(Bitmap.CompressFormat.PNG, /* quality = */ 100, outputStream)
       }
-      Log.i(TAG, "Wrote screenshot to ${SCREENSHOT_FILE_NAME}")
+      Log.i(TAG, "Wrote screenshot to $SCREENSHOT_FILE_NAME")
     } catch (e: IOException) {
-      Log.e(TAG, "Can't write ${SCREENSHOT_FILE_NAME}", e)
+      Log.e(TAG, "Can't write $SCREENSHOT_FILE_NAME", e)
     }
   }
 

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/SecondActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/SecondActivity.kt
@@ -34,7 +34,7 @@ class SecondActivity : AppCompatActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.startFeedbackMenuItem -> {
-                Firebase.appDistribution.startFeedback(R.string.terms_and_conditions)
+                Firebase.appDistribution.startFeedback(R.string.termsAndConditions)
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ShakeForFeedback.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/ShakeForFeedback.kt
@@ -50,7 +50,7 @@ object ShakeForFeedback : ShakeDetector.Listener, Application.ActivityLifecycleC
 
     override fun hearShake() {
         Log.i(TAG, "Shake detected")
-        Firebase.appDistribution.startFeedback(R.string.terms_and_conditions)
+        Firebase.appDistribution.startFeedback(R.string.termsAndConditions)
     }
 
     override fun onActivityResumed(activity: Activity) {

--- a/firebase-appdistribution/test-app/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/test-app/src/main/res/values/strings.xml
@@ -1,10 +1,10 @@
 <resources>
-    <string name="app_name">App Distro Sample</string>
-    <string name="terms_and_conditions"><b>Before giving feedback</b> you might want to check out the <a href="https://policies.google.com/terms">Terms and Conditions</a></string>
+    <string name="appName">App Distro Sample</string>
+    <string name="termsAndConditions"><b>Before giving feedback</b> you might want to check out the <a href="https://policies.google.com/terms">Terms and Conditions</a></string>
     <string name="feedbackTriggerMenuLabel">Choose a feedback trigger</string>
     <string name="startFeedbackLabel">Start feedback</string>
-    <string name="feedback_trigger_notification_title">We want your Feedback!</string>
-    <string name="feedback_trigger_notification_text">Click to leave feedback for the App Distro Sample App</string>
-    <string name="feedback_trigger_notification_channel_name">Feedback Notification</string>
-    <string name="feedback_trigger_notification_channel_description">Used to trigger Feedback</string>
+    <string name="feedbackTriggerNotificationTitle">We want your Feedback!</string>
+    <string name="feedbackTriggerNotificationText">This is a custom notification shown by the App Distro Sample App</string>
+    <string name="feedbackTriggerNotificationChannelName">Feedback notification</string>
+    <string name="feedbackTriggerNotificationChannelDescription">Used to trigger feedback</string>
 </resources>

--- a/firebase-appdistribution/test-app/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/test-app/src/main/res/values/strings.xml
@@ -3,8 +3,8 @@
     <string name="terms_and_conditions"><b>Before giving feedback</b> you might want to check out the <a href="https://policies.google.com/terms">Terms and Conditions</a></string>
     <string name="feedbackTriggerMenuLabel">Choose a feedback trigger</string>
     <string name="startFeedbackLabel">Start feedback</string>
-    <string name="feedback_notification_title">We want your Feedback!</string>
-    <string name="feedback_notification_text">Click to leave feedback for the App Distro Sample App</string>
-    <string name="feedback_notification_channel_name">Feedback Notification</string>
-    <string name="feedback_notification_channel_description">Used to trigger Feedback</string>
+    <string name="feedback_trigger_notification_title">We want your Feedback!</string>
+    <string name="feedback_trigger_notification_text">Click to leave feedback for the App Distro Sample App</string>
+    <string name="feedback_trigger_notification_channel_name">Feedback Notification</string>
+    <string name="feedback_trigger_notification_channel_description">Used to trigger Feedback</string>
 </resources>

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.googletest.firebase.appdistribution.testapp"
         minSdkVersion 23
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionName "2.1"
         versionCode 3
 

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.googletest.firebase.appdistribution.testapp"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 32
         versionName "2.1"
         versionCode 3
 


### PR DESCRIPTION
This adds a new API allowing developers to show a notification that, when tapped, will take a screenshot of the running application and open the feedback form. This way the developers don't need to add any new UI elements to their app to trigger feedback.

Other changes include:

- The lifecycle notifier now tracks the previous activity in addition to the current one, so that we can ignore our own empty activity when taking a screenshot after the notification is tapped.
- Adds the SDK-based notification trigger to the test app