### PR TITLE
Upgrade JaCoCo plugin version

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/Coverage.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ci/Coverage.java
@@ -35,7 +35,7 @@ public final class Coverage {
     File reportsDir = new File(project.getBuildDir(), "/reports/jacoco");
     JacocoPluginExtension jacoco = project.getExtensions().getByType(JacocoPluginExtension.class);
 
-    jacoco.setToolVersion("0.8.5");
+    jacoco.setToolVersion("0.8.8");
     jacoco.setReportsDir(reportsDir);
     project
         .getTasks()


### PR DESCRIPTION
Fixes the issue where JaCoCo cannot produce coverage files for certain kotlin packages.

See details:
- https://github.com/jacoco/jacoco/issues/1155
- https://youtrack.jetbrains.com/issue/KT-44757