### PR TITLE
Secure external Github Actions

### DIFF
--- a/.github/workflows/build-src-check.yml
+++ b/.github/workflows/build-src-check.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           ./gradlew -b buildSrc/build.gradle.kts -PenablePluginTests=true check
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@94ba6dbddef5ec4aa827fc275cf7d563bc4d398f
         with:
           files: "**/build/test-results/**/*.xml"
           check_name: "buildSrc Test Results"

--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -15,11 +15,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Create base branch
-        uses: peterjgrainger/action-create-branch@v2.2.0
+        uses: peterjgrainger/action-create-branch@c2800a3a9edbba2218da6861fa46496cf8f3195a
         with:
           branch: 'releases/${{ inputs.name }}'
       - name: Create release branch
-        uses: peterjgrainger/action-create-branch@v2.2.0
+        uses: peterjgrainger/action-create-branch@c2800a3a9edbba2218da6861fa46496cf8f3195a
         with:
           branch: 'releases/${{ inputs.name }}.release'
 

--- a/.github/workflows/diff-javadoc.yml
+++ b/.github/workflows/diff-javadoc.yml
@@ -62,6 +62,6 @@ jobs:
           > diff.md
 
       - name: Add comment
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1
         with:
           message-path: diff.md

--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: mshick/add-pr-comment@v2
+    - uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1
       with:
         message: >
           ### 📝 PRs merging into main branch

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -62,7 +62,7 @@ jobs:
           ref: main
 
       - name: Get firebase-workflow-trigger token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
         id: generate-token
         with:
           app_id: ${{ secrets.CPP_WORKFLOW_TRIGGER_APP_ID }}


### PR DESCRIPTION
Currently we use third party actions in a handful of places, and tags are targeted. This could hypothetically become an attack vector, so tags are replaced with the commits we're currently using. Of note, third party actions from `ruby/` `actions/` `github/` `google/` and `google-github-actions/` are considered trustworthy to target via tag.