### PR TITLE
Fix broken code elements in docs

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/DataSnapshot.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/DataSnapshot.java
@@ -166,7 +166,7 @@ public class DataSnapshot {
    *
    * An example class might look like:
    *
-   * <pre><code>
+   * <pre>
    *     class Message {
    *         private String author;
    *         private String text;
@@ -190,7 +190,7 @@ public class DataSnapshot {
    *
    *     // Later
    *     Message m = snapshot.getValue(Message.class);
-   * </code></pre>
+   * </pre>
    *
    * @param valueType The class into which this snapshot should be marshalled
    * @param <T> The type to return. Implicitly defined from the class passed in
@@ -208,10 +208,10 @@ public class DataSnapshot {
    * properly-typed Collection. So, in the case where you want a {@link java.util.List} of Message
    * instances, you will need to do something like the following:
    *
-   * <pre><code>
+   * <pre>
    *     GenericTypeIndicator&lt;List&lt;Message&gt;&gt; t = new GenericTypeIndicator&lt;List&lt;Message&gt;&gt;() {};
    *     List&lt;Message&gt; messages = snapshot.getValue(t);
-   * </code></pre>
+   * </pre>
    *
    * It is important to use a subclass of {@link GenericTypeIndicator}. See {@link
    * GenericTypeIndicator} for more details
@@ -255,11 +255,12 @@ public class DataSnapshot {
 
   /**
    * Gives access to all of the immediate children of this snapshot. Can be used in native for
-   * loops: <code>
-   * <br>    for (DataSnapshot child : parent.getChildren()) {
-   * <br>    &nbsp;&nbsp;&nbsp;&nbsp;...
-   * <br>    }
-   * </code>
+   * loops:
+   * <pre>
+   * for (DataSnapshot child : parent.getChildren()) {
+   *   &nbsp;&nbsp;&nbsp;&nbsp;...
+   * }
+   * </pre>
    *
    * @return The immediate children of this snapshot
    */

--- a/firebase-database/src/main/java/com/google/firebase/database/DataSnapshot.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/DataSnapshot.java
@@ -256,6 +256,7 @@ public class DataSnapshot {
   /**
    * Gives access to all of the immediate children of this snapshot. Can be used in native for
    * loops:
+   *
    * <pre>
    * for (DataSnapshot child : parent.getChildren()) {
    *   &nbsp;&nbsp;&nbsp;&nbsp;...

--- a/firebase-database/src/main/java/com/google/firebase/database/GenericTypeIndicator.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/GenericTypeIndicator.java
@@ -25,7 +25,7 @@ package com.google.firebase.database;
  * {@link DataSnapshot}: <br>
  * <br>
  *
- * <pre><code>
+ * <pre>
  *     class Message {
  *         private String author;
  *         private String text;
@@ -51,7 +51,7 @@ package com.google.firebase.database;
  *     GenericTypeIndicator&lt;List&lt;Message&gt;&gt; t = new GenericTypeIndicator&lt;List&lt;Message&gt;&gt;() {};
  *     List&lt;Message&gt; messages = snapshot.getValue(t);
  *
- * </code></pre>
+ * </pre>
  *
  * @param <T> The type of generic collection that this instance servers as an indicator for
  */

--- a/firebase-database/src/main/java/com/google/firebase/database/MutableData.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/MutableData.java
@@ -91,11 +91,12 @@ public class MutableData {
   }
 
   /**
-   * Used to iterate over the immediate children at this location <code>
-   *     <br>for (MutableData child : parent.getChildren()) {
-   *         <br>&nbsp;&nbsp;&nbsp;&nbsp;...
-   *     <br>}
-   * </code>
+   * Used to iterate over the immediate children at this location
+   * <pre>
+   *     for (MutableData child : parent.getChildren()) {
+   *         &nbsp;&nbsp;&nbsp;&nbsp;...
+   *     }
+   * </pre>
    *
    * @return The immediate children at this location
    */
@@ -196,7 +197,7 @@ public class MutableData {
    *
    * An example class might look like:
    *
-   * <pre><code>
+   * <pre>
    *     class Message {
    *         private String author;
    *         private String text;
@@ -220,7 +221,7 @@ public class MutableData {
    *
    *     // Later
    *     Message m = mutableData.getValue(Message.class);
-   * </code></pre>
+   * </pre>
    *
    * @param valueType The class into which this data in this instance should be marshalled
    * @param <T> The type to return. Implicitly defined from the class passed in
@@ -238,11 +239,11 @@ public class MutableData {
    * properly-typed Collection. So, in the case where you want a {@link java.util.List} of Message
    * instances, you will need to do something like the following:
    *
-   * <pre><code>
+   * <pre>
    *     GenericTypeIndicator&lt;List&lt;Message&gt;&gt; t =
    *         new GenericTypeIndicator&lt;List&lt;Message&gt;&gt;() {};
    *     List&lt;Message&gt; messages = mutableData.getValue(t);
-   * </code></pre>
+   * </pre>
    *
    * It is important to use a subclass of {@link GenericTypeIndicator}. See {@link
    * GenericTypeIndicator} for more details

--- a/firebase-database/src/main/java/com/google/firebase/database/MutableData.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/MutableData.java
@@ -92,6 +92,7 @@ public class MutableData {
 
   /**
    * Used to iterate over the immediate children at this location
+   *
    * <pre>
    *     for (MutableData child : parent.getChildren()) {
    *         &nbsp;&nbsp;&nbsp;&nbsp;...

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseMlException.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseMlException.java
@@ -33,9 +33,9 @@ public class FirebaseMlException extends FirebaseException {
   public static final int UNKNOWN = 2;
 
   /**
-   * Client specified an invalid argument. Note that this differs from <code>FAILED_PRECONDITION</code>.
-   * <code>INVALID_ARGUMENT</code> indicates arguments that are problematic regardless of the state
-   * of the system (for example, an invalid field name).
+   * Client specified an invalid argument. Note that this differs from <code>FAILED_PRECONDITION
+   * </code>. <code>INVALID_ARGUMENT</code> indicates arguments that are problematic regardless of
+   * the state of the system (for example, an invalid field name).
    */
   public static final int INVALID_ARGUMENT = 3;
 

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseMlException.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/FirebaseMlException.java
@@ -33,9 +33,9 @@ public class FirebaseMlException extends FirebaseException {
   public static final int UNKNOWN = 2;
 
   /**
-   * Client specified an invalid argument. Note that this differs from <code>FAILED_PRECONDITION
-   * </code>. <code>INVALID_ARGUMENT</code> indicates arguments that are problematic regardless of
-   * the state of the system (for example, an invalid field name).
+   * Client specified an invalid argument. Note that this differs from <code>FAILED_PRECONDITION</code>.
+   * <code>INVALID_ARGUMENT</code> indicates arguments that are problematic regardless of the state
+   * of the system (for example, an invalid field name).
    */
   public static final int INVALID_ARGUMENT = 3;
 


### PR DESCRIPTION
Per [b/257286586](https://b.corp.google.com/issues/257286586), this PR fixes an issue where our docs were producing broken code elements.

This happens mainly because break elements are not supported by Dokka (see https://github.com/Kotlin/dokka/issues/2262). To fix this, we just replace the code elements with pre elements- which is what we should be doing anyhow.

Note that is only a concern for multi-line code elements. Those that are single lined are fine as is (although this PR does fix one or two that were not correctly whitespaced).