### PR TITLE
Fix &lt; and &gt; breaking the Javadoc output

### DIFF
--- a/firebase-database/src/main/java/com/google/firebase/database/DataSnapshot.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/DataSnapshot.java
@@ -105,12 +105,12 @@ public class DataSnapshot {
    * returned are:
    *
    * <ul>
-   *   <li>Boolean
-   *   <li>String
-   *   <li>Long
-   *   <li>Double
-   *   <li>Map&lt;String, Object&gt;
-   *   <li>List&lt;Object&gt;
+   *   <li><code>Boolean</code>
+   *   <li><code>String</code>
+   *   <li><code>Long</code>
+   *   <li><code>Double</code>
+   *   <li><code>Map&lt;String, Object&gt;</code>
+   *   <li><code>List&lt;Object&gt;</code>
    * </ul>
    *
    * This list is recursive; the possible types for {@link java.lang.Object} in the above list is
@@ -129,12 +129,12 @@ public class DataSnapshot {
    * returned are:
    *
    * <ul>
-   *   <li>Boolean
-   *   <li>String
-   *   <li>Long
-   *   <li>Double
-   *   <li>Map&lt;String, Object&gt;
-   *   <li>List&lt;Object&gt;
+   *   <li><code>Boolean</code>
+   *   <li><code>String</code>
+   *   <li><code>Long</code>
+   *   <li><code>Double</code>
+   *   <li><code>Map&lt;String, Object&gt;</code>
+   *   <li><code>List&lt;Object&gt;</code>
    * </ul>
    *
    * This list is recursive; the possible types for {@link java.lang.Object} in the above list is
@@ -300,8 +300,8 @@ public class DataSnapshot {
    * types:
    *
    * <ul>
-   *   <li>Double
-   *   <li>String
+   *   <li><code>Double</code>
+   *   <li><code>String</code>
    * </ul>
    *
    * Note that null is also allowed

--- a/firebase-database/src/main/java/com/google/firebase/database/DatabaseReference.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/DatabaseReference.java
@@ -126,12 +126,12 @@ public class DatabaseReference extends Query {
    * correspond to the JSON types:
    *
    * <ul>
-   *   <li>Boolean
-   *   <li>Long
-   *   <li>Double
-   *   <li>String
-   *   <li>Map&lt;String, Object&gt;
-   *   <li>List&lt;Object&gt;
+   *   <li><code>Boolean</code>
+   *   <li><code>Long</code>
+   *   <li><code>Double</code>
+   *   <li><code>String</code>
+   *   <li><code>Map&lt;String, Object&gt;</code>
+   *   <li><code>List&lt;Object&gt;</code>
    * </ul>
    *
    * <br>
@@ -165,12 +165,12 @@ public class DatabaseReference extends Query {
    * the JSON types:
    *
    * <ul>
-   *   <li>Boolean
-   *   <li>Long
-   *   <li>Double
-   *   <li>String
-   *   <li>Map&lt;String, Object&gt;
-   *   <li>List&lt;Object&gt;
+   *   <li><code>Boolean</code>
+   *   <li><code>Long</code>
+   *   <li><code>Double</code>
+   *   <li><code>String</code>
+   *   <li><code>Map&lt;String, Object&gt;</code>
+   *   <li><code>List&lt;Object&gt;</code>
    * </ul>
    *
    * <br>
@@ -205,12 +205,12 @@ public class DatabaseReference extends Query {
    * correspond to the JSON types:
    *
    * <ul>
-   *   <li>Boolean
-   *   <li>Long
-   *   <li>Double
-   *   <li>String
-   *   <li>Map&lt;String, Object&gt;
-   *   <li>List&lt;Object&gt;
+   *   <li><code>Boolean</code>
+   *   <li><code>Long</code>
+   *   <li><code>Double</code>
+   *   <li><code>String</code>
+   *   <li><code>Map&lt;String, Object&gt;</code>
+   *   <li><code>List&lt;Object&gt;</code>
    * </ul>
    *
    * <br>
@@ -242,12 +242,12 @@ public class DatabaseReference extends Query {
    * value correspond to the JSON types:
    *
    * <ul>
-   *   <li>Boolean
-   *   <li>Long
-   *   <li>Double
-   *   <li>String
-   *   <li>Map&lt;String, Object&gt;
-   *   <li>List&lt;Object&gt;
+   *   <li><code>Boolean</code>
+   *   <li><code>Long</code>
+   *   <li><code>Double</code>
+   *   <li><code>String</code>
+   *   <li><code>Map&lt;String, Object&gt;</code>
+   *   <li><code>List&lt;Object&gt;</code>
    * </ul>
    *
    * <br>

--- a/firebase-database/src/main/java/com/google/firebase/database/MutableData.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/MutableData.java
@@ -166,12 +166,12 @@ public class MutableData {
    * returned are:
    *
    * <ul>
-   *   <li>Boolean
-   *   <li>String
-   *   <li>Long
-   *   <li>Double
-   *   <li>Map&lt;String, Object&gt;
-   *   <li>List&lt;Object&gt;
+   *   <li><code>Boolean</code>
+   *   <li><code>Long</code>
+   *   <li><code>Double</code>
+   *   <li><code>String</code>
+   *   <li><code>Map&lt;String, Object&gt;</code>
+   *   <li><code>List&lt;Object&gt;</code>
    * </ul>
    *
    * This list is recursive; the possible types for {@link java.lang.Object} in the above list is
@@ -267,11 +267,11 @@ public class MutableData {
    * the value correspond to the JSON types:
    *
    * <ul>
-   *   <li>Boolean
-   *   <li>Long
-   *   <li>Double
-   *   <li>Map&lt;String, Object&gt;
-   *   <li>List&lt;Object&gt;
+   *   <li><code>Boolean</code>
+   *   <li><code>Long</code>
+   *   <li><code>Double</code>
+   *   <li><code>Map&lt;String, Object&gt;</code>
+   *   <li><code>List&lt;Object&gt;</code>
    * </ul>
    *
    * <br>
@@ -317,8 +317,8 @@ public class MutableData {
    * Gets the current priority at this location. The possible return types are:
    *
    * <ul>
-   *   <li>Double
-   *   <li>String
+   *   <li><code>Double</code>
+   *   <li><code>String</code>
    * </ul>
    *
    * Note that null is allowed


### PR DESCRIPTION
Per [b/257287954](https://b.corp.google.com/issues/257287954), this PR fixes `&lt;` and `&gt;` symbols breaking the doc output from Dackka.

This occurs because angle brackets are broken in Dackka (see [b/257276445](https://buganizer.corp.google.com/issues/257276445)). A workaround is to wrap them in `<code>` blocks. Although, looking through our existing source, it seems as though we oftentimes wrap types in code blocks anyhow- so this PR just wraps the entire type versus just wrapping the generic type (what's present in the angle brackets).