### PR TITLE
Add Dackka transform to remove leading groupId in Javadocs

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -294,6 +294,7 @@ abstract class DackkaPlugin : Plugin<Project> {
         val transformJavadoc = project.tasks.register<FiresiteTransformTask>("firesiteTransformJavadoc") {
             dependsOnAndMustRunAfter("separateJavadoc")
 
+            removeGoogleGroupId.set(true)
             referencePath.set("/docs/reference/android")
             referenceHeadTagsPath.set("docs/reference/android")
             dackkaFiles.set(project.childFile(separatedFilesDirectory, "android"))

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -98,7 +98,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
      * --> "firebase.appcheck"
      * ```
      */
-    // TODO(b/): Remove when dackka exposes configuration for this
+    // TODO(b/257293594): Remove when dackka exposes configuration for this
     private fun String.removeGoogleGroupId() =
         remove(Regex("(?<=\")com.google.(?=firebase.)"))
 


### PR DESCRIPTION
Per [b/257073544](https://b.corp.google.com/issues/257073544), this PR adds a transform to `FiresiteTransform` that removes the leading `com.google` from our YAML files. This is fine for our kdoc files, but from the javadoc perspective it looks a bit odd as other internal tooling follows the same format (docs that are generated outside the scope of `DackkaPlugin`).

This also removes the old transform for removing the leading Firebase domain from links- as it's no longer needed (see #4258).