### PR TITLE
Set ndkVersion for Crashlytics NDK SDK.

### DIFF
--- a/firebase-crashlytics-ndk/README.md
+++ b/firebase-crashlytics-ndk/README.md
@@ -11,11 +11,6 @@ Initialize them by running the following commands:
 
 ## Building
 
-* `firebase-crashlytics-ndk` must be built with NDK 21. Use Android Studio's
-  SDK Manager to ensure you have the appropriate NDK version installed, and
-  edit `../local.properties` to specify which NDK version to use when building
-  this project. For example:
-  `ndk.dir=$USER_HOME/Library/Android/sdk/ndk/21.4.7075529`
 * All Gradle commands should be run from the root of this repository:
   `./gradlew :firebase-crashlytics-ndk:assemble`
 

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -27,6 +27,7 @@ android {
         timeOutInMs 60 * 1000
     }
 
+    ndkVersion "25.1.8937393"
     compileSdkVersion project.targetSdkVersion
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Set ndkVersion to 25.1.8937393 for Crashlytics NDK SDK.

We used to build with 21... but that is no longer required.