### PR TITLE
Handle the case where we can't identify the release.

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -112,6 +112,11 @@ public class FeedbackActivity extends AppCompatActivity {
   }
 
   public void submitFeedback(View view) {
+    if (releaseName == null) {
+      Toast.makeText(this, R.string.feedback_no_release, Toast.LENGTH_LONG).show();
+      finish();
+      return;
+    }
     setSubmittingStateEnabled(true);
     EditText feedbackText = findViewById(R.id.feedbackText);
     CheckBox screenshotCheckBox = findViewById(R.id.screenshotCheckBox);

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -46,7 +46,7 @@ public class FeedbackActivity extends AppCompatActivity {
       "com.google.firebase.appdistribution.FeedbackActivity.SCREENSHOT_URI";
 
   private FeedbackSender feedbackSender;
-  private String releaseName;
+  @Nullable private String releaseName; // in development-mode the releaseName might be null
   private CharSequence infoText;
   @Nullable private Uri screenshotUri;
 
@@ -113,6 +113,7 @@ public class FeedbackActivity extends AppCompatActivity {
 
   public void submitFeedback(View view) {
     if (releaseName == null) {
+      // Don't actually send feedback in development-mode
       Toast.makeText(this, R.string.feedback_no_release, Toast.LENGTH_LONG).show();
       finish();
       return;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -377,24 +377,36 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
             e ->
                 LogWrapper.getInstance()
                     .e("Failed to sign in tester. Could not collect feedback.", e))
-        .onSuccessTask(taskExecutor, unused -> releaseIdentifier.identifyRelease()
-            .addOnFailureListener(
-                e -> {
-                  LogWrapper.getInstance().e("Failed to identify release", e);
-                  feedbackInProgress.set(false);
-                  Toast.makeText(firebaseApp.getApplicationContext(),
-                      R.string.feedback_unidentified_release, Toast.LENGTH_LONG).show();
-                })
-            .onSuccessTask(
-                taskExecutor,
-                releaseName -> launchFeedbackActivity(releaseName, infoText, screenshotUri)
+        .onSuccessTask(
+            taskExecutor,
+            unused ->
+                releaseIdentifier
+                    .identifyRelease()
                     .addOnFailureListener(
                         e -> {
-                          LogWrapper.getInstance().e("Failed to launch feedback flow", e);
+                          LogWrapper.getInstance().e("Failed to identify release", e);
                           feedbackInProgress.set(false);
-                          Toast.makeText(firebaseApp.getApplicationContext(),
-                              R.string.feedback_launch_failed, Toast.LENGTH_LONG).show();
-                        })));
+                          Toast.makeText(
+                                  firebaseApp.getApplicationContext(),
+                                  R.string.feedback_unidentified_release,
+                                  Toast.LENGTH_LONG)
+                              .show();
+                        })
+                    .onSuccessTask(
+                        taskExecutor,
+                        releaseName ->
+                            launchFeedbackActivity(releaseName, infoText, screenshotUri)
+                                .addOnFailureListener(
+                                    e -> {
+                                      LogWrapper.getInstance()
+                                          .e("Failed to launch feedback flow", e);
+                                      feedbackInProgress.set(false);
+                                      Toast.makeText(
+                                              firebaseApp.getApplicationContext(),
+                                              R.string.feedback_launch_failed,
+                                              Toast.LENGTH_LONG)
+                                          .show();
+                                    })));
   }
 
   private Task<Void> launchFeedbackActivity(

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -397,6 +397,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
                     .onSuccessTask(
                         taskExecutor,
                         releaseName ->
+                            // in development-mode the releaseName might be null
                             launchFeedbackActivity(releaseName, infoText, screenshotUri)
                                 .addOnFailureListener(
                                     e -> {
@@ -417,6 +418,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
         activity -> {
           LogWrapper.getInstance().i("Launching feedback activity");
           Intent intent = new Intent(activity, FeedbackActivity.class);
+          // in development-mode the releaseName might be null
           intent.putExtra(FeedbackActivity.RELEASE_NAME_EXTRA_KEY, releaseName);
           intent.putExtra(FeedbackActivity.INFO_TEXT_EXTRA_KEY, infoText);
           if (screenshotUri != null) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -374,9 +374,11 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
         .signInTester()
         .addOnFailureListener(
             taskExecutor,
-            e ->
-                LogWrapper.getInstance()
-                    .e("Failed to sign in tester. Could not collect feedback.", e))
+            e -> {
+              feedbackInProgress.set(false);
+              LogWrapper.getInstance()
+                  .e("Failed to sign in tester. Could not collect feedback.", e);
+            })
         .onSuccessTask(
             taskExecutor,
             unused ->
@@ -384,8 +386,8 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
                     .identifyRelease()
                     .addOnFailureListener(
                         e -> {
-                          LogWrapper.getInstance().e("Failed to identify release", e);
                           feedbackInProgress.set(false);
+                          LogWrapper.getInstance().e("Failed to identify release", e);
                           Toast.makeText(
                                   firebaseApp.getApplicationContext(),
                                   R.string.feedback_unidentified_release,
@@ -398,9 +400,9 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
                             launchFeedbackActivity(releaseName, infoText, screenshotUri)
                                 .addOnFailureListener(
                                     e -> {
+                                      feedbackInProgress.set(false);
                                       LogWrapper.getInstance()
                                           .e("Failed to launch feedback flow", e);
-                                      feedbackInProgress.set(false);
                                       Toast.makeText(
                                               firebaseApp.getApplicationContext(),
                                               R.string.feedback_launch_failed,

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -412,7 +412,7 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   }
 
   private Task<Void> launchFeedbackActivity(
-      String releaseName, CharSequence infoText, @Nullable Uri screenshotUri) {
+      @Nullable String releaseName, CharSequence infoText, @Nullable Uri screenshotUri) {
     return lifecycleNotifier.consumeForegroundActivity(
         activity -> {
           LogWrapper.getInstance().i("Launching feedback activity");

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ReleaseIdentifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ReleaseIdentifier.java
@@ -56,7 +56,12 @@ class ReleaseIdentifier {
     this.testerApiClient = testerApiClient;
   }
 
-  /** Identify the currently installed release, returning the release name. */
+  /**
+   * Identify the currently installed release, returning the release name.
+   *
+   * <p>Will return {@code Task} with a {@code null} result in "developer mode" which allows the UI
+   * to be used, but no actual feedback to be submitted.
+   */
   Task<String> identifyRelease() {
     if (developmentModeEnabled()) {
       return Tasks.forResult(null);

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ReleaseIdentifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ReleaseIdentifier.java
@@ -27,6 +27,7 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -46,8 +47,8 @@ class ReleaseIdentifier {
   static final String IAS_ARTIFACT_ID_METADATA_KEY = "com.android.vending.internal.apk.id";
 
   private final ConcurrentMap<String, String> cachedApkHashes = new ConcurrentHashMap<>();
-  private FirebaseApp firebaseApp;
-  FirebaseAppDistributionTesterApiClient testerApiClient;
+  private final FirebaseApp firebaseApp;
+  private final FirebaseAppDistributionTesterApiClient testerApiClient;
 
   ReleaseIdentifier(
       FirebaseApp firebaseApp, FirebaseAppDistributionTesterApiClient testerApiClient) {
@@ -57,6 +58,10 @@ class ReleaseIdentifier {
 
   /** Identify the currently installed release, returning the release name. */
   Task<String> identifyRelease() {
+    if (developmentModeEnabled()) {
+      return Tasks.forResult(null);
+    }
+
     // Attempt to find release using IAS artifact ID, which identifies app bundle releases
     String iasArtifactId = null;
     try {
@@ -192,5 +197,26 @@ class ReleaseIdentifier {
       result[i] = list.get(i);
     }
     return result;
+  }
+
+  private static boolean developmentModeEnabled() {
+    return Boolean.valueOf(getSystemProperty("debug.firebase.appdistro.devmode"));
+  }
+
+  @Nullable
+  @SuppressWarnings({"unchecked", "PrivateApi"})
+  private static String getSystemProperty(String propertyName) {
+    String className = "android.os.SystemProperties";
+    try {
+      Class<?> sysProps = Class.forName(className);
+      Method method = sysProps.getDeclaredMethod("get", String.class);
+      Object result = method.invoke(null, propertyName);
+      if (result != null && String.class.isAssignableFrom(result.getClass())) {
+        return (String) result;
+      }
+    } catch (Exception e) {
+      // do nothing
+    }
+    return null;
   }
 }

--- a/firebase-appdistribution/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/src/main/res/values/strings.xml
@@ -32,8 +32,8 @@
   <string name="app_update_notification_channel_name">App updates</string>
   <string name="app_update_notification_channel_description">Shows progress of in-app updates</string>
   <string name="feedback_launch_failed">Failed to launch feedback</string>
-  <string name="feedback_unidentified_release">Release not found. This app may not have been installed by App Distribution, or you may no longer have access</string>
-  <string name="feedback_no_release">Would have sent feedback</string>
+  <string name="feedback_unidentified_release">Release not found. This app may not have been installed by App Distribution, or you may no longer have access.</string>
+  <string name="feedback_no_release">Would have sent feedback, but did not due to development mode.</string>
   <string name="feedback_notification_channel_name">Feedback</string>
   <string name="feedback_notification_channel_description">Tap to leave feedback</string>
   <string name="feedback_notification_title">We want your feedback!</string>

--- a/firebase-appdistribution/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
   <string name="app_update_notification_channel_name">App updates</string>
   <string name="app_update_notification_channel_description">Shows progress of in-app updates</string>
   <string name="feedback_launch_failed">Failed to launch feedback</string>
-  <string name="feedback_unidentified_release">Release not accessible. Probably not installed via App Distribution</string>
+  <string name="feedback_unidentified_release">Release not found. This app may not have been installed by App Distribution, or you may no longer have access</string>
   <string name="feedback_no_release">Would have sent feedback</string>
   <string name="feedback_notification_channel_name">Feedback</string>
   <string name="feedback_notification_channel_description">Tap to leave feedback</string>

--- a/firebase-appdistribution/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/src/main/res/values/strings.xml
@@ -31,6 +31,9 @@
   <string name="notifications_group_name">Firebase App Distribution</string>
   <string name="app_update_notification_channel_name">App updates</string>
   <string name="app_update_notification_channel_description">Shows progress of in-app updates</string>
+  <string name="feedback_launch_failed">Failed to launch feedback</string>
+  <string name="feedback_unidentified_release">Release not accessible. Probably not installed via App Distribution</string>
+  <string name="feedback_no_release">Would have sent feedback</string>
   <string name="feedback_notification_channel_name">Feedback</string>
   <string name="feedback_notification_channel_description">Tap to leave feedback</string>
   <string name="feedback_notification_title">We want your feedback!</string>

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -758,7 +758,7 @@ public class FirebaseAppDistributionServiceImplTest {
     TestUtils.awaitAsyncOperations(taskExecutor);
 
     assertThat(firebaseAppDistribution.isFeedbackInProgress()).isFalse();
-    assertLoggedError("Failed to launch feedback flow", exception);
+    assertLoggedError("Failed to sign in tester", exception);
   }
 
   @Test
@@ -772,7 +772,7 @@ public class FirebaseAppDistributionServiceImplTest {
     TestUtils.awaitAsyncOperations(taskExecutor);
 
     assertThat(firebaseAppDistribution.isFeedbackInProgress()).isFalse();
-    assertLoggedError("Failed to launch feedback flow", exception);
+    assertLoggedError("Failed to identify release", exception);
   }
 
   private static void assertLoggedError(String partialMessage, Throwable e) {


### PR DESCRIPTION
Developers can use `adb shell setprop debug.firebase.appdistro.devmode true` to skip checking the release version (and skip actually submitting feedback - while keeping the UI).