### PR TITLE
Fix Firestore failing to return empty results from the local cache

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+Fix Firestore failing to raise initial snapshot from empty local cache result.
 
 # 24.4.0
 * [unchanged] Updated to accommodate the release of the updated

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-Fix Firestore failing to raise initial snapshot from empty local cache result.
+- [fixed] Fixed Firestore failing to raise initial snapshot from empty local cache result.
 
 # 24.4.0
 * [unchanged] Updated to accommodate the release of the updated

--- a/firebase-firestore/ktx/src/test/java/com/google/firebase/firestore/TestUtil.java
+++ b/firebase-firestore/ktx/src/test/java/com/google/firebase/firestore/TestUtil.java
@@ -105,7 +105,8 @@ public class TestUtil {
             isFromCache,
             mutatedKeys,
             /* didSyncStateChange= */ true,
-            /* excludesMetadataChanges= */ false);
+            /* excludesMetadataChanges= */ false,
+            /* hasCachedResults= */ false);
     return new QuerySnapshot(query(path), viewSnapshot, FIRESTORE);
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java
@@ -87,7 +87,8 @@ public class QueryListener {
               newSnapshot.isFromCache(),
               newSnapshot.getMutatedKeys(),
               newSnapshot.didSyncStateChange(),
-              /* excludesMetadataChanges= */ true);
+              /* excludesMetadataChanges= */ true,
+              newSnapshot.hasCachedResults());
     }
 
     if (!raisedInitialEvent) {
@@ -139,8 +140,11 @@ public class QueryListener {
       return false;
     }
 
-    // Raise data from cache if we have any documents or we are offline
-    return !snapshot.getDocuments().isEmpty() || onlineState.equals(OnlineState.OFFLINE);
+    // Raise data from cache if we have any documents, have cached results before,
+    // or we are offline.
+    return (!snapshot.getDocuments().isEmpty()
+        || snapshot.hasCachedResults()
+        || onlineState.equals(OnlineState.OFFLINE));
   }
 
   private boolean shouldRaiseEvent(ViewSnapshot snapshot) {
@@ -171,7 +175,8 @@ public class QueryListener {
             snapshot.getDocuments(),
             snapshot.getMutatedKeys(),
             snapshot.isFromCache(),
-            snapshot.excludesMetadataChanges());
+            snapshot.excludesMetadataChanges(),
+            snapshot.hasCachedResults());
     raisedInitialEvent = true;
     listener.onEvent(snapshot, null);
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -226,7 +226,6 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
       Query mirrorQuery = this.queriesByTarget.get(targetId).get(0);
       currentTargetSyncState = this.queryViewsByQuery.get(mirrorQuery).getView().getSyncState();
     }
