### PR TITLE
Realtime RC Bug Patch: Fixes deadlock issue that caused app to freeze when transitioning from background to foreground

### DIFF
--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1220,7 +1220,9 @@ public final class FirebaseRemoteConfigTest {
   public void realtime_redirectStatusCode_noRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
-    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
+    doNothing()
+        .when(configRealtimeHttpClientSpy)
+        .closeRealtimeHttpStream(any(HttpURLConnection.class));
     when(mockHttpURLConnection.getResponseCode()).thenReturn(301);
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
 
@@ -1235,7 +1237,9 @@ public final class FirebaseRemoteConfigTest {
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
     doReturn(mockConfigAutoFetch).when(configRealtimeHttpClientSpy).startAutoFetch(any());
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnection();
-    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
+    doNothing()
+        .when(configRealtimeHttpClientSpy)
+        .closeRealtimeHttpStream(any(HttpURLConnection.class));
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
@@ -1248,7 +1252,9 @@ public final class FirebaseRemoteConfigTest {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnection();
-    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
+    doNothing()
+        .when(configRealtimeHttpClientSpy)
+        .closeRealtimeHttpStream(any(HttpURLConnection.class));
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
@@ -1261,7 +1267,9 @@ public final class FirebaseRemoteConfigTest {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doThrow(IOException.class).when(configRealtimeHttpClientSpy).createRealtimeConnection();
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnection();
-    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
+    doNothing()
+        .when(configRealtimeHttpClientSpy)
+        .closeRealtimeHttpStream(any(HttpURLConnection.class));
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     verify(configRealtimeHttpClientSpy, never()).startAutoFetch(any());


### PR DESCRIPTION
**Problem:**  Bug that occurs when app goes from foreground -> background -> foreground causing the app to freezes due to a deadlock. This happens b/c beginRealtimeHttpStream is synchronized and blocking, when the app goes from background -> foreground it tries to restart the stream and calls makeRealtimeHttpConnection. Since beginRealtimeHttpStream is blocking, the call to makeRealtimeHttpConnection is blocked until the connection is finished after 5 min 
due to the synchronization from the first method.

**Solution:** Make beginRealtimeHttpStream not synchronized by moving the "GuardedBy" variable to other, synchronized methods.