### PR TITLE
Fix `FrameMetrics` NPE

### DIFF
--- a/firebase-perf/CHANGELOG.md
+++ b/firebase-perf/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
-* 
+* [fixed] Fixed a `NullPointerException` crash when instrumenting screen traces
+  on Android 7, 8, and 9.
+  (#4146)
 
 
 # 20.2.0

--- a/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/application/FrameMetricsRecorder.java
@@ -15,6 +15,7 @@
 package com.google.firebase.perf.application;
 
 import android.app.Activity;
+import android.os.Build;
 import android.util.SparseIntArray;
 import androidx.core.app.FrameMetricsAggregator;
 import androidx.fragment.app.Fragment;
@@ -107,11 +108,22 @@ public class FrameMetricsRecorder {
     }
     Optional<PerfFrameMetrics> data = this.snapshot();
     try {
+      // No reliable way to check for hardware-acceleration, so we must catch retroactively (#2736).
       frameMetricsAggregator.remove(activity);
-    } catch (IllegalArgumentException err) {
+    } catch (IllegalArgumentException | NullPointerException ex) {
+      // Both of these exceptions result from android.view.View.addFrameMetricsListener silently
+      // failing when the view is not hardware-accelerated. Successful addFrameMetricsListener
+      // stores an observer in a list, and initializes the list if it was uninitialized. Invoking
+      // View.removeFrameMetricsListener(listener) throws IAE if it doesn't exist in the list, or
+      // throws NPE if the list itself was never initialized (#4184).
+      if (ex instanceof NullPointerException && Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+        // Re-throw above API 28, since the NPE is fixed in API 29:
+        // https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b
+        throw ex;
+      }
       logger.warn(
-          "View not hardware accelerated. Unable to collect FrameMetrics. %s", err.toString());
-      return Optional.absent();
+          "View not hardware accelerated. Unable to collect FrameMetrics. %s", ex.toString());
+      data = Optional.absent();
     }
     frameMetricsAggregator.reset();
     isRecording = false;


### PR DESCRIPTION
Copy of https://github.com/firebase/firebase-android-sdk/pull/4184 due to CLA issues (Jeremy leaving).

## Investigation
Let's take a look at [Android's source code, in android.view.View](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/View.java;l=7381;drc=master?q=addFrameMetrics&ss=android%2Fplatform%2Fsuperproject).
The exception was thrown from `findFrameMetricsObserver`, inside `removeFrameMetricsListener`
![image](https://user-images.githubusercontent.com/12737815/197061665-7434623a-b4e7-4ff2-82b5-b0acf5725e6e.png)
![image](https://user-images.githubusercontent.com/12737815/197062300-9b11f5b1-ecee-4f5e-bccc-29caed87eaa9.png)
Since this null check didn't exists, this triggers NPE when `mFrameMetricsObserver` is uninitialized. Jeremy found that [this was fixed in later Android versions](https://android.googlesource.com/platform/frameworks/base/+/140ff5ea8e2d99edc3fbe63a43239e459334c76b). Why then, is `mFrameMetricsObserver` uninitialized? It's because `addFrameMetricsListener` fails silently!
![image](https://user-images.githubusercontent.com/12737815/197064621-78d92202-3c37-44fb-9059-4c99ae9f8c72.png)

## Conclusion
So overall, this is the **same issue caused by the view not being hardware-accelerated**. The correct error message is hidden away because `addFrameMetricsListener` fails silently, that's why we should catch them both and use the same error message. The developer's provided crash versions also lines up with when Android fixed it: the above reference fix was made in 2019, and Android 7, 8, 9 are all before 2019, with Android 10 releasing in 2019 thus fixing the issue. There is no crash before Android 7 because as Rosario pointed out, FrameMetrics was added in Android 7 (API 24). 