### PR TITLE
Make FeedbackSender depend on Blocking executor

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.appdistribution.impl;
 
+import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 import androidx.annotation.Keep;
@@ -82,6 +83,8 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
     return new FeedbackSender(testerApiClient, blockingExecutor);
   }
 
+  // TODO(b/258264924): Migrate to go/firebase-android-executors
+  @SuppressLint("ThreadPoolCreation")
   private FirebaseAppDistribution buildFirebaseAppDistribution(
       ComponentContainer container, Executor blockingExecutor) {
     FirebaseApp firebaseApp = container.get(FirebaseApp.class);

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.appdistribution.impl;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -42,6 +43,8 @@ class ScreenshotTaker {
   private final FirebaseAppDistributionLifecycleNotifier lifecycleNotifier;
   private final Executor taskExecutor;
 
+  // TODO(b/258264924): Migrate to go/firebase-android-executors
+  @SuppressLint("ThreadPoolCreation")
   ScreenshotTaker(
       FirebaseApp firebaseApp, FirebaseAppDistributionLifecycleNotifier lifecycleNotifier) {
     this(firebaseApp, lifecycleNotifier, Executors.newSingleThreadExecutor());


### PR DESCRIPTION
Currently this crashes with launching the FeedbackActivity because the dependency was not declared.