### PR TITLE
Catch SQLException when doing best effort forced send in Crashlytics.

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [changed] Improved crash reporting reliability for crashes that occur early in the app's
+  lifecycle.
 
 # 18.3.2
 * [unchanged] Updated to accommodate the release of the updated

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/send/ReportQueue.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/send/ReportQueue.java
@@ -15,6 +15,7 @@
 package com.google.firebase.crashlytics.internal.send;
 
 import android.annotation.SuppressLint;
+import android.database.SQLException;
 import com.google.android.datatransport.Event;
 import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.Transport;
@@ -128,7 +129,11 @@ final class ReportQueue {
     CountDownLatch latch = new CountDownLatch(1);
     new Thread(
             () -> {
-              ForcedSender.sendBlocking(transport, Priority.HIGHEST);
+              try {
+                ForcedSender.sendBlocking(transport, Priority.HIGHEST);
+              } catch (SQLException ignored) {
+                // best effort only.
+              }
               latch.countDown();
             })
         .start();


### PR DESCRIPTION
This exception gets thrown sometimes when Crashlytics attempts to do a forced send at a bad time (#4496). Since the forced send is best effort anyway, it is safe to just fail in this case and let the regular scheduled send happen on the next launch.