### PR TITLE
Some improvements to firebase-appdistribution/test-app

### DIFF
--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -70,7 +70,6 @@ class MainActivity : AppCompatActivity() {
         feedbackTriggerMenu = findViewById(R.id.feedbackTriggerMenu)
         val items = listOf(
             FeedbackTrigger.NONE.label,
-            FeedbackTrigger.SDK_NOTIFICATION.label,
             FeedbackTrigger.CUSTOM_NOTIFICATION.label,
             FeedbackTrigger.SHAKE.label,
             FeedbackTrigger.SCREENSHOT.label,
@@ -84,12 +83,6 @@ class MainActivity : AppCompatActivity() {
             when(text.toString()) {
                 FeedbackTrigger.NONE.label -> {
                     disableAllFeedbackTriggers()
-                }
-                FeedbackTrigger.SDK_NOTIFICATION.label -> {
-                    disableAllFeedbackTriggers()
-                    Log.i(TAG, "Enabling notification trigger (SDK)")
-                    firebaseAppDistribution.showFeedbackNotification(
-                        R.string.feedbackInfoText, InterruptionLevel.HIGH)
                 }
                 FeedbackTrigger.CUSTOM_NOTIFICATION.label -> {
                     disableAllFeedbackTriggers()
@@ -106,6 +99,9 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+
+        firebaseAppDistribution.showFeedbackNotification(
+            R.string.feedbackInfoText, InterruptionLevel.HIGH)
     }
 
     override fun onDestroy() {
@@ -115,13 +111,15 @@ class MainActivity : AppCompatActivity() {
 
     private fun disableAllFeedbackTriggers() {
         Log.i(TAG, "Disabling all feedback triggers")
-        firebaseAppDistribution.cancelFeedbackNotification()
         ShakeDetectionFeedbackTrigger.disable(application)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         val inflater: MenuInflater = menuInflater
         inflater.inflate(R.menu.action_menu, menu)
+        if (BuildConfig.FLAVOR == "beta") {
+            menu.findItem(R.id.startFeedbackMenuItem).isVisible = true
+        }
         return true
     }
 
@@ -261,10 +259,10 @@ class MainActivity : AppCompatActivity() {
 
     private fun failureListener(exception: Exception) {
         val ex = exception as com.google.firebase.appdistribution.FirebaseAppDistributionException
-        Log.d("FirebaseAppDistribution", "MAINACTIVITY:ERROR ERROR. CODE: " + exception.errorCode)
+        Log.d("MainActivity", "Task failed with an error (${ex.errorCode}): ${ex.message}")
         AlertDialog.Builder(this)
-            .setTitle("Error updating to new release")
-            .setMessage("${ex.message}: ${ex.errorCode}")
+            .setTitle("Task failed")
+            .setMessage("${ex.message}\n\nCode: ${ex.errorCode}")
             .setNeutralButton("Okay") { dialog, _ -> dialog.dismiss() }
             .show()
     }
@@ -320,7 +318,6 @@ class MainActivity : AppCompatActivity() {
             NONE("None"),
             SHAKE("Shake the device"),
             SCREENSHOT("Take a screenshot"),
-            SDK_NOTIFICATION("Tap a notification (SDK)"),
             CUSTOM_NOTIFICATION("Tap a notification (custom)")
         }
     }

--- a/firebase-appdistribution/test-app/src/main/res/menu/action_menu.xml
+++ b/firebase-appdistribution/test-app/src/main/res/menu/action_menu.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@+id/startFeedbackMenuItem"
-        android:title="@string/startFeedbackLabel"/>
+        android:title="@string/startFeedbackLabel"
+        android:visible="false"/>
 </menu>

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "com.googletest.firebase.appdistribution.testapp"
         minSdkVersion 23
         targetSdkVersion 33
-        versionName "2.1"
-        versionCode 3
+        versionName "3.1"
+        versionCode 6
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -37,10 +37,22 @@ android {
             // needing to have the app signed.
             initWith debug
         }
+    }
 
-        debug {
+    flavorDimensions.add("environment")
+
+    productFlavors {
+        prod {
+            dimension "environment"
+            versionNameSuffix "-prod"
+        }
+
+        beta {
+            dimension "environment"
+            versionNameSuffix "-beta"
+
             firebaseAppDistribution {
-                releaseNotes "Debug variant of Android SDK test app"
+                releaseNotes "Beta variant of Android SDK test app"
                 // testers "your email here"
             }
         }
@@ -67,8 +79,8 @@ dependencies {
     implementation project(':firebase-common:ktx')
     implementation "com.google.android.gms:play-services-tasks:18.0.2"
 
-    // Debug uses the full implementation
-    debugImplementation project(':firebase-appdistribution')
+    // Beta flavor uses the full implementation
+    betaImplementation project(':firebase-appdistribution')
 
     // Other dependencies
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"


### PR DESCRIPTION
Mostly changes how the SDK is used to better match the setup guide:
- Use prod/beta build flavors to control whether the full SDK is used
- Only show feedback menu item for beta variant
- Always initialize the default notification-based trigger
- Improve error handling in MainActivity