### PR TITLE
Improve readability of a test in ApkUpdaterTest

### DIFF
--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
@@ -42,6 +42,7 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException.Stat
 import com.google.firebase.appdistribution.UpdateProgress;
 import com.google.firebase.appdistribution.UpdateStatus;
 import com.google.firebase.appdistribution.UpdateTask;
+import com.google.firebase.concurrent.FirebaseExecutors;
 import com.google.firebase.concurrent.TestOnlyExecutors;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -186,12 +187,12 @@ public class ApkUpdaterTest {
         .getInputStream();
     // Block thread actually making the request on a latch, which gives us time to add listeners to
     // the returned UpdateTask in time to get all the progress updates
-    CountDownLatch mockConnectionLatch = new CountDownLatch(1);
+    CountDownLatch countDownLatch = new CountDownLatch(1);
     when(mockHttpsUrlConnectionFactory.openConnection(TEST_URL))
         .thenAnswer(
             invocation -> {
               try {
-                mockConnectionLatch.await();
+                countDownLatch.await();
               } catch (InterruptedException e) {
                 throw new AssertionError("Interrupted while waiting in mock");
               }
@@ -200,11 +201,15 @@ public class ApkUpdaterTest {
     doNothing().when(apkUpdater).validateJarFile(any(), anyLong(), anyBoolean(), anyLong());
     when(mockApkInstaller.installApk(any(), any())).thenReturn(Tasks.forResult(null));
 
+    // Start the update
     UpdateTask updateTask = apkUpdater.updateApk(TEST_RELEASE, true);
-    List<UpdateProgress> events =
-        awaitProgressEvents(updateTask, 3, mockConnectionLatch::countDown);
 
-    assertThat(events).hasSize(3);
+    // Listen for progress events
+    List<UpdateProgress> events = new ArrayList<>();
+    updateTask.addOnProgressListener(FirebaseExecutors.directExecutor(), events::add);
+    countDownLatch.countDown();
+    awaitProgressEvents(events, 3);
+
     assertThat(events.get(0).getUpdateStatus()).isEqualTo(UpdateStatus.PENDING);
     assertThat(events.get(1).getUpdateStatus()).isEqualTo(UpdateStatus.DOWNLOADING);
     assertThat(events.get(1).getApkBytesDownloaded()).isEqualTo(TEST_FILE.length());

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/ApkUpdaterTest.java
@@ -15,7 +15,7 @@
 package com.google.firebase.appdistribution.impl;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.firebase.appdistribution.impl.TestUtils.awaitProgressEvents;
+import static com.google.firebase.appdistribution.impl.TestUtils.awaitCondition;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitTask;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -180,8 +180,7 @@ public class ApkUpdaterTest {
 
   @Test
   public void updateApk_whenSuccessfullyUpdated_notificationsSetCorrectly()
-      throws FirebaseAppDistributionException, ExecutionException, InterruptedException,
-          IOException {
+      throws FirebaseAppDistributionException, InterruptedException, IOException {
     doReturn(new ByteArrayInputStream(TEST_FILE.getBytes()))
         .when(mockHttpsUrlConnection)
         .getInputStream();
@@ -208,7 +207,7 @@ public class ApkUpdaterTest {
     List<UpdateProgress> events = new ArrayList<>();
     updateTask.addOnProgressListener(FirebaseExecutors.directExecutor(), events::add);
     countDownLatch.countDown();
-    awaitProgressEvents(events, 3);
+    awaitCondition(() -> events.size() == 3);
 
     assertThat(events.get(0).getUpdateStatus()).isEqualTo(UpdateStatus.PENDING);
     assertThat(events.get(1).getUpdateStatus()).isEqualTo(UpdateStatus.DOWNLOADING);

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -33,7 +33,7 @@ import static com.google.firebase.appdistribution.impl.FeedbackActivity.INFO_TEX
 import static com.google.firebase.appdistribution.impl.FeedbackActivity.RELEASE_NAME_KEY;
 import static com.google.firebase.appdistribution.impl.FeedbackActivity.SCREENSHOT_URI_KEY;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitAsyncOperations;
-import static com.google.firebase.appdistribution.impl.TestUtils.awaitProgressEvents;
+import static com.google.firebase.appdistribution.impl.TestUtils.awaitCondition;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitTask;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitTaskFailure;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitTermination;
@@ -386,7 +386,7 @@ public class FirebaseAppDistributionServiceImplTest {
     List<UpdateProgress> progressEvents = new ArrayList<>();
     task.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents::add);
     countDownLatch.countDown();
-    awaitProgressEvents(progressEvents, 1);
+    awaitCondition(() -> progressEvents.size() == 1);
 
     assertEquals(UpdateStatus.NEW_RELEASE_NOT_AVAILABLE, progressEvents.get(0).getUpdateStatus());
     assertNull(ShadowAlertDialog.getLatestAlertDialog());

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
@@ -28,22 +28,25 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
-import com.google.firebase.appdistribution.UpdateProgress;
 import com.google.firebase.appdistribution.impl.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
 import com.google.firebase.appdistribution.impl.FirebaseAppDistributionLifecycleNotifier.ActivityFunction;
-import com.google.firebase.concurrent.TestOnlyExecutors;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mockito.stubbing.Answer;
 
 final class TestUtils {
+
+  private static final int AWAIT_TERMINATION_TIMEOUT_MS = 100;
+  private static final int AWAIT_CONDITION_TIMEOUT_MS = 500;
+  private static final int SLEEP_MS = 50;
+
   private TestUtils() {}
 
   static void awaitTaskFailure(Task task, Status status, String messageSubstring) {
@@ -86,7 +89,7 @@ final class TestUtils {
   }
 
   static void awaitTermination(ExecutorService executorService) throws InterruptedException {
-    executorService.awaitTermination(100, TimeUnit.MILLISECONDS);
+    executorService.awaitTermination(AWAIT_TERMINATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
   }
 
   static void awaitAsyncOperations(ExecutorService executorService) throws InterruptedException {
@@ -98,22 +101,19 @@ final class TestUtils {
     shadowOf(getMainLooper()).idle();
   }
 
-  /** Await a specified number of progress events being added to the given collection. */
-  static void awaitProgressEvents(Collection<UpdateProgress> progressEvents, int count)
-      throws InterruptedException {
-    ExecutorService executor = TestOnlyExecutors.blocking();
-    executor.execute(
-        () -> {
-          while (progressEvents.size() < count) {
-            try {
-              Thread.sleep(50);
-            } catch (InterruptedException e) {
-              throw new RuntimeException("Interrupted while waiting for progress events", e);
-            }
-          }
-        });
-    executor.awaitTermination(500, TimeUnit.MILLISECONDS);
-    assertThat(progressEvents).hasSize(count);
+  static void awaitCondition(BooleanSupplier condition) throws InterruptedException {
+    long start = System.currentTimeMillis();
+    while (elapsedTime(start) < AWAIT_CONDITION_TIMEOUT_MS) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(SLEEP_MS);
+    }
+    throw new AssertionError("Timed out waiting for condition");
+  }
+
+  private static long elapsedTime(long start) {
+    return System.currentTimeMillis() - start;
   }
 
   /**

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
@@ -29,16 +29,12 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
 import com.google.firebase.appdistribution.UpdateProgress;
-import com.google.firebase.appdistribution.UpdateTask;
 import com.google.firebase.appdistribution.impl.FirebaseAppDistributionLifecycleNotifier.ActivityConsumer;
 import com.google.firebase.appdistribution.impl.FirebaseAppDistributionLifecycleNotifier.ActivityFunction;
-import com.google.firebase.concurrent.FirebaseExecutors;
 import com.google.firebase.concurrent.TestOnlyExecutors;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -100,15 +96,6 @@ final class TestUtils {
     // Idle the main looper, which is also running these tests, so any Task or lifecycle callbacks
     // can be handled. See http://robolectric.org/blog/2019/06/04/paused-looper/ for more info.
     shadowOf(getMainLooper()).idle();
-  }
-
-  /** Await a specified number of progress events on an {@link UpdateTask}. */
-  static List<UpdateProgress> awaitProgressEvents(UpdateTask updateTask, int count)
-      throws InterruptedException {
-    List<UpdateProgress> progressEvents = new ArrayList<>();
-    updateTask.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents::add);
-    awaitProgressEvents(progressEvents, count);
-    return progressEvents;
   }
 
   /** Await a specified number of progress events being added to the given collection. */


### PR DESCRIPTION
- The latch's name made it seem like it was a mock
- Inlining more of the setup makes it more readable