### PR TITLE
Realtime RC 1P Bug Fix: ConfigAutoFetch listenForNotifications non-fatal error

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
@@ -114,15 +113,6 @@ public class ConfigAutoFetch {
       } finally {
         httpURLConnection.disconnect();
       }
-    }
-
-    // TODO: Factor ConfigUpdateListener out of internal retry logic.
-    retryCallback.onUpdate(ConfigUpdate.create(new HashSet<>()));
-    scheduledExecutorService.shutdownNow();
-    try {
-      scheduledExecutorService.awaitTermination(3L, TimeUnit.SECONDS);
-    } catch (InterruptedException ex) {
-      Log.d(TAG, "Thread Interrupted.");
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -75,12 +75,12 @@ public class ConfigRealtimeHandler {
   }
 
   private synchronized Runnable createRealtimeHttpClientTask(
-      ConfigRealtimeHttpClient configRealtimeHttpClient) {
+      ConfigRealtimeHttpClient realtimeHttpClient) {
     return new Runnable() {
       @Override
       public void run() {
-        configRealtimeHttpClient.beginRealtimeHttpStream();
-        while (configRealtimeHttpClient.getRetryState()) {}
+        realtimeHttpClient.beginRealtimeHttpStream();
+        while (realtimeHttpClient.getRetryState()) {}
       }
     };
   }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -134,6 +134,10 @@ public class ConfigRealtimeHandler {
     }
   }
 
+  private synchronized void closeRealtime() {
+    realtimeHttpClientTask = null;
+  }
+
   private class RealtimeHttpClientFutureTask extends FutureTask<String> {
     private final ConfigRealtimeHttpClient configRealtimeHttpClient;
 
@@ -146,7 +150,7 @@ public class ConfigRealtimeHandler {
     @Override
     protected void done() {
       super.done();
-      realtimeHttpClientTask = null;
+      closeRealtime();
     }
   }
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1192,7 +1192,7 @@ public final class FirebaseRemoteConfigTest {
         .thenReturn(Tasks.forResult(realtimeFetchedContainerResponse));
     configAutoFetch.listenForNotifications();
 
-    verify(mockRetryListener).onUpdate(any());
+    verify(mockHttpURLConnection).disconnect();
   }
 
   @Test


### PR DESCRIPTION
Fixes bug for bug/261868622.
Adds retry flag for ConfigRealtimeHttpClient to stop retries, removes extra retry, and stops thread interruption.