### PR TITLE
Pass trigger header on commit feedback call

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
@@ -47,7 +47,7 @@ class FeedbackSender {
             lightweightExecutor, feedbackName -> attachScreenshot(feedbackName, screenshotUri))
         .onSuccessTask(
             lightweightExecutor,
-            (feedbackName) -> testerApiClient.commitFeedback(feedbackName, trigger));
+            feedbackName -> testerApiClient.commitFeedback(feedbackName, trigger));
   }
 
   private Task<String> attachScreenshot(String feedbackName, @Nullable Uri screenshotUri) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackSender.java
@@ -42,10 +42,12 @@ class FeedbackSender {
       @Nullable Uri screenshotUri,
       FeedbackTrigger trigger) {
     return testerApiClient
-        .createFeedback(releaseName, feedbackText, trigger)
+        .createFeedback(releaseName, feedbackText)
         .onSuccessTask(
             lightweightExecutor, feedbackName -> attachScreenshot(feedbackName, screenshotUri))
-        .onSuccessTask(lightweightExecutor, testerApiClient::commitFeedback);
+        .onSuccessTask(
+            lightweightExecutor,
+            (feedbackName) -> testerApiClient.commitFeedback(feedbackName, trigger));
   }
 
   private Task<String> attachScreenshot(String feedbackName, @Nullable Uri screenshotUri) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
@@ -139,18 +139,14 @@ class FirebaseAppDistributionTesterApiClient {
 
   /** Creates a new feedback from the given text, and returns the feedback name. */
   @NonNull
-  Task<String> createFeedback(
-      String testerReleaseName, String feedbackText, FeedbackTrigger trigger) {
+  Task<String> createFeedback(String testerReleaseName, String feedbackText) {
     return runWithFidAndToken(
         (unused, token) -> {
           LogWrapper.i(TAG, "Creating feedback for release: " + testerReleaseName);
           String path = String.format("v1alpha/%s/feedbackReports", testerReleaseName);
           String requestBody = buildCreateFeedbackBody(feedbackText).toString();
-          Map<String, String> extraHeaders = new HashMap<>();
-          extraHeaders.put(X_APP_DISTRO_FEEDBACK_TRIGGER, trigger.toString());
           JSONObject responseBody =
-              testerApiHttpClient.makePostRequest(
-                  CREATE_FEEDBACK_TAG, path, token, requestBody, extraHeaders);
+              testerApiHttpClient.makePostRequest(CREATE_FEEDBACK_TAG, path, token, requestBody);
           return parseJsonFieldFromResponse(responseBody, "name");
         });
   }
@@ -174,13 +170,15 @@ class FirebaseAppDistributionTesterApiClient {
 
   /** Commits the feedback with the given name. */
   @NonNull
-  Task<Void> commitFeedback(String feedbackName) {
+  Task<Void> commitFeedback(String feedbackName, FeedbackTrigger trigger) {
     return runWithFidAndToken(
         (unused, token) -> {
           LogWrapper.i(TAG, "Committing feedback: " + feedbackName);
           String path = "v1alpha/" + feedbackName + ":commit";
+          Map<String, String> extraHeaders = new HashMap<>();
+          extraHeaders.put(X_APP_DISTRO_FEEDBACK_TRIGGER, trigger.toString());
           testerApiHttpClient.makePostRequest(
-              COMMIT_FEEDBACK_TAG, path, token, /* requestBody= */ "");
+              COMMIT_FEEDBACK_TAG, path, token, /* requestBody= */ "", extraHeaders);
           return null;
         });
   }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FeedbackSenderTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FeedbackSenderTest.java
@@ -59,39 +59,37 @@ public class FeedbackSenderTest {
 
   @Test
   public void sendFeedback_success() throws Exception {
-    when(mockTesterApiClient.createFeedback(
-            TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, FeedbackTrigger.CUSTOM))
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
     when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_URI))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
-    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME)).thenReturn(Tasks.forResult(null));
+    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME, FeedbackTrigger.CUSTOM))
+        .thenReturn(Tasks.forResult(null));
 
     Task<Void> task =
         feedbackSender.sendFeedback(
             TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, TEST_SCREENSHOT_URI, FeedbackTrigger.CUSTOM);
     TestUtils.awaitTask(task);
 
-    verify(mockTesterApiClient)
-        .createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, FeedbackTrigger.CUSTOM);
+    verify(mockTesterApiClient).createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT);
     verify(mockTesterApiClient).attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_URI);
