### PR TITLE
Support multiple progress listeners on an UpdateTask

### DIFF
--- a/firebase-appdistribution/CHANGELOG.md
+++ b/firebase-appdistribution/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 16.0.0-beta04
+* [fixed] Fixed a bug where only the last listener added to an `UpdateTask` using
+  `addOnProgressListener()` would receive updates.
+
 # 16.0.0-beta05
 * [unchanged] Updated to accommodate the release of the updated
   [appdistro] Kotlin extensions library.

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/UpdateTaskImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/UpdateTaskImpl.java
@@ -55,7 +55,7 @@ class UpdateTaskImpl extends UpdateTask {
 
   UpdateTaskImpl() {
     synchronized (taskCompletionLock) {
-      this.taskCompletionSource = new TaskCompletionSource<>();
+      taskCompletionSource = new TaskCompletionSource<>();
     }
   }
 
@@ -75,13 +75,13 @@ class UpdateTaskImpl extends UpdateTask {
   void shadow(UpdateTask updateTask) {
     updateTask
         .addOnProgressListener(FirebaseExecutors.directExecutor(), this::updateProgress)
-        .addOnSuccessListener(FirebaseExecutors.directExecutor(), unused -> this.setResult())
+        .addOnSuccessListener(FirebaseExecutors.directExecutor(), unused -> setResult())
         .addOnFailureListener(FirebaseExecutors.directExecutor(), this::setException);
   }
 
   private Task<Void> getTask() {
-    synchronized (this.taskCompletionLock) {
-      return this.taskCompletionSource.getTask();
+    synchronized (taskCompletionLock) {
+      return taskCompletionSource.getTask();
     }
   }
 
@@ -97,7 +97,7 @@ class UpdateTaskImpl extends UpdateTask {
       @Nullable Executor executor, @NonNull OnProgressListener listener) {
     ManagedListener managedListener = new ManagedListener(executor, listener);
     synchronized (lock) {
-      this.listeners.add(managedListener);
+      listeners.add(managedListener);
       if (snapshot != null) {
         managedListener.invoke(snapshot);
       }
@@ -267,12 +267,12 @@ class UpdateTaskImpl extends UpdateTask {
   public void setResult() {
 
     synchronized (lock) {
-      this.listeners.clear();
+      listeners.clear();
     }
 
     synchronized (taskCompletionLock) {
-      if (!this.taskCompletionSource.getTask().isComplete()) {
-        this.taskCompletionSource.setResult(null);
+      if (!taskCompletionSource.getTask().isComplete()) {
+        taskCompletionSource.setResult(null);
       }
     }
   }
@@ -281,12 +281,12 @@ class UpdateTaskImpl extends UpdateTask {
   public void setException(@NonNull Exception exception) {
 
     synchronized (lock) {
-      this.listeners.clear();
+      listeners.clear();
     }
 
     synchronized (taskCompletionLock) {
-      if (!this.taskCompletionSource.getTask().isComplete()) {
-        this.taskCompletionSource.setException(exception);
+      if (!taskCompletionSource.getTask().isComplete()) {
+        taskCompletionSource.setException(exception);
       }
     }
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/UpdateTaskImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/UpdateTaskImplTest.java
@@ -1,0 +1,144 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.appdistribution.UpdateProgress;
+import com.google.firebase.appdistribution.UpdateStatus;
+import com.google.firebase.concurrent.FirebaseExecutors;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class UpdateTaskImplTest {
+
+  private static final UpdateProgress PROGRESS_DOWNLOADING =
+      UpdateProgressImpl.builder()
+          .setUpdateStatus(UpdateStatus.DOWNLOADING)
+          .setApkBytesDownloaded(100)
+          .setApkFileTotalBytes(123)
+          .build();
+
+  private static final UpdateProgress PROGRESS_DOWNLOADED =
+      UpdateProgressImpl.builder()
+          .setUpdateStatus(UpdateStatus.DOWNLOADED)
+          .setApkBytesDownloaded(123)
+          .setApkFileTotalBytes(123)
+          .build();
+
+  @Test
+  public void addOnProgressListener_supportsMultipleListeners() {
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+    List<UpdateProgress> progressEvents1 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents1::add);
+    List<UpdateProgress> progressEvents2 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents2::add);
+
+    updateTaskImpl.updateProgress(PROGRESS_DOWNLOADING);
+
+    assertThat(progressEvents1).containsExactly(PROGRESS_DOWNLOADING);
+    assertThat(progressEvents2).containsExactly(PROGRESS_DOWNLOADING);
+  }
+
+  @Test
+  public void setException_clearsProgressListeners() {
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+    List<UpdateProgress> progressEvents1 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents1::add);
+    List<UpdateProgress> progressEvents2 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents2::add);
+
+    // Set the result
+    updateTaskImpl.setException(new RuntimeException("Error"));
+
+    // Has no effect on the listeners after the exception is set
+    updateTaskImpl.updateProgress(PROGRESS_DOWNLOADING);
+
+    assertThat(progressEvents1).isEmpty();
+    assertThat(progressEvents2).isEmpty();
+  }
+
+  @Test
+  public void setResult_clearsProgressListeners() {
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+    List<UpdateProgress> progressEvents1 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents1::add);
+    List<UpdateProgress> progressEvents2 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents2::add);
+
+    // Set the result
+    updateTaskImpl.setResult();
+
+    // Has no effect on the listeners after the result is set
+    updateTaskImpl.updateProgress(PROGRESS_DOWNLOADING);
+
+    assertThat(progressEvents1).isEmpty();
+    assertThat(progressEvents2).isEmpty();
+  }
+
+  @Test
+  public void shadow_completesWithShadowedException() {
+    UpdateTaskImpl taskToShadow = new UpdateTaskImpl();
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+
+    // Shadow the task
+    updateTaskImpl.shadow(taskToShadow);
+
+    // Complete the shadowed task
+    RuntimeException expectedException = new RuntimeException("Error");
+    taskToShadow.setException(expectedException);
+
+    assertThat(updateTaskImpl.isComplete()).isEqualTo(true);
+    assertThat(updateTaskImpl.isSuccessful()).isEqualTo(false);
+    assertThat(updateTaskImpl.getException()).isEqualTo(expectedException);
+  }
+
+  @Test
+  public void shadow_completesWithShadowedResult() {
+    UpdateTaskImpl taskToShadow = new UpdateTaskImpl();
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+
+    // Shadow the task
+    updateTaskImpl.shadow(taskToShadow);
+
+    // Complete the shadowed task
+    taskToShadow.setResult();
+
+    assertThat(updateTaskImpl.isComplete()).isEqualTo(true);
+    assertThat(updateTaskImpl.isSuccessful()).isEqualTo(true);
+  }
+
+  @Test
+  public void shadow_updatesWithShadowedProgress() {
+    UpdateTaskImpl taskToShadow = new UpdateTaskImpl();
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+    List<UpdateProgress> progressEvents = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents::add);
+
+    // Shadow the task
+    updateTaskImpl.shadow(taskToShadow);
+
+    // Update the shadowed task
+    taskToShadow.updateProgress(PROGRESS_DOWNLOADING);
+    taskToShadow.updateProgress(PROGRESS_DOWNLOADED);
+
+    assertThat(updateTaskImpl.isComplete()).isEqualTo(false);
+    assertThat(progressEvents).containsExactly(PROGRESS_DOWNLOADING, PROGRESS_DOWNLOADED);
+  }
+}


### PR DESCRIPTION
This is a bug that we should probably fix, even though the typical customer use case is to add only one listener. [The API ](https://firebase.google.com/docs/reference/android/com/google/firebase/appdistribution/UpdateTask#addOnProgressListener(com.google.firebase.appdistribution.OnProgressListener)) definitely seems like it's meant to support multiple listeners.