### PR TITLE
Make a deep copy of the other config before modifying it to compute changes.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -164,7 +164,8 @@ public class ConfigContainer {
    */
   public Set<String> getChangedParams(ConfigContainer other) throws JSONException {
     // Make a copy of the other config before modifying it
-    JSONObject otherConfig = ConfigContainer.copyOf(other.containerJson).getConfigs();
+    JSONObject otherConfig =
+        ConfigContainer.copyOf(new JSONObject(other.containerJson.toString())).getConfigs();
 
     Set<String> changed = new HashSet<>();
     Iterator<String> keys = this.getConfigs().keys();

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -92,7 +92,7 @@ public class ConfigContainer {
   /**
    * Returns a {@link ConfigContainer} that wraps the {@code containerJson}.
    *
-   * <p>The {@code containerJson} must not be modified.
+   * <p>This is a shallow copy so {@code containerJson} must not be modified.
    */
   static ConfigContainer copyOf(JSONObject containerJson) throws JSONException {
     // Personalization metadata may not have been written yet.
@@ -108,6 +108,16 @@ public class ConfigContainer {
         containerJson.getJSONArray(ABT_EXPERIMENTS_KEY),
         personalizationMetadataJSON,
         containerJson.getLong(TEMPLATE_VERSION_NUMBER_KEY));
+  }
+
+  /**
+   * Returns a new {@link ConfigContainer} containing a deep copy of {@code containerJson}.
+   *
+   * <p>This is a deep copy so it may be modified without affecting the original.
+   */
+  private static ConfigContainer deepCopyOf(JSONObject containerJson) throws JSONException {
+    JSONObject deepCopyJson = new JSONObject(containerJson.toString());
+    return ConfigContainer.copyOf(deepCopyJson);
   }
 
   /**
@@ -163,9 +173,8 @@ public class ConfigContainer {
    * @throws JSONException
    */
   public Set<String> getChangedParams(ConfigContainer other) throws JSONException {
-    // Make a copy of the other config before modifying it
-    JSONObject otherConfig =
-        ConfigContainer.copyOf(new JSONObject(other.containerJson.toString())).getConfigs();
+    // Make a deep copy of the other config before modifying it
+    JSONObject otherConfig = ConfigContainer.deepCopyOf(other.containerJson).getConfigs();
 
     Set<String> changed = new HashSet<>();
     Iterator<String> keys = this.getConfigs().keys();

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -235,6 +235,26 @@ public class ConfigContainerTest {
         .containsExactly("string_param", "long_param", "bool_param", "feature_1");
   }
 
+  @Test
+  public void getChangedParams_configsUnmodified() throws Exception {
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .build();
+
+    // ConfigContainer#getChangedParams should not modify either comparison argument.
+    config.getChangedParams(other);
+
+    String configsString = new JSONObject("{string_param: value_1}").toString();
+    assertThat(config.getConfigs().toString()).isEqualTo(configsString);
+    assertThat(other.getConfigs().toString()).isEqualTo(configsString);
+  }
+
   private static JSONArray generateAbtExperiments(int numExperiments) throws JSONException {
     JSONArray experiments = new JSONArray();
     for (int experimentNum = 1; experimentNum <= numExperiments; experimentNum++) {


### PR DESCRIPTION
`ConfigContainer.copyOf` does not make a true "copy". The `other` `ConfigContainer` should not be modified between fetching and activating, since this produces an inaccurate activated config.