### PR TITLE
Adds support to read the build ids

### DIFF
--- a/firebase-crashlytics/src/androidTest/assets/firebase_settings_collect_build_ids.json
+++ b/firebase-crashlytics/src/androidTest/assets/firebase_settings_collect_build_ids.json
@@ -1,0 +1,20 @@
+{
+  "settings_version": 3,
+  "cache_duration": 7200,
+  "features": {
+    "collect_logged_exceptions": true,
+    "collect_reports": true,
+    "collect_anrs": true,
+    "collect_build_ids": true
+  },
+  "app": {
+    "status": "activated",
+    "update_required": true,
+    "report_upload_variant": 2,
+    "native_report_upload_variant": 2
+  },
+  "fabric": {
+    "org_id": "6001bf51c0329dc5da694f7f",
+    "bundle_id": "com.google.firebase.crashlytics.sdk.test"
+  }
+}

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -44,6 +44,7 @@ import com.google.firebase.crashlytics.internal.settings.SettingsProvider;
 import com.google.firebase.crashlytics.internal.settings.TestSettings;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -135,10 +136,13 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
       CrashlyticsFileMarker crashMarker =
           new CrashlyticsFileMarker(CrashlyticsCore.CRASH_MARKER_FILE_NAME, testFileStore);
 
+      List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
+      buildIdInfoList.add(new BuildIdInfo("lib.so", "x86", "aabb"));
       AppData appData =
           new AppData(
               GOOGLE_APP_ID,
               "buildId",
+              buildIdInfoList,
               "installerPackageName",
               "packageName",
               "versionCode",

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -41,6 +41,8 @@ import com.google.firebase.inject.Deferred;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
@@ -256,10 +258,13 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
   }
 
   private void setupAppData(String buildId) {
+    List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
+    buildIdInfoList.add(new BuildIdInfo("lib.so", "x86", "aabb"));
     appData =
         new AppData(
             GOOGLE_APP_ID,
             buildId,
+            buildIdInfoList,
             "installerPackageName",
             "packageName",
             "versionCode",

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -44,7 +44,9 @@ import com.google.firebase.crashlytics.internal.settings.SettingsController;
 import com.google.firebase.crashlytics.internal.settings.TestSettings;
 import com.google.firebase.inject.Deferred;
 import com.google.firebase.installations.FirebaseInstallationsApi;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
@@ -343,10 +345,13 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     when(mockSettingsController.getSettingsSync()).thenReturn(settings);
     when(mockSettingsController.getSettingsAsync()).thenReturn(Tasks.forResult(settings));
 
+    List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
+    buildIdInfoList.add(new BuildIdInfo("lib.so", "x86", "aabb"));
     AppData appData =
         new AppData(
             GOOGLE_APP_ID,
             "buildId",
+            buildIdInfoList,
             "installerPackageName",
             "packageName",
             "versionCode",

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
@@ -101,9 +101,16 @@ public class CrashlyticsReportDataCaptureTest {
     List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
     buildIdInfoList.add(new BuildIdInfo("lib.so", "x86", "aabb"));
     AppData appData =
-        AppData.create(context, idManager, "googleAppId", "buildId", buildIdInfoList, developmentPlatformProvider);
+        AppData.create(
+            context,
+            idManager,
+            "googleAppId",
+            "buildId",
+            buildIdInfoList,
+            developmentPlatformProvider);
     dataCapture =
-        new CrashlyticsReportDataCapture(context, idManager, appData, stackTraceTrimmingStrategy, testSettingsProvider);
+        new CrashlyticsReportDataCapture(
+            context, idManager, appData, stackTraceTrimmingStrategy, testSettingsProvider);
   }
 
   @Test

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCaptureTest.java
@@ -19,6 +19,7 @@ import static com.google.firebase.crashlytics.internal.common.CrashlyticsReportD
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -90,23 +91,18 @@ public class CrashlyticsReportDataCaptureTest {
     eventThreadImportance = 4;
     maxChainedExceptions = 8;
 
-    Settings testSettings = new TestSettings(3);
     testSettingsProvider = mock(SettingsProvider.class);
-    when(testSettingsProvider.getSettingsSync()).thenReturn(testSettings);
-    when(testSettingsProvider.getSettingsAsync()).thenReturn(Tasks.forResult(testSettings));
     initDataCapture();
   }
 
   private void initDataCapture() throws Exception {
-    List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
-    buildIdInfoList.add(new BuildIdInfo("lib.so", "x86", "aabb"));
     AppData appData =
         AppData.create(
             context,
             idManager,
             "googleAppId",
             "buildId",
-            buildIdInfoList,
+            new ArrayList<BuildIdInfo>(),
             developmentPlatformProvider);
     dataCapture =
         new CrashlyticsReportDataCapture(
@@ -145,6 +141,9 @@ public class CrashlyticsReportDataCaptureTest {
 
   @Test
   public void testCaptureAnrEvent_foregroundAnr() {
+    Settings testSettings = new TestSettings(3, 0, 0, false);
+    when(testSettingsProvider.getSettingsSync()).thenReturn(testSettings);
+    when(testSettingsProvider.getSettingsAsync()).thenReturn(Tasks.forResult(testSettings));
     CrashlyticsReport.ApplicationExitInfo testApplicationExitInfo = makeAppExitInfo(false);
     final CrashlyticsReport.Session.Event event =
         dataCapture.captureAnrEventData(testApplicationExitInfo);
@@ -157,6 +156,9 @@ public class CrashlyticsReportDataCaptureTest {
 
   @Test
   public void testCaptureAnrEvent_backgroundAnr() {
+    Settings testSettings = new TestSettings(3, 0, 0, false);
+    when(testSettingsProvider.getSettingsSync()).thenReturn(testSettings);
+    when(testSettingsProvider.getSettingsAsync()).thenReturn(Tasks.forResult(testSettings));
     CrashlyticsReport.ApplicationExitInfo testApplicationExitInfo = makeAppExitInfo(true);
     final CrashlyticsReport.Session.Event event =
         dataCapture.captureAnrEventData(testApplicationExitInfo);
@@ -165,6 +167,143 @@ public class CrashlyticsReportDataCaptureTest {
     assertEquals(testApplicationExitInfo, event.getApp().getExecution().getAppExitInfo());
     assertEquals(testApplicationExitInfo.getTimestamp(), event.getTimestamp());
     assertEquals(true, event.getApp().getBackground());
+  }
+
+  @Test
+  public void testCaptureAnrEvent_collectBuildIds() throws Exception {
+    CrashlyticsReport.ApplicationExitInfo testApplicationExitInfo = makeAppExitInfo(false);
+    Settings testSettings = new TestSettings(3, 0, 0, true);
+    when(testSettingsProvider.getSettingsSync()).thenReturn(testSettings);
+    when(testSettingsProvider.getSettingsAsync()).thenReturn(Tasks.forResult(testSettings));
+    List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
+    buildIdInfoList.add(new BuildIdInfo("lib.so", "x86", "aabb"));
+    AppData appData =
+        AppData.create(
+            context,
+            idManager,
+            "googleAppId",
+            "buildId",
+            buildIdInfoList,
+            developmentPlatformProvider);
+    dataCapture =
+        new CrashlyticsReportDataCapture(
+            context, idManager, appData, stackTraceTrimmingStrategy, testSettingsProvider);
+    final CrashlyticsReport.Session.Event event =
+        dataCapture.captureAnrEventData(testApplicationExitInfo);
+
+    assertEquals("anr", event.getType());
+    CrashlyticsReport.ApplicationExitInfo generatedAppExitInfo =
+        event.getApp().getExecution().getAppExitInfo();
+    assertNotEquals(testApplicationExitInfo, generatedAppExitInfo);
+    assertEquals(testApplicationExitInfo.getTimestamp(), event.getTimestamp());
+    assertEquals(generatedAppExitInfo.getBuildIdMappingForArch().size(), 1);
+    assertEquals(
+        generatedAppExitInfo.getBuildIdMappingForArch().get(0).getLibraryName(),
+        buildIdInfoList.get(0).getLibraryName());
+    assertEquals(
+        generatedAppExitInfo.getBuildIdMappingForArch().get(0).getArch(),
+        buildIdInfoList.get(0).getArch());
+    assertEquals(
+        generatedAppExitInfo.getBuildIdMappingForArch().get(0).getBuildId(),
+        buildIdInfoList.get(0).getBuildId());
+  }
+
+  @Test
+  public void testCaptureAnrEvent_collectMultipleBuildIds() throws Exception {
+    CrashlyticsReport.ApplicationExitInfo testApplicationExitInfo = makeAppExitInfo(false);
+    Settings testSettings = new TestSettings(3, 0, 0, true);
+    when(testSettingsProvider.getSettingsSync()).thenReturn(testSettings);
+    when(testSettingsProvider.getSettingsAsync()).thenReturn(Tasks.forResult(testSettings));
+    List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
+    buildIdInfoList.add(new BuildIdInfo("lib.so", "x86", "aabb"));
+    buildIdInfoList.add(new BuildIdInfo("other.so", "arm", "bbaa"));
+    AppData appData =
+        AppData.create(
+            context,
+            idManager,
+            "googleAppId",
+            "buildId",
+            buildIdInfoList,
+            developmentPlatformProvider);
+    dataCapture =
+        new CrashlyticsReportDataCapture(
+            context, idManager, appData, stackTraceTrimmingStrategy, testSettingsProvider);
+    final CrashlyticsReport.Session.Event event =
+        dataCapture.captureAnrEventData(testApplicationExitInfo);
+
+    assertEquals("anr", event.getType());
+    CrashlyticsReport.ApplicationExitInfo generatedAppExitInfo =
+        event.getApp().getExecution().getAppExitInfo();
+    assertNotEquals(testApplicationExitInfo, generatedAppExitInfo);
+    assertEquals(testApplicationExitInfo.getTimestamp(), event.getTimestamp());
+    assertEquals(generatedAppExitInfo.getBuildIdMappingForArch().size(), 2);
+    for (int i = 0; i < buildIdInfoList.size(); i++) {
+      assertEquals(
+          generatedAppExitInfo.getBuildIdMappingForArch().get(i).getLibraryName(),
+          buildIdInfoList.get(i).getLibraryName());
+      assertEquals(
+          generatedAppExitInfo.getBuildIdMappingForArch().get(i).getArch(),
+          buildIdInfoList.get(i).getArch());
+      assertEquals(
+          generatedAppExitInfo.getBuildIdMappingForArch().get(i).getBuildId(),
+          buildIdInfoList.get(i).getBuildId());
+    }
+  }
+
+  @Test
+  public void testCaptureAnrEvent_settingsOff_buildIdsNull() throws Exception {
+    CrashlyticsReport.ApplicationExitInfo testApplicationExitInfo = makeAppExitInfo(false);
+    Settings testSettings = new TestSettings(3, 0, 0, false);
+    when(testSettingsProvider.getSettingsSync()).thenReturn(testSettings);
+    when(testSettingsProvider.getSettingsAsync()).thenReturn(Tasks.forResult(testSettings));
+    List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
+    buildIdInfoList.add(new BuildIdInfo("lib.so", "x86", "aabb"));
+    AppData appData =
+        AppData.create(
+            context,
+            idManager,
+            "googleAppId",
+            "buildId",
+            buildIdInfoList,
+            developmentPlatformProvider);
+    dataCapture =
+        new CrashlyticsReportDataCapture(
+            context, idManager, appData, stackTraceTrimmingStrategy, testSettingsProvider);
+    final CrashlyticsReport.Session.Event event =
+        dataCapture.captureAnrEventData(testApplicationExitInfo);
+
+    assertEquals("anr", event.getType());
+    CrashlyticsReport.ApplicationExitInfo generatedAppExitInfo =
+        event.getApp().getExecution().getAppExitInfo();
+    assertEquals(testApplicationExitInfo, generatedAppExitInfo);
+    assertEquals(generatedAppExitInfo.getBuildIdMappingForArch(), null);
+  }
+
+  @Test
+  public void testCaptureAnrEvent_noBuildIdInAppData_buildIdsNull() throws Exception {
+    CrashlyticsReport.ApplicationExitInfo testApplicationExitInfo = makeAppExitInfo(false);
+    Settings testSettings = new TestSettings(3, 0, 0, true);
+    when(testSettingsProvider.getSettingsSync()).thenReturn(testSettings);
+    when(testSettingsProvider.getSettingsAsync()).thenReturn(Tasks.forResult(testSettings));
+    AppData appData =
+        AppData.create(
+            context,
+            idManager,
+            "googleAppId",
+            "buildId",
+            new ArrayList<>(),
+            developmentPlatformProvider);
+    dataCapture =
+        new CrashlyticsReportDataCapture(
+            context, idManager, appData, stackTraceTrimmingStrategy, testSettingsProvider);
+    final CrashlyticsReport.Session.Event event =
+        dataCapture.captureAnrEventData(testApplicationExitInfo);
+
+    assertEquals("anr", event.getType());
+    CrashlyticsReport.ApplicationExitInfo generatedAppExitInfo =
+        event.getApp().getExecution().getAppExitInfo();
+    assertEquals(testApplicationExitInfo, generatedAppExitInfo);
+    assertEquals(generatedAppExitInfo.getBuildIdMappingForArch(), null);
   }
 
   @Test

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransformTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransformTest.java
@@ -60,7 +60,16 @@ public class CrashlyticsReportJsonTransformTest {
 
   @Test
   public void testAnrEventToJsonAndBack_equals() throws IOException {
-    final CrashlyticsReport.Session.Event testEvent = makeAnrEvent();
+    final CrashlyticsReport.Session.Event testEvent = makeAnrEvent(false);
+    final String testEventJson = transform.eventToJson(testEvent);
+    final CrashlyticsReport.Session.Event reifiedEvent = transform.eventFromJson(testEventJson);
+    assertNotSame(reifiedEvent, testEvent);
+    assertEquals(reifiedEvent, testEvent);
+  }
+
+  @Test
+  public void testAnrEventWithBuildIdsToJsonAndBack_equals() throws IOException {
+    final CrashlyticsReport.Session.Event testEvent = makeAnrEvent(true);
     final String testEventJson = transform.eventToJson(testEvent);
     final CrashlyticsReport.Session.Event reifiedEvent = transform.eventFromJson(testEventJson);
     assertNotSame(reifiedEvent, testEvent);
@@ -78,7 +87,17 @@ public class CrashlyticsReportJsonTransformTest {
 
   @Test
   public void testAppExitInfoToJsonAndBack_equals() throws IOException {
-    final CrashlyticsReport.ApplicationExitInfo testAppExitInfo = makeAppExitInfo();
+    final CrashlyticsReport.ApplicationExitInfo testAppExitInfo = makeAppExitInfo(false);
+    final String testAppExitInfoJson = transform.applicationExitInfoToJson(testAppExitInfo);
+    final CrashlyticsReport.ApplicationExitInfo reifiedAppExitInfo =
+        transform.applicationExitInfoFromJson(testAppExitInfoJson);
+    assertNotSame(reifiedAppExitInfo, testAppExitInfo);
+    assertEquals(reifiedAppExitInfo, testAppExitInfo);
+  }
+
+  @Test
+  public void testAppExitInfoWithBuildIdsToJsonAndBack_equals() throws IOException {
+    final CrashlyticsReport.ApplicationExitInfo testAppExitInfo = makeAppExitInfo(true);
     final String testAppExitInfoJson = transform.applicationExitInfoToJson(testAppExitInfo);
     final CrashlyticsReport.ApplicationExitInfo reifiedAppExitInfo =
         transform.applicationExitInfoFromJson(testAppExitInfoJson);
@@ -180,7 +199,7 @@ public class CrashlyticsReportJsonTransformTest {
         .build();
   }
 
-  private static Event makeAnrEvent() {
+  private static Event makeAnrEvent(boolean withBuildIds) {
     return Event.builder()
         .setType("anr")
         .setTimestamp(1000)
@@ -198,7 +217,7 @@ public class CrashlyticsReportJsonTransformTest {
                                     .setUuid("uuid")
                                     .build()))
                         .setSignal(Signal.builder().setCode("0").setName("0").setAddress(0).build())
-                        .setAppExitInfo(makeAppExitInfo())
+                        .setAppExitInfo(makeAppExitInfo(withBuildIds))
                         .build())
                 .setUiOrientation(1)
                 .build())
@@ -246,7 +265,19 @@ public class CrashlyticsReportJsonTransformTest {
             .build());
   }
 
-  private static CrashlyticsReport.ApplicationExitInfo makeAppExitInfo() {
+  private static CrashlyticsReport.ApplicationExitInfo makeAppExitInfo(boolean withBuildIds) {
+    ImmutableList<CrashlyticsReport.ApplicationExitInfo.BuildIdMappingForArch>
+        buildIdMappingForArchImmutableList = null;
+    if (withBuildIds) {
+      buildIdMappingForArchImmutableList =
+          ImmutableList.from(
+              CrashlyticsReport.ApplicationExitInfo.BuildIdMappingForArch.builder()
+                  .setLibraryName("lib.so")
+                  .setArch("x86")
+                  .setBuildId("aabb")
+                  .build());
+    }
+
     return CrashlyticsReport.ApplicationExitInfo.builder()
         .setTraceFile("trace")
         .setTimestamp(1L)
@@ -256,6 +287,7 @@ public class CrashlyticsReportJsonTransformTest {
         .setPid(1)
         .setPss(1L)
         .setRss(1L)
+        .setBuildIdMappingForArch(buildIdMappingForArchImmutableList)
         .build();
   }
 }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistenceTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistenceTest.java
@@ -56,7 +56,7 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     Settings.SessionData sessionData =
         new Settings.SessionData(maxCustomExceptionEvents, maxCompleteSessionsCount);
     Settings settings =
-        new Settings(0, sessionData, new FeatureFlagData(true, false), 3, 0, 1.0, 1.0, 1);
+        new Settings(0, sessionData, new FeatureFlagData(true, false, false), 3, 0, 1.0, 1.0, 1);
 
     when(settingsProvider.getSettingsSync()).thenReturn(settings);
     return settingsProvider;
@@ -293,9 +293,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     Settings.SessionData sessionData2 = new Settings.SessionData(VERY_LARGE_UPPER_LIMIT, 8);
 
     Settings settings1 =
-        new Settings(0, sessionData1, new FeatureFlagData(true, true), 3, 0, 1.0, 1.0, 1);
+        new Settings(0, sessionData1, new FeatureFlagData(true, true, false), 3, 0, 1.0, 1.0, 1);
     Settings settings2 =
-        new Settings(0, sessionData2, new FeatureFlagData(true, true), 3, 0, 1.0, 1.0, 1);
+        new Settings(0, sessionData2, new FeatureFlagData(true, true, false), 3, 0, 1.0, 1.0, 1);
 
     when(settingsProvider.getSettingsSync()).thenReturn(settings1);
     reportPersistence = new CrashlyticsReportPersistence(fileStore, settingsProvider);
@@ -558,9 +558,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     Settings.SessionData sessionData2 = new Settings.SessionData(8, VERY_LARGE_UPPER_LIMIT);
 
     Settings settings1 =
-        new Settings(0, sessionData1, new FeatureFlagData(true, true), 3, 0, 1.0, 1.0, 1);
+        new Settings(0, sessionData1, new FeatureFlagData(true, true, false), 3, 0, 1.0, 1.0, 1);
     Settings settings2 =
-        new Settings(0, sessionData2, new FeatureFlagData(true, true), 3, 0, 1.0, 1.0, 1);
+        new Settings(0, sessionData2, new FeatureFlagData(true, true, false), 3, 0, 1.0, 1.0, 1);
 
     when(settingsProvider.getSettingsSync()).thenReturn(settings1);
     reportPersistence = new CrashlyticsReportPersistence(fileStore, settingsProvider);

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/SettingsV3JsonTransformTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/SettingsV3JsonTransformTest.java
@@ -61,9 +61,16 @@ public class SettingsV3JsonTransformTest extends CrashlyticsTestCase {
     verifySettingsDataObject(mockCurrentTimeProvider, settings, false, true);
   }
 
+  public void testFirebaseSettingsTransform_collectBuildIds() throws Exception {
+    JSONObject testJson = getTestJSON("firebase_settings_collect_build_ids.json");
+    Settings settings = transform.buildFromJson(mockCurrentTimeProvider, testJson);
+
+    verifySettingsDataObject(mockCurrentTimeProvider, settings, false, true, true);
+  }
+
   private void verifySettingsDataObject(
       CurrentTimeProvider mockCurrentTimeProvider, Settings settings, boolean isAppNew) {
-    verifySettingsDataObject(mockCurrentTimeProvider, settings, isAppNew, false);
+    verifySettingsDataObject(mockCurrentTimeProvider, settings, isAppNew, false, false);
   }
 
   private void verifySettingsDataObject(
@@ -71,6 +78,15 @@ public class SettingsV3JsonTransformTest extends CrashlyticsTestCase {
       Settings settings,
       boolean isAppNew,
       boolean collectAnrs) {
+    verifySettingsDataObject(mockCurrentTimeProvider, settings, isAppNew, collectAnrs, false);
+  }
+
+  private void verifySettingsDataObject(
+      CurrentTimeProvider mockCurrentTimeProvider,
+      Settings settings,
+      boolean isAppNew,
+      boolean collectAnrs,
+      boolean collectBuildIds) {
     assertEquals(7200010, settings.expiresAtMillis);
 
     assertEquals(3, settings.settingsVersion);
@@ -81,6 +97,7 @@ public class SettingsV3JsonTransformTest extends CrashlyticsTestCase {
 
     assertTrue(settings.featureFlagData.collectReports);
     assertEquals(settings.featureFlagData.collectAnrs, collectAnrs);
+    assertEquals(settings.featureFlagData.collectBuildIds, collectBuildIds);
 
     verify(mockCurrentTimeProvider).getCurrentTimeMillis();
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/TestSettings.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/TestSettings.java
@@ -25,11 +25,27 @@ public class TestSettings extends Settings {
   }
 
   public TestSettings(int settingsVersion, int reportUploadVariant, int nativeReportUploadVariant) {
-    super(5, buildSettingsData(), buildFeatureFlagData(), settingsVersion, 3600, 10, 1.2, 60);
+    this(settingsVersion, reportUploadVariant, nativeReportUploadVariant, false);
   }
 
-  private static Settings.FeatureFlagData buildFeatureFlagData() {
-    return new Settings.FeatureFlagData(true, false, false);
+  public TestSettings(
+      int settingsVersion,
+      int reportUploadVariant,
+      int nativeReportUploadVarian,
+      boolean collectBuildIds) {
+    super(
+        5,
+        buildSettingsData(),
+        buildFeatureFlagData(collectBuildIds),
+        settingsVersion,
+        3600,
+        10,
+        1.2,
+        60);
+  }
+
+  private static Settings.FeatureFlagData buildFeatureFlagData(boolean collectBuildIds) {
+    return new Settings.FeatureFlagData(true, false, collectBuildIds);
   }
 
   private static Settings.SessionData buildSettingsData() {

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/TestSettings.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/TestSettings.java
@@ -29,7 +29,7 @@ public class TestSettings extends Settings {
   }
 
   private static Settings.FeatureFlagData buildFeatureFlagData() {
-    return new Settings.FeatureFlagData(true, false);
+    return new Settings.FeatureFlagData(true, false, false);
   }
 
   private static Settings.SessionData buildSettingsData() {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -29,6 +29,7 @@ import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferr
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.common.AppData;
+import com.google.firebase.crashlytics.internal.common.BuildIdInfo;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.common.CrashlyticsCore;
 import com.google.firebase.crashlytics.internal.common.DataCollectionArbiter;
@@ -39,6 +40,7 @@ import com.google.firebase.crashlytics.internal.persistence.FileStore;
 import com.google.firebase.crashlytics.internal.settings.SettingsController;
 import com.google.firebase.inject.Deferred;
 import com.google.firebase.installations.FirebaseInstallationsApi;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
@@ -99,8 +101,17 @@ public class FirebaseCrashlytics {
 
     final String googleAppId = app.getOptions().getApplicationId();
     final String mappingFileId = CommonUtils.getMappingFileId(context);
+    final List<BuildIdInfo> buildIdInfoList = CommonUtils.getBuildIdInfo(context);
 
     Logger.getLogger().d("Mapping file ID is: " + mappingFileId);
+
+    for (BuildIdInfo buildIdInfo : buildIdInfoList) {
+      Logger.getLogger()
+          .d(
+              String.format(
+                  "Build id for %s on %s: %s",
+                  buildIdInfo.getLibraryName(), buildIdInfo.getArch(), buildIdInfo.getBuildId()));
+    }
 
     final DevelopmentPlatformProvider developmentPlatformProvider =
         new DevelopmentPlatformProvider(context);
@@ -109,7 +120,12 @@ public class FirebaseCrashlytics {
     try {
       appData =
           AppData.create(
-              context, idManager, googleAppId, mappingFileId, developmentPlatformProvider);
+              context,
+              idManager,
+              googleAppId,
+              mappingFileId,
+              buildIdInfoList,
+              developmentPlatformProvider);
     } catch (PackageManager.NameNotFoundException e) {
       Logger.getLogger().e("Error retrieving app package info.", e);
       return null;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/AppData.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/AppData.java
@@ -18,11 +18,13 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
+import java.util.List;
 
 /** Carries static information about the app. */
 public class AppData {
   public final String googleAppId;
   public final String buildId;
+  public final List<BuildIdInfo> buildIdInfoList;
 
   public final String installerPackageName;
 
@@ -37,6 +39,7 @@ public class AppData {
       IdManager idManager,
       String googleAppId,
       String buildId,
+      List<BuildIdInfo> buildIdInfoList,
       DevelopmentPlatformProvider developmentPlatformProvider)
       throws PackageManager.NameNotFoundException {
     final String packageName = context.getPackageName();
@@ -50,6 +53,7 @@ public class AppData {
     return new AppData(
         googleAppId,
         buildId,
+        buildIdInfoList,
         installerPackageName,
         packageName,
         versionCode,
@@ -60,6 +64,7 @@ public class AppData {
   public AppData(
       String googleAppId,
       String buildId,
+      List<BuildIdInfo> buildIdInfoList,
       String installerPackageName,
       String packageName,
       String versionCode,
@@ -67,6 +72,7 @@ public class AppData {
       DevelopmentPlatformProvider developmentPlatformProvider) {
     this.googleAppId = googleAppId;
     this.buildId = buildId;
+    this.buildIdInfoList = buildIdInfoList;
     this.installerPackageName = installerPackageName;
     this.packageName = packageName;
     this.versionCode = versionCode;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/BuildIdInfo.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/BuildIdInfo.java
@@ -1,0 +1,45 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.common;
+
+/** Information about a particular build id which represents a single .so within the project. */
+public class BuildIdInfo {
+  private final String libraryName;
+  private final String arch;
+  private final String buildId;
+
+  /**
+   * @param libraryName The file name of the .so file
+   * @param arch the architecture for which the .so was built
+   * @param buildId the build id of the .so file as found in the ELF header section
+   */
+  public BuildIdInfo(String libraryName, String arch, String buildId) {
+    this.libraryName = libraryName;
+    this.arch = arch;
+    this.buildId = buildId;
+  }
+
+  public String getLibraryName() {
+    return libraryName;
+  }
+
+  public String getArch() {
+    return arch;
+  }
+
+  public String getBuildId() {
+    return buildId;
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -66,6 +66,12 @@ public class CommonUtils {
   static final String MAPPING_FILE_ID_RESOURCE_NAME =
       "com.google.firebase.crashlytics.mapping_file_id";
   static final String LEGACY_MAPPING_FILE_ID_RESOURCE_NAME = "com.crashlytics.android.build_id";
+  static final String BUILD_IDS_LIB_NAMES_RESOURCE_NAME =
+      "com.google.firebase.crashlytics.build_ids_lib";
+  static final String BUILD_IDS_ARCH_RESOURCE_NAME =
+      "com.google.firebase.crashlytics.build_ids_arch";
+  static final String BUILD_IDS_BUILD_ID_RESOURCE_NAME =
+      "com.google.firebase.crashlytics.build_ids_build_id";
 
   private static final long UNCALCULATED_TOTAL_RAM = -1;
   static final int BYTES_IN_A_GIGABYTE = 1073741824;
@@ -595,6 +601,42 @@ public class CommonUtils {
       mappingFileId = context.getResources().getString(id);
     }
     return mappingFileId;
+  }
+
+  public static List<BuildIdInfo> getBuildIdInfo(Context context) {
+    // TODO: This functionality should be refactored into an InstanceIdProvider class or similar.
+    List<BuildIdInfo> buildIdInfoList = new ArrayList<>();
+    String[] libNames;
+    String[] arch;
+    String[] buildIds;
+    int libId =
+        CommonUtils.getResourcesIdentifier(context, BUILD_IDS_LIB_NAMES_RESOURCE_NAME, "array");
+    int archId = CommonUtils.getResourcesIdentifier(context, BUILD_IDS_ARCH_RESOURCE_NAME, "array");
+    int buildId =
+        CommonUtils.getResourcesIdentifier(context, BUILD_IDS_BUILD_ID_RESOURCE_NAME, "array");
+
+    if (libId != 0 && archId != 0 && buildId != 0) {
+      libNames = context.getResources().getStringArray(libId);
+      arch = context.getResources().getStringArray(archId);
+      buildIds = context.getResources().getStringArray(buildId);
+
+      if (libNames.length != buildIds.length || arch.length != buildIds.length) {
+        Logger.getLogger()
+            .d(
+                String.format(
+                    "Lengths did not match: %d %d %d",
+                    libNames.length, arch.length, buildIds.length));
+        return buildIdInfoList;
+      }
+
+      for (int i = 0; i < buildIds.length; i++) {
+        buildIdInfoList.add(new BuildIdInfo(libNames[i], arch[i], buildIds[i]));
+      }
+    } else {
+      Logger.getLogger()
+          .d(String.format("Could not find resources: %d %d %d", libId, archId, buildId));
+    }
+    return buildIdInfoList;
   }
 
   public static void closeQuietly(Closeable closeable) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -615,27 +615,29 @@ public class CommonUtils {
     int buildId =
         CommonUtils.getResourcesIdentifier(context, BUILD_IDS_BUILD_ID_RESOURCE_NAME, "array");
 
-    if (libId != 0 && archId != 0 && buildId != 0) {
-      libNames = context.getResources().getStringArray(libId);
-      arch = context.getResources().getStringArray(archId);
-      buildIds = context.getResources().getStringArray(buildId);
-
-      if (libNames.length != buildIds.length || arch.length != buildIds.length) {
-        Logger.getLogger()
-            .d(
-                String.format(
-                    "Lengths did not match: %d %d %d",
-                    libNames.length, arch.length, buildIds.length));
-        return buildIdInfoList;
-      }
-
-      for (int i = 0; i < buildIds.length; i++) {
-        buildIdInfoList.add(new BuildIdInfo(libNames[i], arch[i], buildIds[i]));
-      }
-    } else {
+    if (libId == 0 || archId == 0 || buildId == 0) {
       Logger.getLogger()
           .d(String.format("Could not find resources: %d %d %d", libId, archId, buildId));
+      return buildIdInfoList;
     }
+
+    libNames = context.getResources().getStringArray(libId);
+    arch = context.getResources().getStringArray(archId);
+    buildIds = context.getResources().getStringArray(buildId);
+
+    if (libNames.length != buildIds.length || arch.length != buildIds.length) {
+      Logger.getLogger()
+          .d(
+              String.format(
+                  "Lengths did not match: %d %d %d",
+                  libNames.length, arch.length, buildIds.length));
+      return buildIdInfoList;
+    }
+
+    for (int i = 0; i < buildIds.length; i++) {
+      buildIdInfoList.add(new BuildIdInfo(libNames[i], arch[i], buildIds[i]));
+    }
+
     return buildIdInfoList;
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -70,7 +70,8 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
       SettingsProvider settingsProvider,
       OnDemandCounter onDemandCounter) {
     final CrashlyticsReportDataCapture dataCapture =
-        new CrashlyticsReportDataCapture(context, idManager, appData, stackTraceTrimmingStrategy);
+        new CrashlyticsReportDataCapture(
+            context, idManager, appData, stackTraceTrimmingStrategy, settingsProvider);
     final CrashlyticsReportPersistence reportPersistence =
         new CrashlyticsReportPersistence(fileStore, settingsProvider);
     final DataTransportCrashlyticsReportSender reportSender =

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -1064,6 +1064,10 @@ public abstract class CrashlyticsReport {
     // Not all ApplicationExitInfos have a trace file.
     public abstract String getTraceFile();
 
+    @Nullable
+    // Not all ApplicationExitInfos have build id info
+    public abstract ImmutableList<BuildIdMappingForArch> getBuildIdMappingForArch();
+
     /** Builder for {@link ApplicationExitInfo}. */
     @AutoValue.Builder
     public abstract static class Builder {
@@ -1092,7 +1096,45 @@ public abstract class CrashlyticsReport {
       public abstract ApplicationExitInfo.Builder setTraceFile(@Nullable String value);
 
       @NonNull
+      public abstract ApplicationExitInfo.Builder setBuildIdMappingForArch(
+          @Nullable ImmutableList<BuildIdMappingForArch> value);
+
+      @NonNull
       public abstract ApplicationExitInfo build();
+    }
+
+    @AutoValue
+    public abstract static class BuildIdMappingForArch {
+
+      @NonNull
+      public static BuildIdMappingForArch.Builder builder() {
+        return new AutoValue_CrashlyticsReport_ApplicationExitInfo_BuildIdMappingForArch.Builder();
+      }
+
+      @NonNull
+      public abstract String getArch();
+
+      @NonNull
+      public abstract String getLibraryName();
+
+      @NonNull
+      public abstract String getBuildId();
+
+      @AutoValue.Builder
+      public abstract static class Builder {
+
+        @NonNull
+        public abstract Builder setArch(@NonNull String value);
+
+        @NonNull
+        public abstract Builder setLibraryName(@NonNull String value);
+
+        @NonNull
+        public abstract Builder setBuildId(@NonNull String value);
+
+        @NonNull
+        public abstract BuildIdMappingForArch build();
+      }
     }
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
@@ -19,6 +19,7 @@ import android.util.JsonReader;
 import androidx.annotation.NonNull;
 import com.google.firebase.crashlytics.internal.model.AutoCrashlyticsReportEncoder;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.ApplicationExitInfo.BuildIdMappingForArch;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.CustomAttribute;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;
 import com.google.firebase.crashlytics.internal.model.ImmutableList;
@@ -233,6 +234,10 @@ public class CrashlyticsReportJsonTransform {
           break;
         case "traceFile":
           builder.setTraceFile(jsonReader.nextString());
+          break;
+        case "buildIdMappingForArch":
+          builder.setBuildIdMappingForArch(
+              parseArray(jsonReader, CrashlyticsReportJsonTransform::parseBuildIdMappingForArch));
           break;
         default:
           jsonReader.skipValue();
@@ -736,6 +741,33 @@ public class CrashlyticsReportJsonTransform {
           break;
         case "value":
           builder.setValue(jsonReader.nextString());
+          break;
+        default:
+          jsonReader.skipValue();
+          break;
+      }
+    }
+    jsonReader.endObject();
+    return builder.build();
+  }
+
+  @NonNull
+  private static BuildIdMappingForArch parseBuildIdMappingForArch(@NonNull JsonReader jsonReader)
+      throws IOException {
+    BuildIdMappingForArch.Builder builder = BuildIdMappingForArch.builder();
+
+    jsonReader.beginObject();
+    while (jsonReader.hasNext()) {
+      String name = jsonReader.nextName();
+      switch (name) {
+        case "libraryName":
+          builder.setLibraryName(jsonReader.nextString());
+          break;
+        case "arch":
+          builder.setArch(jsonReader.nextString());
+          break;
+        case "buildId":
+          builder.setBuildId(jsonReader.nextString());
           break;
         default:
           jsonReader.skipValue();

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsJsonTransform.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsJsonTransform.java
@@ -46,7 +46,8 @@ class DefaultSettingsJsonTransform implements SettingsJsonTransform {
     final Settings.FeatureFlagData featureFlagData =
         new Settings.FeatureFlagData(
             SettingsJsonConstants.FEATURES_COLLECT_REPORTS_DEFAULT,
-            SettingsJsonConstants.FEATURES_COLLECT_ANRS_DEFAULT);
+            SettingsJsonConstants.FEATURES_COLLECT_ANRS_DEFAULT,
+            SettingsJsonConstants.FEATURES_COLLECT_BUILD_IDS_DEFAULT);
 
     long expiresAtMillis =
         currentTimeProvider.getCurrentTimeMillis() + (cacheDurationSeconds * 1000);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/Settings.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/Settings.java
@@ -31,10 +31,12 @@ public class Settings {
   public static class FeatureFlagData {
     public final boolean collectReports;
     public final boolean collectAnrs;
+    public final boolean collectBuildIds;
 
-    public FeatureFlagData(boolean collectReports, boolean collectAnrs) {
+    public FeatureFlagData(boolean collectReports, boolean collectAnrs, boolean collectBuildIds) {
       this.collectReports = collectReports;
       this.collectAnrs = collectAnrs;
+      this.collectBuildIds = collectBuildIds;
     }
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsJsonConstants.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsJsonConstants.java
@@ -32,10 +32,12 @@ class SettingsJsonConstants {
   // Feature Switch Keys
   static final String FEATURES_COLLECT_REPORTS_KEY = "collect_reports";
   static final String FEATURES_COLLECT_ANRS_KEY = "collect_anrs";
+  static final String FEATURES_COLLECT_BUILD_IDS_KEY = "collect_build_ids";
 
   // Feature Switch Defaults
   static final boolean FEATURES_COLLECT_REPORTS_DEFAULT = true;
   static final boolean FEATURES_COLLECT_ANRS_DEFAULT = false;
+  static final boolean FEATURES_COLLECT_BUILD_IDS_DEFAULT = false;
 
   // App JSON Keys
   static final String APP_STATUS_KEY = "status";

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsV3JsonTransform.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsV3JsonTransform.java
@@ -77,7 +77,12 @@ class SettingsV3JsonTransform implements SettingsJsonTransform {
             SettingsJsonConstants.FEATURES_COLLECT_ANRS_KEY,
             SettingsJsonConstants.FEATURES_COLLECT_ANRS_DEFAULT);
 
-    return new Settings.FeatureFlagData(collectReports, collectAnrs);
+    final boolean collectBuildIds =
+        json.optBoolean(
+            SettingsJsonConstants.FEATURES_COLLECT_BUILD_IDS_KEY,
+            SettingsJsonConstants.FEATURES_COLLECT_BUILD_IDS_DEFAULT);
+
+    return new Settings.FeatureFlagData(collectReports, collectAnrs, collectBuildIds);
   }
 
   private static Settings.SessionData buildSessionDataFrom(JSONObject json) {


### PR DESCRIPTION
Reads the resource file containing the list of build ids and their associated library name and architecture.  Writes the payload into the report.