### PR TITLE
Add change log entry missing from previous commit

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 * [changed] Improved crash reporting reliability for crashes that occur early in the app's
   lifecycle.
+* [changed] Add improved support capturing build ids for Native ANRs on older
+  Android versions.
 
 # 18.3.2
 * [unchanged] Updated to accommodate the release of the updated


### PR DESCRIPTION
Previous commit to add build ids for Native ANRs on pre-Android 12 versions: https://github.com/firebase/firebase-android-sdk/pull/4444