### PR TITLE
Initial version of the build release artifacts workflow.

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -7,7 +7,7 @@ on:
       - 'releases/**'
 
 jobs:
-  create-branches:
+  build-artifacts:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -1,0 +1,25 @@
+name: Build Release Artifacts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - 'releases/**'
+
+jobs:
+  create-branches:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Perform gradle build
+        run: |
+          ./gradlew  firebasePublish -PprojectsToPublish=firebase-firestore -PpublishMode=RELEASE -PincludeFireEscapeArtifacts=true
+      - name: Upload generated artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: release_artifacts.zip
+          path: build/*.zip
+          retention-days: 5


### PR DESCRIPTION
This version of the workflow hardcodes the list of sdks to release to include Firestore only. Also, generated javadoc is not yet equivalent to what's generated by the regular release process.