### PR TITLE
Realtime RC 1P Bug Fix: Remove thread interruption logic

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -652,8 +652,8 @@ public class FirebaseRemoteConfig {
    *
    * @hide
    */
-  void pauseAllConfigUpdateListeners() {
-    configRealtimeHandler.pauseRealtime();
+  void changeConfigUpdateBackgroundState(boolean backgroundState) {
+    configRealtimeHandler.setBackgroundState(backgroundState);
   }
 
   /**

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -648,7 +648,7 @@ public class FirebaseRemoteConfig {
   }
 
   /**
-   * Immediately stops all ConfigUpdateListeners from receiving update messages.
+   * Notifies Realtime handler if the app is in the background or not.
    *
    * @hide
    */

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -652,7 +652,7 @@ public class FirebaseRemoteConfig {
    *
    * @hide
    */
-  void changeConfigUpdateBackgroundState(boolean backgroundState) {
+  void setConfigUpdateBackgroundState(boolean backgroundState) {
     configRealtimeHandler.setBackgroundState(backgroundState);
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -335,7 +335,7 @@ public class RemoteConfigComponent {
 
   private static synchronized void notifyRCInstances(boolean isInBackground) {
     for (FirebaseRemoteConfig frc : frcNamespaceInstancesStatic.values()) {
-      frc.changeConfigUpdateBackgroundState(isInBackground);
+      frc.setConfigUpdateBackgroundState(isInBackground);
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -75,8 +75,6 @@ public class RemoteConfigComponent {
   private static final Clock DEFAULT_CLOCK = DefaultClock.getInstance();
   private static final Random DEFAULT_RANDOM = new Random();
 
-  private static final ConfigUpdateListener EMPTY_CONFIG_LISTENER = createEmptyConfigListener();
-
   @GuardedBy("this")
   private final Map<String, FirebaseRemoteConfig> frcNamespaceInstances = new HashMap<>();
 
@@ -335,20 +333,9 @@ public class RemoteConfigComponent {
     return firebaseApp.getName().equals(FirebaseApp.DEFAULT_APP_NAME);
   }
 
-  private static ConfigUpdateListener createEmptyConfigListener() {
-    return new ConfigRealtimeHandler.EmptyConfigUpdateListener();
-  }
-
   private static synchronized void notifyRCInstances(boolean isInBackground) {
     for (FirebaseRemoteConfig frc : frcNamespaceInstancesStatic.values()) {
-      if (!isInBackground) {
-        // Add dummy listener and remove to trigger http stream flow.
-        ConfigUpdateListenerRegistration registration =
-            frc.addOnConfigUpdateListener(EMPTY_CONFIG_LISTENER);
-        registration.remove();
-      } else {
-        frc.pauseAllConfigUpdateListeners();
-      }
+      frc.changeConfigUpdateBackgroundState(isInBackground);
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
@@ -114,15 +113,6 @@ public class ConfigAutoFetch {
       } finally {
         httpURLConnection.disconnect();
       }
-    }
-
-    // TODO: Factor ConfigUpdateListener out of internal retry logic.
-    retryCallback.onUpdate(ConfigUpdate.create(new HashSet<>()));
-    scheduledExecutorService.shutdownNow();
-    try {
-      scheduledExecutorService.awaitTermination(3L, TimeUnit.SECONDS);
-    } catch (InterruptedException ex) {
-      Log.d(TAG, "Thread Interrupted.");
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -92,7 +92,7 @@ public class ConfigRealtimeHandler {
     return new ConfigUpdateListenerRegistrationInternal(configUpdateListener);
   }
 
-  public void setBackgroundState(boolean isInBackground) {
+  public synchronized void setBackgroundState(boolean isInBackground) {
     configRealtimeHttpClient.setRealtimeBackgroundState(isInBackground);
     if (!isInBackground) {
       beginRealtime();

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -77,7 +77,7 @@ public class ConfigRealtimeHandler {
 
   // Kicks off Http stream listening and autofetch
   private synchronized void beginRealtime() {
-    if (canCreateRealtimeHttpClientTask()) {
+    if (!listeners.isEmpty()) {
       configRealtimeHttpClient.startHttpConnection();
     }
   }
@@ -86,9 +86,7 @@ public class ConfigRealtimeHandler {
   public synchronized ConfigUpdateListenerRegistration addRealtimeConfigUpdateListener(
       @NonNull ConfigUpdateListener configUpdateListener) {
     listeners.add(configUpdateListener);
-    if (canCreateRealtimeHttpClientTask()) {
-      beginRealtime();
-    }
+    beginRealtime();
     return new ConfigUpdateListenerRegistrationInternal(configUpdateListener);
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -74,22 +74,20 @@ public class ConfigRealtimeHandler {
   }
 
   private synchronized boolean canCreateRealtimeHttpClientTask() {
-    return !listeners.isEmpty() && configRealtimeHttpClient != null;
+    return !listeners.isEmpty();
   }
 
   // Kicks off Http stream listening and autofetch
   private synchronized void beginRealtime() {
     if (canCreateRealtimeHttpClientTask()) {
       configRealtimeHttpClient.setRealtimeRetryState(true);
-      configRealtimeHttpClient.retryHTTPConnection(0);
+      configRealtimeHttpClient.tryHttpConnection(0);
     }
   }
 
   // Pauses Http stream listening
   public synchronized void pauseRealtime() {
-    if (configRealtimeHttpClient != null) {
-      configRealtimeHttpClient.setRealtimeRetryState(false);
-    }
+    configRealtimeHttpClient.setRealtimeRetryState(false);
   }
 
   @NonNull

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -75,12 +75,12 @@ public class ConfigRealtimeHandler {
   }
 
   private synchronized Runnable createRealtimeHttpClientTask(
-      ConfigRealtimeHttpClient configRealtimeHttpClient) {
+      ConfigRealtimeHttpClient realtimeHttpClient) {
     return new Runnable() {
       @Override
       public void run() {
-        configRealtimeHttpClient.beginRealtimeHttpStream();
-        while (configRealtimeHttpClient.getRetryState()) {}
+        realtimeHttpClient.beginRealtimeHttpStream();
+        while (realtimeHttpClient.getRetryState()) {}
       }
     };
   }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -71,10 +71,6 @@ public class ConfigRealtimeHandler {
     this.scheduledExecutorService = scheduledExecutorService;
   }
 
-  private synchronized boolean canCreateRealtimeHttpClientTask() {
-    return !listeners.isEmpty();
-  }
-
   // Kicks off Http stream listening and autofetch
   private synchronized void beginRealtime() {
     if (!listeners.isEmpty()) {

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -134,6 +134,10 @@ public class ConfigRealtimeHandler {
     }
   }
 
+  private synchronized void closeRealtime() {
+    realtimeHttpClientTask = null;
+  }
+
   private class RealtimeHttpClientFutureTask extends FutureTask<String> {
     private final ConfigRealtimeHttpClient configRealtimeHttpClient;
 
@@ -146,7 +150,7 @@ public class ConfigRealtimeHandler {
     @Override
     protected void done() {
       super.done();
-      realtimeHttpClientTask = null;
+      closeRealtime();
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -262,7 +262,7 @@ public class ConfigRealtimeHttpClient {
 
   /** Retries HTTP stream connection asyncly in random time intervals. */
   @SuppressLint("VisibleForTests")
-  public synchronized void retryHTTPConnection(long retrySeconds) {
+  public synchronized void tryHttpConnection(long retrySeconds) {
     if (canMakeHttpStreamConnection() && httpRetriesRemaining > 0) {
       if (httpRetriesRemaining < ORIGINAL_RETRIES) {
         retrySeconds *= getRetryMultiplier();
@@ -371,7 +371,7 @@ public class ConfigRealtimeHttpClient {
       if (responseCode == null
           || responseCode == HttpURLConnection.HTTP_OK
           || isStatusCodeRetryable(responseCode)) {
-        retryHTTPConnection(httpRetrySeconds);
+        tryHttpConnection(httpRetrySeconds);
       } else {
         propagateErrors(
             new FirebaseRemoteConfigServerException(

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -77,8 +77,9 @@ public class ConfigRealtimeHttpClient {
   @GuardedBy("this")
   private boolean isRealtimeDisabled;
 
-  /*
-   * Controls whether or not the this client should retry. Disablement is permanent for the client.
+  /**
+   * Controls whether or not this client should retry. Does not need to be synchronized because
+   * ordering of thread actions is not important since all connections will timeout after 5 minutes.
    */
   private boolean canRetry;
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -270,7 +270,7 @@ public class ConfigRealtimeHttpClient {
 
   /** Retries HTTP stream connection asyncly in random time intervals. */
   @SuppressLint("VisibleForTests")
-  public void retryHttpConnection() {
+  public synchronized void retryHttpConnection() {
     if (httpRetriesRemaining < ORIGINAL_RETRIES) {
       httpRetrySeconds *= getRetryMultiplier();
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -265,7 +265,7 @@ public class ConfigRealtimeHttpClient {
   @SuppressLint("VisibleForTests")
   public synchronized void tryHttpConnection(long retrySeconds) {
     if (canMakeHttpStreamConnection() && httpRetriesRemaining > 0) {
-      if (httpRetriesRemaining < ORIGINAL_RETRIES) {
+      if (httpRetriesRemaining < ORIGINAL_RETRIES && retrySeconds > 0) {
         retrySeconds *= getRetryMultiplier();
         httpRetrySeconds = retrySeconds;
       }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -77,10 +77,7 @@ public class ConfigRealtimeHttpClient {
   @GuardedBy("this")
   private boolean isRealtimeDisabled;
 
-  /**
-   * Controls whether or not this client should retry. Does not need to be synchronized because
-   * ordering of thread actions is not important since all connections will timeout after 5 minutes.
-   */
+  /** Flag to indicate whether or not the app is in the background or not. */
   private boolean isInBackground;
 
   private final int ORIGINAL_RETRIES = 7;
@@ -263,9 +260,9 @@ public class ConfigRealtimeHttpClient {
     return httpURLConnection;
   }
 
-  /** Initial Http stream attempt. */
+  /** Initial Http stream attempt that makes call without waiting. */
   public void startHttpConnection() {
-    tryHttpConnection(0);
+    makeRealtimeHttpConnection(/*retrySeconds*/ 0);
   }
 
   /** Retries HTTP stream connection asyncly in random time intervals. */
@@ -275,10 +272,10 @@ public class ConfigRealtimeHttpClient {
       httpRetrySeconds *= getRetryMultiplier();
     }
 
-    tryHttpConnection(httpRetrySeconds);
+    makeRealtimeHttpConnection(httpRetrySeconds);
   }
 
-  private synchronized void tryHttpConnection(long retrySeconds) {
+  private synchronized void makeRealtimeHttpConnection(long retrySeconds) {
     if (canMakeHttpStreamConnection() && httpRetriesRemaining > 0) {
       httpRetriesRemaining--;
       scheduledExecutorService.schedule(

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1192,7 +1192,7 @@ public final class FirebaseRemoteConfigTest {
         .thenReturn(Tasks.forResult(realtimeFetchedContainerResponse));
     configAutoFetch.listenForNotifications();
 
-    verify(mockRetryListener).onUpdate(any());
+    verify(mockHttpURLConnection).disconnect();
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1225,7 +1225,7 @@ public final class FirebaseRemoteConfigTest {
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
 
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy, never()).tryHttpConnection(any(Long.class));
+    verify(configRealtimeHttpClientSpy, never()).retryHttpConnection();
     verify(mockStreamErrorEventListener).onError(any(FirebaseRemoteConfigServerException.class));
   }
 
@@ -1234,38 +1234,38 @@ public final class FirebaseRemoteConfigTest {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
     doReturn(mockConfigAutoFetch).when(configRealtimeHttpClientSpy).startAutoFetch(any());
-    doNothing().when(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
+    doNothing().when(configRealtimeHttpClientSpy).retryHttpConnection();
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(mockConfigAutoFetch).listenForNotifications();
-    verify(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
+    verify(configRealtimeHttpClientSpy).retryHttpConnection();
   }
 
   @Test
   public void realtime_badGatewayStatusCode_noAutofetchButRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
+    doNothing().when(configRealtimeHttpClientSpy).retryHttpConnection();
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
+    verify(configRealtimeHttpClientSpy).retryHttpConnection();
   }
 
   @Test
   public void realtime_exceptionThrown_noAutofetchButRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doThrow(IOException.class).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
+    doNothing().when(configRealtimeHttpClientSpy).retryHttpConnection();
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
+    verify(configRealtimeHttpClientSpy).retryHttpConnection();
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1225,7 +1225,7 @@ public final class FirebaseRemoteConfigTest {
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
 
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy, never()).retryHTTPConnection();
+    verify(configRealtimeHttpClientSpy, never()).retryHTTPConnection(any());
     verify(mockStreamErrorEventListener).onError(any(FirebaseRemoteConfigServerException.class));
   }
 
@@ -1234,38 +1234,38 @@ public final class FirebaseRemoteConfigTest {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
     doReturn(mockConfigAutoFetch).when(configRealtimeHttpClientSpy).startAutoFetch(any());
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection();
+    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any());
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(mockConfigAutoFetch).listenForNotifications();
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection();
+    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any());
   }
 
   @Test
   public void realtime_badGatewayStatusCode_noAutofetchButRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection();
+    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any());
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection();
+    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any());
   }
 
   @Test
   public void realtime_exceptionThrown_noAutofetchButRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doThrow(IOException.class).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection();
+    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any());
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection();
+    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any());
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1225,7 +1225,7 @@ public final class FirebaseRemoteConfigTest {
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
 
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy, never()).retryHTTPConnection(any(Long.class));
+    verify(configRealtimeHttpClientSpy, never()).tryHttpConnection(any(Long.class));
     verify(mockStreamErrorEventListener).onError(any(FirebaseRemoteConfigServerException.class));
   }
 
@@ -1234,38 +1234,38 @@ public final class FirebaseRemoteConfigTest {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
     doReturn(mockConfigAutoFetch).when(configRealtimeHttpClientSpy).startAutoFetch(any());
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
+    doNothing().when(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(mockConfigAutoFetch).listenForNotifications();
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
+    verify(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
   }
 
   @Test
   public void realtime_badGatewayStatusCode_noAutofetchButRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
+    doNothing().when(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
+    verify(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
   }
 
   @Test
   public void realtime_exceptionThrown_noAutofetchButRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doThrow(IOException.class).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
+    doNothing().when(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
+    verify(configRealtimeHttpClientSpy).tryHttpConnection(any(Long.class));
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1225,7 +1225,7 @@ public final class FirebaseRemoteConfigTest {
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
 
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy, never()).retryHTTPConnection(any());
+    verify(configRealtimeHttpClientSpy, never()).retryHTTPConnection(any(Long.class));
     verify(mockStreamErrorEventListener).onError(any(FirebaseRemoteConfigServerException.class));
   }
 
@@ -1234,38 +1234,38 @@ public final class FirebaseRemoteConfigTest {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
     doReturn(mockConfigAutoFetch).when(configRealtimeHttpClientSpy).startAutoFetch(any());
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any());
+    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(mockConfigAutoFetch).listenForNotifications();
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any());
+    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
   }
 
   @Test
   public void realtime_badGatewayStatusCode_noAutofetchButRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any());
+    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any());
+    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
   }
 
   @Test
   public void realtime_exceptionThrown_noAutofetchButRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doThrow(IOException.class).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any());
+    doNothing().when(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
     doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());
-    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any());
+    verify(configRealtimeHttpClientSpy).retryHTTPConnection(any(Long.class));
   }
 
   @Test


### PR DESCRIPTION
Fixes bug for bug/261868622.

The source of the problem was that we when the app was going from the foreground to background, we would interrupt the thread running the Http Stream to signal to the client that we didn't want anymore connection retries.

The fix is to add update the background state change flow and not use the thread interruption anymore