### PR TITLE
Focus some synchronized blocks in lifecycle notifier

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifier.java
@@ -235,22 +235,27 @@ class FirebaseAppDistributionLifecycleNotifier implements Application.ActivityLi
         return Tasks.forResult(
             getActivityWithIgnoredClass(currentActivity, previousActivity, classToIgnore));
       }
+    }
 
-      TaskCompletionSource<Activity> task = new TaskCompletionSource<>();
+    TaskCompletionSource<Activity> task = new TaskCompletionSource<>();
 
-      addOnActivityResumedListener(
-          new OnActivityResumedListener() {
-            @Override
-            public void onResumed(Activity activity) {
-              synchronized (lock) {
-                task.setResult(
-                    getActivityWithIgnoredClass(activity, previousActivity, classToIgnore));
-              }
-              removeOnActivityResumedListener(this);
-            }
-          });
+    addOnActivityResumedListener(
+        new OnActivityResumedListener() {
+          @Override
+          public void onResumed(Activity activity) {
+            task.setResult(
+                getActivityWithIgnoredClass(activity, getPreviousActivity(), classToIgnore));
+            removeOnActivityResumedListener(this);
+          }
+        });
 
-      return task.getTask();
+    return task.getTask();
+  }
+
+  @Nullable
+  private Activity getPreviousActivity() {
+    synchronized (lock) {
+      return previousActivity;
     }
   }
 


### PR DESCRIPTION
We were including some code inside `synchronized` blocks that did not need the lock.