### PR TITLE
Store feedback trigger state on screen rotation

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -102,6 +102,7 @@ public class FeedbackActivity extends AppCompatActivity {
     outState.putString(RELEASE_NAME_KEY, releaseName);
     outState.putCharSequence(INFO_TEXT_KEY, infoText);
     outState.putString(SCREENSHOT_URI_KEY, screenshotUri.toString());
+    outState.putString(FEEDBACK_TRIGGER_KEY, feedbackTrigger.toString());
     super.onSaveInstanceState(outState);
   }
 


### PR DESCRIPTION
Not storing the state causes a crash when trying to restore it in `onCreate()`.