### PR TITLE
Only enqueue SharedPreferences creation to background

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -244,9 +244,8 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
 
   @Override
   public void signOutTester() {
-    cachedNewRelease
-        .set(null)
-        .addOnSuccessListener(lightweightExecutor, unused -> signInStorage.setSignInStatus(false));
+    cachedNewRelease.set(null);
+    signInStorage.setSignInStatus(false);
   }
 
   @Override

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
@@ -24,12 +24,16 @@ import java.util.concurrent.Executor;
 
 /** Class that handles storage for App Distribution SignIn persistence. */
 class SignInStorage {
-
   private static final String SIGNIN_PREFERENCES_NAME = "FirebaseAppDistributionSignInStorage";
   private static final String SIGNIN_TAG = "firebase_app_distribution_signin";
 
   private final Context applicationContext;
   @Background private final Executor backgroundExecutor;
+  private SharedPreferences sharedPreferences;
+
+  private interface SharedPreferencesFunction<T> {
+    T apply(SharedPreferences sharedPreferences);
+  }
 
   SignInStorage(Context applicationContext, @Background Executor backgroundExecutor) {
     this.applicationContext = applicationContext;
@@ -37,35 +41,39 @@ class SignInStorage {
   }
 
   Task<Void> setSignInStatus(boolean testerSignedIn) {
-    return getSharedPreferences()
-        .onSuccessTask(
-            backgroundExecutor,
-            sharedPreferences -> {
-              sharedPreferences.edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
-              return null;
-            });
+    return applyToSharedPreferences(
+        sharedPreferences -> {
+          sharedPreferences.edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
+          return null;
+        });
   }
 
   Task<Boolean> getSignInStatus() {
-    return getSharedPreferences()
-        .onSuccessTask(
-            backgroundExecutor,
-            sharedPreferences -> Tasks.forResult(sharedPreferences.getBoolean(SIGNIN_TAG, false)));
+    return applyToSharedPreferences(
+        sharedPreferences -> sharedPreferences.getBoolean(SIGNIN_TAG, false));
   }
 
   boolean getSignInStatusBlocking() {
     return getSharedPreferencesBlocking().getBoolean(SIGNIN_TAG, false);
   }
 
-  private Task<SharedPreferences> getSharedPreferences() {
-    TaskCompletionSource<SharedPreferences> taskCompletionSource = new TaskCompletionSource<>();
-    backgroundExecutor.execute(
-        () -> taskCompletionSource.setResult(getSharedPreferencesBlocking()));
-    return taskCompletionSource.getTask();
-  }
-
   private SharedPreferences getSharedPreferencesBlocking() {
     // This may construct a new SharedPreferences object, which requires storage I/O
     return applicationContext.getSharedPreferences(SIGNIN_PREFERENCES_NAME, Context.MODE_PRIVATE);
+  }
+
+  private <T> Task<T> applyToSharedPreferences(SharedPreferencesFunction<T> func) {
+    // Check nullness of sharedPreferences directly because even if it is initialized twice on
+    // different threads it will be to an equivalent SharedPreferences reference.
+    if (sharedPreferences != null) {
+      return Tasks.forResult(func.apply(sharedPreferences));
+    }
+    TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<>();
+    backgroundExecutor.execute(
+        () -> {
+          sharedPreferences = getSharedPreferencesBlocking();
+          taskCompletionSource.setResult(func.apply(sharedPreferences));
+        });
+    return taskCompletionSource.getTask();
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
@@ -101,8 +101,8 @@ class TesterSignInManager {
     // result of the signIn Task in the onActivityCreated callback
     if (activity instanceof SignInResultActivity) {
       LogWrapper.v(TAG, "Sign in completed");
-      this.setSuccessfulSignInResult();
       this.signInStorage.setSignInStatus(true);
+      this.setSuccessfulSignInResult();
     }
   }
 


### PR DESCRIPTION
Previously all reads and writes were enqueued to the background executor, but that is unnecessary. We want reads/writes to happen ASAP because the sign in related operations on the API (`isTesterSignedIn`, `signOutTester`) return immediately.