### PR TITLE
Configurable executor limit for download/upload tasks on FirebaseStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ smoke-test-logs/
 smoke-tests/build-debug-headGit-smoke-test
 smoke-tests/firehorn.log
 macrobenchmark-output.json
+.java-version

--- a/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/FirebaseStorage.java
@@ -267,6 +267,44 @@ public class FirebaseStorage {
     sMaxQueryRetry = maxTransferRetryMillis;
   }
 
+  /**
+   * Returns the number of executors configured for upload operations
+   *
+   * @return the integer number for the upload executors.
+   */
+  public long getsMaxUploadExecutors() {
+    return StorageTaskScheduler.maxUploadExecutors;
+  }
+
+  /**
+   * Sets the maximum number of parallel executors on upload operations.
+   *
+   * @param maxUploadExecutors the maximum number of parallel executors. Defaults to 2
+   */
+  @SuppressWarnings("unused")
+  public void setMaxUploadExecutors(int maxUploadExecutors) {
+    StorageTaskScheduler.maxUploadExecutors = maxUploadExecutors;
+  }
+
+  /**
+   * Returns the number of executors configured for download operations
+   *
+   * @return the integer number for the download executors.
+   */
+  public long getsMaxDownloadExecutors() {
+    return StorageTaskScheduler.maxDownloadExecutors;
+  }
+
+  /**
+   * Sets the maximum number of parallel executors on download operations.
+   *
+   * @param maxDownloadExecutors the maximum number of parallel executors. Defaults to 3
+   */
+  @SuppressWarnings("unused")
+  public void setMaxDownloadExecutors(int maxDownloadExecutors) {
+    StorageTaskScheduler.maxDownloadExecutors = maxDownloadExecutors;
+  }
+
   @Nullable
   private String getBucketName() {
     return mBucketName;

--- a/firebase-storage/src/main/java/com/google/firebase/storage/StorageTaskScheduler.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/StorageTaskScheduler.java
@@ -38,6 +38,9 @@ public class StorageTaskScheduler {
 
   private static BlockingQueue<Runnable> mCommandQueue = new LinkedBlockingQueue<>();
 
+  public static int maxDownloadExecutors = 3;
+  public static int maxUploadExecutors = 2;
+
   // TODO(b/258426744): Migrate to go/firebase-android-executors
   @SuppressLint("ThreadPoolCreation")
   private static final ThreadPoolExecutor COMMAND_POOL_EXECUTOR =
@@ -88,10 +91,22 @@ public class StorageTaskScheduler {
   }
 
   public void scheduleUpload(Runnable task) {
+    int corePoolSize = UPLOAD_QUEUE_EXECUTOR.getCorePoolSize();
+    int maxPoolSize = UPLOAD_QUEUE_EXECUTOR.getMaximumPoolSize();
+    if (corePoolSize != maxUploadExecutors && maxPoolSize != maxUploadExecutors) {
+      UPLOAD_QUEUE_EXECUTOR.setCorePoolSize(maxUploadExecutors);
+      UPLOAD_QUEUE_EXECUTOR.setMaximumPoolSize(maxUploadExecutors);
+    }
     UPLOAD_QUEUE_EXECUTOR.execute(task);
   }
 
   public void scheduleDownload(Runnable task) {
+    int corePoolSize = DOWNLOAD_QUEUE_EXECUTOR.getCorePoolSize();
+    int maxPoolSize = DOWNLOAD_QUEUE_EXECUTOR.getMaximumPoolSize();
+    if (corePoolSize != maxDownloadExecutors && maxPoolSize != maxDownloadExecutors) {
+      DOWNLOAD_QUEUE_EXECUTOR.setCorePoolSize(maxDownloadExecutors);
+      DOWNLOAD_QUEUE_EXECUTOR.setMaximumPoolSize(maxDownloadExecutors);
+    }
     DOWNLOAD_QUEUE_EXECUTOR.execute(task);
   }
 


### PR DESCRIPTION
Right now this library only works with a limit of 2 threads for upload operations and 3 for download operations. With this limitation being fixed it can create problems for applications in which rely heavily on firebase storage for uploading/downloading a huge number of files at a time (Eg: 400+). This limitation in this scenario leads to a bad user experience when the users have to wait several minutes, even hours, and this is also a totally different experience that the iOS library provides too with more than 2/3 requests at a time.

The goal with this PR is to make it more configurable giving the developers the ability to manually adjust this limit on their applications if they want to!

Here are some threads related to this:
https://stackoverflow.com/questions/50917737/firebase-storage-limit-of-simultaneous-file-uploads-with-sdk
https://stackoverflow.com/questions/60163889/android-firebase-storage-sdk-maximum-parallel-uploads