### PR TITLE
Remove now-unnecessary lint suppression

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/UpdateTaskImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/UpdateTaskImpl.java
@@ -14,7 +14,6 @@
 
 package com.google.firebase.appdistribution.impl;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
@@ -141,7 +140,6 @@ class UpdateTaskImpl extends UpdateTask {
     return getTask().getException();
   }
 
-  @SuppressLint("TaskMainThread") // Uses default (main thread) executor to match caller's intent
   @NonNull
   @Override
   public Task<Void> addOnSuccessListener(
@@ -163,7 +161,6 @@ class UpdateTaskImpl extends UpdateTask {
     return getTask().addOnSuccessListener(activity, onSuccessListener);
   }
 
-  @SuppressLint("TaskMainThread") // Uses default (main thread) executor to match caller's intent
   @NonNull
   @Override
   public Task<Void> addOnFailureListener(@NonNull OnFailureListener onFailureListener) {
@@ -184,7 +181,6 @@ class UpdateTaskImpl extends UpdateTask {
     return getTask().addOnFailureListener(activity, onFailureListener);
   }
 
-  @SuppressLint("TaskMainThread") // Uses default (main thread) executor to match caller's intent
   @NonNull
   @Override
   public Task<Void> addOnCompleteListener(@NonNull OnCompleteListener<Void> onCompleteListener) {
@@ -205,7 +201,6 @@ class UpdateTaskImpl extends UpdateTask {
     return getTask().addOnCompleteListener(activity, onCompleteListener);
   }
 
-  @SuppressLint("TaskMainThread") // Uses default (main thread) executor to match caller's intent
   @NonNull
   @Override
   public Task<Void> addOnCanceledListener(@NonNull OnCanceledListener onCanceledListener) {
@@ -226,7 +221,6 @@ class UpdateTaskImpl extends UpdateTask {
     return getTask().addOnCanceledListener(activity, onCanceledListener);
   }
 
-  @SuppressLint("TaskMainThread") // Uses default (main thread) executor to match caller's intent
   @NonNull
   @Override
   public <TContinuationResult> Task<TContinuationResult> continueWith(
@@ -241,7 +235,6 @@ class UpdateTaskImpl extends UpdateTask {
     return getTask().continueWith(executor, continuation);
   }
 
-  @SuppressLint("TaskMainThread") // Uses default (main thread) executor to match caller's intent
   @NonNull
   @Override
   public <TContinuationResult> Task<TContinuationResult> continueWithTask(
@@ -257,7 +250,6 @@ class UpdateTaskImpl extends UpdateTask {
     return getTask().continueWithTask(executor, continuation);
   }
 
-  @SuppressLint("TaskMainThread") // Uses default (main thread) executor to match caller's intent
   @NonNull
   @Override
   public <TContinuationResult> Task<TContinuationResult> onSuccessTask(


### PR DESCRIPTION
These annotations are unnecessary since https://github.com/firebase/firebase-android-sdk/pull/4394