### PR TITLE
Use file-based release configuration for the build release action.

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Perform gradle build
         run: |
-          ./gradlew  firebasePublish -PprojectsToPublish=firebase-firestore -PpublishMode=RELEASE -PincludeFireEscapeArtifacts=true
+          ./gradlew firebasePublish -PpublishConfigFilePath=release.cfg -PpublishMode=RELEASE -PincludeFireEscapeArtifacts=true
       - name: Upload generated artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The action was using a dummy configuration that only created release artifacts for Firestore.