-    ;
     synthesizedCurrentChange =
         TargetChange.createSynthesizedTargetChangeForCurrentChange(
             currentTargetSyncState == SyncState.SYNCED, resumeToken);

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/SyncEngine.java
@@ -225,10 +225,11 @@ public class SyncEngine implements RemoteStore.RemoteStoreCallback {
     if (this.queriesByTarget.get(targetId) != null) {
       Query mirrorQuery = this.queriesByTarget.get(targetId).get(0);
       currentTargetSyncState = this.queryViewsByQuery.get(mirrorQuery).getView().getSyncState();
-      synthesizedCurrentChange =
-          TargetChange.createSynthesizedTargetChangeForCurrentChange(
-              currentTargetSyncState == SyncState.SYNCED, resumeToken);
     }
+    ;
+    synthesizedCurrentChange =
+        TargetChange.createSynthesizedTargetChangeForCurrentChange(
+            currentTargetSyncState == SyncState.SYNCED, resumeToken);
 
     // TODO(wuandy): Investigate if we can extract the logic of view change computation and
     // update tracked limbo in one place, and have both emitNewSnapsAndNotifyLocalStore

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
@@ -311,7 +311,10 @@ public class View {
               fromCache,
               docChanges.mutatedKeys,
               syncStatedChanged,
-              /* excludesMetadataChanges= */ false);
+              /* excludesMetadataChanges= */ false,
+              /* hasCachedResults= */ targetChange == null
+                  ? false
+                  : !targetChange.getResumeToken().isEmpty());
     }
     return new ViewChange(snapshot, limboDocumentChanges);
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
@@ -300,8 +300,11 @@ public class View {
     boolean syncStatedChanged = newSyncState != syncState;
     syncState = newSyncState;
     ViewSnapshot snapshot = null;
+
     if (viewChanges.size() != 0 || syncStatedChanged) {
       boolean fromCache = newSyncState == SyncState.LOCAL;
+      boolean hasCachedResults =
+          targetChange == null ? false : !targetChange.getResumeToken().isEmpty();
       snapshot =
           new ViewSnapshot(
               query,
@@ -312,9 +315,7 @@ public class View {
               docChanges.mutatedKeys,
               syncStatedChanged,
               /* excludesMetadataChanges= */ false,
-              /* hasCachedResults= */ targetChange == null
-                  ? false
-                  : !targetChange.getResumeToken().isEmpty());
+              hasCachedResults);
     }
     return new ViewChange(snapshot, limboDocumentChanges);
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
@@ -39,6 +39,7 @@ public class ViewSnapshot {
   private final ImmutableSortedSet<DocumentKey> mutatedKeys;
   private final boolean didSyncStateChange;
   private boolean excludesMetadataChanges;
+  private boolean hasCachedResults;
 
   public ViewSnapshot(
       Query query,
@@ -48,7 +49,8 @@ public class ViewSnapshot {
       boolean isFromCache,
       ImmutableSortedSet<DocumentKey> mutatedKeys,
       boolean didSyncStateChange,
-      boolean excludesMetadataChanges) {
+      boolean excludesMetadataChanges,
+      boolean hasCachedResults) {
     this.query = query;
     this.documents = documents;
     this.oldDocuments = oldDocuments;
@@ -57,6 +59,7 @@ public class ViewSnapshot {
     this.mutatedKeys = mutatedKeys;
     this.didSyncStateChange = didSyncStateChange;
     this.excludesMetadataChanges = excludesMetadataChanges;
+    this.hasCachedResults = hasCachedResults;
   }
 
   /** Returns a view snapshot as if all documents in the snapshot were added. */
@@ -65,7 +68,8 @@ public class ViewSnapshot {
       DocumentSet documents,
       ImmutableSortedSet<DocumentKey> mutatedKeys,
       boolean fromCache,
-      boolean excludesMetadataChanges) {
+      boolean excludesMetadataChanges,
+      boolean hasCachedResults) {
     List<DocumentViewChange> viewChanges = new ArrayList<>();
     for (Document doc : documents) {
       viewChanges.add(DocumentViewChange.create(DocumentViewChange.Type.ADDED, doc));
@@ -78,7 +82,8 @@ public class ViewSnapshot {
         fromCache,
         mutatedKeys,
         /* didSyncStateChange= */ true,
-        excludesMetadataChanges);
+        excludesMetadataChanges,
+        hasCachedResults);
   }
 
   public Query getQuery() {
@@ -117,6 +122,10 @@ public class ViewSnapshot {
     return excludesMetadataChanges;
   }
 
+  public boolean hasCachedResults() {
+    return hasCachedResults;
+  }
+
   @Override
   public final boolean equals(Object o) {
     if (this == o) {
@@ -147,6 +156,9 @@ public class ViewSnapshot {
       return false;
     }
     if (!oldDocuments.equals(that.oldDocuments)) {
+      return false;
+    }
+    if (hasCachedResults != that.hasCachedResults) {
       return false;
     }
     return changes.equals(that.changes);
@@ -183,6 +195,8 @@ public class ViewSnapshot {
         + didSyncStateChange
         + ", excludesMetadataChanges="
         + excludesMetadataChanges
+        + ", hasCachedResults="
+        + hasCachedResults
         + ")";
   }
 }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/ViewSnapshot.java
@@ -174,6 +174,7 @@ public class ViewSnapshot {
     result = 31 * result + (isFromCache ? 1 : 0);
     result = 31 * result + (didSyncStateChange ? 1 : 0);
     result = 31 * result + (excludesMetadataChanges ? 1 : 0);
+    result = 31 * result + (hasCachedResults ? 1 : 0);
     return result;
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/TargetChange.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/TargetChange.java
@@ -31,9 +31,10 @@ public final class TargetChange {
   private final ImmutableSortedSet<DocumentKey> modifiedDocuments;
   private final ImmutableSortedSet<DocumentKey> removedDocuments;
 
-  public static TargetChange createSynthesizedTargetChangeForCurrentChange(boolean isCurrent) {
+  public static TargetChange createSynthesizedTargetChangeForCurrentChange(
+      boolean isCurrent, ByteString resumeToken) {
     return new TargetChange(
-        ByteString.EMPTY,
+        resumeToken,
         isCurrent,
         DocumentKey.emptyKeySet(),
         DocumentKey.emptyKeySet(),

--- a/firebase-firestore/src/roboUtil/java/com/google/firebase/firestore/TestUtil.java
+++ b/firebase-firestore/src/roboUtil/java/com/google/firebase/firestore/TestUtil.java
@@ -116,7 +116,8 @@ public class TestUtil {
             isFromCache,
             mutatedKeys,
             /* didSyncStateChange= */ true,
-            /* excludesMetadataChanges= */ false);
+            /* excludesMetadataChanges= */ false,
+            /* hasCachedResults= */ false);
     return new QuerySnapshot(query(path), viewSnapshot, FIRESTORE);
   }
 

--- a/firebase-firestore/src/roboUtil/java/com/google/firebase/firestore/TestUtil.java
+++ b/firebase-firestore/src/roboUtil/java/com/google/firebase/firestore/TestUtil.java
@@ -83,7 +83,8 @@ public class TestUtil {
       Map<String, ObjectValue> oldDocs,
       Map<String, ObjectValue> docsToAdd,
       boolean hasPendingWrites,
-      boolean isFromCache) {
+      boolean isFromCache,
+      boolean hasCachedResults) {
     DocumentSet oldDocuments = docSet(Document.KEY_COMPARATOR);
     ImmutableSortedSet<DocumentKey> mutatedKeys = DocumentKey.emptyKeySet();
     for (Map.Entry<String, ObjectValue> pair : oldDocs.entrySet()) {
@@ -117,7 +118,7 @@ public class TestUtil {
             mutatedKeys,
             /* didSyncStateChange= */ true,
             /* excludesMetadataChanges= */ false,
-            /* hasCachedResults= */ false);
+            hasCachedResults);
     return new QuerySnapshot(query(path), viewSnapshot, FIRESTORE);
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/QuerySnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/QuerySnapshotTest.java
@@ -126,7 +126,8 @@ public class QuerySnapshotTest {
             /*isFromCache=*/ false,
             /*mutatedKeys=*/ keySet(),
             /*didSyncStateChange=*/ true,
-            /* excludesMetadataChanges= */ false);
+            /* excludesMetadataChanges= */ false,
+            /* hasCachedResults= */ false);
 
     QuerySnapshot snapshot =
         new QuerySnapshot(new Query(fooQuery, firestore), viewSnapshot, firestore);

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/QuerySnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/QuerySnapshotTest.java
@@ -56,21 +56,26 @@ public class QuerySnapshotTest {
     ObjectValue firstValue = wrapObject("a", 1);
     ObjectValue secondValue = wrapObject("b", 1);
 
-    QuerySnapshot foo = TestUtil.querySnapshot("foo", map(), map("a", firstValue), true, false);
-    QuerySnapshot fooDup = TestUtil.querySnapshot("foo", map(), map("a", firstValue), true, false);
+    QuerySnapshot foo =
+        TestUtil.querySnapshot("foo", map(), map("a", firstValue), true, false, false);
+    QuerySnapshot fooDup =
+        TestUtil.querySnapshot("foo", map(), map("a", firstValue), true, false, false);
     QuerySnapshot differentPath =
-        TestUtil.querySnapshot("bar", map(), map("a", firstValue), true, false);
+        TestUtil.querySnapshot("bar", map(), map("a", firstValue), true, false, false);
     QuerySnapshot differentDoc =
-        TestUtil.querySnapshot("foo", map(), map("a", secondValue), true, false);
+        TestUtil.querySnapshot("foo", map(), map("a", secondValue), true, false, false);
     QuerySnapshot noPendingWrites =
-        TestUtil.querySnapshot("foo", map(), map("a", firstValue), false, false);
+        TestUtil.querySnapshot("foo", map(), map("a", firstValue), false, false, false);
     QuerySnapshot fromCache =
-        TestUtil.querySnapshot("foo", map(), map("a", firstValue), true, true);
+        TestUtil.querySnapshot("foo", map(), map("a", firstValue), true, true, false);
+    QuerySnapshot hasCachedResults =
+        TestUtil.querySnapshot("foo", map(), map("a", firstValue), true, false, true);
     assertEquals(foo, fooDup);
     assertNotEquals(foo, differentPath);
     assertNotEquals(foo, differentDoc);
     assertNotEquals(foo, noPendingWrites);
     assertNotEquals(foo, fromCache);
+    assertNotEquals(foo, hasCachedResults);
 
     // Note: `foo` and `differentDoc` have the same hash code since we no longer take document
     // contents into account.
@@ -88,7 +93,8 @@ public class QuerySnapshotTest {
 
     ObjectValue objectData =
         ObjectValue.fromMap(map("timestamp", ServerTimestamps.valueOf(Timestamp.now(), null)));
-    QuerySnapshot foo = TestUtil.querySnapshot("foo", map(), map("a", objectData), true, false);
+    QuerySnapshot foo =
+        TestUtil.querySnapshot("foo", map(), map("a", objectData), true, false, false);
 
     List<POJO> docs = foo.toObjects(POJO.class);
     assertEquals(1, docs.size());

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryListenerTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/QueryListenerTest.java
@@ -108,7 +108,8 @@ public class QueryListenerTest {
             snap2.isFromCache(),
             snap2.getMutatedKeys(),
             /* didSyncStateChange= */ true,
-            /* excludesMetadataChanges= */ false);
+            /* excludesMetadataChanges= */ false,
+            /* hasCachedResults= */ false);
     assertEquals(asList(snap2Prime), otherAccum);
   }
 
@@ -262,7 +263,8 @@ public class QueryListenerTest {
             snap4.isFromCache(),
             snap4.getMutatedKeys(),
             snap4.didSyncStateChange(),
-            /* excludeMetadataChanges= */ true); // This test excludes document metadata changes
+            /* excludeMetadataChanges= */ true,
+            /* hasCachedResults= */ false); // This test excludes document metadata changes
 
     assertEquals(
         asList(
@@ -302,7 +304,9 @@ public class QueryListenerTest {
             snap2.isFromCache(),
             snap2.getMutatedKeys(),
             snap2.didSyncStateChange(),
-            /* excludesMetadataChanges= */ true);
+            /* excludesMetadataChanges= */ true,
+            /* hasCachedResults= */ false);
+
     assertEquals(
         asList(applyExpectedMetadata(snap1, MetadataChanges.EXCLUDE), expectedSnapshot2),
         filteredAccum);
@@ -344,7 +348,8 @@ public class QueryListenerTest {
             /* isFromCache= */ false,
             snap3.getMutatedKeys(),
             /* didSyncStateChange= */ true,
-            /* excludesMetadataChanges= */ true);
+            /* excludesMetadataChanges= */ true,
+            /* hasCachedResults= */ false);
     assertEquals(asList(expectedSnapshot), events);
   }
 
@@ -382,7 +387,9 @@ public class QueryListenerTest {
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
             /* didSyncStateChange= */ true,
-            /* excludesMetadataChanges= */ true);
+            /* excludesMetadataChanges= */ true,
+            /* hasCachedResults= */ false);
+
     ViewSnapshot expectedSnapshot2 =
         new ViewSnapshot(
             snap2.getQuery(),
@@ -392,7 +399,8 @@ public class QueryListenerTest {
             /* isFromCache= */ true,
             snap2.getMutatedKeys(),
             /* didSyncStateChange= */ false,
-            /* excludesMetadataChanges= */ true);
+            /* excludesMetadataChanges= */ true,
+            /* hasCachedResults= */ false);
     assertEquals(asList(expectedSnapshot1, expectedSnapshot2), events);
   }
 
@@ -419,7 +427,8 @@ public class QueryListenerTest {
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
             /* didSyncStateChange= */ true,
-            /* excludesMetadataChanges= */ true);
+            /* excludesMetadataChanges= */ true,
+            /* hasCachedResults= */ false);
     assertEquals(asList(expectedSnapshot), events);
   }
 
@@ -445,7 +454,8 @@ public class QueryListenerTest {
             /* isFromCache= */ true,
             snap1.getMutatedKeys(),
             /* didSyncStateChange= */ true,
-            /* excludesMetadataChanges= */ true);
+            /* excludesMetadataChanges= */ true,
+            /* hasCachedResults= */ false);
     assertEquals(asList(expectedSnapshot), events);
   }
 
@@ -458,6 +468,7 @@ public class QueryListenerTest {
         snap.isFromCache(),
         snap.getMutatedKeys(),
         snap.didSyncStateChange(),
-        MetadataChanges.EXCLUDE.equals(metadata));
+        MetadataChanges.EXCLUDE.equals(metadata),
+        snap.hasCachedResults());
   }
 }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewSnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewSnapshotTest.java
