### PR TITLE
Remove GenericTypeIndicator in error messages

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -3,6 +3,7 @@
   (#5871).
 
 - [fixed] Fixed Firestore failing to raise initial snapshot from empty local cache result.
+- [fixed] Removed invalid suggestions to use `GenericTypeIndicator` from error messages.
 
 # 24.4.0
 * [feature] Added

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
@@ -246,10 +246,7 @@ public class CustomClassMapper {
           context.errorPath, "Converting to Arrays is not supported, please use Lists instead");
     } else if (clazz.getTypeParameters().length > 0) {
       throw deserializeError(
-          context.errorPath,
-          "Class "
-              + clazz.getName()
-              + " has generic type parameters, please use GenericTypeIndicator instead");
+          context.errorPath, "Class " + clazz.getName() + " has generic type parameters");
     } else if (clazz.equals(Object.class)) {
       return (T) o;
     } else if (clazz.isEnum()) {

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
@@ -1883,16 +1883,14 @@ public class MapperTest {
   @Test
   public void passingInListTopLevelThrows() {
     assertExceptionContains(
-        "Class java.util.List has generic type parameters, please use GenericTypeIndicator "
-            + "instead",
+        "Class java.util.List has generic type parameters",
         () -> convertToCustomClass(Collections.singletonList("foo"), List.class));
   }
 
   @Test
   public void passingInMapTopLevelThrows() {
     assertExceptionContains(
-        "Class java.util.Map has generic type parameters, please use GenericTypeIndicator "
-            + "instead",
+        "Class java.util.Map has generic type parameters",
         () -> convertToCustomClass(Collections.singletonMap("foo", "bar"), Map.class));
   }
 
@@ -1920,7 +1918,7 @@ public class MapperTest {
   public void passingInGenericBeanTopLevelThrows() {
     assertExceptionContains(
         "Class com.google.firebase.firestore.util.MapperTest$GenericBean has generic type "
-            + "parameters, please use GenericTypeIndicator instead",
+            + "parameters",
         () -> deserialize("{'value': 'foo'}", GenericBean.class));
   }
 


### PR DESCRIPTION
#no-changelog
GenericTypeIndicator is used in firebase database (https://firebase.google.com/docs/reference/android/com/google/firebase/database/GenericTypeIndicator?hl=id) and not existing in Firestore. #222 