### PR TITLE
Some cleanup in App Distro's Dagger usage

### DIFF
--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -55,11 +55,11 @@ dependencies {
     testImplementation project(':integ-testing')
     runtimeOnly project(':firebase-installations')
 
-    implementation 'javax.inject:javax.inject:1'
-    vendor ('com.google.dagger:dagger:2.43.2') {
+    implementation libs.javax.inject
+    vendor (libs.dagger.dagger) {
         exclude group: "javax.inject", module: "javax.inject"
     }
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.43.2'
+    annotationProcessor libs.dagger.compiler
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/AabUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/AabUpdater.java
@@ -32,9 +32,11 @@ import com.google.firebase.appdistribution.UpdateTask;
 import java.io.IOException;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.net.ssl.HttpsURLConnection;
 
 /** Class that handles updateApp functionality for AABs in {@link FirebaseAppDistribution}. */
+@Singleton // Only one update should happen at a time, even across FirebaseAppDistribution instances
 class AabUpdater {
   private static final String TAG = "AabUpdater";
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkInstaller.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkInstaller.java
@@ -24,8 +24,10 @@ import com.google.firebase.appdistribution.FirebaseAppDistribution;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /** Class that handles installing APKs in {@link FirebaseAppDistribution}. */
+@Singleton // Only one update should happen at a time, even across FirebaseAppDistribution instances
 class ApkInstaller {
   private static final String TAG = "ApkInstaller";
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
@@ -37,9 +37,11 @@ import java.io.InputStream;
 import java.util.concurrent.Executor;
 import java.util.jar.JarFile;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.net.ssl.HttpsURLConnection;
 
 /** Class that handles updateApp functionality for APKs in {@link FirebaseAppDistribution}. */
+@Singleton // Only one update should happen at a time, even across FirebaseAppDistribution instances
 class ApkUpdater {
   private static final String TAG = "ApkUpdater";
   private static final int UPDATE_INTERVAL_MS = 250;

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -48,11 +48,14 @@ import com.google.firebase.appdistribution.UpdateTask;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * This class is the "real" implementation of the Firebase App Distribution API which should only be
  * included in pre-release builds.
  */
+// TODO(b/266704696): This currently only supports one FirebaseAppDistribution instance app-wide
+@Singleton
 class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
 
   private static final String TAG = "Impl";

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionRegistrar.java
@@ -99,7 +99,7 @@ public class FirebaseAppDistributionRegistrar implements ComponentRegistrar {
 
     if (applicationContext instanceof Application) {
       Application application = (Application) applicationContext;
-      application.registerActivityLifecycleCallbacks(appDistroComponent.getLifecycleNotifier());
+      appDistroComponent.getLifecycleNotifier().registerActivityLifecycleCallbacks(application);
     } else {
       LogWrapper.e(
           TAG,

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ScreenshotTaker.java
@@ -37,8 +37,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /** A class that takes screenshots of the host app. */
+@Singleton // All instances store images at the same URI, so there should really only be one
 class ScreenshotTaker {
 
   static final String SCREENSHOT_FILE_NAME =

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
@@ -23,8 +23,11 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.annotations.concurrent.Background;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /** Class that handles storage for App Distribution SignIn persistence. */
+// TODO(b/266704696): This currently only supports one FirebaseAppDistribution instance app-wide
+@Singleton
 class SignInStorage {
   @VisibleForTesting
   static final String SIGNIN_PREFERENCES_NAME = "FirebaseAppDistributionSignInStorage";

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
@@ -39,8 +39,11 @@ import com.google.firebase.installations.FirebaseInstallationsApi;
 import java.util.List;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /** Class that handles signing in the tester. */
+// TODO(b/266704696): This currently only supports one FirebaseAppDistribution instance app-wide
+@Singleton
 class TesterSignInManager {
   private static final String TAG = "TesterSignInManager";
 

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifierTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionLifecycleNotifierTest.java
@@ -71,7 +71,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     Task<Void> task = lifecycleNotifier.consumeForegroundActivity(consumer);
 
     // Simulate an activity resuming
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     assertThat(task.isComplete()).isTrue();
     assertThat(task.isSuccessful()).isTrue();
@@ -83,7 +83,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
   public void consumeForegroundActivity_withCurrentActivity_succeedsAndCallsConsumer() {
     // Resume an activity so there is a current foreground activity already when
     // consumeForegroundActivity is called
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     ActivityConsumer consumer = mock(ActivityConsumer.class);
     Task<Void> task = lifecycleNotifier.consumeForegroundActivity(consumer);
@@ -102,7 +102,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     Task<Void> task = lifecycleNotifier.consumeForegroundActivity(consumer);
 
     // Simulate an activity resuming
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     awaitTaskFailure(task, Status.UNKNOWN, "Unknown", consumerException);
   }
@@ -115,7 +115,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     Task<String> task = lifecycleNotifier.applyToForegroundActivity(function);
 
     // Simulate an activity resuming
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     assertThat(task.isComplete()).isTrue();
     assertThat(task.isSuccessful()).isTrue();
@@ -129,7 +129,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     when(function.apply(activity)).thenReturn("return-value");
     // Resume an activity so there is a current foreground activity already when
     // applyToForegroundActivity is called
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     Task<String> task = lifecycleNotifier.applyToForegroundActivity(function);
 
@@ -147,7 +147,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     Task<String> task = lifecycleNotifier.applyToForegroundActivity(function);
 
     // Simulate an activity resuming
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     awaitTaskFailure(task, Status.UNKNOWN, "Unknown", functionException);
   }
@@ -157,7 +157,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
       throws Exception {
     // Resume an activity so there is a current foreground activity already when
     // applyToForegroundActivityTask is called
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     SuccessContinuation<Activity, String> continuation = mock(SuccessContinuation.class);
     when(continuation.then(activity)).thenReturn(Tasks.forResult("result"));
@@ -176,7 +176,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     Task<String> task = lifecycleNotifier.applyToForegroundActivityTask(continuation);
 
     // Simulate an activity resuming
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     assertThat(task.isComplete()).isTrue();
     assertThat(task.isSuccessful()).isTrue();
@@ -193,7 +193,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     Task<String> task = lifecycleNotifier.applyToForegroundActivityTask(continuation);
 
     // Simulate an activity resuming
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     awaitTaskFailure(task, Status.AUTHENTICATION_CANCELED, "exception in continuation task");
   }
@@ -207,7 +207,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     Task<String> task = lifecycleNotifier.applyToForegroundActivityTask(continuation);
 
     // Simulate an activity resuming
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     awaitTaskFailure(task, Status.UNKNOWN, "Unknown", continuationException);
   }
@@ -221,7 +221,7 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
     Task<String> task = lifecycleNotifier.applyToForegroundActivityTask(continuation);
 
     // Simulate an activity resuming
-    lifecycleNotifier.onActivityResumed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(activity);
 
     assertThat(task.isSuccessful()).isFalse();
     assertThat(task.getException()).isInstanceOf(RuntimeException.class);
@@ -234,7 +234,8 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
       throws FirebaseAppDistributionException {
     NullableActivityFunction<String> function = mock(NullableActivityFunction.class);
     when(function.apply(any())).thenReturn("return-value");
-    lifecycleNotifier.onActivityResumed(activity); // Current activity is a TestActivity
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(
+        activity); // Current activity is a TestActivity
 
     Task<String> task =
         lifecycleNotifier.applyToNullableForegroundActivity(OtherTestActivity.class, function);
@@ -251,9 +252,11 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
       throws FirebaseAppDistributionException {
     NullableActivityFunction<String> function = mock(NullableActivityFunction.class);
     when(function.apply(any())).thenReturn("return-value");
-    lifecycleNotifier.onActivityResumed(activity); // First activity is a TestActivity
-    lifecycleNotifier.onActivityPaused(activity);
-    lifecycleNotifier.onActivityResumed(otherActivity); // Second activity is a OtherTestActivity
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(
+        activity); // First activity is a TestActivity
+    lifecycleNotifier.lifecycleCallbacks.onActivityPaused(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(
+        otherActivity); // Second activity is a OtherTestActivity
 
     Task<String> task =
         lifecycleNotifier.applyToNullableForegroundActivity(OtherTestActivity.class, function);
@@ -270,10 +273,12 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
       throws FirebaseAppDistributionException {
     NullableActivityFunction<String> function = mock(NullableActivityFunction.class);
     when(function.apply(any())).thenReturn("return-value");
-    lifecycleNotifier.onActivityResumed(activity); // First activity is a TestActivity
-    lifecycleNotifier.onActivityPaused(activity);
-    lifecycleNotifier.onActivityResumed(otherActivity); // Second activity is a OtherTestActivity
-    lifecycleNotifier.onActivityDestroyed(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(
+        activity); // First activity is a TestActivity
+    lifecycleNotifier.lifecycleCallbacks.onActivityPaused(activity);
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(
+        otherActivity); // Second activity is a OtherTestActivity
+    lifecycleNotifier.lifecycleCallbacks.onActivityDestroyed(activity);
 
     Task<String> task =
         lifecycleNotifier.applyToNullableForegroundActivity(OtherTestActivity.class, function);
@@ -290,7 +295,8 @@ public class FirebaseAppDistributionLifecycleNotifierTest {
       throws FirebaseAppDistributionException {
     NullableActivityFunction<String> function = mock(NullableActivityFunction.class);
     when(function.apply(any())).thenReturn("return-value");
-    lifecycleNotifier.onActivityResumed(activity); // Current activity is a TestActivity
+    lifecycleNotifier.lifecycleCallbacks.onActivityResumed(
+        activity); // Current activity is a TestActivity
 
     Task<String> task =
         lifecycleNotifier.applyToNullableForegroundActivity(TestActivity.class, function);


### PR DESCRIPTION
- Use the project-wide dagger version
- Mark classes as `@Singleton` if there should only be one instance present in the app
- Ensure the singleton `FirebaseAppDistributionLifecycleNotifier` is only registered with the application once
