### PR TITLE
Integrate `AppCheckProvider`s with Firebase Components.

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/src/main/AndroidManifest.xml
+++ b/appcheck/firebase-appcheck-debug-testing/src/main/AndroidManifest.xml
@@ -17,4 +17,11 @@
     package="com.google.firebase.appcheck.debug.testing">
   <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
   <!--<uses-sdk android:minSdkVersion="16"/>-->
+  <application>
+    <service android:name="com.google.firebase.components.ComponentDiscoveryService"
+        android:exported="false">
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.appcheck.debug.testing.FirebaseAppCheckDebugTestingRegistrar"
+          android:value="com.google.firebase.components.ComponentRegistrar" />
+    </service>
+  </application>
 </manifest>

--- a/appcheck/firebase-appcheck-debug-testing/src/main/java/com/google/firebase/appcheck/debug/testing/DebugAppCheckTestHelper.java
+++ b/appcheck/firebase-appcheck-debug-testing/src/main/java/com/google/firebase/appcheck/debug/testing/DebugAppCheckTestHelper.java
@@ -15,13 +15,10 @@
 package com.google.firebase.appcheck.debug.testing;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
-import androidx.test.platform.app.InstrumentationRegistry;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.AppCheckProviderFactory;
 import com.google.firebase.appcheck.FirebaseAppCheck;
 import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory;
