### PR TITLE
Wrap target backend property in double quotes

### DIFF
--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -100,7 +100,7 @@ tasks.withType(Test) {
 
 android.libraryVariants.all { variant ->
     if (findProperty('targetBackend')) {
-        variant.buildConfigField("String", "TARGET_BACKEND", property("targetBackend"))
+        variant.buildConfigField("String", "TARGET_BACKEND", "\"${property("targetBackend")}\"")
     } else {
         // By default set the target backend to 'emulator'
         variant.buildConfigField("String", "TARGET_BACKEND", "\"emulator\"")


### PR DESCRIPTION
Without it, it's generated as a symbol, causing the build to break.