@@ -49,7 +49,7 @@ public class ViewSnapshotTest {
     boolean hasPendingWrites = true;
     boolean syncStateChanges = true;
     boolean excludesMetadataChanges = true;
-    boolean hasCachedResults = false;
+    boolean hasCachedResults = true;
 
     ViewSnapshot snapshot =
         new ViewSnapshot(

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewSnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/core/ViewSnapshotTest.java
@@ -49,6 +49,7 @@ public class ViewSnapshotTest {
     boolean hasPendingWrites = true;
     boolean syncStateChanges = true;
     boolean excludesMetadataChanges = true;
+    boolean hasCachedResults = false;
 
     ViewSnapshot snapshot =
         new ViewSnapshot(
@@ -59,7 +60,8 @@ public class ViewSnapshotTest {
             fromCache,
             mutatedKeys,
             syncStateChanges,
-            excludesMetadataChanges);
+            excludesMetadataChanges,
+            hasCachedResults);
 
     assertEquals(query, snapshot.getQuery());
     assertEquals(docs, snapshot.getDocuments());
@@ -70,5 +72,6 @@ public class ViewSnapshotTest {
     assertEquals(hasPendingWrites, snapshot.hasPendingWrites());
     assertEquals(syncStateChanges, snapshot.didSyncStateChange());
     assertEquals(excludesMetadataChanges, snapshot.excludesMetadataChanges());
+    assertEquals(hasCachedResults, snapshot.hasCachedResults());
   }
 }

--- a/firebase-firestore/src/test/resources/json/listen_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/listen_spec_test.json
@@ -2257,6 +2257,892 @@
       }
     ]
   },