-import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactoryHelper;
 import com.google.firebase.appcheck.internal.DefaultFirebaseAppCheck;
 
 /**
@@ -66,28 +63,16 @@ import com.google.firebase.appcheck.internal.DefaultFirebaseAppCheck;
  * </pre>
  */
 public final class DebugAppCheckTestHelper {
-  private static final String DEBUG_SECRET_KEY = "firebaseAppCheckDebugSecret";
-
-  private final String debugSecret;
-
   /**
-   * Creates a {@link DebugAppCheckTestHelper} instance with the debug secret obtained from {@link
-   * InstrumentationRegistry} arguments.
+   * Creates a {@link DebugAppCheckTestHelper} instance with a debug secret obtained from {@link
+   * androidx.test.platform.app.InstrumentationRegistry} arguments.
    */
   @NonNull
   public static DebugAppCheckTestHelper fromInstrumentationArgs() {
-    String debugSecret = InstrumentationRegistry.getArguments().getString(DEBUG_SECRET_KEY);
-    return new DebugAppCheckTestHelper(debugSecret);
+    return new DebugAppCheckTestHelper();
   }
 
-  @VisibleForTesting
-  static DebugAppCheckTestHelper fromString(String debugSecret) {
-    return new DebugAppCheckTestHelper(debugSecret);
-  }
-
-  private DebugAppCheckTestHelper(String debugSecret) {
-    this.debugSecret = debugSecret;
-  }
+  private DebugAppCheckTestHelper() {}
 
   /**
    * Installs a {@link DebugAppCheckProviderFactory} to the default {@link FirebaseApp} and runs the
@@ -109,8 +94,7 @@ public final class DebugAppCheckTestHelper {
         (DefaultFirebaseAppCheck) FirebaseAppCheck.getInstance(firebaseApp);
     AppCheckProviderFactory currentAppCheckProviderFactory =
         firebaseAppCheck.getInstalledAppCheckProviderFactory();
-    firebaseAppCheck.installAppCheckProviderFactory(
-        DebugAppCheckProviderFactoryHelper.createDebugAppCheckProviderFactory(debugSecret));
+    firebaseAppCheck.installAppCheckProviderFactory(DebugAppCheckProviderFactory.getInstance());
     try {
       runnable.run();
     } catch (Throwable throwable) {

--- a/appcheck/firebase-appcheck-debug-testing/src/main/java/com/google/firebase/appcheck/debug/testing/DebugSecretProvider.java
+++ b/appcheck/firebase-appcheck-debug-testing/src/main/java/com/google/firebase/appcheck/debug/testing/DebugSecretProvider.java
@@ -1,0 +1,35 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appcheck.debug.testing;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.google.firebase.appcheck.debug.InternalDebugSecretProvider;
+
+/** @hide */
+public class DebugSecretProvider implements InternalDebugSecretProvider {
+  private static final String DEBUG_SECRET_KEY = "firebaseAppCheckDebugSecret";
+
+  DebugSecretProvider() {}
+
+  /**
+   * Returns a debug secret from {@link InstrumentationRegistry} arguments to be used with the
+   * {@link com.google.firebase.appcheck.debug.internal.DebugAppCheckProvider} in continuous
+   * integration testing flows.
+   */
+  @Override
+  public String getDebugSecret() {
+    return InstrumentationRegistry.getArguments().getString(DEBUG_SECRET_KEY);
+  }
+}

--- a/appcheck/firebase-appcheck-debug-testing/src/main/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckDebugTestingRegistrar.java
+++ b/appcheck/firebase-appcheck-debug-testing/src/main/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckDebugTestingRegistrar.java
@@ -12,35 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.firebase.appcheck.safetynet;
+package com.google.firebase.appcheck.debug.testing;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.appcheck.safetynet.internal.SafetyNetAppCheckProvider;
+import com.google.firebase.appcheck.debug.BuildConfig;
+import com.google.firebase.appcheck.debug.InternalDebugSecretProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
-import com.google.firebase.components.Dependency;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Arrays;
 import java.util.List;
 
 /**
- * {@link ComponentRegistrar} for setting up FirebaseAppCheck safety net's dependency injections in
- * Firebase Android Components.
+ * {@link ComponentRegistrar} for setting up FirebaseAppCheck debug testing's dependency injections
+ * in Firebase Android Components.
  *
  * @hide
  */
 @KeepForSdk
-public class FirebaseAppCheckSafetyNetRegistrar implements ComponentRegistrar {
-  private static final String LIBRARY_NAME = "fire-app-check-safety-net";
+public class FirebaseAppCheckDebugTestingRegistrar implements ComponentRegistrar {
+  private static final String LIBRARY_NAME = "fire-app-check-debug-testing";
 
   @Override
   public List<Component<?>> getComponents() {
     return Arrays.asList(
-        Component.builder(SafetyNetAppCheckProvider.class)
+        Component.builder(DebugSecretProvider.class, (InternalDebugSecretProvider.class))
             .name(LIBRARY_NAME)
-            .add(Dependency.required(FirebaseApp.class))
-            .factory((container) -> new SafetyNetAppCheckProvider(container.get(FirebaseApp.class)))
+            .factory((container) -> new DebugSecretProvider())
             .build(),
         LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
   }

--- a/appcheck/firebase-appcheck-debug-testing/src/test/java/com/google/firebase/appcheck/debug/testing/DebugAppCheckTestHelperTest.java
+++ b/appcheck/firebase-appcheck-debug-testing/src/test/java/com/google/firebase/appcheck/debug/testing/DebugAppCheckTestHelperTest.java
@@ -35,10 +35,9 @@ public class DebugAppCheckTestHelperTest {
   private static final String PROJECT_ID = "projectId";
   private static final String APP_ID = "appId";
   private static final String OTHER_FIREBASE_APP_NAME = "otherFirebaseAppName";
-  private static final String DEBUG_SECRET = "debugSecret";
 
   private final DebugAppCheckTestHelper debugAppCheckTestHelper =
-      DebugAppCheckTestHelper.fromString(DEBUG_SECRET);
+      DebugAppCheckTestHelper.fromInstrumentationArgs();
 
   @Before
   public void setUp() {

--- a/appcheck/firebase-appcheck-debug-testing/src/test/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckDebugTestingRegistrarTest.java
+++ b/appcheck/firebase-appcheck-debug-testing/src/test/java/com/google/firebase/appcheck/debug/testing/FirebaseAppCheckDebugTestingRegistrarTest.java
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appcheck.debug.testing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.components.Component;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for {@link FirebaseAppCheckDebugTestingRegistrar}. */
+@RunWith(RobolectricTestRunner.class)
+public class FirebaseAppCheckDebugTestingRegistrarTest {
+  @Test
+  public void testGetComponents() {
+    FirebaseAppCheckDebugTestingRegistrar registrar = new FirebaseAppCheckDebugTestingRegistrar();
+    List<Component<?>> components = registrar.getComponents();
+    assertThat(components).isNotEmpty();
+    assertThat(components).hasSize(2);
+    Component<?> appCheckDebugTestingComponent = components.get(0);
+    assertThat(appCheckDebugTestingComponent.getDependencies()).isEmpty();
+    assertThat(appCheckDebugTestingComponent.isLazy()).isTrue();
+  }
+}

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/DebugAppCheckProviderFactory.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/DebugAppCheckProviderFactory.java
@@ -27,20 +27,7 @@ public class DebugAppCheckProviderFactory implements AppCheckProviderFactory {
 
   private static final DebugAppCheckProviderFactory instance = new DebugAppCheckProviderFactory();
 
-  private String debugSecret;
-
-  private DebugAppCheckProviderFactory() {
-    this.debugSecret = null;
-  }
-
-  /**
-   * This constructor is package-private in order to prevent debug secrets from being hard-coded in
-   * application logic. This constructor is used by the firebase-appcheck-debug-testing SDK, to
-   * inject debug secrets in integration tests.
-   */
-  DebugAppCheckProviderFactory(String debugSecret) {
-    this.debugSecret = debugSecret;
-  }
+  private DebugAppCheckProviderFactory() {}
 
   /**
    * Gets an instance of this class for installation into a {@link
@@ -55,7 +42,8 @@ public class DebugAppCheckProviderFactory implements AppCheckProviderFactory {
 
   @NonNull
   @Override
+  @SuppressWarnings("FirebaseUseExplicitDependencies")
   public AppCheckProvider create(@NonNull FirebaseApp firebaseApp) {
-    return new DebugAppCheckProvider(firebaseApp, debugSecret);
+    return firebaseApp.get(DebugAppCheckProvider.class);
   }
 }

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/FirebaseAppCheckDebugRegistrar.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/FirebaseAppCheckDebugRegistrar.java
@@ -15,8 +15,11 @@
 package com.google.firebase.appcheck.debug;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.appcheck.debug.internal.DebugAppCheckProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
+import com.google.firebase.components.Dependency;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +36,17 @@ public class FirebaseAppCheckDebugRegistrar implements ComponentRegistrar {
 
   @Override
   public List<Component<?>> getComponents() {
-    return Arrays.asList(LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
+    return Arrays.asList(
+        Component.builder(DebugAppCheckProvider.class)
+            .name(LIBRARY_NAME)
+            .add(Dependency.required(FirebaseApp.class))
+            .add(Dependency.optionalProvider(InternalDebugSecretProvider.class))
+            .factory(
+                (container) ->
+                    new DebugAppCheckProvider(
+                        container.get(FirebaseApp.class),
+                        container.getProvider(InternalDebugSecretProvider.class)))
+            .build(),
+        LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
   }
 }

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/InternalDebugSecretProvider.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/InternalDebugSecretProvider.java
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,19 +14,15 @@
 
 package com.google.firebase.appcheck.debug;
 
-import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
- * Helper class used by {@link com.google.firebase.appcheck.debug.testing.DebugAppCheckTestHelper}
- * in order to access the package-private {@link DebugAppCheckProviderFactory} constructor that
- * takes in a debug secret.
+ * An interface for obtaining a debug secret to be used with {@link
+ * com.google.firebase.appcheck.debug.internal.DebugAppCheckProvider}.
  *
  * @hide
  */
-public class DebugAppCheckProviderFactoryHelper {
-  @NonNull
-  public static DebugAppCheckProviderFactory createDebugAppCheckProviderFactory(
-      @NonNull String debugSecret) {
-    return new DebugAppCheckProviderFactory(debugSecret);
-  }
+public interface InternalDebugSecretProvider {
+  @Nullable
+  String getDebugSecret();
 }

--- a/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/FirebaseAppCheckDebugRegistrarTest.java
+++ b/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/FirebaseAppCheckDebugRegistrarTest.java
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appcheck.debug;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.components.Component;
+import com.google.firebase.components.Dependency;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for {@link FirebaseAppCheckDebugRegistrar}. */
+@RunWith(RobolectricTestRunner.class)
+public class FirebaseAppCheckDebugRegistrarTest {
+  @Test
+  public void testGetComponents() {
+    FirebaseAppCheckDebugRegistrar registrar = new FirebaseAppCheckDebugRegistrar();
+    List<Component<?>> components = registrar.getComponents();
+    assertThat(components).isNotEmpty();
+    assertThat(components).hasSize(2);
+    Component<?> appCheckDebugComponent = components.get(0);
+    assertThat(appCheckDebugComponent.getDependencies())
+        .containsExactly(
+            Dependency.required(FirebaseApp.class),
+            Dependency.optionalProvider(InternalDebugSecretProvider.class));
+    assertThat(appCheckDebugComponent.isLazy()).isTrue();
+  }
+}

--- a/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/FirebaseAppCheckPlayIntegrityRegistrar.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/FirebaseAppCheckPlayIntegrityRegistrar.java
@@ -15,8 +15,11 @@
 package com.google.firebase.appcheck.playintegrity;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.appcheck.playintegrity.internal.PlayIntegrityAppCheckProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
+import com.google.firebase.components.Dependency;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +36,13 @@ public class FirebaseAppCheckPlayIntegrityRegistrar implements ComponentRegistra
 
   @Override
   public List<Component<?>> getComponents() {
-    return Arrays.asList(LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
+    return Arrays.asList(
+        Component.builder(PlayIntegrityAppCheckProvider.class)
+            .name(LIBRARY_NAME)
+            .add(Dependency.required(FirebaseApp.class))
+            .factory(
+                (container) -> new PlayIntegrityAppCheckProvider(container.get(FirebaseApp.class)))
+            .build(),
+        LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
   }
 }

--- a/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/PlayIntegrityAppCheckProviderFactory.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/PlayIntegrityAppCheckProviderFactory.java
@@ -40,7 +40,8 @@ public class PlayIntegrityAppCheckProviderFactory implements AppCheckProviderFac
 
   @NonNull
   @Override
+  @SuppressWarnings("FirebaseUseExplicitDependencies")
   public AppCheckProvider create(@NonNull FirebaseApp firebaseApp) {
-    return new PlayIntegrityAppCheckProvider(firebaseApp);
+    return firebaseApp.get(PlayIntegrityAppCheckProvider.class);
   }
 }

--- a/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/FirebaseAppCheckPlayIntegrityRegistrarTest.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/FirebaseAppCheckPlayIntegrityRegistrarTest.java
@@ -1,0 +1,41 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appcheck.playintegrity;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.components.Component;
+import com.google.firebase.components.Dependency;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for {@link FirebaseAppCheckPlayIntegrityRegistrar}. */
+@RunWith(RobolectricTestRunner.class)
+public class FirebaseAppCheckPlayIntegrityRegistrarTest {
+  @Test
+  public void testGetComponents() {
+    FirebaseAppCheckPlayIntegrityRegistrar registrar = new FirebaseAppCheckPlayIntegrityRegistrar();
+    List<Component<?>> components = registrar.getComponents();
+    assertThat(components).isNotEmpty();
+    assertThat(components).hasSize(2);
+    Component<?> appCheckPlayIntegrityComponent = components.get(0);
+    assertThat(appCheckPlayIntegrityComponent.getDependencies())
+        .containsExactly(Dependency.required(FirebaseApp.class));
+    assertThat(appCheckPlayIntegrityComponent.isLazy()).isTrue();
+  }
+}

--- a/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/FirebaseAppCheckSafetyNetRegistrar.java
+++ b/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/FirebaseAppCheckSafetyNetRegistrar.java
@@ -15,8 +15,12 @@
 package com.google.firebase.appcheck.safetynet;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.appcheck.AppCheckProvider;
+import com.google.firebase.appcheck.safetynet.internal.SafetyNetAppCheckProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
+import com.google.firebase.components.Dependency;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +37,12 @@ public class FirebaseAppCheckSafetyNetRegistrar implements ComponentRegistrar {
 
   @Override
   public List<Component<?>> getComponents() {
-    return Arrays.asList(LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
+    return Arrays.asList(
+        Component.builder(SafetyNetAppCheckProvider.class, (AppCheckProvider.class))
+            .name(LIBRARY_NAME)
+            .add(Dependency.required(FirebaseApp.class))
+            .factory((container) -> new SafetyNetAppCheckProvider(container.get(FirebaseApp.class)))
+            .build(),
+        LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
   }
 }

--- a/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
+++ b/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
@@ -43,6 +43,6 @@ public class SafetyNetAppCheckProviderFactory implements AppCheckProviderFactory
   @NonNull
   @Override
   public AppCheckProvider create(@NonNull FirebaseApp firebaseApp) {
-    return new SafetyNetAppCheckProvider(firebaseApp);
+    return firebaseApp.get(SafetyNetAppCheckProvider.class);
   }
 }

--- a/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
+++ b/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
@@ -42,6 +42,7 @@ public class SafetyNetAppCheckProviderFactory implements AppCheckProviderFactory
 
   @NonNull
   @Override
+  @SuppressWarnings("FirebaseUseExplicitDependencies")
   public AppCheckProvider create(@NonNull FirebaseApp firebaseApp) {
     return firebaseApp.get(SafetyNetAppCheckProvider.class);
   }

--- a/appcheck/firebase-appcheck-safetynet/src/test/java/com/google/firebase/appcheck/safetynet/FirebaseAppCheckSafetyNetRegistrarTest.java
+++ b/appcheck/firebase-appcheck-safetynet/src/test/java/com/google/firebase/appcheck/safetynet/FirebaseAppCheckSafetyNetRegistrarTest.java
@@ -1,0 +1,41 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appcheck.safetynet;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.components.Component;
+import com.google.firebase.components.Dependency;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for {@link FirebaseAppCheckSafetyNetRegistrar}. */
+@RunWith(RobolectricTestRunner.class)
+public class FirebaseAppCheckSafetyNetRegistrarTest {
+  @Test
+  public void testGetComponents() {
+    FirebaseAppCheckSafetyNetRegistrar registrar = new FirebaseAppCheckSafetyNetRegistrar();
+    List<Component<?>> components = registrar.getComponents();
+    assertThat(components).isNotEmpty();
+    assertThat(components).hasSize(2);
+    Component<?> appCheckSafetyNetComponent = components.get(0);
+    assertThat(appCheckSafetyNetComponent.getDependencies())
+        .containsExactly(Dependency.required(FirebaseApp.class));
+    assertThat(appCheckSafetyNetComponent.isLazy()).isTrue();
+  }
+}


### PR DESCRIPTION
Integrate `SafetyNetAppCheckProvider`, `PlayIntegrityAppCheckProvider`, and `DebugAppCheckProvider` with Firebase Components. This is a prerequisite for migrating the `firebase-appcheck-safetynet`, `firebase-appcheck-playintegrity`, and the `firebase-appcheck-debug` SDKs to use go/firebase-android-executors.

Note: This PR involves a refactor in the logic for initializing a `DebugAppCheckProvider` with a debug secret obtained from `InstrumentationRegistry` arguments, in order to integrate `DebugAppCheckProvider` with Firebase Components.