### PR TITLE
Fix 'Continuation returned null' error when there is no previous activity

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -97,7 +97,7 @@ class ScreenshotTaker {
           if (activity == null) {
             // TakeScreenshotAndStartFeedbackActivity was the current activity and there was no
             // active previous activity
-            return null;
+            return Tasks.forResult(null);
           }
           // We only take the screenshot here because this will be called on the main thread, so we
           // want to do as little work as possible


### PR DESCRIPTION
The continuation method needs to return a non-null `Task`. This change doesn't have any practical effect: either way no screenshot is captured and the feedback flow opens without a screenshot attached. But right now this prints an NPE and stack trace to the logs.

```
Failed to take screenshot for feedback
java.lang.NullPointerException: Continuation returned null
	at com.google.android.gms.tasks.zzo.run(com.google.android.gms:play-services-tasks@@18.0.2:7)
	at com.google.firebase.appdistribution.impl.FirebaseAppDistributionLifecycleNotifier$$ExternalSyntheticLambda5.execute(Unknown Source:0)
	at com.google.android.gms.tasks.zzp.zzd(com.google.android.gms:play-services-tasks@@18.0.2:1)
	at com.google.android.gms.tasks.zzr.zzb(com.google.android.gms:play-services-tasks@@18.0.2:5)
	at com.google.android.gms.tasks.zzw.zzi(com.google.android.gms:play-services-tasks@@18.0.2:3)
	at com.google.android.gms.tasks.zzw.onSuccessTask(com.google.android.gms:play-services-tasks@@18.0.2:7)
	at com.google.firebase.appdistribution.impl.FirebaseAppDistributionLifecycleNotifier.applyToNullableForegroundActivityTask(FirebaseAppDistributionLifecycleNotifier.java:178)
	at com.google.firebase.appdistribution.impl.ScreenshotTaker.captureScreenshot(ScreenshotTaker.java:93)
        ...
```