### PR TITLE
Bump google-services from 4.3.3 to 4.3.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ buildscript {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.14'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:1.3.0'
         classpath 'gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.9'
-        classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'com.google.gms:google-services:4.3.15'
         classpath "com.ncorti.ktfmt.gradle:plugin:0.11.0"
     }
 }


### PR DESCRIPTION
Bumps google-services from 4.3.3 to 4.3.15.

updated-dependencies:
- dependency-name: com.google.gms:google-services
  dependency-type: direct:production
  update-type: version-update:semver-patch

Signed-off-by: dependabot[bot] <support@github.com>