### PR TITLE
Add deprecation tagging to `SafetyNetAppCheckProviderFactory`.

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug-testing/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* [unchanged] Updated to keep [app_check] SDK versions aligned.
+
+# 16.1.1
 * [changed] Integrated the [app_check] Debug Testing SDK with Firebase Components. (#4436)
 
 # 16.1.0

--- a/appcheck/firebase-appcheck-debug/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-debug/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* [unchanged] Updated to keep [app_check] SDK versions aligned.
+
+# 16.1.1
 * [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)
 * [changed] Integrated the [app_check] Debug SDK with Firebase Components. (#4436)
 * [changed] Moved Task continuations off the main thread. (#4453)

--- a/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* [unchanged] Updated to keep [app_check] SDK versions aligned.
+
+# 16.1.1
 * [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)
 * [changed] Integrated the [app_check] Play Integrity SDK with Firebase Components. (#4436)
 * [changed] Moved Task continuations off the main thread. (#4453)

--- a/appcheck/firebase-appcheck-safetynet/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-safetynet/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* [deprecated] Added deprecation tagging to the `SafetyNetAppCheckProviderFactory` class.
+
+# 16.1.1
 * [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)
 * [changed] Integrated the [app_check] SafetyNet SDK with Firebase Components. (#4436)
 * [changed] Moved Task continuations off the main thread. (#4453)

--- a/appcheck/firebase-appcheck-safetynet/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-safetynet/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [deprecated] Added deprecation tagging to the `SafetyNetAppCheckProviderFactory` class.
+* [deprecated] Added deprecation tagging to the `SafetyNetAppCheckProviderFactory` class. (#4686)
 
 # 16.1.1
 * [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)

--- a/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
+++ b/appcheck/firebase-appcheck-safetynet/src/main/java/com/google/firebase/appcheck/safetynet/SafetyNetAppCheckProviderFactory.java
@@ -23,7 +23,10 @@ import com.google.firebase.appcheck.safetynet.internal.SafetyNetAppCheckProvider
 /**
  * Implementation of an {@link AppCheckProviderFactory} that builds {@link
  * SafetyNetAppCheckProvider}s. This is the default implementation.
+ *
+ * @deprecated Use {@code PlayIntegrityAppCheckProviderFactory} instead.
  */
+@Deprecated
 public class SafetyNetAppCheckProviderFactory implements AppCheckProviderFactory {
 
   private static final SafetyNetAppCheckProviderFactory instance =
@@ -34,7 +37,10 @@ public class SafetyNetAppCheckProviderFactory implements AppCheckProviderFactory
   /**
    * Gets an instance of this class for installation into a {@link
    * com.google.firebase.appcheck.FirebaseAppCheck} instance.
+   *
+   * @deprecated Use {@code PlayIntegrityAppCheckProviderFactory#getInstance} instead.
    */
+  @Deprecated
   @NonNull
   public static SafetyNetAppCheckProviderFactory getInstance() {
     return instance;

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* [unchanged] Updated to keep [app_check] SDK versions aligned.
+
+# 16.1.1
 * [changed] Migrated [app_check] SDKs to use standard Firebase executors. (#4431, #4449)
 * [changed] Moved Task continuations off the main thread. (#4453)
 


### PR DESCRIPTION
Per discussion, add deprecation tags to the App Check SafetyNet SDK.