### PR TITLE
Deprecate App Check SafetyNet SDK

### DIFF
--- a/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
+++ b/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
@@ -23,6 +23,8 @@ import com.google.firebase.appcheck.safetynet.internal.SafetyNetAppCheckProvider
 /**
  * Implementation of an {@link AppCheckProviderFactory} that builds {@link
  * SafetyNetAppCheckProvider}s. This is the default implementation.
+ *
+ * @deprecated Use {@code PlayIntegrityAppCheckProviderFactory} instead.
  */
 @Deprecated
 public class SafetyNetAppCheckProviderFactory implements AppCheckProviderFactory {
@@ -35,6 +37,8 @@ public class SafetyNetAppCheckProviderFactory implements AppCheckProviderFactory
   /**
    * Gets an instance of this class for installation into a {@link
    * com.google.firebase.appcheck.FirebaseAppCheck} instance.
+   *
+   * @deprecated Use {@code PlayIntegrityAppCheckProviderFactory#getInstance} instead.
    */
   @Deprecated
   @NonNull

--- a/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
+++ b/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
@@ -24,6 +24,7 @@ import com.google.firebase.appcheck.safetynet.internal.SafetyNetAppCheckProvider
  * Implementation of an {@link AppCheckProviderFactory} that builds {@link
  * SafetyNetAppCheckProvider}s. This is the default implementation.
  */
+@Deprecated
 public class SafetyNetAppCheckProviderFactory implements AppCheckProviderFactory {
 
   private static final SafetyNetAppCheckProviderFactory instance =
@@ -35,6 +36,7 @@ public class SafetyNetAppCheckProviderFactory implements AppCheckProviderFactory
    * Gets an instance of this class for installation into a {@link
    * com.google.firebase.appcheck.FirebaseAppCheck} instance.
    */
+  @Deprecated
   @NonNull
   public static SafetyNetAppCheckProviderFactory getInstance() {
     return instance;


### PR DESCRIPTION
[The SafetyNet Attestation API is being deprecated and replaced with the Play Integrity API](https://developer.android.com/training/safetynet/deprecation-timeline); as such, we will also be deprecating App Check's use of SafetyNet.