+  "Empty initial snapshot is raised from cache": {
+    "describeName": "Listens:",
+    "itName": "Empty initial snapshot is raised from cache",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Empty initial snapshot is raised from cache in multiple tabs": {
+    "describeName": "Listens:",
+    "itName": "Empty initial snapshot is raised from cache in multiple tabs",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Empty-due-to-delete initial snapshot is raised from cache": {
+    "describeName": "Listens:",
+    "itName": "Empty-due-to-delete initial snapshot is raised from cache",
+    "tags": [
+    ],
+    "config": {
+      "numClients": 1,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userDelete": "collection/a"
+      },
+      {
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "Empty-due-to-delete initial snapshot is raised from cache in multiple tabs": {
+    "describeName": "Listens:",
+    "itName": "Empty-due-to-delete initial snapshot is raised from cache in multiple tabs",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "v": 1
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "v": 1
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userDelete": "collection/a"
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "value": null,
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "Ensure correct query results with latency-compensated deletes": {
     "describeName": "Listens:",
     "itName": "Ensure correct query results with latency-compensated deletes",
@@ -2970,6 +3856,25 @@
           },
           "targetId": 2
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "visible",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeTargets": {
             "2": {
@@ -3091,6 +3996,20 @@
           },
           "targetId": 4
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeTargets": {
             "4": {
@@ -3467,6 +4386,25 @@
           },
           "targetId": 2
         },
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+                [
+                  "visible",
+                  "==",
+                  true
+                ]
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
         "expectedState": {
           "activeTargets": {
             "2": {
@@ -11471,6 +12409,780 @@
       }
     ]
   },
+  "Secondary client advances query state with global snapshot from primary": {
+    "describeName": "Listens:",
+    "itName": "Secondary client advances query state with global snapshot from primary",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "1"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "1"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "1"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "1"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1500"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1500
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userDelete": "collection/a"
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "1"
+                },
+                "version": 1000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "writeAck": {
+          "version": 2000
+        },
+        "expectedState": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": [
+            ]
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "value": null,
+              "version": 2000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 2000
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "key": "2"
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "key": "2"
+                },
+                "version": 0
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "Secondary client raises latency compensated snapshot from primary mutation": {
+    "describeName": "Listens:",
+    "itName": "Secondary client raises latency compensated snapshot from primary mutation",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "numClients": 2,
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "applyClientState": {
+          "visibility": "visible"
+        },
+        "clientIndex": 0,
+        "expectedState": {
+          "isPrimary": true
+        }
+      },
+      {
+        "clientIndex": 0,
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "1"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1000
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "1"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "userUnlisten": [
+          2,
+          {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 1,
+        "userListen": {
+          "query": {
+            "filters": [
+            ],
+            "orderBys": [
+            ],
+            "path": "collection"
+          },
+          "targetId": 2
+        },
+        "expectedSnapshotEvents": [
+          {
+            "added": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": false
+                },
+                "value": {
+                  "key": "1"
+                },
+                "version": 1000
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ],
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true,
+        "expectedState": {
+          "activeTargets": {
+            "2": {
+              "queries": [
+                {
+                  "filters": [
+                  ],
+                  "orderBys": [
+                  ],
+                  "path": "collection"
+                }
+              ],
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "options": {
+                "hasCommittedMutations": false,
+                "hasLocalMutations": false
+              },
+              "value": {
+                "key": "1"
+              },
+              "version": 1000
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "clientIndex": 0,
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1500"
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "watchSnapshot": {
+          "targetIds": [
+          ],
+          "version": 1500
+        }
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false,
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      },
+      {
+        "clientIndex": 0,
+        "drainQueue": true
+      },
+      {
+        "clientIndex": 0,
+        "userSet": [
+          "collection/a",
+          {
+            "key": "2"
+          }
+        ]
+      },
+      {
+        "clientIndex": 1,
+        "drainQueue": true,
+        "expectedSnapshotEvents": [
+          {
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true,
+            "modified": [
+              {
+                "key": "collection/a",
+                "options": {
+                  "hasCommittedMutations": false,
+                  "hasLocalMutations": true
+                },
+                "value": {
+                  "key": "2"
+                },
+                "version": 0
+              }
+            ],
+            "query": {
+              "filters": [
+              ],
+              "orderBys": [
+              ],
+              "path": "collection"
+            }
+          }
+        ]
+      }
+    ]
+  },
   "Secondary client uses primary client's online state": {
     "describeName": "Listens:",
     "itName": "Secondary client uses primary client's online state",
@@ -14035,7 +15747,7 @@
                 "value": {
                   "v": 2
                 },
-                "version": 1000
+                "version": 0
               }
             ],
             "query": {
@@ -14251,7 +15963,7 @@
                 "value": {
                   "v": 2
                 },
-                "version": 1000
+                "version": 0
               }
             ],
             "query": {
@@ -14295,7 +16007,7 @@
                 "value": {
                   "v": 3
                 },
-                "version": 1000
+                "version": 0
               }
             ],
             "query": {
@@ -14334,7 +16046,7 @@
                 "value": {
                   "v": 4
                 },
-                "version": 1000
+                "version": 0
               }
             ],
             "query": {
@@ -14602,7 +16314,7 @@
                 "value": {
                   "v": 2
                 },
-                "version": 1000
+                "version": 0
               }
             ],
             "query": {
@@ -14627,7 +16339,7 @@
                 "value": {
                   "v": 2
                 },
-                "version": 1000
+                "version": 0
               }
             ],
             "query": {


### PR DESCRIPTION
Fix a bug where Firestore fails to return results from the local cache if the result set was empty.

This bug is due to the following logic in `QueryListener.java`:
https://github.com/firebase/firebase-android-sdk/blob/ae3bdb895e47b3d9a688dfbfe5ef3e94f2918c59/firebase-firestore/src/main/java/com/google/firebase/firestore/core/QueryListener.java#L143


which assumes that if the result set from the local cache is empty that there is no cached result; however, if the result set of the query is indeed empty then it should be returning that empty result set from the cache.

This fix improves the logic to use the presence of a hasCachedResults flag to indicate that the empty result set is cached data and should be raised to the client.

This bug fix is ported from https://github.com/firebase/firebase-js-sdk/pull/6624, which fixed [#5873](https://github.com/firebase/firebase-js-sdk/issues/5873)