### PR TITLE
Use BufferedOutputStream to prevent StrictMode violations

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -33,8 +33,8 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.annotations.concurrent.Background;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
+import java.io.BufferedOutputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.concurrent.Executor;
 
@@ -141,7 +141,7 @@ class ScreenshotTaker {
     // First delete the previous file if it's still there
     deleteScreenshot();
 
-    try (FileOutputStream outputStream = openFileOutputStream()) {
+    try (BufferedOutputStream outputStream = openFileOutputStream()) {
       // PNG is a lossless format, the compression factor (100) is ignored
       bitmap.compress(Bitmap.CompressFormat.PNG, /* quality= */ 100, outputStream);
     } catch (IOException e) {
@@ -157,9 +157,10 @@ class ScreenshotTaker {
     firebaseApp.getApplicationContext().deleteFile(SCREENSHOT_FILE_NAME);
   }
 
-  private FileOutputStream openFileOutputStream() throws FileNotFoundException {
-    return firebaseApp
-        .getApplicationContext()
-        .openFileOutput(SCREENSHOT_FILE_NAME, Context.MODE_PRIVATE);
+  private BufferedOutputStream openFileOutputStream() throws FileNotFoundException {
+    return new BufferedOutputStream(
+        firebaseApp
+            .getApplicationContext()
+            .openFileOutput(SCREENSHOT_FILE_NAME, Context.MODE_PRIVATE));
   }
 }


### PR DESCRIPTION
```
StrictMode policy violation: android.os.strictmode.UnbufferedIoViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onUnbufferedIO(StrictMode.java:1647)
	at libcore.io.IoTracker.trackIo(IoTracker.java:35)
	at libcore.io.IoTracker.trackIo(IoTracker.java:45)
	at java.io.FileOutputStream.write(FileOutputStream.java:398)
	at android.graphics.Bitmap.nativeCompress(Native Method)
	at android.graphics.Bitmap.compress(Bitmap.java:1445)
	at com.google.firebase.appdistribution.impl.ScreenshotTaker.writeToFile(ScreenshotTaker.java:147)
	at com.google.firebase.appdistribution.impl.ScreenshotTaker.lambda$takeScreenshot$0$com-google-firebase-appdistribution-impl-ScreenshotTaker(ScreenshotTaker.java:69)
	at com.google.firebase.appdistribution.impl.ScreenshotTaker$$ExternalSyntheticLambda1.then(Unknown Source:4)
	at com.google.android.gms.tasks.zzo.run(com.google.android.gms:play-services-tasks@@18.0.2:1)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
```
