### PR TITLE
Catch NPE when removing activity from frameMetricsAggregator

### DIFF
--- a/firebase-perf/CHANGELOG.md
+++ b/firebase-perf/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-* 
+* [fixed] Fixed a `NullPointerException` crash when instrumenting screen traces
+  on Android 7, 8, and 9.
+  (#4146)
 
 ## Kotlin
 The Kotlin extensions library transitively includes the updated

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
@@ -108,7 +108,7 @@ public class FrameMetricsRecorder {
     Optional<PerfFrameMetrics> data = this.snapshot();
     try {
       frameMetricsAggregator.remove(activity);
-    } catch (IllegalArgumentException err) {
+    } catch (IllegalArgumentException | NullPointerException err) {
       logger.warn(
           "View not hardware accelerated. Unable to collect FrameMetrics. %s", err.toString());
       return Optional.absent();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
@@ -15,6 +15,7 @@
 package com.google.firebase.perf.application;
 
 import android.app.Activity;
+import android.os.Build;
 import android.util.SparseIntArray;
 import androidx.core.app.FrameMetricsAggregator;
 import androidx.fragment.app.Fragment;
@@ -113,7 +114,10 @@ public class FrameMetricsRecorder {
       // failing when the view is not hardware-accelerated. Successful addFrameMetricsListener
       // stores an observer in a list, and initializes the list if it was uninitialized. Invoking
       // View.removeFrameMetricsListener(listener) throws IAE if it doesn't exist in the list, or
-      // throws NPE if the list itself was never initialized.
+      // throws NPE if the list itself was never initialized. This NPE is fixed in API 29.
+      if (ex instanceof NullPointerException && Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+        throw ex;
+      }
       logger.warn(
           "View not hardware accelerated. Unable to collect FrameMetrics. %s", ex.toString());
       data = Optional.absent();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
@@ -108,9 +108,15 @@ public class FrameMetricsRecorder {
     Optional<PerfFrameMetrics> data = this.snapshot();
     try {
       frameMetricsAggregator.remove(activity);
-    } catch (IllegalArgumentException | NullPointerException err) {
+    } catch (IllegalArgumentException err) {
       logger.warn(
           "View not hardware accelerated. Unable to collect FrameMetrics. %s", err.toString());
+      frameMetricsAggregator.reset();
+      return Optional.absent();
+    } catch (NullPointerException err) {
+      frameMetricsAggregator.reset();
+      logger.warn(
+          "NullPointerException. %s", err.toString());
       return Optional.absent();
     }
     frameMetricsAggregator.reset();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
@@ -108,14 +108,17 @@ public class FrameMetricsRecorder {
     }
     Optional<PerfFrameMetrics> data = this.snapshot();
     try {
+      // No reliable way to check for hardware-acceleration, so we must catch retroactively (#2736).
       frameMetricsAggregator.remove(activity);
     } catch (IllegalArgumentException | NullPointerException ex) {
       // Both of these exceptions result from android.view.View.addFrameMetricsListener silently
       // failing when the view is not hardware-accelerated. Successful addFrameMetricsListener
       // stores an observer in a list, and initializes the list if it was uninitialized. Invoking
       // View.removeFrameMetricsListener(listener) throws IAE if it doesn't exist in the list, or
-      // throws NPE if the list itself was never initialized. This NPE is fixed in API 29.
+      // throws NPE if the list itself was never initialized (#4184).
       if (ex instanceof NullPointerException && Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+        // Re-throw above API 28, since the NPE is fixed in API 29:
+        // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
         throw ex;
       }
       logger.warn(


### PR DESCRIPTION
Potential fix of #4146 

I was not able to reproduce the issue locally. I tried with Android version 7.1 API 25 and turned off hardware acceleration, but could not reproduce the issue.

It could be a bug from older Android versions.

Reference:
- A similar issue: https://bytemeta.vip/repo/getsentry/sentry-java/issues/1798
- Android's fix on Fix NPE in findFrameMetricsObserver: https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b

## Update by @leotianlizhan
Let's take a look at [Android's source code, in android.view.View](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/View.java;l=7381;drc=master?q=addFrameMetrics&ss=android%2Fplatform%2Fsuperproject).
The exception was thrown from `findFrameMetricsObserver`, inside `removeFrameMetricsListener`
![image](https://user-images.githubusercontent.com/12737815/197061665-7434623a-b4e7-4ff2-82b5-b0acf5725e6e.png)
![image](https://user-images.githubusercontent.com/12737815/197062300-9b11f5b1-ecee-4f5e-bccc-29caed87eaa9.png)
Since this null check didn't exists, this triggers NPE when `mFrameMetricsObserver` is uninitialized. As Jeremy listed in his reference, this was fixed in later Android versions. Why then, is `mFrameMetricsObserver` uninitialized? It's because `addFrameMetricsListener` fails silently!
![image](https://user-images.githubusercontent.com/12737815/197064621-78d92202-3c37-44fb-9059-4c99ae9f8c72.png)

## Conclusion
So overall, this is the **same issue caused by the view not being hardware-accelerated**. The correct error message is hidden away because `addFrameMetricsListener` fails silently, that's why we should catch them both and use the same error message. The developer's provided crash versions also lines up with when Android fixed it: the above reference fix was made in 2019, and Android 7, 8, 9 are all before 2019, with Android 10 releasing in 2019 thus fixing the issue. There is no crash before Android 7 because as Rosario pointed out, FrameMetrics was added in Android 7 (API 24). 