### PR TITLE
[Fireperf][AASA] Additional experiments for `_experiment_as_ttid`

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -383,7 +383,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
 
   @Override
   public void onActivityPaused(Activity activity) {
-    if (this.firstDrawDone != null && this.preDraw != null) {
+    if (isExperimentTraceDone()) {
       return;
     }
     Timer onPauseTime = clock.getTime();
@@ -397,7 +397,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
 
   @Override
   public void onActivityStopped(Activity activity) {
-    if (this.firstDrawDone != null && this.preDraw != null) {
+    if (isExperimentTraceDone()) {
       return;
     }
     Timer onStopTime = clock.getTime();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -99,7 +99,6 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
   private Timer onResumeTime = null;
   private Timer firstDrawDone = null;
   private Timer preDraw = null;
-  private List<TraceMetric> preDrawSubtraces = new ArrayList<>();
 
   private PerfSession startSession;
   private boolean isStartedFromBackground = false;
@@ -236,7 +235,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
     this.experimentTtid.addPerfSessions(this.startSession.build());
 
     if (subtraceCount > 0) {
-      executorService.execute(() -> this.logColdStart(this.experimentTtid));
+      executorService.execute(() -> this.logExperimentTtid(this.experimentTtid));
 
       if (isRegisteredForLifecycleCallbacks) {
         // After AppStart trace is queued to be logged, we can unregister this callback.
@@ -267,7 +266,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
     this.experimentTtid.addSubtraces(subtrace.build());
 
     if (subtraceCount > 0) {
-      executorService.execute(() -> this.logColdStart(this.experimentTtid));
+      executorService.execute(() -> this.logExperimentTtid(this.experimentTtid));
 
       if (isRegisteredForLifecycleCallbacks) {
         // After AppStart trace is queued to be logged, we can unregister this callback.
@@ -342,7 +341,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
     }
   }
 
-  private void logColdStart(TraceMetric.Builder metric) {
+  private void logExperimentTtid(TraceMetric.Builder metric) {
     transportManager.log(metric.build(), ApplicationProcessState.FOREGROUND_BACKGROUND);
   }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -380,10 +380,30 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
   }
 
   @Override
-  public void onActivityPaused(Activity activity) {}
+  public void onActivityPaused(Activity activity) {
+    if (this.firstDrawDone != null && this.preDraw != null) {
+      return;
+    }
+    Timer onPauseTime = clock.getTime();
+    TraceMetric.Builder subtrace = TraceMetric.newBuilder()
+            .setName("_experiment_onPause")
+            .setClientStartTimeUs(onPauseTime.getMicros())
+            .setDurationUs(getStartTimer().getDurationMicros(onPauseTime));
+    this.experimentTtid.addSubtraces(subtrace.build());
+  }
 
   @Override
-  public synchronized void onActivityStopped(Activity activity) {}
+  public void onActivityStopped(Activity activity) {
+    if (this.firstDrawDone != null && this.preDraw != null) {
+      return;
+    }
+    Timer onStopTime = clock.getTime();
+    TraceMetric.Builder subtrace = TraceMetric.newBuilder()
+            .setName("_experiment_onStop")
+            .setClientStartTimeUs(onStopTime.getMicros())
+            .setDurationUs(getStartTimer().getDurationMicros(onStopTime));
+    this.experimentTtid.addSubtraces(subtrace.build());
+  }
 
   @Override
   public void onActivityDestroyed(Activity activity) {}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -212,7 +212,6 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
     }
     Timer start = getStartTimer();
     this.firstDrawDone = clock.getTime();
-    int subtraceCount = this.experimentTtid.getSubtracesCount();
     this.experimentTtid
         .setClientStartTimeUs(start.getMicros())
         .setDurationUs(start.getDurationMicros(this.firstDrawDone));
@@ -234,7 +233,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
 
     this.experimentTtid.addPerfSessions(this.startSession.build());
 
-    if (subtraceCount > 0) {
+    if (isExperimentTraceDone()) {
       executorService.execute(() -> this.logExperimentTtid(this.experimentTtid));
 
       if (isRegisteredForLifecycleCallbacks) {
@@ -250,7 +249,6 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
     }
     Timer start = getStartTimer();
     this.preDraw = clock.getTime();
-    int subtraceCount = this.experimentTtid.getSubtracesCount();
     TraceMetric.Builder subtrace =
         TraceMetric.newBuilder()
             .setName("_experiment_preDraw")
@@ -265,7 +263,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
         .setDurationUs(start.getDurationUptimeMicros(this.preDraw));
     this.experimentTtid.addSubtraces(subtrace.build());
 
-    if (subtraceCount > 0) {
+    if (isExperimentTraceDone()) {
       executorService.execute(() -> this.logExperimentTtid(this.experimentTtid));
 
       if (isRegisteredForLifecycleCallbacks) {
@@ -273,6 +271,10 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
         unregisterActivityLifecycleCallbacks();
       }
     }
+  }
+
+  private boolean isExperimentTraceDone() {
+    return this.preDraw != null && this.firstDrawDone != null;
   }
 
   @Override
@@ -385,7 +387,8 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
       return;
     }
     Timer onPauseTime = clock.getTime();
-    TraceMetric.Builder subtrace = TraceMetric.newBuilder()
+    TraceMetric.Builder subtrace =
+        TraceMetric.newBuilder()
             .setName("_experiment_onPause")
             .setClientStartTimeUs(onPauseTime.getMicros())
             .setDurationUs(getStartTimer().getDurationMicros(onPauseTime));
@@ -398,7 +401,8 @@ public class AppStartTrace implements ActivityLifecycleCallbacks {
       return;
     }
     Timer onStopTime = clock.getTime();
-    TraceMetric.Builder subtrace = TraceMetric.newBuilder()
+    TraceMetric.Builder subtrace =
+        TraceMetric.newBuilder()
             .setName("_experiment_onStop")
             .setClientStartTimeUs(onStopTime.getMicros())
             .setDurationUs(getStartTimer().getDurationMicros(onStopTime));

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
@@ -23,10 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * OnDrawListener that unregisters itself and invokes callback when the next draw is done. This API
- * 16+ implementation is an approximation of the initial display time. {@link
- * android.view.Choreographer#postFrameCallback} is an Android API that provides a simpler and more
- * accurate initial display time, but it was bugged before API 30, hence we use this backported
- * implementation.
+ * 16+ implementation is an approximation of the initial-display-time defined by Android Vitals.
  */
 @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
 public class FirstDrawDoneListener implements ViewTreeObserver.OnDrawListener {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/FirstDrawDoneListener.java
@@ -18,14 +18,12 @@ import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
 import android.view.ViewTreeObserver;
-import androidx.annotation.RequiresApi;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * OnDrawListener that unregisters itself and invokes callback when the next draw is done. This API
  * 16+ implementation is an approximation of the initial-display-time defined by Android Vitals.
  */
-@RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
 public class FirstDrawDoneListener implements ViewTreeObserver.OnDrawListener {
   private final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
   private final AtomicReference<View> viewReference;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
@@ -41,13 +41,11 @@ public class PreDrawListener implements ViewTreeObserver.OnPreDrawListener {
 
   @Override
   public boolean onPreDraw() {
-    // Set viewReference to null so any onDraw past the first is a no-op
+    // Set viewReference to null so any onPreDraw past the first is a no-op
     View view = viewReference.getAndSet(null);
     if (view == null) {
       return true;
     }
-    // OnDrawListeners cannot be removed within onDraw, so we remove it with a
-    // GlobalLayoutListener
     view.getViewTreeObserver().removeOnPreDrawListener(this);
     mainThreadHandler.post(callback);
     return true;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
@@ -1,3 +1,16 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package com.google.firebase.perf.util;
 
 import android.os.Handler;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
@@ -1,0 +1,38 @@
+package com.google.firebase.perf.util;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.view.View;
+import android.view.ViewTreeObserver;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PreDrawListener implements ViewTreeObserver.OnPreDrawListener {
+  private final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
+  private final AtomicReference<View> viewReference;
+  private final Runnable callback;
+
+  /** Registers a post-draw callback for the next draw of a view. */
+  public static void registerForNextDraw(View view, Runnable drawDoneCallback) {
+    final PreDrawListener listener = new PreDrawListener(view, drawDoneCallback);
+    view.getViewTreeObserver().addOnPreDrawListener(listener);
+  }
+
+  private PreDrawListener(View view, Runnable callback) {
+    this.viewReference = new AtomicReference<>(view);
+    this.callback = callback;
+  }
+
+  @Override
+  public boolean onPreDraw() {
+    // Set viewReference to null so any onDraw past the first is a no-op
+    View view = viewReference.getAndSet(null);
+    if (view == null) {
+      return true;
+    }
+    // OnDrawListeners cannot be removed within onDraw, so we remove it with a
+    // GlobalLayoutListener
+    view.getViewTreeObserver().removeOnPreDrawListener(this);
+    mainThreadHandler.post(callback);
+    return true;
+  }
+}

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
@@ -19,6 +19,10 @@ import android.view.View;
 import android.view.ViewTreeObserver;
 import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * OnPreDraw listener that unregisters itself and post a callback to the main thread during
+ * OnPreDraw. This is an approximation of the initial-display time defined by Android Vitals.
+ */
 public class PreDrawListener implements ViewTreeObserver.OnPreDrawListener {
   private final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
   private final AtomicReference<View> viewReference;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Timer.java
@@ -127,6 +127,7 @@ public class Timer implements Parcelable {
     // TODO: consider removing this method and make Timer immutable thus fully thread-safe
     wallClockMicros = wallClockMicros();
     elapsedRealtimeMicros = elapsedRealtimeMicros();
+    uptimeMicros = uptimeMicros();
   }
 
   /** Return wall-clock time in microseconds. */

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -305,6 +305,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     // Simulate draw and manually stepping time forward
     ShadowSystemClock.advanceBy(Duration.ofMillis(1000));
     long drawTime = TimeUnit.NANOSECONDS.toMicros(SystemClock.elapsedRealtimeNanos());
+    testView.getViewTreeObserver().dispatchOnPreDraw();
     testView.getViewTreeObserver().dispatchOnDraw();
     shadowOf(Looper.getMainLooper()).idle();
     fakeExecutorService.runNext();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -298,6 +298,11 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     trace.onActivityCreated(activity1, bundle);
     trace.onActivityStarted(activity1);
     trace.onActivityResumed(activity1);
+    // Experiment: simulate backgrounding before draw
+    trace.onActivityPaused(activity1);
+    trace.onActivityStopped(activity1);
+    trace.onActivityStarted(activity1);
+    trace.onActivityResumed(activity1);
     fakeExecutorService.runAll();
     verify(transportManager, times(1))
         .log(isA(TraceMetric.class), isA(ApplicationProcessState.class));
@@ -318,5 +323,6 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     assertThat(ttid.getName()).isEqualTo("_experiment_app_start_ttid");
     assertThat(ttid.getDurationUs()).isNotEqualTo(resumeTime - appStartTime);
     assertThat(ttid.getDurationUs()).isEqualTo(drawTime - appStartTime);
+    assertThat(ttid.getSubtracesCount()).isEqualTo(6);
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
@@ -53,8 +53,8 @@ public class TimerTest {
     // Robolectric shadows SystemClock, which is paused and can only change via specific methods.
     long refElapsedRealtime = SystemClock.elapsedRealtime();
     Timer ref = new Timer();
-    Timer past = Timer.ofElapsedRealtime(refElapsedRealtime - 100);
-    Timer future = Timer.ofElapsedRealtime(refElapsedRealtime + 100);
+    Timer past = Timer.ofElapsedRealtime(refElapsedRealtime - 100, 0);
+    Timer future = Timer.ofElapsedRealtime(refElapsedRealtime + 100, 0);
 
     assertThat(past.getDurationMicros(ref)).isEqualTo(MILLISECONDS.toMicros(100));
     assertThat(ref.getDurationMicros(future)).isEqualTo(MILLISECONDS.toMicros(100));
@@ -67,10 +67,10 @@ public class TimerTest {
     ShadowSystemClock.advanceBy(Duration.ofMillis(10000000));
     long nowElapsedRealtime = SystemClock.elapsedRealtime();
     Timer now = new Timer();
-    Timer morePast = Timer.ofElapsedRealtime(nowElapsedRealtime - 2000);
-    Timer past = Timer.ofElapsedRealtime(nowElapsedRealtime - 1000);
-    Timer future = Timer.ofElapsedRealtime(nowElapsedRealtime + 1000);
-    Timer moreFuture = Timer.ofElapsedRealtime(nowElapsedRealtime + 2000);
+    Timer morePast = Timer.ofElapsedRealtime(nowElapsedRealtime - 2000, 0);
+    Timer past = Timer.ofElapsedRealtime(nowElapsedRealtime - 1000, 0);
+    Timer future = Timer.ofElapsedRealtime(nowElapsedRealtime + 1000, 0);
+    Timer moreFuture = Timer.ofElapsedRealtime(nowElapsedRealtime + 2000, 0);
 
     // We cannot manipulate System.currentTimeMillis() so multiple comparisons are used to test
     assertThat(morePast.getMicros()).isLessThan(past.getMicros());
@@ -103,7 +103,7 @@ public class TimerTest {
 
   @Test
   public void testGetCurrentTimestampMicros() {
-    Timer timer = new Timer(0, 0);
+    Timer timer = new Timer(0, 0, 0);
     long currentTimeSmallest = timer.getCurrentTimestampMicros();
 
     assertThat(timer.getMicros()).isEqualTo(0);
@@ -112,7 +112,7 @@ public class TimerTest {
 
   @Test
   public void testParcel() {
-    Timer timer1 = new Timer(1000, 1000000);
+    Timer timer1 = new Timer(1000, 1000000, 1000000);
 
     Parcel p1 = Parcel.obtain();
     timer1.writeToParcel(p1, 0);
@@ -132,6 +132,6 @@ public class TimerTest {
 
   /** Helper for other tests that returns elapsedRealtimeMicros from a Timer object */
   public static long getElapsedRealtimeMicros(Timer timer) {
-    return new Timer(0, 0).getDurationMicros(timer);
+    return new Timer(0, 0, 0).getDurationMicros(timer);
   }
 }


### PR DESCRIPTION
These experiments helps single out certain possibilities from the outliers we see in `_experiment_as_ttid`:
1. `SystemClock.uptimeMillis()` is another monotonic timebase, but excluding deep sleep. This helps single out if the app was entering deep sleep thus causing massive duration
2. `OnPreDraw` is what PRIMES uses for all of 1P Google, thus with lots of success. Just looking at onDraw there were many bugs and hoops the code has to deal with, and `onPreDraw` just looks more stable, so perhaps it can be a bug or something else there as well. 