### PR TITLE
Make isTesterSignedIn more reliable

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -244,8 +244,9 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
 
   @Override
   public void signOutTester() {
-    cachedNewRelease.set(null);
+    // Set sign in status first so isTesterSigned returns the correct state as soon as possible
     signInStorage.setSignInStatus(false);
+    cachedNewRelease.set(null);
   }
 
   @Override


### PR DESCRIPTION
There was an edge case where, if the first thing you did when opening the app was to call `signOutTester`, calling `isTesterSignedIn` immediately afterwords would return `true`. This makes a few tweaks which should prevent this from happening in any reasonable scenario:

- Sets the sign in status in storage immediately when `signOutTester()` is called
- Stores SharedPreferences even when `getSignInStatusBlocking()` is called

Also adds some more tests to cover the failure mode, and some general test cleanup.