### PR TITLE
Don't diff experiment metadata to determine updated keys.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -166,20 +166,10 @@ public class ConfigContainer {
     // Make a copy of the other config before modifying it
     JSONObject otherConfig = ConfigContainer.copyOf(other.containerJson).getConfigs();
 
-    // Experiments aren't associated with params, so we can just compare arrays once
-    Boolean experimentsChanged = !this.getAbtExperiments().equals(other.getAbtExperiments());
-
     Set<String> changed = new HashSet<>();
     Iterator<String> keys = this.getConfigs().keys();
     while (keys.hasNext()) {
       String key = keys.next();
-
-      // If the ABT Experiments have changed, add all keys since we don't know which keys the ABT
-      // experiments apply to
-      if (experimentsChanged) {
-        changed.add(key);
-        continue;
-      }
 
       // If the other config doesn't have the key
       if (!other.getConfigs().has(key)) {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -138,7 +138,7 @@ public class ConfigContainerTest {
   }
 
   @Test
-  public void getChangedParams_changedExperimentsMetadata_returnsAllParamKeys() throws Exception {
+  public void getChangedParams_changedExperimentsMetadata_returnsNoParamKeys() throws Exception {
     ConfigContainer config =
         ConfigContainer.newBuilder()
             .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
@@ -152,7 +152,7 @@ public class ConfigContainerTest {
 
     Set<String> changedParams = config.getChangedParams(other);
 
-    assertThat(changedParams).containsExactly("string_param");
+    assertThat(changedParams).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
For parity with iOS, which needs to persist active ABT metadata before it can perform the diff. See b/263139421.