### PR TITLE
Migrate `firebase-appcheck` to use standard executors provided by Firebase Common.

### DIFF
--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Migrated the `firebase-appcheck` library to use standard Firebase executors. (#4431)
 
 # 16.1.0
 * [unchanged] Updated to accommodate the release of the updated

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -41,6 +41,7 @@ android {
 }
 
 dependencies {
+    implementation project(':firebase-annotations')
     implementation project(':firebase-common')
     implementation project(':firebase-components')
     implementation project(":appcheck:firebase-appcheck-interop")

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -50,6 +50,7 @@ dependencies {
 
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
+    testImplementation project(':integ-testing')
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-inline:2.25.0'

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/FirebaseAppCheckRegistrar.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/FirebaseAppCheckRegistrar.java
@@ -29,7 +29,7 @@ import com.google.firebase.heartbeatinfo.HeartBeatController;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -44,8 +44,7 @@ public class FirebaseAppCheckRegistrar implements ComponentRegistrar {
 
   @Override
   public List<Component<?>> getComponents() {
-    Qualified<ExecutorService> backgroundExecutorService =
-        Qualified.qualified(Background.class, ExecutorService.class);
+    Qualified<Executor> backgroundExecutor = Qualified.qualified(Background.class, Executor.class);
     Qualified<ScheduledExecutorService> blockingScheduledExecutorService =
         Qualified.qualified(Blocking.class, ScheduledExecutorService.class);
 
@@ -53,7 +52,7 @@ public class FirebaseAppCheckRegistrar implements ComponentRegistrar {
         Component.builder(FirebaseAppCheck.class, (InternalAppCheckTokenProvider.class))
             .name(LIBRARY_NAME)
             .add(Dependency.required(FirebaseApp.class))
-            .add(Dependency.required(backgroundExecutorService))
+            .add(Dependency.required(backgroundExecutor))
             .add(Dependency.required(blockingScheduledExecutorService))
             .add(Dependency.optionalProvider(HeartBeatController.class))
             .factory(
@@ -61,7 +60,7 @@ public class FirebaseAppCheckRegistrar implements ComponentRegistrar {
                     new DefaultFirebaseAppCheck(
                         container.get(FirebaseApp.class),
                         container.getProvider(HeartBeatController.class),
-                        container.get(backgroundExecutorService),
+                        container.get(backgroundExecutor),
                         container.get(blockingScheduledExecutorService)))
             .alwaysEager()
             .build(),

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -52,7 +52,6 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
   private final StorageHelper storageHelper;
   private final TokenRefreshManager tokenRefreshManager;
   private final Executor backgroundExecutor;
-  private final ScheduledExecutorService scheduledExecutorService;
   private final Task<Void> retrieveStoredTokenTask;
   private final Clock clock;
 
@@ -74,9 +73,11 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
     this.storageHelper =
         new StorageHelper(firebaseApp.getApplicationContext(), firebaseApp.getPersistenceKey());
     this.tokenRefreshManager =
-        new TokenRefreshManager(firebaseApp.getApplicationContext(), /* firebaseAppCheck= */ this);
+        new TokenRefreshManager(
+            firebaseApp.getApplicationContext(),
+            /* firebaseAppCheck= */ this,
+            scheduledExecutorService);
     this.backgroundExecutor = backgroundExecutor;
-    this.scheduledExecutorService = scheduledExecutorService;
     this.retrieveStoredTokenTask = retrieveStoredAppCheckTokenInBackground(backgroundExecutor);
     this.clock = new Clock.DefaultClock();
   }
@@ -248,11 +249,6 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
   @NonNull
   Provider<HeartBeatController> getHeartbeatControllerProvider() {
     return heartbeatControllerProvider;
-  }
-
-  @NonNull
-  ScheduledExecutorService getScheduledExecutorService() {
-    return scheduledExecutorService;
   }
 
   /** Sets the in-memory cached {@link AppCheckToken}. */

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -38,7 +38,7 @@ import com.google.firebase.heartbeatinfo.HeartBeatController;
 import com.google.firebase.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
@@ -51,7 +51,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
   private final List<AppCheckListener> appCheckListenerList;
   private final StorageHelper storageHelper;
   private final TokenRefreshManager tokenRefreshManager;
-  private final ExecutorService backgroundExecutor;
+  private final Executor backgroundExecutor;
   private final ScheduledExecutorService scheduledExecutorService;
   private final Task<Void> retrieveStoredTokenTask;
   private final Clock clock;
@@ -63,7 +63,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
   public DefaultFirebaseAppCheck(
       @NonNull FirebaseApp firebaseApp,
       @NonNull Provider<HeartBeatController> heartBeatController,
-      @Background ExecutorService backgroundExecutor,
+      @Background Executor backgroundExecutor,
       @Blocking ScheduledExecutorService scheduledExecutorService) {
     checkNotNull(firebaseApp);
     checkNotNull(heartBeatController);
@@ -81,7 +81,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
     this.clock = new Clock.DefaultClock();
   }
 
-  private Task<Void> retrieveStoredAppCheckTokenInBackground(@NonNull ExecutorService executor) {
+  private Task<Void> retrieveStoredAppCheckTokenInBackground(@NonNull Executor executor) {
     TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
     executor.execute(
         () -> {

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck.java
@@ -25,6 +25,8 @@ import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseException;
+import com.google.firebase.annotations.concurrent.Background;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.appcheck.AppCheckProvider;
 import com.google.firebase.appcheck.AppCheckProviderFactory;
 import com.google.firebase.appcheck.AppCheckToken;
@@ -37,7 +39,7 @@ import com.google.firebase.inject.Provider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
 
@@ -50,6 +52,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
   private final StorageHelper storageHelper;
   private final TokenRefreshManager tokenRefreshManager;
   private final ExecutorService backgroundExecutor;
+  private final ScheduledExecutorService scheduledExecutorService;
   private final Task<Void> retrieveStoredTokenTask;
   private final Clock clock;
 
@@ -57,22 +60,11 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
   private AppCheckProvider appCheckProvider;
   private AppCheckToken cachedToken;
 
-  // TODO(b/258273630): Migrate to go/firebase-android-executors
-  @SuppressLint("ThreadPoolCreation")
   public DefaultFirebaseAppCheck(
       @NonNull FirebaseApp firebaseApp,
-      @NonNull Provider<HeartBeatController> heartBeatController) {
-    this(
-        checkNotNull(firebaseApp),
-        checkNotNull(heartBeatController),
-        Executors.newCachedThreadPool());
-  }
-
-  @VisibleForTesting
-  DefaultFirebaseAppCheck(
-      @NonNull FirebaseApp firebaseApp,
       @NonNull Provider<HeartBeatController> heartBeatController,
-      @NonNull ExecutorService backgroundExecutor) {
+      @Background ExecutorService backgroundExecutor,
+      @Blocking ScheduledExecutorService scheduledExecutorService) {
     checkNotNull(firebaseApp);
     checkNotNull(heartBeatController);
     this.firebaseApp = firebaseApp;
@@ -84,6 +76,7 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
     this.tokenRefreshManager =
         new TokenRefreshManager(firebaseApp.getApplicationContext(), /* firebaseAppCheck= */ this);
     this.backgroundExecutor = backgroundExecutor;
+    this.scheduledExecutorService = scheduledExecutorService;
     this.retrieveStoredTokenTask = retrieveStoredAppCheckTokenInBackground(backgroundExecutor);
     this.clock = new Clock.DefaultClock();
   }
@@ -255,6 +248,11 @@ public class DefaultFirebaseAppCheck extends FirebaseAppCheck {
   @NonNull
   Provider<HeartBeatController> getHeartbeatControllerProvider() {
     return heartbeatControllerProvider;
+  }
+
+  @NonNull
+  ScheduledExecutorService getScheduledExecutorService() {
+    return scheduledExecutorService;
   }
 
   /** Sets the in-memory cached {@link AppCheckToken}. */

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultTokenRefresher.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultTokenRefresher.java
@@ -21,7 +21,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 
@@ -41,10 +40,8 @@ public class DefaultTokenRefresher {
   private volatile ScheduledFuture<?> refreshFuture;
   private volatile long delayAfterFailureSeconds;
 
-  // TODO(b/258273630): Migrate to go/firebase-android-executors
-  @SuppressLint("ThreadPoolCreation")
   DefaultTokenRefresher(@NonNull DefaultFirebaseAppCheck firebaseAppCheck) {
-    this(checkNotNull(firebaseAppCheck), Executors.newScheduledThreadPool(/* corePoolSize= */ 1));
+    this(checkNotNull(firebaseAppCheck), firebaseAppCheck.getScheduledExecutorService());
   }
 
   @VisibleForTesting

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultTokenRefresher.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultTokenRefresher.java
@@ -21,6 +21,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import com.google.firebase.annotations.concurrent.Blocking;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 
@@ -40,14 +41,10 @@ public class DefaultTokenRefresher {
   private volatile ScheduledFuture<?> refreshFuture;
   private volatile long delayAfterFailureSeconds;
 
-  DefaultTokenRefresher(@NonNull DefaultFirebaseAppCheck firebaseAppCheck) {
-    this(checkNotNull(firebaseAppCheck), firebaseAppCheck.getScheduledExecutorService());
-  }
-
-  @VisibleForTesting
   DefaultTokenRefresher(
-      DefaultFirebaseAppCheck firebaseAppCheck, ScheduledExecutorService scheduledExecutorService) {
-    this.firebaseAppCheck = firebaseAppCheck;
+      @NonNull DefaultFirebaseAppCheck firebaseAppCheck,
+      @Blocking ScheduledExecutorService scheduledExecutorService) {
+    this.firebaseAppCheck = checkNotNull(firebaseAppCheck);
     this.scheduledExecutorService = scheduledExecutorService;
     this.delayAfterFailureSeconds = UNSET_DELAY;
   }

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/TokenRefreshManager.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/TokenRefreshManager.java
@@ -22,8 +22,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.api.internal.BackgroundDetector;
 import com.google.android.gms.common.api.internal.BackgroundDetector.BackgroundStateChangeListener;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.appcheck.AppCheckToken;
 import com.google.firebase.appcheck.internal.util.Clock;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** Class to manage whether or not to schedule an {@link AppCheckToken} refresh attempt. */
 public final class TokenRefreshManager {
@@ -41,10 +43,13 @@ public final class TokenRefreshManager {
   private volatile long nextRefreshTimeMillis;
   private volatile boolean isAutoRefreshEnabled;
 
-  TokenRefreshManager(@NonNull Context context, @NonNull DefaultFirebaseAppCheck firebaseAppCheck) {
+  TokenRefreshManager(
+      @NonNull Context context,
+      @NonNull DefaultFirebaseAppCheck firebaseAppCheck,
+      @Blocking ScheduledExecutorService scheduledExecutorService) {
     this(
         checkNotNull(context),
-        new DefaultTokenRefresher(checkNotNull(firebaseAppCheck)),
+        new DefaultTokenRefresher(checkNotNull(firebaseAppCheck), scheduledExecutorService),
         new Clock.DefaultClock());
   }
 

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/FirebaseAppCheckRegistrarTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/FirebaseAppCheckRegistrarTest.java
@@ -17,10 +17,15 @@ package com.google.firebase.appcheck;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.concurrent.Background;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.Dependency;
+import com.google.firebase.components.Qualified;
 import com.google.firebase.heartbeatinfo.HeartBeatController;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -39,6 +44,9 @@ public class FirebaseAppCheckRegistrarTest {
     assertThat(firebaseAppCheckComponent.getDependencies())
         .containsExactly(
             Dependency.required(FirebaseApp.class),
+            Dependency.required(Qualified.qualified(Background.class, ExecutorService.class)),
+            Dependency.required(
+                Qualified.qualified(Blocking.class, ScheduledExecutorService.class)),
             Dependency.optionalProvider(HeartBeatController.class));
     assertThat(firebaseAppCheckComponent.isAlwaysEager()).isTrue();
   }

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/FirebaseAppCheckRegistrarTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/FirebaseAppCheckRegistrarTest.java
@@ -24,7 +24,7 @@ import com.google.firebase.components.Dependency;
 import com.google.firebase.components.Qualified;
 import com.google.firebase.heartbeatinfo.HeartBeatController;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +44,7 @@ public class FirebaseAppCheckRegistrarTest {
     assertThat(firebaseAppCheckComponent.getDependencies())
         .containsExactly(
             Dependency.required(FirebaseApp.class),
-            Dependency.required(Qualified.qualified(Background.class, ExecutorService.class)),
+            Dependency.required(Qualified.qualified(Background.class, Executor.class)),
             Dependency.required(
                 Qualified.qualified(Blocking.class, ScheduledExecutorService.class)),
             Dependency.optionalProvider(HeartBeatController.class));

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
@@ -43,12 +43,11 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
-import org.robolectric.annotation.LooperMode.Mode;
 
 /** Tests for {@link DefaultFirebaseAppCheck}. */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
-@LooperMode(Mode.LEGACY)
+@LooperMode(LooperMode.Mode.LEGACY)
 public class DefaultFirebaseAppCheckTest {
 
   private static final String EXCEPTION_TEXT = "exceptionText";

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/DefaultFirebaseAppCheckTest.java
@@ -17,6 +17,7 @@ package com.google.firebase.appcheck.internal;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +34,7 @@ import com.google.firebase.appcheck.AppCheckTokenResult;
 import com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener;
 import com.google.firebase.appcheck.interop.AppCheckTokenListener;
 import com.google.firebase.heartbeatinfo.HeartBeatController;
+import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,7 +82,8 @@ public class DefaultFirebaseAppCheckTest {
         new DefaultFirebaseAppCheck(
             mockFirebaseApp,
             () -> mockHeartBeatController,
-            MoreExecutors.newDirectExecutorService());
+            MoreExecutors.newDirectExecutorService(),
+            mock(ScheduledExecutorService.class));
   }
 
   @Test
@@ -88,7 +91,11 @@ public class DefaultFirebaseAppCheckTest {
     assertThrows(
         NullPointerException.class,
         () -> {
-          new DefaultFirebaseAppCheck(null, () -> mockHeartBeatController);
+          new DefaultFirebaseAppCheck(
+              null,
+              () -> mockHeartBeatController,
+              MoreExecutors.newDirectExecutorService(),
+              mock(ScheduledExecutorService.class));
         });
   }
 
@@ -97,7 +104,11 @@ public class DefaultFirebaseAppCheckTest {
     assertThrows(
         NullPointerException.class,
         () -> {
-          new DefaultFirebaseAppCheck(mockFirebaseApp, null);
+          new DefaultFirebaseAppCheck(
+              mockFirebaseApp,
+              null,
+              MoreExecutors.newDirectExecutorService(),
+              mock(ScheduledExecutorService.class));
         });
   }
 


### PR DESCRIPTION
App Check executor migration:

- [x] `firebase-appcheck`
- [ ] `firebase-appcheck-safetynet`
- [ ] `firebase-appcheck-playintegrity`
- [ ] `firebase-appcheck-debug`