### PR TITLE
Assign ConfigContainer Builder return values.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -413,7 +413,7 @@ public class ConfigFetchHttpClient {
         // Do nothing if entries do not exist.
       }
       if (entries != null) {
-        containerBuilder.replaceConfigsWith(entries);
+        containerBuilder = containerBuilder.replaceConfigsWith(entries);
       }
 
       JSONArray experimentDescriptions = null;
@@ -423,7 +423,7 @@ public class ConfigFetchHttpClient {
         // Do nothing if entries do not exist.
       }
       if (experimentDescriptions != null) {
-        containerBuilder.withAbtExperiments(experimentDescriptions);
+        containerBuilder = containerBuilder.withAbtExperiments(experimentDescriptions);
       }
 
       JSONObject personalizationMetadata = null;
@@ -433,7 +433,7 @@ public class ConfigFetchHttpClient {
         // Do nothing if personalizationMetadata does not exist.
       }
       if (personalizationMetadata != null) {
-        containerBuilder.withPersonalizationMetadata(personalizationMetadata);
+        containerBuilder = containerBuilder.withPersonalizationMetadata(personalizationMetadata);
       }
 
       return containerBuilder.build();

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHandlerTest.java
@@ -1033,10 +1033,10 @@ public class ConfigFetchHandlerTest {
         ConfigContainer.newBuilder().withFetchTime(fetchTime);
 
     JSONObject entries = fetchResponse.getJSONObject(ENTRIES);
-    containerBuilder.replaceConfigsWith(entries);
+    containerBuilder = containerBuilder.replaceConfigsWith(entries);
 
     JSONArray experimentDescriptions = fetchResponse.getJSONArray(EXPERIMENT_DESCRIPTIONS);
-    containerBuilder.withAbtExperiments(experimentDescriptions);
+    containerBuilder = containerBuilder.withAbtExperiments(experimentDescriptions);
 
     return containerBuilder.build();
   }


### PR DESCRIPTION
Assign the few builder setter return values to satisfy `@CheckReturnValue` requirements for Google's build system. This avoids a dependency on `com.google.errorprone:error_prone_annotations` -- firebase-components already has error_prone (so we include it transitively) but we don't need the annotation extensively and can avoid maintaining/updating more dep versions.

This is a no-op change.

Internal: b/245979943#comment4