### PR TITLE
Read file length on background thread to avoid StrictMode violation

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
@@ -111,11 +111,12 @@ class ApkUpdater {
             activity -> apkInstaller.installApk(file.getPath(), activity))
         .addOnSuccessListener(lightweightExecutor, unused -> cachedUpdateTask.setResult())
         .addOnFailureListener(
-            lightweightExecutor,
+            blockingExecutor, // Getting the file length performs disk IO
             e -> {
+              long fileLength = file.length();
               postUpdateProgress(
-                  file.length(),
-                  file.length(),
+                  fileLength,
+                  fileLength,
                   UpdateStatus.INSTALL_FAILED,
                   showDownloadNotificationManager,
                   R.string.install_failed);


### PR DESCRIPTION
```
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at libcore.io.BlockGuardOs.stat(BlockGuardOs.java:419)
	at libcore.io.ForwardingOs.stat(ForwardingOs.java:846)
	at android.app.ActivityThread$AndroidOs.stat(ActivityThread.java:7798)
	at java.io.UnixFileSystem.getLength(UnixFileSystem.java:298)
	at java.io.File.length(File.java:968)
	at com.google.firebase.appdistribution.impl.ApkUpdater.lambda$installApk$5$com-google-firebase-appdistribution-impl-ApkUpdater(ApkUpdater.java:101)
	at com.google.firebase.appdistribution.impl.ApkUpdater$$ExternalSyntheticLambda1.onFailure(Unknown Source:6)
	at com.google.android.gms.tasks.zzk.run(com.google.android.gms:play-services-tasks@@18.0.2:1)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
```