### PR TITLE
Clean up ApkUpdater

### DIFF
--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import androidx.test.core.app.ApplicationProvider;
-import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
@@ -262,13 +261,6 @@ public class ApkUpdaterTest {
         assertThrows(FirebaseAppDistributionException.class, () -> onCompleteListener.await());
     assertThat(e.getErrorCode()).isEqualTo(Status.INSTALLATION_FAILURE);
     verifyNoInteractions(mockNotificationsManager);
-  }
-
-  @Test
-  public void downloadApk_whenCalledMultipleTimes_returnsSameTask() {
-    Task<File> task1 = apkUpdater.downloadApk(TEST_RELEASE, false);
-    Task<File> task2 = apkUpdater.downloadApk(TEST_RELEASE, false);
-    assertThat(task1).isEqualTo(task2);
   }
 
   @Test


### PR DESCRIPTION
It was caching a Task so that `downloadApk` could only create one task even if called multiple times in a row. But that can't happen because it's only called from `updateApk`, and that method is already caching a Task to avoid multiple simultaneous calls.

Also, it was self-managing a `TaskCompletionSource` when `TaskUtils.runAsyncInTask` can manage it instead.