### PR TITLE
Implement the GitSubmodulePlugin

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/ShellExecutor.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/bomgenerator/tagging/ShellExecutor.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.gradle.api.GradleException;
 
+// TODO(b/267668143): With modernization efforts
 public class ShellExecutor {
   private final Runtime runtime;
   private final File cwd;

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.java
@@ -123,6 +123,8 @@ public class FirebaseLibraryPlugin implements Plugin<Project> {
                         ImmutableList.of("-module-name", kotlinModuleName(project))));
 
     project.getPluginManager().apply(DackkaPlugin.class);
+    project.getPluginManager().apply(GitSubmodulePlugin.class);
+    project.getTasks().getByName("preBuild").dependsOn("updateGitSubmodules");
   }
 
   private static void setupApiInformationAnalysis(Project project, LibraryExtension android) {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GitSubmodulePlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GitSubmodulePlugin.kt
@@ -11,8 +11,7 @@ import org.gradle.kotlin.dsl.register
 /**
  * Exposes configuration for [GitSubmodulePlugin].
  *
- * @param submodules the parent directory of the given SDK's Git Submodules.
- * This defaults to `src/third_party`
+ * @param submodules the parent directory of the SDK's Git Submodules. Defaults to `src/third_party`
  */
 interface GitSubmodulePluginExtension {
   val submodules: Property<File>
@@ -29,9 +28,9 @@ interface GitSubmodulePluginExtension {
  * subsequently bound to the `preBuild` task that is apart of all gradle modules.
  *
  * The following tasks are registered when this plugin is applied:
- *  - [initializeGitSubmodules][registerInitializeGitSubmodulesTask]
- *  - [updateGitSubmodules][registerUpdateGitSubmodulesTask]
- *  - [removeGitSubmodules][registerRemoveGitSubmodulesTask]
+ * - [initializeGitSubmodules][registerInitializeGitSubmodulesTask]
+ * - [updateGitSubmodules][registerUpdateGitSubmodulesTask]
+ * - [removeGitSubmodules][registerRemoveGitSubmodulesTask]
  *
  * __Documentation explaining each task is provided in the annotation for each task__
  *

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GitSubmodulePlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GitSubmodulePlugin.kt
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.gradle.plugins
 
 import java.io.File

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GitSubmodulePlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GitSubmodulePlugin.kt
@@ -21,10 +21,9 @@ interface GitSubmodulePluginExtension {
 /**
  * Helper plugin for common actions regarding Git Submodules
  *
- * At the time of writing this, we only have one SDK with submodules. Although, that could go
- * grow in the future. More importantly though, this provides a way for us to make sure the
- * submodules are initilized whenever we are building said SDKs- while keeping our system clean
- * and modular.
+ * At the time of writing this, we only have one SDK with submodules. Although, that could grow in
+ * the future. More importantly though, this provides a way for us to make sure the submodules are
+ * initilized whenever we are building said SDKs- while keeping our system clean and modular.
  *
  * This plugin is automatically applied to all SDKs that utilize [FirebaseLibraryPlugin], and is
  * subsequently bound to the `preBuild` task that is apart of all gradle modules.

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GitSubmodulePlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GitSubmodulePlugin.kt
@@ -1,0 +1,116 @@
+package com.google.firebase.gradle.plugins
+
+import java.io.File
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Exec
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Exposes configuration for [GitSubmodulePlugin].
+ *
+ * @param submodules the parent directory of the given SDK's Git Submodules.
+ * This defaults to `src/third_party`
+ */
+interface GitSubmodulePluginExtension {
+  val submodules: Property<File>
+}
+
+/**
+ * Helper plugin for common actions regarding Git Submodules
+ *
+ * At the time of writing this, we only have one SDK with submodules. Although, that could go
+ * grow in the future. More importantly though, this provides a way for us to make sure the
+ * submodules are initilized whenever we are building said SDKs- while keeping our system clean
+ * and modular.
+ *
+ * This plugin is automatically applied to all SDKs that utilize [FirebaseLibraryPlugin], and is
+ * subsequently bound to the `preBuild` task that is apart of all gradle modules.
+ *
+ * The following tasks are registered when this plugin is applied:
+ *  - [initializeGitSubmodules][registerInitializeGitSubmodulesTask]
+ *  - [updateGitSubmodules][registerUpdateGitSubmodulesTask]
+ *  - [removeGitSubmodules][registerRemoveGitSubmodulesTask]
+ *
+ * __Documentation explaining each task is provided in the annotation for each task__
+ *
+ * @see [GitSubmodulePluginExtension]
+ */
+abstract class GitSubmodulePlugin : Plugin<Project> {
+
+  override fun apply(project: Project) {
+    with(configureExtension(project)) {
+      registerInitializeGitSubmodulesTask(project, submodules.get())
+      registerUpdateGitSubmodulesTask(project, submodules.get())
+      registerRemoveGitSubmodulesTask(project, submodules.get())
+    }
+  }
+
+  private fun configureExtension(project: Project) =
+    project.extensions.create<GitSubmodulePluginExtension>("GitSubmodule").apply {
+      submodules.convention(project.file("src/third_party"))
+    }
+
+  /**
+   * Registers the initializeGitSubmodules Task for the provided [Project].
+   *
+   * Creates a local configuration for the predefined submodules. It does this by running the
+   * command `git submodule init` from the [project]'s root directory.
+   *
+   * If there aren't any submodules to initialize, this task is skipped- saving resources.
+   *
+   * @param project the [Project] to register this task to
+   * @param submodules the root directory of where the submodules live
+   */
+  private fun registerInitializeGitSubmodulesTask(project: Project, submodules: File) =
+    project.tasks.register<Exec>("initializeGitSubmodules") {
+      onlyIf { hasEmptySubmodules(submodules) }
+
+      workingDir = project.projectDir
+      commandLine = "git submodule init".split(" ")
+    }
+
+  /**
+   * Registers the updateGitSubmodules Task for the provided [Project].
+   *
+   * Pulls the latest data for each submodule, similiar to `git pull`. It does this by running the
+   * command `git submodule update` from the [project]'s root directory.
+   *
+   * If there aren't any submodules, this task is skipped- saving resources.
+   *
+   * @param project the [Project] to register this task to
+   * @param submodules the root directory of where the submodules live
+   */
+  private fun registerUpdateGitSubmodulesTask(project: Project, submodules: File) =
+    project.tasks.register<Exec>("updateGitSubmodules") {
+      onlyIf { hasEmptySubmodules(submodules) }
+      dependsOn("initializeGitSubmodules")
+
+      workingDir = project.projectDir
+      commandLine = "git submodule update".split(" ")
+    }
+
+  /**
+   * Registers the removeGitSubmodules Task for the provided [Project].
+   *
+   * Removes and de initilizes all submodules for the given [project]. It does this by running the
+   * command `git submodule deinit --all` from the [project]'s root directory.
+   *
+   * If there aren't any submodules to remove, this task is skipped- saving resources.
+   *
+   * @param project the [Project] to register this task to
+   * @param submodules the root directory of where the submodules live
+   */
+  private fun registerRemoveGitSubmodulesTask(project: Project, submodules: File) =
+    project.tasks.register<Exec>("removeGitSubmodules") {
+      onlyIf { submodules.exists() }
+
+      workingDir = project.projectDir
+      commandLine = "git submodule deinit --all".split(" ")
+    }
+
+  private fun hasEmptySubmodules(parentFolder: File) =
+    parentFolder.listFilesOrEmpty().any { it.isDirectory && it.listFilesOrEmpty().isEmpty() }
+}

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
@@ -44,3 +44,15 @@ fun Project.fileFromBuildDir(path: String) = file("$buildDir/$path")
  */
 fun Project.childFile(provider: Provider<File>, childPath: String) =
   provider.map { file("${it.path}/$childPath") }
+
+/**
+ * Returns a list of children files, or an empty list if this [File] doesn't exist or doesn't have
+ * any children.
+ *
+ * Syntax sugar for:
+ *
+ * ```
+ * listFiles().orEmpty()
+ * ```
+ */
+fun File.listFilesOrEmpty() = listFiles().orEmpty()


### PR DESCRIPTION
Per [b/267779128](https://b.corp.google.com/issues/267779128),

This adds a new Plugin called `GitSubmodulePlugin`. It's a light weight plugin that facilitates interaction with Git Submodules from Gradle. 

Our current release action is broken ([b/267188389](https://b.corp.google.com/issues/267188389)), because we have SDKs with submodules- but never actually pull the submodules as apart of our build process. We _could_ get away with just a quick little hacky task to fix this, but I opted for a Plugin instead. Primarily to take advantage of the following benefits:
 - Better build times through native Gradle plugin improvements
 - More modular implementation, should any other SDKs start using Git Submodules
 - Further establishment of plugin design principles in Gradle/Kotlin
 - Easier to maintain and document

Documentation is provided as annotations in KDoc form for everything added, including the tasks themselves. Namely, the plugin adds three tasks:

`initializeGitSubmodules`
`updateGitSubmodules`
`removeGitSubmodules`

Each task is annotated with background information on what it does.

_Note that this plugin also binds the updating of submodules to the build process, so this immediately fixes our release pipeline without further action._