### PR TITLE
Fix a NoSuchElementException crash in FirebaseMessagingService

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [fixed] Fixed a `NoSuchElementException` crash in `FirebaseMessagingService`.
+
 
 # 23.1.0
 * [unchanged] Updated to accommodate the release of the updated

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java
@@ -239,17 +239,19 @@ public class FirebaseMessagingService extends EnhancedIntentService {
     if (TextUtils.isEmpty(messageId)) {
       return false;
     }
-    if (recentlyReceivedMessageIds.contains(messageId)) {
-      if (Log.isLoggable(TAG, Log.DEBUG)) {
-        Log.d(TAG, "Received duplicate message: " + messageId);
+    synchronized (recentlyReceivedMessageIds) {
+      if (recentlyReceivedMessageIds.contains(messageId)) {
+        if (Log.isLoggable(TAG, Log.DEBUG)) {
+          Log.d(TAG, "Received duplicate message: " + messageId);
+        }
+        return true;
       }
-      return true;
+      // Add this message ID to the queue
+      if (recentlyReceivedMessageIds.size() >= RECENTLY_RECEIVED_MESSAGE_IDS_MAX_SIZE) {
+        recentlyReceivedMessageIds.remove();
+      }
+      recentlyReceivedMessageIds.add(messageId);
     }
-    // Add this message ID to the queue
-    if (recentlyReceivedMessageIds.size() >= RECENTLY_RECEIVED_MESSAGE_IDS_MAX_SIZE) {
-      recentlyReceivedMessageIds.remove();
-    }
-    recentlyReceivedMessageIds.add(messageId);
     return false;
   }
 


### PR DESCRIPTION
Not reproducible locally, but seeing the following crash stack trace (958 crashes in last 8 days):

```java
java.util.NoSuchElementException
  at java.util.ArrayDeque.removeFirst(ArrayDeque.java:270)
  at java.util.ArrayDeque.remove(ArrayDeque.java:435)
  at com.google.firebase.messaging.FirebaseMessagingService.alreadyReceivedMessage(SourceFile:6)
  at com.google.firebase.messaging.FirebaseMessagingService.handleMessageIntent(SourceFile:2)
  at com.google.firebase.messaging.FirebaseMessagingService.handleIntent(SourceFile:9)
  at com.google.firebase.messaging.g.lambda$processIntent$0$EnhancedIntentService(Unknown Source:1)
  at com.google.firebase.messaging.d.run(Unknown Source:6)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
  at com.google.android.gms.common.util.concurrent.zza.run(SourceFile:2)
  at java.lang.Thread.run(Thread.java:1012)
```

The reason of the crash is `FirebaseMessagingService.recentlyReceivedMessageIds` is accessed concurrently. `EnhancedIntentService.executor` is a single-threaded executor, but it's not a `static` field, so every `EnhancedIntentService` instance will have its own executor (with a thread in it). Thus, non-thread-safe collection `static recentlyReceivedMessageIds` can be accessed concurrently, causing crash (`ArrayDeque.remove()` will set `elements[head]` to `null` internally before advancing the `head` pointer, so another thread can read a `null` value from `elements[head]`).

@VinayGuthal @zwu52 @thatfiredev Could you take a look at this PR? Thanks.