### PR TITLE
Fix multiline hyperlink renders

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/Timestamp.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/Timestamp.java
@@ -30,9 +30,7 @@ import java.util.Date;
  * 9999-12-31T23:59:59.999999999Z. By restricting to that range, we ensure that we can convert to
  * and from RFC 3339 date strings.
  *
- * @see <a href="
- *     https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto">The
- *     reference timestamp definition</a>
+ * @see <a href="https://git.page.link/timestamp-proto">Timestamp</a>The ref timestamp definition
  */
 public final class Timestamp implements Comparable<Timestamp>, Parcelable {
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/Trace.java
@@ -689,8 +689,7 @@ public class Trace extends AppStateUpdateHandler
    * Describes the kinds of special objects contained in this Parcelable's marshalled
    * representation.
    *
-   * @see <a href="https://developer.android.com/reference/android/os/Parcelable.html">
-   *     https://developer.android.com/reference/android/os/Parcelable.html</a>
+   * @see Parcelable
    * @return always returns 0.
    */
   @Keep


### PR DESCRIPTION
Per [b/256180692](https://b.corp.google.com/issues/256180692), this PR fixes an issue where multiline `@see` blocks were leaking HTML into the final output for documentation.

This occurs due to an upstream issue with Dokka (see https://github.com/Kotlin/dokka/issues/2665), where line breaks inside of `@see` tags break the generated Javadoc. This *also* prevents hyperlinks from being utilized in `@see` blocks. Thankfully, this issue only occurs in two places throughout our codebase (at least on the public API, which is what matters for doc generation).

One instance was resolved by providing a direct reference to the object- as it just so happens to be present on our classpath (and as such, a hyperlink is not needed).

The remaining instance was solved in three ways:

1. We reduce the link to a shorthand variant (thanks [dynamic links!](https://firebase.google.com/docs/dynamic-links)) as to keep everything on one line
2. We provide text to be present in the link (as this is usually generated from the package-list, but can't occur here as it's an external reference outside the scope of Java)
3. We provide a new `FiresiteTransform` method to handle the remaining leakage, and patch it up as expected.

The reason for keeping the link on one line and *then* implementing a transform versus just implementing one to handle the multiline issue is so that we can keep this state to a single issue; hyperlinks not working. Versus being bound to two separate issues; hyperlinks not working AND newlines breaking the output. So should Dockka only fix one of the issues, it will not break our transform.