### PR TITLE
test(functions): fix instrumentation tests

### DIFF
--- a/firebase-functions/src/androidTest/java/com/google/firebase/functions/TestFirebaseInstanceIdInternal.java
+++ b/firebase-functions/src/androidTest/java/com/google/firebase/functions/TestFirebaseInstanceIdInternal.java
@@ -16,11 +16,9 @@ package com.google.firebase.functions;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.iid.internal.FirebaseInstanceIdInternal;
-
 import java.io.IOException;
 
 public class TestFirebaseInstanceIdInternal implements FirebaseInstanceIdInternal {

--- a/firebase-functions/src/androidTest/java/com/google/firebase/functions/TestFirebaseInstanceIdInternal.java
+++ b/firebase-functions/src/androidTest/java/com/google/firebase/functions/TestFirebaseInstanceIdInternal.java
@@ -14,8 +14,14 @@
 
 package com.google.firebase.functions;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.iid.internal.FirebaseInstanceIdInternal;
+
+import java.io.IOException;
 
 public class TestFirebaseInstanceIdInternal implements FirebaseInstanceIdInternal {
   private final String testToken;
@@ -33,5 +39,21 @@ public class TestFirebaseInstanceIdInternal implements FirebaseInstanceIdInterna
   @Override
   public String getToken() {
     return testToken;
+  }
+
+  @NonNull
+  @Override
+  public Task<String> getTokenTask() {
+    return Tasks.forResult(testToken);
+  }
+
+  @Override
+  public void deleteToken(@NonNull String s, @NonNull String s1) throws IOException {
+    // No-op: We're not using this method in our tests
+  }
+
+  @Override
+  public void addNewTokenListener(NewTokenListener newTokenListener) {
+    // No-op: We're not using this method in our tests
   }
 }


### PR DESCRIPTION
The firebase-functions instrumentation tests broke after updating the firebase-iid version in #4225 . This PR should fix them.