### PR TITLE
Avoid throwing in ForcedSender.sendBlocking

### DIFF
--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/ForcedSender.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/ForcedSender.java
@@ -14,21 +14,28 @@
 
 package com.google.android.datatransport.runtime;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.Discouraged;
 import androidx.annotation.WorkerThread;
 import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.Transport;
+import com.google.android.datatransport.runtime.logging.Logging;
 
 @Discouraged(
     message =
         "TransportRuntime is not a realtime delivery system, don't use unless you absolutely must.")
 public final class ForcedSender {
+  private static final String LOG_TAG = "ForcedSender";
+
+  @SuppressLint("DiscouragedApi")
   @WorkerThread
   public static void sendBlocking(Transport<?> transport, Priority priority) {
     if (transport instanceof TransportImpl) {
       TransportContext context =
           ((TransportImpl<?>) transport).getTransportContext().withPriority(priority);
       TransportRuntime.getInstance().getUploader().logAndUpdateState(context, 1);
+    } else {
+      Logging.w(LOG_TAG, "Expected instance of `TransportImpl`, got `%s`.", transport);
     }
   }
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/ForcedSender.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/ForcedSender.java
@@ -14,7 +14,6 @@
 
 package com.google.android.datatransport.runtime;
 
-import android.annotation.SuppressLint;
 import androidx.annotation.Discouraged;
 import androidx.annotation.WorkerThread;
 import com.google.android.datatransport.Priority;
@@ -26,16 +25,11 @@ import com.google.android.datatransport.Transport;
 public final class ForcedSender {
   @WorkerThread
   public static void sendBlocking(Transport<?> transport, Priority priority) {
-    @SuppressLint("DiscouragedApi")
-    TransportContext context = getTransportContextOrThrow(transport).withPriority(priority);
-    TransportRuntime.getInstance().getUploader().logAndUpdateState(context, 1);
-  }
-
-  private static TransportContext getTransportContextOrThrow(Transport<?> transport) {
     if (transport instanceof TransportImpl) {
-      return ((TransportImpl<?>) transport).getTransportContext();
+      TransportContext context =
+          ((TransportImpl<?>) transport).getTransportContext().withPriority(priority);
+      TransportRuntime.getInstance().getUploader().logAndUpdateState(context, 1);
     }
-    throw new IllegalArgumentException("Expected instance of TransportImpl.");
   }
 
   private ForcedSender() {}


### PR DESCRIPTION
Make ForcedSender.sendBlocking do nothing, instead of throw, when given a wrong Transport type.

This will make it easier to mock Transport in tests. This method is best-effort anyway, so doing nothing instead of throwing is fine.