### PR TITLE
Fix errors after rebase on fad/next

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -17,6 +17,7 @@ package com.google.firebase.appdistribution.impl;
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 
+import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Bundle;
@@ -144,6 +145,8 @@ public class FeedbackActivity extends AppCompatActivity {
     return bitmap;
   }
 
+  // TODO(b/261014422): Use an explicit executor in continuations.
+  @SuppressLint("TaskMainThread")
   public void submitFeedback(View view) {
     setSubmittingStateEnabled(true);
     if (releaseName == null) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.appdistribution.impl;
 
+import android.annotation.SuppressLint;
 import android.net.Uri;
 import androidx.annotation.Nullable;
 import com.google.android.gms.tasks.Task;
@@ -37,6 +38,8 @@ class FeedbackSender {
     return FirebaseApp.getInstance().get(FeedbackSender.class);
   }
 
+  // TODO(b/261014422): Use an explicit executor in continuations.
+  @SuppressLint("TaskMainThread")
   /** Send feedback text and optionally a screenshot to the Tester API for the given release. */
   Task<Void> sendFeedback(String releaseName, String feedbackText, @Nullable Uri screenshotUri) {
     return testerApiClient

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -372,6 +372,8 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
     notificationsManager.cancelFeedbackNotification();
   }
 
+  // TODO(b/261014422): Use an explicit executor in continuations.
+  @SuppressLint("TaskMainThread")
   private void doStartFeedback(CharSequence infoText, @Nullable Uri screenshotUri) {
     testerSignInManager
         .signInTester()

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
@@ -242,8 +242,10 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
           new OnActivityResumedListener() {
             @Override
             public void onResumed(Activity activity) {
-              task.setResult(
-                  getActivityWithIgnoredClass(activity, previousActivity, classToIgnore));
+              synchronized (lock) {
+                task.setResult(
+                    getActivityWithIgnoredClass(activity, previousActivity, classToIgnore));
+              }
               removeOnActivityResumedListener(this);
             }
           });

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -72,6 +72,8 @@ class ScreenshotTaker {
    * @return a {@link Task} that will complete with the file URI in app-level storage where the
    *     screenshot was written, or null if no activity could be found to screenshot.
    */
+  // TODO(b/261014422): Use an explicit executor in continuations.
+  @SuppressLint("TaskMainThread")
   Task<Uri> takeScreenshot() {
     return deleteScreenshot()
         .onSuccessTask(unused -> captureScreenshot())

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionNotificationsManagerTest.java
@@ -95,7 +95,7 @@ public class FirebaseAppDistributionNotificationsManagerTest {
     Notification notification =
         shadowOf(notificationManager).getNotification(APP_UPDATE.tag, APP_UPDATE.id);
     assertThat(shadowOf(notification).getProgress()).isEqualTo(100);
-    assertThat(shadowOf(notification).getContentTitle().toString()).contains("Download completed");
+    assertThat(shadowOf(notification).getContentTitle().toString()).contains("Download complete");
   }
 
   @Test


### PR DESCRIPTION
- Update expected string in unit test
- Guard protected member reference with synchronized block
- Add TODO and suppress explicit executor lint errors