### PR TITLE
Change concurrency group for health metrics test to "github.sha"

### DIFF
--- a/.github/workflows/health-metrics.yml
+++ b/.github/workflows/health-metrics.yml
@@ -1,7 +1,7 @@
 name: Health Metrics
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
The problem with `github.ref` was that when two consecutive commits are pushed to a feature branch (e.g. `master`) around the same time, the execution of health metrics test for the second commit will cancel the execution for the first one, and thus make the metrics measurement for the first commit unavailable.