### PR TITLE
Use shared executors in App Distribution SDK

### DIFF
--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -44,6 +44,7 @@ android {
 dependencies {
     implementation 'org.jetbrains:annotations:15.0'
     implementation project(':firebase-appdistribution-api')
+    implementation project(':firebase-annotations')
     implementation project(':firebase-components')
     implementation project(':firebase-installations-interop')
     implementation project(':firebase-common')

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/LogWrapper.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/LogWrapper.java
@@ -80,6 +80,10 @@ class LogWrapper {
     Log.e(LOG_TAG, msg, tr);
   }
 
+  void e(@NonNull String additionalTag, @NonNull String msg) {
+    Log.e(LOG_TAG, prependTag(additionalTag, msg));
+  }
+
   void e(@NonNull String additionalTag, @NonNull String msg, @NonNull Throwable tr) {
     Log.e(LOG_TAG, prependTag(additionalTag, msg), tr);
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
@@ -35,6 +35,7 @@ import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
 import java.io.File;
+import java.util.concurrent.Executors;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -102,7 +103,10 @@ public class FirebaseAppDistributionTesterApiClientTest {
 
     firebaseAppDistributionTesterApiClient =
         new FirebaseAppDistributionTesterApiClient(
-            firebaseApp, mockFirebaseInstallationsProvider, mockTesterApiHttpClient);
+            firebaseApp,
+            mockFirebaseInstallationsProvider,
+            mockTesterApiHttpClient,
+            Executors.newSingleThreadExecutor());
   }
 
   @Test


### PR DESCRIPTION
Following [the guide](https://github.com/firebase/firebase-android-sdk/blob/e0cfdd60b8c7204805f78874892a03dccbe174af/docs/executors.md).

In all three cases we either block for network I/O or synchronization.