### PR TITLE
Remove plexus-utils from firebase-database's test dependency

### DIFF
--- a/firebase-database/firebase-database.gradle
+++ b/firebase-database/firebase-database.gradle
@@ -100,7 +100,6 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation 'org.codehaus.plexus:plexus-utils:3.4.2'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'com.firebase:firebase-token-generator:2.0.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.9.8'

--- a/firebase-database/src/test/java/com/google/firebase/database/PushIdGeneratorTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/PushIdGeneratorTest.java
@@ -19,7 +19,6 @@ import static com.google.firebase.database.snapshot.ChildKey.MIN_KEY_NAME;
 import static org.junit.Assert.assertEquals;
 
 import com.google.firebase.database.core.utilities.PushIdGenerator;
-import org.codehaus.plexus.util.StringUtils;
 import org.junit.Test;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -41,8 +40,7 @@ public class PushIdGeneratorTest {
         PushIdGenerator.successor(String.valueOf(Integer.MAX_VALUE)));
     assertEquals(
         MAX_KEY_NAME,
-        PushIdGenerator.successor(
-            StringUtils.repeat(Character.toString(MAX_PUSH_CHAR), MAX_KEY_LEN)));
+        PushIdGenerator.successor(repeat(Character.toString(MAX_PUSH_CHAR), MAX_KEY_LEN)));
   }
 
   @Test
@@ -51,9 +49,7 @@ public class PushIdGeneratorTest {
     assertEquals(
         "abd",
         PushIdGenerator.successor(
-            "abc"
-                + StringUtils.repeat(
-                    Character.toString(MAX_PUSH_CHAR), MAX_KEY_LEN - "abc".length())));
+            "abc" + repeat(Character.toString(MAX_PUSH_CHAR), MAX_KEY_LEN - "abc".length())));
     assertEquals(
         "abc" + MIN_PUSH_CHAR + MIN_PUSH_CHAR, PushIdGenerator.successor("abc" + MIN_PUSH_CHAR));
   }
@@ -69,8 +65,18 @@ public class PushIdGeneratorTest {
   @Test
   public void testPredecessorBasicValue() {
     assertEquals(
-        "abb" + StringUtils.repeat(Character.toString(MAX_PUSH_CHAR), MAX_KEY_LEN - "abc".length()),
+        "abb" + repeat(Character.toString(MAX_PUSH_CHAR), MAX_KEY_LEN - "abc".length()),
         PushIdGenerator.predecessor("abc"));
     assertEquals("abc", PushIdGenerator.predecessor("abc" + MIN_PUSH_CHAR));
+  }
+
+  private static String repeat(String str, int repeat) {
+    // Copied from
+    // https://github.com/codehaus-plexus/plexus-utils/blob/master/src/main/java/org/codehaus/plexus/util/StringUtils.java.
+    StringBuilder buffer = new StringBuilder(repeat * str.length());
+    for (int i = 0; i < repeat; i++) {
+      buffer.append(str);
+    }
+    return buffer.toString();
   }
 }


### PR DESCRIPTION
firebase-database only uses `StringUtils#repeat` in test code, and it is easy to port repeat method to test file and remove plexus-utils from test dependency.