### PR TITLE
Use dagger in functions.

### DIFF
--- a/firebase-functions/CHANGELOG.md
+++ b/firebase-functions/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * [changed] Avoid executing code on the UI thread as much as possible.
+* [changed] Internal infrastructure improvements.
 
 # 20.2.1
 * [changed] Updated dependency of `firebase-iid` to its latest

--- a/firebase-functions/firebase-functions.gradle
+++ b/firebase-functions/firebase-functions.gradle
@@ -14,6 +14,7 @@
 
 plugins {
     id 'firebase-library'
+    id 'firebase-vendor'
 }
 
 firebaseLibrary {
@@ -67,6 +68,12 @@ dependencies {
     implementation 'com.google.firebase:firebase-iid-interop:17.1.0'
 
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
+
+    implementation 'javax.inject:javax.inject:1'
+    vendor ('com.google.dagger:dagger:2.43.2') {
+        exclude group: "javax.inject", module: "javax.inject"
+    }
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.43.2'
 
     annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
 

--- a/firebase-functions/src/androidTest/java/com/google/firebase/functions/CallTest.java
+++ b/firebase-functions/src/androidTest/java/com/google/firebase/functions/CallTest.java
@@ -85,7 +85,6 @@ public class CallTest {
     // Override the normal token provider to simulate FirebaseAuth being logged in.
     FirebaseFunctions functions =
         new FirebaseFunctions(
-            app,
             app.getApplicationContext(),
             app.getOptions().getProjectId(),
             "us-central1",
@@ -108,7 +107,6 @@ public class CallTest {
     // Override the normal token provider to simulate FirebaseAuth being logged in.
     FirebaseFunctions functions =
         new FirebaseFunctions(
-            app,
             app.getApplicationContext(),
             app.getOptions().getProjectId(),
             "us-central1",
@@ -131,7 +129,6 @@ public class CallTest {
     // Override the normal token provider to simulate FirebaseAuth being logged in.
     FirebaseFunctions functions =
         new FirebaseFunctions(
-            app,
             app.getApplicationContext(),
             app.getOptions().getProjectId(),
             "us-central1",

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseContextProvider.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseContextProvider.java
@@ -26,8 +26,11 @@ import com.google.firebase.inject.Provider;
 import com.google.firebase.internal.api.FirebaseNoSignedInUserException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /** A ContextProvider that uses FirebaseAuth to get the token. */
+@Singleton
 class FirebaseContextProvider implements ContextProvider {
   private final String TAG = "FirebaseContextProvider";
 
@@ -37,6 +40,7 @@ class FirebaseContextProvider implements ContextProvider {
       new AtomicReference<>();
   private final Executor executor;
 
+  @Inject
   FirebaseContextProvider(
       Provider<InternalAuthProvider> tokenProvider,
       Provider<FirebaseInstanceIdInternal> instanceId,

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.java
@@ -30,6 +30,8 @@ import com.google.firebase.annotations.concurrent.Lightweight;
 import com.google.firebase.annotations.concurrent.UiThread;
 import com.google.firebase.emulators.EmulatedServiceSettings;
 import com.google.firebase.functions.FirebaseFunctionsException.Code;
+import dagger.assisted.Assisted;
+import dagger.assisted.AssistedInject;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.MalformedURLException;
@@ -37,6 +39,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import javax.inject.Named;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.MediaType;
@@ -58,9 +61,6 @@ public class FirebaseFunctions {
    * providerInstalled lock.
    */
   private static boolean providerInstallStarted = false;
-
-  // The FirebaseApp instance
-  private final FirebaseApp app;
 
   // The network client to use for HTTPS requests.
   private final OkHttpClient client;
@@ -88,15 +88,14 @@ public class FirebaseFunctions {
   // Emulator settings
   @Nullable private EmulatedServiceSettings emulatorSettings;
 
+  @AssistedInject
   FirebaseFunctions(
-      FirebaseApp app,
       Context context,
-      String projectId,
-      String regionOrCustomDomain,
+      @Named("projectId") String projectId,
+      @Assisted String regionOrCustomDomain,
       ContextProvider contextProvider,
       @Lightweight Executor executor,
       @UiThread Executor uiExecutor) {
-    this.app = app;
     this.executor = executor;
     this.client = new OkHttpClient();
     this.serializer = new Serializer();

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FunctionsComponent.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FunctionsComponent.java
@@ -1,0 +1,78 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.functions;
+
+import android.content.Context;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.annotations.concurrent.Lightweight;
+import com.google.firebase.annotations.concurrent.UiThread;
+import com.google.firebase.appcheck.interop.InternalAppCheckTokenProvider;
+import com.google.firebase.auth.internal.InternalAuthProvider;
+import com.google.firebase.iid.internal.FirebaseInstanceIdInternal;
+import com.google.firebase.inject.Deferred;
+import com.google.firebase.inject.Provider;
+import dagger.Binds;
+import dagger.BindsInstance;
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+import java.util.concurrent.Executor;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/** @hide */
+@Component(modules = FunctionsComponent.MainModule.class)
+@Singleton
+interface FunctionsComponent {
+  FunctionsMultiResourceComponent getMultiResourceComponent();
+
+  @Component.Builder
+  interface Builder {
+    @BindsInstance
+    Builder setApplicationContext(Context applicationContext);
+
+    @BindsInstance
+    Builder setFirebaseOptions(FirebaseOptions options);
+
+    @BindsInstance
+    Builder setLiteExecutor(@Lightweight Executor executor);
+
+    @BindsInstance
+    Builder setUiExecutor(@UiThread Executor executor);
+
+    @BindsInstance
+    Builder setAuth(Provider<InternalAuthProvider> auth);
+
+    @BindsInstance
+    Builder setIid(Provider<FirebaseInstanceIdInternal> iid);
+
+    @BindsInstance
+    Builder setAppCheck(Deferred<InternalAppCheckTokenProvider> appCheck);
+
+    FunctionsComponent build();
+  }
+
+  @Module
+  interface MainModule {
+    @Provides
+    @Named("projectId")
+    static String bindProjectId(FirebaseOptions options) {
+      return options.getProjectId();
+    }
+
+    @Binds
+    ContextProvider contextProvider(FirebaseContextProvider provider);
+  }
+}

--- a/firebase-functions/src/main/java/com/google/firebase/functions/Serializer.java
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/Serializer.java
@@ -38,7 +38,7 @@ class Serializer {
 
   private final DateFormat dateFormat;
 
-  public Serializer() {
+  Serializer() {
     // Encode Dates as UTC ISO 8601 strings.
     dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
     dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));


### PR DESCRIPTION
This simplifies injection of firebase components so they don't have to be passed all the way from the registrar into classes that actually use components.

This change adds `+4.22 kB` to the size of the sdk, but is a small enough increase compared to the advantages it provides