### PR TITLE
Remove smoke test for app indexing

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -83,6 +83,10 @@ dependencies {
   implementation "com.google.firebase:firebase-perf"
   implementation "com.google.firebase:firebase-storage"
 
+  // TODO(yifany): remove after the issue is fixed
+  // https://github.com/firebase/firebase-android-sdk/issues/4206
+  implementation "com.google.firebase:firebase-iid:21.1.0"
+
   // Common utilities (application side)
   implementation "androidx.test:rules:1.4.0"
   implementation "androidx.test:runner:1.4.0"

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -69,7 +69,6 @@ dependencies {
   implementation "com.google.firebase:firebase-annotations"
   implementation "com.google.firebase:firebase-appdistribution:16.0.0-beta03"
   implementation "com.google.firebase:firebase-appdistribution-api:16.0.0-beta03"
-  implementation "com.google.firebase:firebase-appindexing"
   implementation "com.google.firebase:firebase-auth"
   implementation "com.google.firebase:firebase-common"
   implementation "com.google.firebase:firebase-config"

--- a/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
+++ b/smoke-tests/src/main/java/com/google/firebase/testing/BuildOnlyTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.testing;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.firebase.appindexing.FirebaseAppIndex;
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.ml.modeldownloader.FirebaseModelDownloader;
@@ -31,11 +30,6 @@ import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 /** Contains initialization test cases for build-only libraries. */
 @RunWith(JUnit4.class)
 public final class BuildOnlyTest {
-
-  @Test
-  public void appindexing_IsNotNull() {
-    assertThat(FirebaseAppIndex.getInstance(getApplicationContext())).isNotNull();
-  }
 
   @Test
   public void inappmessaging_IsNotNull() {


### PR DESCRIPTION
App Indexing is deprecated starting BoM 31.0.0.

https://firebase.google.com/support/release-notes/android#bom_v31-0-0