### PR TITLE
Fix deadlock when handling simultaneous messages.

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
+# 23.1.1
+
+* [fixed] Fixed deadlock when handling simultaneous messages.
+
 # 23.1.0
 * [unchanged] Updated to accommodate the release of the updated
   [messaging_longer] Kotlin extensions library.
-
 
 ## Kotlin
 The Kotlin extensions library transitively includes the updated

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/WakeLockHolder.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/WakeLockHolder.java
@@ -108,9 +108,7 @@ final class WakeLockHolder {
         wakeLock.acquire(WAKE_LOCK_ACQUIRE_TIMEOUT_MILLIS);
       }
 
-      connection
-          .sendIntent(intent)
-          .addOnCompleteListener(Runnable::run, t -> completeWakefulIntent(intent));
+      connection.sendIntent(intent).addOnCompleteListener(t -> completeWakefulIntent(intent));
     }
   }
 

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/WakeLockHolderRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/WakeLockHolderRoboTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.shadows.ShadowPowerManager;
 
 @RunWith(RobolectricTestRunner.class)
@@ -77,6 +78,7 @@ public class WakeLockHolderRoboTest {
     WakeLock wakeLock = ShadowPowerManager.getLatestWakeLock();
     taskCompletionSource.setResult(null);
 
+    ShadowLooper.idleMainLooper();
     assertThat(wakeLock.isHeld()).isFalse();
   }
 


### PR DESCRIPTION
https://github.com/firebase/firebase-android-sdk/issues/4315
* Released sendWakefulServiceIntent()'s WakeLock on the main thread instead of within WithinAppServiceConnection to prevent a deadlock trying to acquire the WakeLockHolder.syncObject.