### PR TITLE
Add "create release PR" github action

### DIFF
--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -1,0 +1,49 @@
+name: Create release
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Release name'
+        required: true
+        type: string
+
+jobs:
+  create-branches:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Create base branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        with:
+          branch: '${{ inputs.name }}'
+      - name: Create release branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        with:
+          branch: '${{ inputs.name }}.release'
+
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create release configuration template
+        run: |
+          git config user.name 'Create Release GA'
+          git config user.email 'noreply@google.com'
+          echo "[release]" > release.cfg
+          echo "name = ${{ inputs.name }}" >> release.cfg
+          echo "mode = RELEASE" >> release.cfg
+          echo "" >> release.cfg
+          echo "[modules]" >> release.cfg
+          echo "" >> release.cfg
+          git add release.cfg
+          git commit -a -m 'Create release config'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: '${{ inputs.name }}'
+          branch: '${{ inputs.name }}.release'
+          title: '${{ inputs.name}} release'


### PR DESCRIPTION
This implementation:

- Creates the base branch (name is based in user input)
- Creates the release branch (name is based in user input)
- Creates the release.cfg file in the release branch without adding any SDK (module) to it.

It can create the branches based on any existing branch of the repo.