-    verify(mockTesterApiClient).commitFeedback(TEST_FEEDBACK_NAME);
+    verify(mockTesterApiClient).commitFeedback(TEST_FEEDBACK_NAME, FeedbackTrigger.CUSTOM);
   }
 
   @Test
   public void sendFeedback_withoutScreenshot_success() throws Exception {
-    when(mockTesterApiClient.createFeedback(
-            TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, FeedbackTrigger.CUSTOM))
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
-    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME)).thenReturn(Tasks.forResult(null));
+    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME, FeedbackTrigger.CUSTOM))
+        .thenReturn(Tasks.forResult(null));
 
     Task<Void> task =
         feedbackSender.sendFeedback(
             TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, /* screenshot= */ null, FeedbackTrigger.CUSTOM);
     TestUtils.awaitTask(task);
 
-    verify(mockTesterApiClient)
-        .createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, FeedbackTrigger.CUSTOM);
-    verify(mockTesterApiClient).commitFeedback(TEST_FEEDBACK_NAME);
+    verify(mockTesterApiClient).createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT);
+    verify(mockTesterApiClient).commitFeedback(TEST_FEEDBACK_NAME, FeedbackTrigger.CUSTOM);
     verify(mockTesterApiClient, never()).attachScreenshot(any(), any());
   }
 
@@ -99,8 +97,7 @@ public class FeedbackSenderTest {
   public void sendFeedback_createFeedbackFails_failsTask() {
     FirebaseAppDistributionException cause =
         new FirebaseAppDistributionException("test ex", Status.AUTHENTICATION_FAILURE);
-    when(mockTesterApiClient.createFeedback(
-            TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, FeedbackTrigger.CUSTOM))
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
         .thenReturn(Tasks.forException(cause));
 
     Task<Void> task =
@@ -112,8 +109,7 @@ public class FeedbackSenderTest {
 
   @Test
   public void sendFeedback_attachScreenshotFails_failsTask() {
-    when(mockTesterApiClient.createFeedback(
-            TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, FeedbackTrigger.CUSTOM))
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
     FirebaseAppDistributionException cause =
         new FirebaseAppDistributionException("test ex", Status.AUTHENTICATION_FAILURE);
@@ -129,14 +125,13 @@ public class FeedbackSenderTest {
 
   @Test
   public void sendFeedback_commitFeedbackFails_failsTask() {
-    when(mockTesterApiClient.createFeedback(
-            TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT, FeedbackTrigger.CUSTOM))
+    when(mockTesterApiClient.createFeedback(TEST_RELEASE_NAME, TEST_FEEDBACK_TEXT))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
     when(mockTesterApiClient.attachScreenshot(TEST_FEEDBACK_NAME, TEST_SCREENSHOT_URI))
         .thenReturn(Tasks.forResult(TEST_FEEDBACK_NAME));
     FirebaseAppDistributionException cause =
         new FirebaseAppDistributionException("test ex", Status.AUTHENTICATION_FAILURE);
-    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME))
+    when(mockTesterApiClient.commitFeedback(TEST_FEEDBACK_NAME, FeedbackTrigger.CUSTOM))
         .thenReturn(Tasks.forException(cause));
 
     Task<Void> task =

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
@@ -305,15 +305,12 @@ public class FirebaseAppDistributionTesterApiClientTest {
   @Test
   public void createFeedback_whenResponseSuccessful_returnsFeedbackName() throws Exception {
     String postBody = String.format("{\"text\":\"%s\"}", FEEDBACK_TEXT);
-    Map<String, String> extraHeaders = new HashMap<>();
-    extraHeaders.put("X-APP-DISTRO-FEEDBACK-TRIGGER", "custom");
     when(mockTesterApiHttpClient.makePostRequest(
-            any(), eq(CREATE_FEEDBACK_PATH), eq(TEST_AUTH_TOKEN), eq(postBody), eq(extraHeaders)))
+            any(), eq(CREATE_FEEDBACK_PATH), eq(TEST_AUTH_TOKEN), eq(postBody)))
         .thenReturn(buildFeedbackJson());
 
     Task<String> task =
-        firebaseAppDistributionTesterApiClient.createFeedback(
-            RELEASE_NAME, FEEDBACK_TEXT, FeedbackTrigger.CUSTOM);
+        firebaseAppDistributionTesterApiClient.createFeedback(RELEASE_NAME, FEEDBACK_TEXT);
     String result = awaitTask(task);
 
     assertThat(result).isEqualTo(FEEDBACK_NAME);
@@ -325,8 +322,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forException(expectedException));
 
     Task<String> task =
-        firebaseAppDistributionTesterApiClient.createFeedback(
-            RELEASE_NAME, FEEDBACK_TEXT, FeedbackTrigger.CUSTOM);
+        firebaseAppDistributionTesterApiClient.createFeedback(RELEASE_NAME, FEEDBACK_TEXT);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex", expectedException);
   }
@@ -338,8 +334,7 @@ public class FirebaseAppDistributionTesterApiClientTest {
         .thenReturn(Tasks.forException(expectedException));
 
     Task<String> task =
-        firebaseAppDistributionTesterApiClient.createFeedback(
-            RELEASE_NAME, FEEDBACK_TEXT, FeedbackTrigger.CUSTOM);
+        firebaseAppDistributionTesterApiClient.createFeedback(RELEASE_NAME, FEEDBACK_TEXT);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex", expectedException);
   }
@@ -347,26 +342,29 @@ public class FirebaseAppDistributionTesterApiClientTest {
   @Test
   public void createFeedback_whenClientThrowsException_failsTask() throws Exception {
     String postBody = String.format("{\"text\":\"%s\"}", FEEDBACK_TEXT);
-    Map<String, String> extraHeaders = new HashMap<>();
-    extraHeaders.put("X-APP-DISTRO-FEEDBACK-TRIGGER", "custom");
+
     when(mockTesterApiHttpClient.makePostRequest(
-            any(), eq(CREATE_FEEDBACK_PATH), eq(TEST_AUTH_TOKEN), eq(postBody), eq(extraHeaders)))
+            any(), eq(CREATE_FEEDBACK_PATH), eq(TEST_AUTH_TOKEN), eq(postBody)))
         .thenThrow(new FirebaseAppDistributionException("test ex", Status.UNKNOWN));
 
     Task<String> task =
-        firebaseAppDistributionTesterApiClient.createFeedback(
-            RELEASE_NAME, FEEDBACK_TEXT, FeedbackTrigger.CUSTOM);
+        firebaseAppDistributionTesterApiClient.createFeedback(RELEASE_NAME, FEEDBACK_TEXT);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex");
   }
 
   @Test
   public void commitFeedback_whenResponseSuccessful_makesPostRequest() throws Exception {
-    Task<Void> task = firebaseAppDistributionTesterApiClient.commitFeedback(FEEDBACK_NAME);
+    Task<Void> task =
+        firebaseAppDistributionTesterApiClient.commitFeedback(
+            FEEDBACK_NAME, FeedbackTrigger.CUSTOM);
     awaitTask(task);
 
+    Map<String, String> extraHeaders = new HashMap<>();
+    extraHeaders.put("X-APP-DISTRO-FEEDBACK-TRIGGER", "custom");
     verify(mockTesterApiHttpClient)
-        .makePostRequest(any(), eq(COMMIT_FEEDBACK_PATH), eq(TEST_AUTH_TOKEN), eq(""));
+        .makePostRequest(
+            any(), eq(COMMIT_FEEDBACK_PATH), eq(TEST_AUTH_TOKEN), eq(""), eq(extraHeaders));
   }
 
   @Test
@@ -374,7 +372,9 @@ public class FirebaseAppDistributionTesterApiClientTest {
     Exception expectedException = new Exception("test ex");
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forException(expectedException));
 
-    Task<Void> task = firebaseAppDistributionTesterApiClient.commitFeedback(FEEDBACK_NAME);
+    Task<Void> task =
+        firebaseAppDistributionTesterApiClient.commitFeedback(
+            FEEDBACK_NAME, FeedbackTrigger.CUSTOM);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex", expectedException);
   }
