### PR TITLE
[Fireperf][AASA] Experiment time-to-initial-display 3

### DIFF
--- a/firebase-perf/dev-app/dev-app.gradle
+++ b/firebase-perf/dev-app/dev-app.gradle
@@ -16,6 +16,7 @@ apply plugin: 'com.android.application'
 // Firebase performance plugin, the relevant dependency is specified in the "buildSrc/build-src.gradle"
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabPlugin
+apply plugin: 'com.google.gms.google-services'
 
 firebaseTestLab {
     device 'model=Pixel2,version=28,locale=en,orientation=portrait'

--- a/firebase-perf/dev-app/dev-app.gradle
+++ b/firebase-perf/dev-app/dev-app.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.application'
 // Firebase performance plugin, the relevant dependency is specified in the "buildSrc/build-src.gradle"
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabPlugin
-apply plugin: 'com.google.gms.google-services'
 
 firebaseTestLab {
     device 'model=Pixel2,version=28,locale=en,orientation=portrait'

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "androidx.annotation:annotation:1.1.0"
-    implementation "androidx.lifecycle:lifecycle-process:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-process:2.3.1"
 
     // 3rd Party Deps
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -109,6 +109,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "androidx.annotation:annotation:1.1.0"
+    implementation "androidx.lifecycle:lifecycle-process:2.5.1"
 
     // 3rd Party Deps
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -123,7 +123,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
   // TODO: remove after experiment
   private int onDrawCount = 0;
   private final DrawCounter onDrawCounterListener = new DrawCounter();
-  private boolean systemBackgroundCheck = false;
+  private boolean systemForegroundCheck = false;
 
   /**
    * Called from onCreate() method of an activity by instrumented byte code.
@@ -213,7 +213,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
     Context appContext = context.getApplicationContext();
     if (appContext instanceof Application) {
       ((Application) appContext).registerActivityLifecycleCallbacks(this);
-      systemBackgroundCheck = systemBackgroundCheck || isAnyAppProcessInForeground(appContext);
+      systemForegroundCheck = systemForegroundCheck || isAnyAppProcessInForeground(appContext);
       isRegisteredForLifecycleCallbacks = true;
       this.appContext = appContext;
     }
@@ -308,7 +308,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
             .setDurationUs(getStartTimerCompat().getDurationMicros(getClassLoadTimeCompat()))
             .build());
     this.experimentTtid.putCustomAttributes(
-        "systemDeterminedBackground", systemBackgroundCheck ? "true" : "false");
+        "systemDeterminedForeground", systemForegroundCheck ? "true" : "false");
     this.experimentTtid.putCounters("onDrawCount", onDrawCount);
     this.experimentTtid.addPerfSessions(this.startSession.build());
     logExperimentTrace(this.experimentTtid);
@@ -321,7 +321,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
       return;
     }
 
-    systemBackgroundCheck = systemBackgroundCheck || isAnyAppProcessInForeground(appContext);
+    systemForegroundCheck = systemForegroundCheck || isAnyAppProcessInForeground(appContext);
     launchActivity = new WeakReference<Activity>(activity);
     onCreateTime = clock.getTime();
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -26,8 +26,9 @@ import android.view.View;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.lifecycle.DefaultLifecycleObserver;
-import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.OnLifecycleEvent;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import com.google.android.gms.common.util.VisibleForTesting;
 import com.google.firebase.FirebaseApp;
@@ -66,7 +67,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @hide
  */
-public class AppStartTrace implements ActivityLifecycleCallbacks, DefaultLifecycleObserver {
+public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObserver {
 
   private static final Timer PERF_CLASS_LOAD_TIME = new Clock().getTime();
   private static final long MAX_LATENCY_BEFORE_UI_INIT = TimeUnit.MINUTES.toMicros(1);
@@ -411,10 +412,10 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, DefaultLifecyc
   @Override
   public void onActivityStopped(Activity activity) {}
 
-  /** App is entering foreground */
-  @Override
-  public void onStart(@NonNull LifecycleOwner owner) {
-    DefaultLifecycleObserver.super.onStart(owner);
+  /** App is entering foreground. Keep annotation is required so R8 does not remove this method. */
+  @Keep
+  @OnLifecycleEvent(Lifecycle.Event.ON_START)
+  public void onAppEnteredForeground() {
     if (isStartedFromBackground || isTooLateToInitUI || firstForegroundTime != null) {
       return;
     }
@@ -429,10 +430,10 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, DefaultLifecyc
             .build());
   }
 
-  /** App is entering background */
-  @Override
-  public void onStop(@NonNull LifecycleOwner owner) {
-    DefaultLifecycleObserver.super.onStop(owner);
+  /** App is entering background. Keep annotation is required so R8 does not remove this method. */
+  @Keep
+  @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+  public void onAppEnteredBackground() {
     if (isStartedFromBackground || isTooLateToInitUI || firstBackgroundTime != null) {
       return;
     }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -261,10 +261,10 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, DefaultLifecyc
             .setDurationUs(getClassLoadTime().getDurationMicros(this.firstDrawDone));
     this.experimentTtid.addSubtraces(subtrace.build());
     this.experimentTtid.putCounters("count_background_before_draw", backgroundCount);
-    if (firstBackgroundTime != null && firstBackgroundTime.getDurationMicros(firstDrawDone) <= 0) {
-      this.experimentTtid.putCustomAttributes("backgrounded_before_draw", "false");
-    } else {
+    if (firstBackgroundTime != null && firstBackgroundTime.getDurationMicros(firstDrawDone) > 0) {
       this.experimentTtid.putCustomAttributes("backgrounded_before_draw", "true");
+    } else {
+      this.experimentTtid.putCustomAttributes("backgrounded_before_draw", "false");
     }
 
     this.experimentTtid.addPerfSessions(this.startSession.build());
@@ -292,10 +292,10 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, DefaultLifecyc
             .setDurationUs(start.getDurationMicros(this.preDraw));
     this.experimentTtid.addSubtraces(subtrace.build());
     this.experimentTtid.putCounters("count_background_before_predraw", backgroundCount);
-    if (firstBackgroundTime != null && firstBackgroundTime.getDurationMicros(preDraw) <= 0) {
-      this.experimentTtid.putCustomAttributes("backgrounded_before_predraw", "false");
-    } else {
+    if (firstBackgroundTime != null && firstBackgroundTime.getDurationMicros(preDraw) > 0) {
       this.experimentTtid.putCustomAttributes("backgrounded_before_predraw", "true");
+    } else {
+      this.experimentTtid.putCustomAttributes("backgrounded_before_predraw", "false");
     }
 
     if (isExperimentTraceDone()) {

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -29,7 +29,6 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ProcessLifecycleOwner;
-
 import com.google.android.gms.common.util.VisibleForTesting;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.StartupTime;
@@ -209,6 +208,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, DefaultLifecyc
    * Gets the timestamp that marks the beginning of app start, defined as the beginning of
    * BIND_APPLICATION, when the forked process is about to start loading the app's resources and
    * classes. Fallback to class-load time of a Firebase class below API 24.
+   *
    * @return {@link Timer} at the beginning of app start by Fireperf definition.
    */
   private static Timer getStartTimer() {
@@ -225,6 +225,7 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, DefaultLifecyc
    * loading of a particular Firebase class, the order of which CANNOT be guaranteed to be prior to
    * all other classes of an app, nor prior to resource-loading of an app. Thus this timestamp is
    * NOT PREFERRED to be used as starting-point of app-start.
+   *
    * @return {@link Timer} captured by static-initializer during class-loading of a Firebase class.
    */
   private static Timer getClassLoadTime() {
@@ -419,10 +420,10 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, DefaultLifecyc
       firstBackgroundTime = clock.getTime();
       // TODO: remove this subtrace after the experiment
       TraceMetric.Builder subtrace =
-              TraceMetric.newBuilder()
-                      .setName("_experiment_onStop")
-                      .setClientStartTimeUs(firstBackgroundTime.getMicros())
-                      .setDurationUs(getStartTimer().getDurationMicros(firstBackgroundTime));
+          TraceMetric.newBuilder()
+              .setName("_experiment_onStop")
+              .setClientStartTimeUs(firstBackgroundTime.getMicros())
+              .setDurationUs(getStartTimer().getDurationMicros(firstBackgroundTime));
       this.experimentTtid.addSubtraces(subtrace.build());
     }
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java
@@ -301,12 +301,14 @@ public class AppStartTrace implements ActivityLifecycleCallbacks, LifecycleObser
             .setDurationUs(
                 getStartTimerCompat().getDurationMicros(this.onDrawPostAtFrontOfQueueTime))
             .build());
-    this.experimentTtid.addSubtraces(
-        TraceMetric.newBuilder()
-            .setName("_experiment_procStart_to_classLoad")
-            .setClientStartTimeUs(getStartTimerCompat().getMicros())
-            .setDurationUs(getStartTimerCompat().getDurationMicros(getClassLoadTimeCompat()))
-            .build());
+    if (processStartTime != null) {
+      this.experimentTtid.addSubtraces(
+          TraceMetric.newBuilder()
+              .setName("_experiment_procStart_to_classLoad")
+              .setClientStartTimeUs(getStartTimerCompat().getMicros())
+              .setDurationUs(getStartTimerCompat().getDurationMicros(getClassLoadTimeCompat()))
+              .build());
+    }
     this.experimentTtid.putCustomAttributes(
         "systemDeterminedForeground", systemForegroundCheck ? "true" : "false");
     this.experimentTtid.putCounters("onDrawCount", onDrawCount);

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/PreDrawListener.java
@@ -30,17 +30,21 @@ public class PreDrawListener implements ViewTreeObserver.OnPreDrawListener {
   private final Handler mainThreadHandler = new Handler(Looper.getMainLooper());
 
   private final AtomicReference<View> viewReference;
-  private final Runnable callback;
+  private final Runnable callbackBoQ;
+  private final Runnable callbackFoQ;
 
   /** Registers a post-draw callback for the next draw of a view. */
-  public static void registerForNextDraw(View view, Runnable drawDoneCallback) {
-    final PreDrawListener listener = new PreDrawListener(view, drawDoneCallback);
+  public static void registerForNextDraw(
+      View view, Runnable drawDoneCallbackBoQ, Runnable drawDoneCallbackFoQ) {
+    final PreDrawListener listener =
+        new PreDrawListener(view, drawDoneCallbackBoQ, drawDoneCallbackFoQ);
     view.getViewTreeObserver().addOnPreDrawListener(listener);
   }
 
-  private PreDrawListener(View view, Runnable callback) {
+  private PreDrawListener(View view, Runnable callbackBoQ, Runnable callbackFoQ) {
     this.viewReference = new AtomicReference<>(view);
-    this.callback = callback;
+    this.callbackBoQ = callbackBoQ;
+    this.callbackFoQ = callbackFoQ;
   }
 
   @Override
@@ -51,7 +55,8 @@ public class PreDrawListener implements ViewTreeObserver.OnPreDrawListener {
       return true;
     }
     view.getViewTreeObserver().removeOnPreDrawListener(this);
-    mainThreadHandler.post(callback);
+    mainThreadHandler.post(callbackBoQ);
+    mainThreadHandler.postAtFrontOfQueue(callbackFoQ);
     return true;
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/metrics/AppStartTraceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.os.Looper;
 import android.os.Process;
@@ -70,6 +71,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   @Mock private Activity activity2;
   @Mock private Bundle bundle;
 
+  private final Context appContext = ApplicationProvider.getApplicationContext();
   private ArgumentCaptor<TraceMetric> traceArgumentCaptor;
 
   // a mocked current wall-clock time in microseconds.
@@ -103,6 +105,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.registerActivityLifecycleCallbacks(appContext);
     // first activity goes through onCreate()->onStart()->onResume() state change.
     currentTime = 1;
     trace.onActivityCreated(activity1, bundle);
@@ -176,6 +179,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.registerActivityLifecycleCallbacks(appContext);
     // first activity onCreate()
     currentTime = 1;
     trace.onActivityCreated(activity1, bundle);
@@ -212,6 +216,7 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
+    trace.registerActivityLifecycleCallbacks(appContext);
     // Delays activity creation after 1 minute from app start time.
     currentTime =
         TimeUnit.MILLISECONDS.toMicros(SystemClock.elapsedRealtime())
@@ -258,14 +263,14 @@ public class AppStartTraceTest extends FirebasePerformanceTestBase {
   public void timeToInitialDisplay_isLogged() {
     // Test setup
     when(clock.getTime()).thenCallRealMethod(); // Use robolectric shadows to manipulate time
-    View testView = new View(ApplicationProvider.getApplicationContext());
+    View testView = new View(appContext);
     when(activity1.findViewById(android.R.id.content)).thenReturn(testView);
     when(activity2.findViewById(android.R.id.content)).thenReturn(testView);
     when(configResolver.getIsExperimentTTIDEnabled()).thenReturn(true);
     FakeScheduledExecutorService fakeExecutorService = new FakeScheduledExecutorService();
     AppStartTrace trace =
         new AppStartTrace(transportManager, clock, configResolver, fakeExecutorService);
-
+    trace.registerActivityLifecycleCallbacks(appContext);
     // Simulate resume and manually stepping time forward
     ShadowSystemClock.advanceBy(Duration.ofMillis(1000));
     long resumeTime = TimeUnit.NANOSECONDS.toMicros(SystemClock.elapsedRealtimeNanos());

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/TimerTest.java
@@ -53,8 +53,8 @@ public class TimerTest {
     // Robolectric shadows SystemClock, which is paused and can only change via specific methods.
     long refElapsedRealtime = SystemClock.elapsedRealtime();
     Timer ref = new Timer();
-    Timer past = Timer.ofElapsedRealtime(refElapsedRealtime - 100, 0);
-    Timer future = Timer.ofElapsedRealtime(refElapsedRealtime + 100, 0);
+    Timer past = Timer.ofElapsedRealtime(refElapsedRealtime - 100);
+    Timer future = Timer.ofElapsedRealtime(refElapsedRealtime + 100);
 
     assertThat(past.getDurationMicros(ref)).isEqualTo(MILLISECONDS.toMicros(100));
     assertThat(ref.getDurationMicros(future)).isEqualTo(MILLISECONDS.toMicros(100));
@@ -67,10 +67,10 @@ public class TimerTest {
     ShadowSystemClock.advanceBy(Duration.ofMillis(10000000));
     long nowElapsedRealtime = SystemClock.elapsedRealtime();
     Timer now = new Timer();
-    Timer morePast = Timer.ofElapsedRealtime(nowElapsedRealtime - 2000, 0);
-    Timer past = Timer.ofElapsedRealtime(nowElapsedRealtime - 1000, 0);
-    Timer future = Timer.ofElapsedRealtime(nowElapsedRealtime + 1000, 0);
-    Timer moreFuture = Timer.ofElapsedRealtime(nowElapsedRealtime + 2000, 0);
+    Timer morePast = Timer.ofElapsedRealtime(nowElapsedRealtime - 2000);
+    Timer past = Timer.ofElapsedRealtime(nowElapsedRealtime - 1000);
+    Timer future = Timer.ofElapsedRealtime(nowElapsedRealtime + 1000);
+    Timer moreFuture = Timer.ofElapsedRealtime(nowElapsedRealtime + 2000);
 
     // We cannot manipulate System.currentTimeMillis() so multiple comparisons are used to test
     assertThat(morePast.getMicros()).isLessThan(past.getMicros());
@@ -103,7 +103,7 @@ public class TimerTest {
 
   @Test
   public void testGetCurrentTimestampMicros() {
-    Timer timer = new Timer(0, 0, 0);
+    Timer timer = new Timer(0, 0);
     long currentTimeSmallest = timer.getCurrentTimestampMicros();
 
     assertThat(timer.getMicros()).isEqualTo(0);
@@ -112,7 +112,7 @@ public class TimerTest {
 
   @Test
   public void testParcel() {
-    Timer timer1 = new Timer(1000, 1000000, 1000000);
+    Timer timer1 = new Timer(1000, 1000000);
 
     Parcel p1 = Parcel.obtain();
     timer1.writeToParcel(p1, 0);
@@ -132,6 +132,6 @@ public class TimerTest {
 
   /** Helper for other tests that returns elapsedRealtimeMicros from a Timer object */
   public static long getElapsedRealtimeMicros(Timer timer) {
-    return new Timer(0, 0, 0).getDurationMicros(timer);
+    return new Timer(0, 0).getDurationMicros(timer);
   }
 }


### PR DESCRIPTION
This PR is the 3rd iteration of experiments for Android App Start Alignment. 
The changes from the 2nd iteration are the following:
1. removed `uptimeMillis`
2. reprioritized trace/subtraces (default trace is now `preDraw + post`)
3. (fixed) real background detection
4. added `preDraw + postAtFrontOfQueue` subtrace
5. added `procStart-to-classLoad` subtrace
6. added `firstForeground` subtrace
7. added `firstBackground` subtrace

### Reasoning
`procStart-to-classLoad` and `firstForegound` can be used to experiment thresholds for filtering out non-detectable backgrounding and interruptions.
`firstBackground` can be used to filter detected backgrounding for all 3 different methodologies (preDraw, preDrawFoQ, onDrawFoQ)