### PR TITLE
Fix ndk build.

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/NdkBinaryFixTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/NdkBinaryFixTask.kt
@@ -29,7 +29,9 @@ abstract class NdkBinaryFixTask : DefaultTask() {
 
     @get:OutputFile
     val outputFile: File
-        get() = File("${inputFile.get().asFile.absolutePath}.so")
+        get() = inputFile.get().asFile.let {
+            File(it.parentFile, "lib${it.name}.so")
+        }
 
     @get:Internal
     val into: String
@@ -39,7 +41,7 @@ abstract class NdkBinaryFixTask : DefaultTask() {
     fun run() {
         Files.copy(
             inputFile.get().asFile.toPath(),
-            File("${inputFile.get().asFile.absolutePath}.so").toPath(),
+            outputFile.toPath(),
             StandardCopyOption.REPLACE_EXISTING
         )
     }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/NdkBinaryFixTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/NdkBinaryFixTask.kt
@@ -1,0 +1,46 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.firebase.gradle
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class NdkBinaryFixTask : DefaultTask() {
+    @get:InputFile
+    abstract val inputFile: RegularFileProperty
+
+    @get:OutputFile
+    val outputFile: File
+        get() = File("${inputFile.get().asFile.absolutePath}.so")
+
+    @get:Internal
+    val into: String
+        get() = "jni/${outputFile.parentFile.name}"
+
+    @TaskAction
+    fun run() {
+        Files.copy(
+            inputFile.get().asFile.toPath(),
+            File("${inputFile.get().asFile.absolutePath}.so").toPath(),
+            StandardCopyOption.REPLACE_EXISTING
+        )
+    }
+}

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -65,45 +65,31 @@ android {
         }
     }
 
+    // There is not any normal way to package native executables in an Android APK.
+    // It is normal to package native code as a loadable module but Android's APK
+    // installer will ignore files not named like a shared object, so give the
+    // handler executable an acceptable name
     libraryVariants.all { variant ->
-        variant.outputs.each { output ->
-            def func = fixTrampolineFilenames(variant.baseName)
-
-            tasks.findAll {
-                it.name.startsWith("bundleReleaseAar")
-            }.each {
-                it.dependsOn func
-            }
-
-            tasks.findAll {
-                it.name.startsWith("externalNativeBuild") && !it.name.contains("Clean")
-            }.each {
-                func.dependsOn it
+        def fixTasks = ["x86", "x86_64", "armeabi-v7a", "arm64-v8a"].collect { arch ->
+            tasks.register("fixTrampolineFilenames${variant.baseName}${arch}", com.google.firebase.gradle.NdkBinaryFixTask) {
+                it.inputFile =
+                        file("${buildDir}/intermediates/ndkBuild/${variant.baseName}/obj/local/${arch}/crashlytics-trampoline")
             }
         }
-    }
-}
 
-
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
-
-// There is not any normal way to package native executables in an Android APK.
-// It is normal to package native code as a loadable module but Android's APK
-// installer will ignore files not named like a shared object, so give the
-// handler executable an acceptable name
-def fixTrampolineFilenames(variantBaseName) {
-    project.task("fixTrampolineFilenames${variantBaseName}").configure({
-    }).doFirst {
-        ["x86", "x86_64", "armeabi-v7a", "arm64-v8a"].each { arch ->
-            def initial = new File(
-                    "${buildDir}/intermediates/ndkBuild/${variantBaseName}/obj/local/${arch}/crashlytics-trampoline")
-            def renamed = new File(
-                    "${buildDir}/intermediates/ndkBuild/${variantBaseName}/obj/local/${arch}/libcrashlytics-trampoline.so")
-
-            // There is no need to delete the original file, it will not be
-            // packaged into the APK
-            Files.copy(initial.toPath(), renamed.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        tasks.withType(com.android.build.gradle.tasks.BundleAar) {
+            if (it.variantName != variant.baseName) return
+            fixTasks.each { fix ->
+                it.dependsOn fix
+                it.from(fix.map { it.outputFile }) {
+                    into fix.map { it.into }
+                }
+            }
+        }
+        tasks.findAll {
+            it.name.startsWith("externalNativeBuild") && !it.name.contains("Clean")
+        }.each { task ->
+            fixTasks.each { fix -> fix.configure { it.dependsOn task } }
         }
     }
 }


### PR DESCRIPTION
Due to AGP upgrade the crashlytics-trampoline.so file stopped being included in the resulting AAR, this causes issues on devices with api 29+.