### PR TITLE
Use an executor for Realtime HTTP onSuccess task.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -130,6 +130,7 @@ public class ConfigRealtimeHttpClient {
   private void getInstallationAuthToken(HttpURLConnection httpURLConnection) {
     Task<InstallationTokenResult> installationAuthTokenTask = firebaseInstallations.getToken(false);
     installationAuthTokenTask.onSuccessTask(
+        scheduledExecutorService,
         unusedToken -> {
           httpURLConnection.setRequestProperty(
               INSTALLATIONS_AUTH_TOKEN_HEADER, unusedToken.getToken());


### PR DESCRIPTION
Fixes a linter error.