### PR TITLE
Empty Modelname for ML Model Downloader should not continue

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -434,23 +434,26 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
 
   private List<Action> extractActions(InAppMessage message) {
     List<Action> actions = new ArrayList<>();
-    switch (message.getMessageType()) {
-      case BANNER:
-        actions.add(((BannerMessage) message).getAction());
-        break;
-      case CARD:
-        actions.add(((CardMessage) message).getPrimaryAction());
-        actions.add(((CardMessage) message).getSecondaryAction());
-        break;
-      case IMAGE_ONLY:
-        actions.add(((ImageOnlyMessage) message).getAction());
-        break;
-      case MODAL:
-        actions.add(((ModalMessage) message).getAction());
-        break;
-      default:
-        // An empty action is treated like a dismiss
-        actions.add(Action.builder().build());
+
+    if (message != null) {
+      switch (message.getMessageType()) {
+        case BANNER:
+          actions.add(((BannerMessage) message).getAction());
+          break;
+        case CARD:
+          actions.add(((CardMessage) message).getPrimaryAction());
+          actions.add(((CardMessage) message).getSecondaryAction());
+          break;
+        case IMAGE_ONLY:
+          actions.add(((ImageOnlyMessage) message).getAction());
+          break;
+        case MODAL:
+          actions.add(((ModalMessage) message).getAction());
+          break;
+        default:
+          // An empty action is treated like a dismiss
+          actions.add(Action.builder().build());
+      }
     }
     return actions;
   }

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/CustomModelDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/CustomModelDownloadService.java
@@ -16,6 +16,7 @@ package com.google.firebase.ml.modeldownloader.internal;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.text.TextUtils;
 import android.util.JsonReader;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -148,6 +149,12 @@ public class CustomModelDownloadService {
   public Task<CustomModel> getCustomModelDetails(
       String projectNumber, String modelName, String modelHash) {
     try {
+
+      if(TextUtils.isEmpty(modelName))
+        throw new FirebaseMlException(
+          "Error reading empty modelName",
+          FirebaseMlException.INVALID_ARGUMENT);
+
       URL url =
           new URL(String.format(DOWNLOAD_MODEL_REGEX, downloadHost, projectNumber, modelName));
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -206,6 +213,8 @@ public class CustomModelDownloadService {
           new FirebaseMlException(
               "Error reading custom model from download service: " + e.getMessage(),
               FirebaseMlException.INVALID_ARGUMENT));
+    } catch (FirebaseMlException e) {
+      return Tasks.forException(e);
     }
   }
 


### PR DESCRIPTION
Proposed fix for #4157, throw exception when modelname is empty.

Since `CustomModelDownloadService` still continues to download the custom model even though an empty modelname is supplied. Error 401 is received, instead of an error 403. To resolve this, I think the proper solution is to either:

A. Change the way the REST API is being handled on the backend. 
B. Or, the simplest solution is to have a `TextUtil.isEmpty` checker for the modelName, and throw an exception.