### PR TITLE
Enable dead code elimination for vendored deps.

### DIFF
--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/VendorTests.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/VendorTests.kt
@@ -86,11 +86,11 @@ class VendorPluginTests {
       )
 
     // ImmutableList is not used, so it should be stripped out.
-    assertThat(classes).doesNotContain("com/google/common/collect/ImmutableList.class")
+    assertThat(classes).doesNotContain("com/example/com/google/common/collect/ImmutableList.class")
   }
 
   @Test
-  fun `vendor dagger excluding javax transitive deps and not using it should include dagger`() {
+  fun `vendor dagger excluding javax transitive deps and not using it should not include dagger`() {
     val classes =
       buildWith(
         """
@@ -113,12 +113,7 @@ class VendorPluginTests {
         )
       )
     // expected classes
-    assertThat(classes)
-      .containsAtLeast(
-        "com/example/Hello.class",
-        "com/example/BuildConfig.class",
-        "com/example/dagger/Lazy.class"
-      )
+    assertThat(classes).containsExactly("com/example/Hello.class", "com/example/BuildConfig.class")
   }
 
   @Test

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -67,6 +67,12 @@ firebaseLibrary {
     }
 }
 
+vendor {
+    // Integration tests use dagger classes that are not used in the main SDK,
+    // so we disable dead code elimination to ensure those classes are preserved.
+    optimize = false
+}
+
 android {
     compileSdkVersion project.targetSdkVersion
     defaultConfig {


### PR DESCRIPTION
This change removes parts of dagger that are not used by SDKs that vendor it in.