### PR TITLE
Extend publishing plugin to support release configFiles.

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
@@ -101,7 +101,7 @@ public class PublishingPlugin implements Plugin<Project> {
             gradle -> {
               List<String> projectsNames;
               if (!publishConfigFilePath.isEmpty()) {
-                projectsNames = readReleaseConfigFile(publishConfigFilePath, project);
+                projectsNames = readReleaseConfigFile(publishConfigFilePath);
               } else {
                 projectsNames =
                     Arrays.asList(projectNamesToPublish.split(projectsToPublishSeparator, -1));
@@ -218,15 +218,15 @@ public class PublishingPlugin implements Plugin<Project> {
             });
   }
 
-  private List<String> readReleaseConfigFile(String publishConfigurationFilePath, Project project) {
+  private List<String> readReleaseConfigFile(String publishConfigurationFilePath) {
     try (Stream<String> stream = Files.lines(Path.of(publishConfigurationFilePath))) {
       return stream
           .dropWhile((line) -> !line.equals("[modules]"))
           .skip(1)
           .collect(Collectors.toList());
     } catch (IOException e) {
-      project.getLogger().error("Error reading publish configuration file. ", e);
-      return List.of();
+      throw new IllegalArgumentException(
+          "Error reading configuration file " + publishConfigurationFilePath, e);
     }
   }
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
@@ -16,9 +16,14 @@ package com.google.firebase.gradle.plugins.publish;
 
 import com.google.firebase.gradle.plugins.FirebaseLibraryExtension;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -41,12 +46,22 @@ import org.gradle.api.tasks.bundling.Zip;
  * <p><strong>Prepare a release</strong>
  *
  * <pre>
+ * ./gradlew -PpublishConfigFilePath=release.cfg
+ *           -PpublishMode=(RELEASE|SNAPSHOT) \
+ *           firebasePublish
+ * </pre>
+ *
+ * <pre>
  * ./gradlew -PprojectsToPublish="firebase-inappmessaging,firebase-inappmessaging-display"\
  *           -PpublishMode=(RELEASE|SNAPSHOT) \
  *           firebasePublish
  * </pre>
  *
  * <ul>
+ *   <li>{@code publishConfigFilePath} is the path to the configuration file from which to read the
+ *       list of projects to release. The file format should be consistent with Python's
+ *       configparser, and the list of projects should be in a section called "modules". If both
+ *       this, and {@code projectsToPublish} are specified, this property takes precedence.
  *   <li>{@code projectsToPublish} is a list of projects to release separated by {@code
  *       projectsToPublishSeparator}(default: ","), these projects will have their versions depend
  *       on the {@code publishMode} parameter.
@@ -73,6 +88,7 @@ public class PublishingPlugin implements Plugin<Project> {
   public void apply(Project project) {
     String projectNamesToPublish = getPropertyOr(project, "projectsToPublish", "");
     String projectsToPublishSeparator = getPropertyOr(project, "projectsToPublishSeparator", ",");
+    String publishConfigFilePath = getPropertyOr(project, "publishConfigFilePath", "");
     Mode publishMode = Enum.valueOf(Mode.class, getPropertyOr(project, "publishMode", "SNAPSHOT"));
 
     Task publishAllToLocal = project.task("publishAllToLocal");
@@ -83,8 +99,16 @@ public class PublishingPlugin implements Plugin<Project> {
         .getGradle()
         .projectsEvaluated(
             gradle -> {
+              List<String> projectsNames;
+              if (!publishConfigFilePath.isEmpty()) {
+                projectsNames = readReleaseConfigFile(publishConfigFilePath, project);
+              } else {
+                projectsNames =
+                    Arrays.asList(projectNamesToPublish.split(projectsToPublishSeparator, -1));
+              }
+
               Set<FirebaseLibraryExtension> projectsToPublish =
-                  Arrays.stream(projectNamesToPublish.split(projectsToPublishSeparator, -1))
+                  projectsNames.stream()
                       .filter(name -> !name.isEmpty())
                       .map(
                           name ->
@@ -192,6 +216,18 @@ public class PublishingPlugin implements Plugin<Project> {
               buildKotlindocZip.mustRunAfter(info);
               firebasePublish.dependsOn(info, buildMavenZip, buildKotlindocZip);
             });
+  }
+
+  private List<String> readReleaseConfigFile(String publishConfigurationFilePath, Project project) {
+    try (Stream<String> stream = Files.lines(Path.of(publishConfigurationFilePath))) {
+      return stream
+          .dropWhile((line) -> !line.equals("[modules]"))
+          .skip(1)
+          .collect(Collectors.toList());
+    } catch (IOException e) {
+      project.getLogger().error("Error reading publish configuration file. ", e);
+      return List.of();
+    }
   }
 
   private static String getPropertyOr(Project p, String property, String defaultValue) {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -104,7 +103,7 @@ public class PublishingPlugin implements Plugin<Project> {
                 projectsNames = readReleaseConfigFile(publishConfigFilePath);
               } else {
                 projectsNames =
-                    Arrays.asList(projectNamesToPublish.split(projectsToPublishSeparator, -1));
+                    List.of(projectNamesToPublish.split(projectsToPublishSeparator, -1));
               }
 
               Set<FirebaseLibraryExtension> projectsToPublish =

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
@@ -222,6 +222,7 @@ public class PublishingPlugin implements Plugin<Project> {
     try (Stream<String> stream = Files.lines(Path.of(publishConfigurationFilePath))) {
       return stream
           .dropWhile((line) -> !line.equals("[modules]"))
+          // We need to skip the "[modules]" line since it's not dropped
           .skip(1)
           .collect(Collectors.toList());
     } catch (IOException e) {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
@@ -60,8 +60,7 @@ import org.gradle.api.tasks.bundling.Zip;
  *   <li>{@code publishConfigFilePath} is the path to the configuration file from which to read the
  *       list of projects to release. The file format should be consistent with Python's
  *       configparser, and the list of projects should be in a section called "modules". If both
- *       this, and {@code projectsToPublish} are specified, this property takes precedence.
- *       <br>
+ *       this, and {@code projectsToPublish} are specified, this property takes precedence. <br>
  *       <br>
  *       Example config file content:
  *       <pre>

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/publish/PublishingPlugin.java
@@ -61,6 +61,18 @@ import org.gradle.api.tasks.bundling.Zip;
  *       list of projects to release. The file format should be consistent with Python's
  *       configparser, and the list of projects should be in a section called "modules". If both
  *       this, and {@code projectsToPublish} are specified, this property takes precedence.
+ *       <br>
+ *       <br>
+ *       Example config file content:
+ *       <pre>
+ *         [release]
+ *         name = M126
+ *         ...
+ *         [modules]
+ *         firebase-database
+ *         firebase-common
+ *         firebase-firestore
+ *       </pre>
  *   <li>{@code projectsToPublish} is a list of projects to release separated by {@code
  *       projectsToPublishSeparator}(default: ","), these projects will have their versions depend
  *       on the {@code publishMode} parameter.


### PR DESCRIPTION
This enables the plugin to read the list of projects to be released from a configuration file, besides getting them from the CLI.