### PR TITLE
Move SharedPreferences usage to background thread

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
@@ -110,14 +110,15 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
             firebaseInstallationsApiProvider,
             new TesterApiHttpClient(firebaseApp),
             blockingExecutor);
-    SignInStorage signInStorage = new SignInStorage(context);
+    SignInStorage signInStorage = new SignInStorage(context, backgroundExecutor);
     FirebaseAppDistributionLifecycleNotifier lifecycleNotifier =
         FirebaseAppDistributionLifecycleNotifier.getInstance();
     ReleaseIdentifier releaseIdentifier = new ReleaseIdentifier(firebaseApp, testerApiClient);
     FirebaseAppDistribution appDistribution =
         new FirebaseAppDistributionImpl(
             firebaseApp,
-            new TesterSignInManager(firebaseApp, firebaseInstallationsApiProvider, signInStorage),
+            new TesterSignInManager(
+                firebaseApp, firebaseInstallationsApiProvider, signInStorage, blockingExecutor),
             new NewReleaseFetcher(
                 firebaseApp.getApplicationContext(), testerApiClient, releaseIdentifier),
             new ApkUpdater(firebaseApp, new ApkInstaller(), blockingExecutor),

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.appdistribution.impl;
 
-import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.appdistribution.impl;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
@@ -65,6 +65,7 @@ class SignInStorage {
   }
 
   private SharedPreferences getSharedPreferencesBlocking() {
+    // This may construct a new SharedPreferences object, which requires storage I/O
     return applicationContext.getSharedPreferences(SIGNIN_PREFERENCES_NAME, Context.MODE_PRIVATE);
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TaskUtils.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TaskUtils.java
@@ -132,14 +132,15 @@ class TaskUtils {
       Task<T> task, Executor executor, UpdateTaskContinuation<T> continuation) {
     UpdateTaskImpl updateTask = new UpdateTaskImpl();
     task.addOnSuccessListener(
-        executor,
-        result -> {
-          try {
-            updateTask.shadow(continuation.then(result));
-          } catch (Throwable t) {
-            updateTask.setException(FirebaseAppDistributionExceptions.wrap(t));
-          }
-        });
+            executor,
+            result -> {
+              try {
+                updateTask.shadow(continuation.then(result));
+              } catch (Throwable t) {
+                updateTask.setException(FirebaseAppDistributionExceptions.wrap(t));
+              }
+            })
+        .addOnFailureListener(executor, updateTask::setException);
     return updateTask;
   }
 

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
@@ -110,13 +110,13 @@ final class TestUtils {
         () -> {
           while (progressEvents.size() < count) {
             try {
-              Thread.sleep(100);
+              Thread.sleep(50);
             } catch (InterruptedException e) {
               throw new RuntimeException("Interrupted while waiting for progress events", e);
             }
           }
         });
-    executor.awaitTermination(100, TimeUnit.MILLISECONDS);
+    executor.awaitTermination(500, TimeUnit.MILLISECONDS);
     assertThat(progressEvents).hasSize(count);
     return progressEvents;
   }


### PR DESCRIPTION
Followup from https://github.com/firebase/firebase-android-sdk/pull/4350

Creating a SharedPreferences object can touch storage, so we should do so only on a background thread.