### PR TITLE
Migrate remaining App Check SDKs to go/firebase-android-executors.

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Integrated the [app_check] Debug Testing SDK with Firebase Components. (#4436)
 
 # 16.1.0
 * [unchanged] Updated to accommodate the release of the updated

--- a/appcheck/firebase-appcheck-debug/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)
+* [changed] Integrated the [app_check] Debug SDK with Firebase Components. (#4436)
 
 # 16.1.0
 * [unchanged] Updated to accommodate the release of the updated

--- a/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
+++ b/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
@@ -41,6 +41,7 @@ android {
 }
 
 dependencies {
+    implementation project(':firebase-annotations')
     implementation project(':firebase-common')
     implementation project(':firebase-components')
     implementation project(':appcheck:firebase-appcheck')
@@ -49,6 +50,7 @@ dependencies {
 
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
+    testImplementation project(':integ-testing')
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/FirebaseAppCheckDebugRegistrar.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/FirebaseAppCheckDebugRegistrar.java
@@ -16,13 +16,17 @@ package com.google.firebase.appcheck.debug;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.concurrent.Background;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.appcheck.debug.internal.DebugAppCheckProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.components.Dependency;
+import com.google.firebase.components.Qualified;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * {@link ComponentRegistrar} for setting up FirebaseAppCheck debug's dependency injections in
@@ -36,16 +40,23 @@ public class FirebaseAppCheckDebugRegistrar implements ComponentRegistrar {
 
   @Override
   public List<Component<?>> getComponents() {
+    Qualified<Executor> backgroundExecutor = Qualified.qualified(Background.class, Executor.class);
+    Qualified<Executor> blockingExecutor = Qualified.qualified(Blocking.class, Executor.class);
+
     return Arrays.asList(
         Component.builder(DebugAppCheckProvider.class)
             .name(LIBRARY_NAME)
             .add(Dependency.required(FirebaseApp.class))
             .add(Dependency.optionalProvider(InternalDebugSecretProvider.class))
+            .add(Dependency.required(backgroundExecutor))
+            .add(Dependency.required(blockingExecutor))
             .factory(
                 (container) ->
                     new DebugAppCheckProvider(
                         container.get(FirebaseApp.class),
-                        container.getProvider(InternalDebugSecretProvider.class)))
+                        container.getProvider(InternalDebugSecretProvider.class),
+                        container.get(backgroundExecutor),
+                        container.get(blockingExecutor)))
             .build(),
         LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
   }

--- a/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProvider.java
+++ b/appcheck/firebase-appcheck-debug/src/main/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProvider.java
@@ -24,6 +24,8 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.concurrent.Background;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.appcheck.AppCheckProvider;
 import com.google.firebase.appcheck.AppCheckToken;
 import com.google.firebase.appcheck.debug.InternalDebugSecretProvider;
@@ -32,8 +34,7 @@ import com.google.firebase.appcheck.internal.NetworkClient;
 import com.google.firebase.appcheck.internal.RetryManager;
 import com.google.firebase.inject.Provider;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 
 public class DebugAppCheckProvider implements AppCheckProvider {
 
@@ -41,18 +42,18 @@ public class DebugAppCheckProvider implements AppCheckProvider {
   private static final String UTF_8 = "UTF-8";
 
   private final NetworkClient networkClient;
-  private final ExecutorService backgroundExecutor;
+  private final Executor blockingExecutor;
   private final RetryManager retryManager;
   private final Task<String> debugSecretTask;
 
-  // TODO(b/258273630): Migrate to go/firebase-android-executors
-  @SuppressLint("ThreadPoolCreation")
   public DebugAppCheckProvider(
       @NonNull FirebaseApp firebaseApp,
-      @NonNull Provider<InternalDebugSecretProvider> debugSecretProvider) {
+      @NonNull Provider<InternalDebugSecretProvider> debugSecretProvider,
+      @Background Executor backgroundExecutor,
+      @Blocking Executor blockingExecutor) {
     checkNotNull(firebaseApp);
     this.networkClient = new NetworkClient(firebaseApp);
-    this.backgroundExecutor = Executors.newCachedThreadPool();
+    this.blockingExecutor = blockingExecutor;
     this.retryManager = new RetryManager();
 
     String debugSecret = null;
@@ -61,7 +62,7 @@ public class DebugAppCheckProvider implements AppCheckProvider {
     }
     this.debugSecretTask =
         debugSecret == null
-            ? determineDebugSecret(firebaseApp, this.backgroundExecutor)
+            ? determineDebugSecret(firebaseApp, backgroundExecutor)
             : Tasks.forResult(debugSecret);
   }
 
@@ -69,10 +70,10 @@ public class DebugAppCheckProvider implements AppCheckProvider {
   DebugAppCheckProvider(
       @NonNull String debugSecret,
       @NonNull NetworkClient networkClient,
-      @NonNull ExecutorService backgroundExecutor,
+      @NonNull Executor blockingExecutor,
       @NonNull RetryManager retryManager) {
     this.networkClient = networkClient;
-    this.backgroundExecutor = backgroundExecutor;
+    this.blockingExecutor = blockingExecutor;
     this.retryManager = retryManager;
     this.debugSecretTask = Tasks.forResult(debugSecret);
   }
@@ -80,7 +81,7 @@ public class DebugAppCheckProvider implements AppCheckProvider {
   @VisibleForTesting
   @NonNull
   static Task<String> determineDebugSecret(
-      @NonNull FirebaseApp firebaseApp, @NonNull ExecutorService executor) {
+      @NonNull FirebaseApp firebaseApp, @NonNull Executor executor) {
     TaskCompletionSource<String> taskCompletionSource = new TaskCompletionSource<>();
     executor.execute(
         () -> {
@@ -111,7 +112,7 @@ public class DebugAppCheckProvider implements AppCheckProvider {
             task -> {
               ExchangeDebugTokenRequest request = new ExchangeDebugTokenRequest(task.getResult());
               return Tasks.call(
-                  backgroundExecutor,
+                  blockingExecutor,
                   () ->
                       networkClient.exchangeAttestationForAppCheckToken(
                           request.toJsonString().getBytes(UTF_8),

--- a/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/FirebaseAppCheckDebugRegistrarTest.java
+++ b/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/FirebaseAppCheckDebugRegistrarTest.java
@@ -17,9 +17,13 @@ package com.google.firebase.appcheck.debug;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.concurrent.Background;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.Dependency;
+import com.google.firebase.components.Qualified;
 import java.util.List;
+import java.util.concurrent.Executor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -37,7 +41,9 @@ public class FirebaseAppCheckDebugRegistrarTest {
     assertThat(appCheckDebugComponent.getDependencies())
         .containsExactly(
             Dependency.required(FirebaseApp.class),
-            Dependency.optionalProvider(InternalDebugSecretProvider.class));
+            Dependency.optionalProvider(InternalDebugSecretProvider.class),
+            Dependency.required(Qualified.qualified(Background.class, Executor.class)),
+            Dependency.required(Qualified.qualified(Blocking.class, Executor.class)));
     assertThat(appCheckDebugComponent.isLazy()).isTrue();
   }
 }

--- a/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProviderTest.java
+++ b/appcheck/firebase-appcheck-debug/src/test/java/com/google/firebase/appcheck/debug/internal/DebugAppCheckProviderTest.java
@@ -33,8 +33,9 @@ import com.google.firebase.appcheck.internal.AppCheckTokenResponse;
 import com.google.firebase.appcheck.internal.DefaultAppCheckToken;
 import com.google.firebase.appcheck.internal.NetworkClient;
 import com.google.firebase.appcheck.internal.RetryManager;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,7 +73,8 @@ public class DebugAppCheckProviderTest {
 
   private StorageHelper storageHelper;
   private SharedPreferences sharedPreferences;
-  private ExecutorService backgroundExecutor = MoreExecutors.newDirectExecutorService();
+  // TODO(b/258273630): Use TestOnlyExecutors instead of MoreExecutors.directExecutor().
+  private Executor executor = MoreExecutors.directExecutor();
 
   @Before
   public void setup() {
@@ -100,7 +102,8 @@ public class DebugAppCheckProviderTest {
     assertThrows(
         NullPointerException.class,
         () -> {
-          new DebugAppCheckProvider(null, null);
+          new DebugAppCheckProvider(
+              null, null, TestOnlyExecutors.background(), TestOnlyExecutors.blocking());
         });
   }
 
@@ -110,7 +113,7 @@ public class DebugAppCheckProviderTest {
     assertThat(storageHelper.retrieveDebugSecret()).isNull();
 
     Task<String> debugSecretTask =
-        DebugAppCheckProvider.determineDebugSecret(mockFirebaseApp, backgroundExecutor);
+        DebugAppCheckProvider.determineDebugSecret(mockFirebaseApp, executor);
     assertThat(storageHelper.retrieveDebugSecret()).isNotNull();
     assertThat(storageHelper.retrieveDebugSecret()).isEqualTo(debugSecretTask.getResult());
   }
@@ -120,7 +123,7 @@ public class DebugAppCheckProviderTest {
     storageHelper.saveDebugSecret(DEBUG_SECRET);
 
     Task<String> debugSecretTask =
-        DebugAppCheckProvider.determineDebugSecret(mockFirebaseApp, backgroundExecutor);
+        DebugAppCheckProvider.determineDebugSecret(mockFirebaseApp, executor);
     assertThat(debugSecretTask.getResult()).isEqualTo(DEBUG_SECRET);
     assertThat(storageHelper.retrieveDebugSecret()).isEqualTo(DEBUG_SECRET);
   }
@@ -134,8 +137,7 @@ public class DebugAppCheckProviderTest {
     when(mockAppCheckTokenResponse.getTimeToLive()).thenReturn(TIME_TO_LIVE);
 
     DebugAppCheckProvider provider =
-        new DebugAppCheckProvider(
-            DEBUG_SECRET, mockNetworkClient, backgroundExecutor, mockRetryManager);
+        new DebugAppCheckProvider(DEBUG_SECRET, mockNetworkClient, executor, mockRetryManager);
     Task<AppCheckToken> task = provider.getToken();
 
     verify(mockNetworkClient)
@@ -153,8 +155,7 @@ public class DebugAppCheckProviderTest {
         .thenThrow(new IOException());
 
     DebugAppCheckProvider provider =
-        new DebugAppCheckProvider(
-            DEBUG_SECRET, mockNetworkClient, backgroundExecutor, mockRetryManager);
+        new DebugAppCheckProvider(DEBUG_SECRET, mockNetworkClient, executor, mockRetryManager);
     Task<AppCheckToken> task = provider.getToken();
 
     verify(mockNetworkClient)

--- a/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)
+* [changed] Integrated the [app_check] Play Integrity SDK with Firebase Components. (#4436)
 
 # 16.1.0
 * [unchanged] Updated to accommodate the release of the updated

--- a/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
+++ b/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
@@ -41,6 +41,7 @@ android {
 }
 
 dependencies {
+    implementation project(':firebase-annotations')
     implementation project(':firebase-common')
     implementation project(':firebase-components')
     implementation project(':appcheck:firebase-appcheck')
@@ -50,6 +51,7 @@ dependencies {
 
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
+    testImplementation project(':integ-testing')
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.6'
     testImplementation "com.google.truth:truth:$googleTruthVersion"

--- a/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/FirebaseAppCheckPlayIntegrityRegistrar.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/main/java/com/google/firebase/appcheck/playintegrity/FirebaseAppCheckPlayIntegrityRegistrar.java
@@ -16,13 +16,16 @@ package com.google.firebase.appcheck.playintegrity;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.appcheck.playintegrity.internal.PlayIntegrityAppCheckProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.components.Dependency;
+import com.google.firebase.components.Qualified;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * {@link ComponentRegistrar} for setting up FirebaseAppCheck play integrity's dependency injections
@@ -36,12 +39,17 @@ public class FirebaseAppCheckPlayIntegrityRegistrar implements ComponentRegistra
 
   @Override
   public List<Component<?>> getComponents() {
+    Qualified<Executor> blockingExecutor = Qualified.qualified(Blocking.class, Executor.class);
+
     return Arrays.asList(
         Component.builder(PlayIntegrityAppCheckProvider.class)
             .name(LIBRARY_NAME)
             .add(Dependency.required(FirebaseApp.class))
+            .add(Dependency.required(blockingExecutor))
             .factory(
-                (container) -> new PlayIntegrityAppCheckProvider(container.get(FirebaseApp.class)))
+                (container) ->
+                    new PlayIntegrityAppCheckProvider(
+                        container.get(FirebaseApp.class), container.get(blockingExecutor)))
             .build(),
         LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
   }

--- a/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/FirebaseAppCheckPlayIntegrityRegistrarTest.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/FirebaseAppCheckPlayIntegrityRegistrarTest.java
@@ -17,9 +17,12 @@ package com.google.firebase.appcheck.playintegrity;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.Dependency;
+import com.google.firebase.components.Qualified;
 import java.util.List;
+import java.util.concurrent.Executor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -35,7 +38,9 @@ public class FirebaseAppCheckPlayIntegrityRegistrarTest {
     assertThat(components).hasSize(2);
     Component<?> appCheckPlayIntegrityComponent = components.get(0);
     assertThat(appCheckPlayIntegrityComponent.getDependencies())
-        .containsExactly(Dependency.required(FirebaseApp.class));
+        .containsExactly(
+            Dependency.required(FirebaseApp.class),
+            Dependency.required(Qualified.qualified(Blocking.class, Executor.class)));
     assertThat(appCheckPlayIntegrityComponent.isLazy()).isTrue();
   }
 }

--- a/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/internal/PlayIntegrityAppCheckProviderTest.java
+++ b/appcheck/firebase-appcheck-playintegrity/src/test/java/com/google/firebase/appcheck/playintegrity/internal/PlayIntegrityAppCheckProviderTest.java
@@ -34,8 +34,9 @@ import com.google.firebase.appcheck.internal.AppCheckTokenResponse;
 import com.google.firebase.appcheck.internal.DefaultAppCheckToken;
 import com.google.firebase.appcheck.internal.NetworkClient;
 import com.google.firebase.appcheck.internal.RetryManager;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -70,7 +71,8 @@ public class PlayIntegrityAppCheckProviderTest {
   @Captor private ArgumentCaptor<IntegrityTokenRequest> integrityTokenRequestCaptor;
   @Captor private ArgumentCaptor<byte[]> exchangePlayIntegrityTokenRequestCaptor;
 
-  private ExecutorService backgroundExecutor = MoreExecutors.newDirectExecutorService();
+  // TODO(b/258273630): Use TestOnlyExecutors instead of MoreExecutors.directExecutor().
+  private Executor backgroundExecutor = MoreExecutors.directExecutor();
 
   @Before
   public void setup() {
@@ -85,7 +87,7 @@ public class PlayIntegrityAppCheckProviderTest {
     assertThrows(
         NullPointerException.class,
         () -> {
-          new PlayIntegrityAppCheckProvider(null);
+          new PlayIntegrityAppCheckProvider(null, TestOnlyExecutors.blocking());
         });
   }
 

--- a/appcheck/firebase-appcheck-safetynet/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-safetynet/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)
+* [changed] Integrated the [app_check] SafetyNet SDK with Firebase Components. (#4436)
 
 # 16.1.0
 * [unchanged] Updated to accommodate the release of the updated

--- a/appcheck/firebase-appcheck-safetynet/firebase-appcheck-safetynet.gradle
+++ b/appcheck/firebase-appcheck-safetynet/firebase-appcheck-safetynet.gradle
@@ -41,6 +41,7 @@ android {
 }
 
 dependencies {
+    implementation project(':firebase-annotations')
     implementation project(':firebase-common')
     implementation project(':firebase-components')
     implementation project(':appcheck:firebase-appcheck')
@@ -51,6 +52,7 @@ dependencies {
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
     javadocClasspath 'org.checkerframework:checker-qual:2.5.2'
 
+    testImplementation project(':integ-testing')
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/FirebaseAppCheckSafetyNetRegistrar.java
+++ b/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/FirebaseAppCheckSafetyNetRegistrar.java
@@ -16,13 +16,17 @@ package com.google.firebase.appcheck.safetynet;
 
 import com.google.android.gms.common.annotation.KeepForSdk;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.concurrent.Background;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.appcheck.safetynet.internal.SafetyNetAppCheckProvider;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.components.Dependency;
+import com.google.firebase.components.Qualified;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * {@link ComponentRegistrar} for setting up FirebaseAppCheck safety net's dependency injections in
@@ -36,11 +40,21 @@ public class FirebaseAppCheckSafetyNetRegistrar implements ComponentRegistrar {
 
   @Override
   public List<Component<?>> getComponents() {
+    Qualified<Executor> backgroundExecutor = Qualified.qualified(Background.class, Executor.class);
+    Qualified<Executor> blockingExecutor = Qualified.qualified(Blocking.class, Executor.class);
+
     return Arrays.asList(
         Component.builder(SafetyNetAppCheckProvider.class)
             .name(LIBRARY_NAME)
             .add(Dependency.required(FirebaseApp.class))
-            .factory((container) -> new SafetyNetAppCheckProvider(container.get(FirebaseApp.class)))
+            .add(Dependency.required(backgroundExecutor))
+            .add(Dependency.required(blockingExecutor))
+            .factory(
+                (container) ->
+                    new SafetyNetAppCheckProvider(
+                        container.get(FirebaseApp.class),
+                        container.get(backgroundExecutor),
+                        container.get(blockingExecutor)))
             .build(),
         LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME));
   }

--- a/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/internal/SafetyNetAppCheckProvider.java
+++ b/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/internal/SafetyNetAppCheckProvider.java
@@ -49,10 +49,8 @@ public class SafetyNetAppCheckProvider implements AppCheckProvider {
   private static final String NONCE = "";
   private static final String UTF_8 = "UTF-8";
 
-  private final Context context;
   private final Task<SafetyNetClient> safetyNetClientTask;
   private final NetworkClient networkClient;
-  private final Executor backgroundExecutor;
   private final Executor blockingExecutor;
   private final RetryManager retryManager;
   private final String apiKey;
@@ -81,12 +79,11 @@ public class SafetyNetAppCheckProvider implements AppCheckProvider {
     checkNotNull(networkClient);
     checkNotNull(googleApiAvailability);
     checkNotNull(backgroundExecutor);
-    this.context = firebaseApp.getApplicationContext();
     this.apiKey = firebaseApp.getOptions().getApiKey();
-    this.backgroundExecutor = backgroundExecutor;
     this.blockingExecutor = blockingExecutor;
     this.safetyNetClientTask =
-        initSafetyNetClient(this.context, googleApiAvailability, this.backgroundExecutor);
+        initSafetyNetClient(
+            firebaseApp.getApplicationContext(), googleApiAvailability, backgroundExecutor);
     this.networkClient = networkClient;
     this.retryManager = new RetryManager();
   }
@@ -96,14 +93,11 @@ public class SafetyNetAppCheckProvider implements AppCheckProvider {
       @NonNull FirebaseApp firebaseApp,
       @NonNull SafetyNetClient safetyNetClient,
       @NonNull NetworkClient networkClient,
-      @NonNull Executor backgroundExecutor,
       @NonNull Executor blockingExecutor,
       @NonNull RetryManager retryManager) {
-    this.context = firebaseApp.getApplicationContext();
     this.apiKey = firebaseApp.getOptions().getApiKey();
     this.safetyNetClientTask = Tasks.forResult(safetyNetClient);
     this.networkClient = networkClient;
-    this.backgroundExecutor = backgroundExecutor;
     this.blockingExecutor = blockingExecutor;
     this.retryManager = retryManager;
   }

--- a/appcheck/firebase-appcheck-safetynet/src/test/java/com/google/firebase/appcheck/safetynet/FirebaseAppCheckSafetyNetRegistrarTest.java
+++ b/appcheck/firebase-appcheck-safetynet/src/test/java/com/google/firebase/appcheck/safetynet/FirebaseAppCheckSafetyNetRegistrarTest.java
@@ -17,9 +17,13 @@ package com.google.firebase.appcheck.safetynet;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.annotations.concurrent.Background;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.components.Component;
 import com.google.firebase.components.Dependency;
+import com.google.firebase.components.Qualified;
 import java.util.List;
+import java.util.concurrent.Executor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -35,7 +39,10 @@ public class FirebaseAppCheckSafetyNetRegistrarTest {
     assertThat(components).hasSize(2);
     Component<?> appCheckSafetyNetComponent = components.get(0);
     assertThat(appCheckSafetyNetComponent.getDependencies())
-        .containsExactly(Dependency.required(FirebaseApp.class));
+        .containsExactly(
+            Dependency.required(FirebaseApp.class),
+            Dependency.required(Qualified.qualified(Background.class, Executor.class)),
+            Dependency.required(Qualified.qualified(Blocking.class, Executor.class)));
     assertThat(appCheckSafetyNetComponent.isLazy()).isTrue();
   }
 }

--- a/appcheck/firebase-appcheck-safetynet/src/test/java/com/google/firebase/appcheck/safetynet/internal/SafetyNetAppCheckProviderTest.java
+++ b/appcheck/firebase-appcheck-safetynet/src/test/java/com/google/firebase/appcheck/safetynet/internal/SafetyNetAppCheckProviderTest.java
@@ -205,8 +205,7 @@ public class SafetyNetAppCheckProviderTest {
     when(mockAppCheckTokenResponse.getToken()).thenReturn(APP_CHECK_TOKEN);
     when(mockAppCheckTokenResponse.getTimeToLive()).thenReturn(TIME_TO_LIVE);
 
-    // TODO(b/258273630): Use TestOnlyExecutors.background() instead of
-    // MoreExecutors.directExecutor().
+    // TODO(b/258273630): Use TestOnlyExecutors instead of MoreExecutors.directExecutor().
     SafetyNetAppCheckProvider provider =
         new SafetyNetAppCheckProvider(
             firebaseApp,
@@ -234,8 +233,7 @@ public class SafetyNetAppCheckProviderTest {
             any(), eq(NetworkClient.SAFETY_NET), eq(mockRetryManager)))
         .thenThrow(new IOException());
 
-    // TODO(b/258273630): Use TestOnlyExecutors.background() instead of
-    // MoreExecutors.directExecutor().
+    // TODO(b/258273630): Use TestOnlyExecutors instead of MoreExecutors.directExecutor().
     SafetyNetAppCheckProvider provider =
         new SafetyNetAppCheckProvider(
             firebaseApp,

--- a/appcheck/firebase-appcheck-safetynet/src/test/java/com/google/firebase/appcheck/safetynet/internal/SafetyNetAppCheckProviderTest.java
+++ b/appcheck/firebase-appcheck-safetynet/src/test/java/com/google/firebase/appcheck/safetynet/internal/SafetyNetAppCheckProviderTest.java
@@ -128,7 +128,6 @@ public class SafetyNetAppCheckProviderTest {
             firebaseApp,
             mockSafetyNetClient,
             mockNetworkClient,
-            TestOnlyExecutors.background(),
             TestOnlyExecutors.blocking(),
             mockRetryManager);
     assertThat(provider.getSafetyNetClientTask().getResult()).isEqualTo(mockSafetyNetClient);
@@ -151,7 +150,6 @@ public class SafetyNetAppCheckProviderTest {
             firebaseApp,
             mockSafetyNetClient,
             mockNetworkClient,
-            TestOnlyExecutors.background(),
             TestOnlyExecutors.blocking(),
             mockRetryManager);
     assertThrows(
@@ -170,7 +168,6 @@ public class SafetyNetAppCheckProviderTest {
             firebaseApp,
             mockSafetyNetClient,
             mockNetworkClient,
-            TestOnlyExecutors.background(),
             TestOnlyExecutors.blocking(),
             mockRetryManager);
     assertThrows(
@@ -188,7 +185,6 @@ public class SafetyNetAppCheckProviderTest {
             firebaseApp,
             mockSafetyNetClient,
             mockNetworkClient,
-            TestOnlyExecutors.background(),
             TestOnlyExecutors.blocking(),
             mockRetryManager);
     Task<AppCheckToken> task =
@@ -211,7 +207,6 @@ public class SafetyNetAppCheckProviderTest {
             firebaseApp,
             mockSafetyNetClient,
             mockNetworkClient,
-            MoreExecutors.directExecutor(),
             MoreExecutors.directExecutor(),
             mockRetryManager);
     Task<AppCheckToken> task =
@@ -239,7 +234,6 @@ public class SafetyNetAppCheckProviderTest {
             firebaseApp,
             mockSafetyNetClient,
             mockNetworkClient,
-            MoreExecutors.directExecutor(),
             MoreExecutors.directExecutor(),
             mockRetryManager);
     Task<AppCheckToken> task =

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [changed] Migrated the `firebase-appcheck` library to use standard Firebase executors. (#4431)
+* [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)
 
 # 16.1.0
 * [unchanged] Updated to accommodate the release of the updated


### PR DESCRIPTION
#4431 migrated the base `firebase-appcheck` SDK to go/firebase-android-executors. This PR migrates the remaining App Check SDKs (`firebase-appcheck-safetynet`, `firebase-appcheck-playintegrity`, `firebase-appcheck-debug`).