### PR TITLE
Replace Doclava with Dackka

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/MultiProjectReleasePlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/MultiProjectReleasePlugin.java
@@ -15,24 +15,19 @@ package com.google.firebase.gradle;
 
 import static com.google.firebase.gradle.plugins.ProjectUtilsKt.toBoolean;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.gradle.bomgenerator.BomGeneratorTask;
 import com.google.firebase.gradle.plugins.FireEscapeArtifactPlugin;
 import com.google.firebase.gradle.plugins.FirebaseLibraryExtension;
 import com.google.firebase.gradle.plugins.JavadocPlugin;
-import com.google.firebase.gradle.plugins.TasksKt;
 import com.google.firebase.gradle.plugins.publish.PublishingPlugin;
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.bundling.Zip;
 
 /**
@@ -62,10 +57,7 @@ public class MultiProjectReleasePlugin implements Plugin<Project> {
     project.apply(ImmutableMap.of("plugin", PublishingPlugin.class));
 
     boolean releaseJavadocs = toBoolean(System.getProperty("releaseJavadocs", "true"));
-
-    File firebaseDevsiteJavadoc = new File(project.getBuildDir(), "firebase-javadocs/");
-    File firebaseClientBuildDest = new File(firebaseDevsiteJavadoc, "client/");
-    firebaseClientBuildDest.mkdirs();
+    File firebaseDevsiteJavadoc = new File(project.getBuildDir(), "firebase-kotlindoc/android");
 
     project.subprojects(
         sub -> {
@@ -118,107 +110,9 @@ public class MultiProjectReleasePlugin implements Plugin<Project> {
                       "generateAllJavadocs",
                       task -> {
                         for (Project p : projectsToPublish) {
-                          task.dependsOn(p.getPath() + ":" + TasksKt.JAVADOC_TASK_NAME);
-
-                          task.doLast(
-                              t -> {
-                                for (Project publishableProject : projectsToPublish) {
-                                  publishableProject.copy(
-                                      copy -> {
-                                        copy.from(
-                                            publishableProject.getBuildDir()
-                                                + "/docs/javadoc/reference");
-                                        copy.include("**/*");
-                                        copy.into(firebaseDevsiteJavadoc);
-                                      });
-
-                                  publishableProject.copy(
-                                      copy -> {
-                                        copy.from(
-                                            publishableProject.getBuildDir()
-                                                + "/docs/javadoc/reference/_toc.yaml");
-                                        copy.include("**/*");
-                                        copy.into(
-                                            firebaseClientBuildDest
-                                                + "/"
-                                                + publishableProject.getName());
-                                      });
-                                }
-                              });
+                          task.dependsOn(p.getPath() + ":kotlindoc");
                         }
                       });
-
-              Delete prepareJavadocs =
-                  project
-                      .getTasks()
-                      .create(
-                          "prepareJavadocs",
-                          Delete.class,
-                          del -> {
-                            del.dependsOn(generateAllJavadocs);
-                            del.doLast(
-                                d -> {
-                                  // cleanup docs
-                                  project.delete(
-                                      delSpec -> {
-                                        ImmutableList<String> relativeDeletablePaths =
-                                            ImmutableList.of(
-                                                "timestamp.js",
-                                                "navtree_data.js",
-                                                "assets/",
-                                                "classes.html",
-                                                "hierarchy.html",
-                                                "lists.js",
-                                                "package-list",
-                                                "packages.html",
-                                                "index.html",
-                                                "current.xml",
-                                                "_toc.yaml");
-                                        delSpec.delete(
-                                            relativeDeletablePaths.stream()
-                                                .map(
-                                                    path ->
-                                                        firebaseDevsiteJavadoc.getPath()
-                                                            + "/"
-                                                            + path)
-                                                .collect(Collectors.toList()));
-                                      });
-                                  // Transform
-                                  project.exec(
-                                      execSpec -> {
-                                        execSpec.setIgnoreExitValue(true);
-                                        execSpec.setWorkingDir(firebaseDevsiteJavadoc);
-                                        execSpec.setCommandLine(
-                                            project.getRootProject().file("buildSrc").getPath()
-                                                + "/firesite_transform.sh");
-                                      });
-
-                                  // Tidy
-                                  String tidyBinary = System.getProperty("tidyBinaryPath", null);
-                                  String tidyConfig = System.getProperty("tidyConfigPath", null);
-                                  if (tidyBinary != null && tidyConfig != null) {
-                                    try {
-                                      Files.walk(firebaseDevsiteJavadoc.toPath())
-                                          .filter(
-                                              p ->
-                                                  p.toFile().isFile()
-                                                      && p.toString().endsWith(".html"))
-                                          .forEach(
-                                              p -> {
-                                                project.exec(
-                                                    execSpec -> {
-                                                      System.out.println("Tidying " + p);
-                                                      execSpec.setIgnoreExitValue(true);
-                                                      execSpec.commandLine(
-                                                          tidyBinary, "-config", tidyConfig, p);
-                                                    });
-                                              });
-                                    } catch (IOException e) {
-                                      throw new GradleException("Directory walk failed.", e);
-                                    }
-                                  }
-                                });
-                          });
 
               Zip assembleFirebaseJavadocZip =
                   project
@@ -227,7 +121,7 @@ public class MultiProjectReleasePlugin implements Plugin<Project> {
                           "assembleFirebaseJavadocZip",
                           Zip.class,
                           zip -> {
-                            zip.dependsOn(prepareJavadocs);
+                            zip.dependsOn(generateAllJavadocs);
                             zip.getDestinationDirectory().set(project.getBuildDir());
                             zip.getArchiveFileName().set("firebase-javadoc.zip");
                             zip.from(firebaseDevsiteJavadoc);

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -338,21 +338,14 @@ abstract class DackkaPlugin : Plugin<Project> {
     outputDirectory: Provider<File>
   ) =
     project.tasks.register<Copy>("copyJavaDocToCommonDirectory") {
-      /**
-       * This is not currently cache compliant. The need for this property is temporary while we
-       * test it alongside the current javaDoc task. Since it's such a temporary behavior, losing
-       * cache compliance is fine for now.
-       */
-      if (project.rootProject.findProperty("dackkaJavadoc") == "true") {
-        mustRunAfter("firesiteTransform")
+      mustRunAfter("firesiteTransform")
 
-        val outputFolder = project.rootProject.fileFromBuildDir("firebase-kotlindoc/android")
-        val javaFolder = project.childFile(outputDirectory, "android")
+      val outputFolder = project.rootProject.fileFromBuildDir("firebase-kotlindoc")
+      val javaFolder = project.childFile(outputDirectory, "android")
 
-        fromDirectory(javaFolder)
+      fromDirectory(javaFolder)
 
-        into(outputFolder)
-      }
+      into(outputFolder)
     }
 
   // TODO(b/246593212): Migrate doc files to single directory


### PR DESCRIPTION
Per [b/255992607](https://b.corp.google.com/issues/255992607), this replaces our old Javadoc generation through Doclava with our new implementation with Dackka- so that our release process now generates Javadocs through the `DackkaPlugin`.

For the sake of brevity (and ensuring everything works), this does not change any task names or even the general format of our release plugins. Especially since some of these plugins are very inter-tangled. This will be addressed in a future PR (probably in relation with my `firebase-library` refactor work coming up).