### PR TITLE
Resolve javadoc diff failures

### DIFF
--- a/.github/workflows/diff-javadoc.yml
+++ b/.github/workflows/diff-javadoc.yml
@@ -31,7 +31,7 @@ jobs:
           echo "run=$(cat modules.json | sed "s/[]\"[]//g" | sed "s/,/\n/g" | xargs printf -- "%s:kotlinDoc ")" >> $GITHUB_OUTPUT
 
       - name: Build
-        run: ./gradlew ${{ steps.changed-modules.outputs.run }}
+        run: mkdir build && ./gradlew ${{ steps.changed-modules.outputs.run }}
 
       - name: Move original docs
         run: mv build ~/diff/modified
@@ -41,7 +41,7 @@ jobs:
           ref: ${{ github.base_ref }}
 
       - name: Build
-        run: ./gradlew ${{ steps.changed-modules.outputs.run }}
+        run: mkdir build && ./gradlew ${{ steps.changed-modules.outputs.run }}
 
       - name: Move modified docs
         run: mv build ~/diff/original
@@ -62,6 +62,7 @@ jobs:
           > diff.md
 
       - name: Add comment
+        continue-on-error: true
         uses: mshick/add-pr-comment@a65df5f64fc741e91c59b8359a4bc56e57aaf5b1
         with:
           message-path: diff.md


### PR DESCRIPTION
This PR resolves two issues relating to the javadoc diff action failing. Both scenarios involved no diff existing as far as I can tell, but it's much cleaner to succeed and no-op. Part one is just making empty build folders to move over if the changed SDKs don't output anything to build when generating javadoc (I didn't realize this was possible originally). The second change however involves letting the final step of posting the comment fail without issue. As of yet I've only seen this fail when provided with an empty file, however this might also mean we miss a breakage (though, the comment consistently disappearing is probably also a reasonable tip off). My original approach involved checking the length of the comment and skipping the step if it was too small, but it seemed hacky and prone to breakage, so I went with this solution instead.