### PR TITLE
Changed protobuf-java to latest version 3.21.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
     googleTruthVersion = '1.1.2'
     grpcVersion = '1.50.2'
     robolectricVersion = '4.9'
-    protocVersion = '3.17.3'
+    protocVersion = '3.21.9'
     javaliteVersion = '3.17.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ ext {
     googleTruthVersion = '1.1.2'
     grpcVersion = '1.50.2'
     robolectricVersion = '4.9'
-    protocVersion = '3.21.9'
+    protocVersion = '3.17.3'
     javaliteVersion = '3.17.3'
 }
 

--- a/encoders/protoc-gen-firebase-encoders/protoc-gen-firebase-encoders.gradle
+++ b/encoders/protoc-gen-firebase-encoders/protoc-gen-firebase-encoders.gradle
@@ -37,7 +37,7 @@ jar {
 
 dependencies {
 
-    implementation "com.google.protobuf:protobuf-java:3.14.0"
+    implementation "com.google.protobuf:protobuf-java:3.21.9"
     implementation 'com.squareup:javapoet:1.13.0'
     implementation 'com.google.guava:guava:30.0-jre'
     implementation 'com.google.dagger:dagger:2.43.2'

--- a/encoders/protoc-gen-firebase-encoders/tests/tests.gradle
+++ b/encoders/protoc-gen-firebase-encoders/tests/tests.gradle
@@ -49,7 +49,7 @@ protobuf {
 dependencies {
     testImplementation project(":encoders:firebase-encoders")
     testImplementation project(":encoders:firebase-encoders-proto")
-    testImplementation "com.google.protobuf:protobuf-java:3.14.0"
+    testImplementation "com.google.protobuf:protobuf-java:3.21.9"
     testImplementation 'junit:junit:4.13.1'
     testImplementation "com.google.truth:truth:1.0.1"
 

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -92,5 +92,5 @@ dependencies {
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
-    androidTestImplementation 'com.google.protobuf:protobuf-java:3.14.0'
+    androidTestImplementation 'com.google.protobuf:protobuf-java:3.21.9'
 }

--- a/firebase-perf/ktx/ktx.gradle
+++ b/firebase-perf/ktx/ktx.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation project(':firebase-perf')
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    testCompileOnly "com.google.protobuf:protobuf-java:$protocVersion"
+    testCompileOnly "com.google.protobuf:protobuf-java:3.21.9"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"


### PR DESCRIPTION
Fix for #4371. 

Updating dependency to the latest patched version to avoid vulnerability issue.

- `com.google.protobuf:protobuf-java` from `3.17.3` to `3.21.9`