### PR TITLE
Change sendUnsentReports return type to async

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -404,8 +404,8 @@ public class FirebaseCrashlytics {
    * If automatic data collection is disabled, this method queues up all the reports on a device to
    * send to Crashlytics. Otherwise, this method is a no-op.
    */
-  public void sendUnsentReports() {
-    core.sendUnsentReports();
+  public Task<Void> sendUnsentReports() {
+    return core.sendUnsentReports();
   }
 
   /**


### PR DESCRIPTION
Change `FirebaseCrashlytics#sendUnsentReports` return type to `Task<Void>`

With  a `Task` type result returned, we can hold and wait the task to be finished if we want.