### PR TITLE
Rename updatedParams to updatedKeys in ConfigUpdate.

### DIFF
--- a/firebase-config/api.txt
+++ b/firebase-config/api.txt
@@ -4,7 +4,7 @@ package com.google.firebase.remoteconfig {
   @com.google.auto.value.AutoValue public abstract class ConfigUpdate {
     ctor public ConfigUpdate();
     method @NonNull public static com.google.firebase.remoteconfig.ConfigUpdate create(@NonNull java.util.Set<java.lang.String>);
-    method @NonNull public abstract java.util.Set<java.lang.String> getUpdatedParams();
+    method @NonNull public abstract java.util.Set<java.lang.String> getUpdatedKeys();
   }
 
   public interface ConfigUpdateListener {

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/ConfigUpdate.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/ConfigUpdate.java
@@ -25,8 +25,8 @@ import java.util.Set;
 @AutoValue
 public abstract class ConfigUpdate {
   @NonNull
-  public static ConfigUpdate create(@NonNull Set<String> updatedParams) {
-    return new AutoValue_ConfigUpdate(updatedParams);
+  public static ConfigUpdate create(@NonNull Set<String> updatedKeys) {
+    return new AutoValue_ConfigUpdate(updatedKeys);
   }
 
   /**
@@ -34,5 +34,5 @@ public abstract class ConfigUpdate {
    * keys that are added, deleted, and whose value, value source, or metadata has changed.
    */
   @NonNull
-  public abstract Set<String> getUpdatedParams();
+  public abstract Set<String> getUpdatedKeys();
 }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -250,14 +250,14 @@ public class ConfigAutoFetch {
                 activatedConfigs = ConfigContainer.newBuilder().build();
               }
 
-              Set<String> updatedParams =
+              Set<String> updatedKeys =
                   activatedConfigs.getChangedParams(fetchResponse.getFetchedConfigs());
-              if (updatedParams.isEmpty()) {
+              if (updatedKeys.isEmpty()) {
                 Log.d(TAG, "Config was fetched, but no params changed.");
                 return Tasks.forResult(null);
               }
 
-              ConfigUpdate configUpdate = ConfigUpdate.create(updatedParams);
+              ConfigUpdate configUpdate = ConfigUpdate.create(updatedKeys);
               executeAllListenerCallbacks(configUpdate);
               return Tasks.forResult(null);
             });

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1326,9 +1326,9 @@ public final class FirebaseRemoteConfigTest {
 
     flushScheduledTasks();
 
-    Set<String> updatedParams = Sets.newHashSet("realtime_param");
+    Set<String> updatedKeys = Sets.newHashSet("realtime_param");
     verify(mockOnUpdateListener)
-        .onUpdate(argThat(configUpdate -> configUpdate.getUpdatedParams().equals(updatedParams)));
+        .onUpdate(argThat(configUpdate -> configUpdate.getUpdatedKeys().equals(updatedKeys)));
   }
 
   @Test
@@ -1344,9 +1344,9 @@ public final class FirebaseRemoteConfigTest {
     configAutoFetch.fetchLatestConfig(1, 1);
     flushScheduledTasks();
 
-    Set<String> updatedParams = Sets.newHashSet("string_param", "long_param", "realtime_param");
+    Set<String> updatedKeys = Sets.newHashSet("string_param", "long_param", "realtime_param");
     verify(mockOnUpdateListener)
-        .onUpdate(argThat(configUpdate -> configUpdate.getUpdatedParams().equals(updatedParams)));
+        .onUpdate(argThat(configUpdate -> configUpdate.getUpdatedKeys().equals(updatedKeys)));
   }
 
   @Test


### PR DESCRIPTION
`updatedKeys` better describes this value and we use "key"/"keys" consistently throughout the SDKs.