@@ -385,18 +385,24 @@ public class FirebaseAppDistributionTesterApiClientTest {
     when(mockFirebaseInstallations.getToken(false))
         .thenReturn(Tasks.forException(expectedException));
 
-    Task<Void> task = firebaseAppDistributionTesterApiClient.commitFeedback(FEEDBACK_NAME);
+    Task<Void> task =
+        firebaseAppDistributionTesterApiClient.commitFeedback(
+            FEEDBACK_NAME, FeedbackTrigger.CUSTOM);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex", expectedException);
   }
 
   @Test
   public void commitFeedback_whenClientThrowsException_failsTask() throws Exception {
+    Map<String, String> extraHeaders = new HashMap<>();
+    extraHeaders.put("X-APP-DISTRO-FEEDBACK-TRIGGER", "custom");
     when(mockTesterApiHttpClient.makePostRequest(
-            any(), eq(COMMIT_FEEDBACK_PATH), eq(TEST_AUTH_TOKEN), eq("")))
+            any(), eq(COMMIT_FEEDBACK_PATH), eq(TEST_AUTH_TOKEN), eq(""), eq(extraHeaders)))
         .thenThrow(new FirebaseAppDistributionException("test ex", Status.UNKNOWN));
 
-    Task<Void> task = firebaseAppDistributionTesterApiClient.commitFeedback(FEEDBACK_NAME);
+    Task<Void> task =
+        firebaseAppDistributionTesterApiClient.commitFeedback(
+            FEEDBACK_NAME, FeedbackTrigger.CUSTOM);
 
     awaitTaskFailure(task, Status.UNKNOWN, "test ex");
   }


### PR DESCRIPTION
Note to self: confirm which endpoint is actually recording the metric before changing the client 🤦🏿‍♂️