### PR TITLE
Merge changes from fad/next into master to prepare for release

### DIFF
--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -38,7 +38,6 @@ android {
 }
 
 dependencies {
-    implementation 'org.jetbrains:annotations:15.0'
     implementation project(':firebase-components')
     implementation project(':firebase-common')
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'

--- a/firebase-appdistribution/CHANGELOG.md
+++ b/firebase-appdistribution/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 16.0.0-beta04
+* [fixed] Fixed a bug where only the last listener added to an `UpdateTask` using
+  `addOnProgressListener()` would receive updates.
+
 # 16.0.0-beta05
 * [unchanged] Updated to accommodate the release of the updated
   [appdistro] Kotlin extensions library.

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(':firebase-installations-interop')
     implementation project(':firebase-common')
     testImplementation project(path: ':firebase-appdistribution')
+    testImplementation project(':integ-testing')
     runtimeOnly project(':firebase-installations')
 
     testImplementation 'junit:junit:4.13.2'

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -42,7 +42,6 @@ android {
 }
 
 dependencies {
-    implementation 'org.jetbrains:annotations:15.0'
     implementation project(':firebase-appdistribution-api')
     implementation project(':firebase-annotations')
     implementation project(':firebase-components')

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -54,7 +54,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-inline:3.4.0'
-    androidTestImplementation "org.mockito:mockito-android:3.4.0"
     testImplementation 'androidx.test:core:1.2.0'
 
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
@@ -64,4 +63,13 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation "androidx.browser:browser:1.3.0"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+
+    androidTestImplementation project(':integ-testing')
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation "androidx.annotation:annotation:1.0.0"
+    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
 }

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -44,6 +44,7 @@ android {
 dependencies {
     implementation 'org.jetbrains:annotations:15.0'
     implementation project(':firebase-appdistribution-api')
+    implementation project(':firebase-annotations')
     implementation project(':firebase-components')
     implementation project(':firebase-installations-interop')
     implementation project(':firebase-common')

--- a/firebase-appdistribution/src/androidTest/AndroidManifest.xml
+++ b/firebase-appdistribution/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2022 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.firebase.installations">
+
+    <application>
+        <uses-library android:name="android.test.runner"/>
+    </application>
+
+    <instrumentation
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:targetPackage="com.google.firebase.appdistribution" />
+</manifest>

--- a/firebase-appdistribution/src/androidTest/AndroidManifest.xml
+++ b/firebase-appdistribution/src/androidTest/AndroidManifest.xml
@@ -14,7 +14,7 @@
 <!-- limitations under the License. -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.firebase.installations">
+    package="com.google.firebase.appdistribution.test">
 
     <application>
         <uses-library android:name="android.test.runner"/>

--- a/firebase-appdistribution/src/androidTest/java/com/google/firebase/appdistribution/StrictModeTest.java
+++ b/firebase-appdistribution/src/androidTest/java/com/google/firebase/appdistribution/StrictModeTest.java
@@ -1,0 +1,48 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.firebase.appdistribution;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.appdistribution.internal.FirebaseAppDistributionProxy;
+import com.google.firebase.testing.integ.StrictModeRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class StrictModeTest {
+
+  @Rule public StrictModeRule strictMode = new StrictModeRule();
+
+  @Test
+  public void initializingFirebaseAppdistribution_shouldNotViolateStrictMode() {
+    strictMode.runOnMainThread(
+        () -> {
+          FirebaseApp app =
+              FirebaseApp.initializeApp(
+                  ApplicationProvider.getApplicationContext(),
+                  new FirebaseOptions.Builder()
+                      .setApiKey("api")
+                      .setProjectId("123")
+                      .setApplicationId("appId")
+                      .build(),
+                  "hello");
+          app.get(FirebaseAppDistribution.class);
+          app.get(FirebaseAppDistributionProxy.class);
+        });
+  }
+}

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/AabUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/AabUpdater.java
@@ -19,7 +19,6 @@ import static com.google.firebase.appdistribution.FirebaseAppDistributionExcepti
 import static com.google.firebase.appdistribution.impl.TaskUtils.runAsyncInTask;
 import static com.google.firebase.appdistribution.impl.TaskUtils.safeSetTaskException;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
@@ -31,7 +30,6 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.UpdateStatus;
 import java.io.IOException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import javax.net.ssl.HttpsURLConnection;
 
 /** Class that handles updateApp functionality for AABs in {@link FirebaseAppDistribution}. */
@@ -40,7 +38,7 @@ class AabUpdater {
 
   private final FirebaseAppDistributionLifecycleNotifier lifecycleNotifier;
   private final HttpsUrlConnectionFactory httpsUrlConnectionFactory;
-  private final Executor executor;
+  private final Executor blockingExecutor;
 
   private final Object updateAabLock = new Object();
 
@@ -53,23 +51,21 @@ class AabUpdater {
   @GuardedBy("updateAabLock")
   private boolean hasBeenSentToPlayForCurrentTask = false;
 
-  // TODO(b/261014422): Migrate to go/firebase-android-executors
-  @SuppressLint("ThreadPoolCreation")
-  AabUpdater() {
+  AabUpdater(@NonNull Executor blockingExecutor) {
     this(
         FirebaseAppDistributionLifecycleNotifier.getInstance(),
         new HttpsUrlConnectionFactory(),
-        Executors.newSingleThreadExecutor());
+        blockingExecutor);
   }
 
   AabUpdater(
       @NonNull FirebaseAppDistributionLifecycleNotifier lifecycleNotifier,
       @NonNull HttpsUrlConnectionFactory httpsUrlConnectionFactory,
-      @NonNull Executor executor) {
+      @NonNull Executor blockingExecutor) {
     this.lifecycleNotifier = lifecycleNotifier;
     this.httpsUrlConnectionFactory = httpsUrlConnectionFactory;
     lifecycleNotifier.addOnActivityStartedListener(this::onActivityStarted);
-    this.executor = executor;
+    this.blockingExecutor = blockingExecutor;
   }
 
   @VisibleForTesting
@@ -97,13 +93,13 @@ class AabUpdater {
       hasBeenSentToPlayForCurrentTask = false;
 
       // On a background thread, fetch the redirect URL and open it in the Play app
-      runAsyncInTask(executor, () -> fetchDownloadRedirectUrl(newRelease.getDownloadUrl()))
+      runAsyncInTask(blockingExecutor, () -> fetchDownloadRedirectUrl(newRelease.getDownloadUrl()))
           .onSuccessTask(
-              executor,
+              blockingExecutor,
               redirectUrl ->
                   lifecycleNotifier.consumeForegroundActivity(
                       activity -> openRedirectUrlInPlay(redirectUrl, activity)))
-          .addOnFailureListener(executor, this::setUpdateTaskCompletionError);
+          .addOnFailureListener(blockingExecutor, this::setUpdateTaskCompletionError);
 
       return cachedUpdateTask;
     }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ApkUpdater.java
@@ -19,7 +19,6 @@ import static com.google.firebase.appdistribution.FirebaseAppDistributionExcepti
 import static com.google.firebase.appdistribution.impl.TaskUtils.safeSetTaskException;
 import static com.google.firebase.appdistribution.impl.TaskUtils.safeSetTaskResult;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
@@ -38,7 +37,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.jar.JarFile;
 import javax.net.ssl.HttpsURLConnection;
 
@@ -51,7 +49,7 @@ class ApkUpdater {
   private static final String DEFAULT_APK_FILE_NAME = "downloaded_release.apk";
 
   private TaskCompletionSource<File> downloadTaskCompletionSource;
-  private final Executor taskExecutor; // Executor to run task listeners on a background thread
+  private final Executor blockingExecutor; // Executor to run task listeners on a background thread
   private final Context context;
   private final ApkInstaller apkInstaller;
   private final FirebaseAppDistributionNotificationsManager appDistributionNotificationsManager;
@@ -63,11 +61,12 @@ class ApkUpdater {
 
   private final Object updateTaskLock = new Object();
 
-  // TODO(b/261014422): Migrate to go/firebase-android-executors
-  @SuppressLint("ThreadPoolCreation")
-  public ApkUpdater(@NonNull FirebaseApp firebaseApp, @NonNull ApkInstaller apkInstaller) {
+  public ApkUpdater(
+      @NonNull FirebaseApp firebaseApp,
+      @NonNull ApkInstaller apkInstaller,
+      @NonNull Executor blockingExecutor) {
     this(
-        Executors.newSingleThreadExecutor(),
+        blockingExecutor,
         firebaseApp.getApplicationContext(),
         apkInstaller,
         new FirebaseAppDistributionNotificationsManager(firebaseApp.getApplicationContext()),
@@ -77,13 +76,13 @@ class ApkUpdater {
 
   @VisibleForTesting
   public ApkUpdater(
-      @NonNull Executor taskExecutor,
+      @NonNull Executor blockingExecutor,
       @NonNull Context context,
       @NonNull ApkInstaller apkInstaller,
       @NonNull FirebaseAppDistributionNotificationsManager appDistributionNotificationsManager,
       @NonNull HttpsUrlConnectionFactory httpsUrlConnectionFactory,
       @NonNull FirebaseAppDistributionLifecycleNotifier lifeCycleNotifier) {
-    this.taskExecutor = taskExecutor;
+    this.blockingExecutor = blockingExecutor;
     this.context = context;
     this.apkInstaller = apkInstaller;
     this.appDistributionNotificationsManager = appDistributionNotificationsManager;
@@ -102,9 +101,9 @@ class ApkUpdater {
     }
 
     downloadApk(newRelease, showNotification)
-        .addOnSuccessListener(taskExecutor, file -> installApk(file, showNotification))
+        .addOnSuccessListener(blockingExecutor, file -> installApk(file, showNotification))
         .addOnFailureListener(
-            taskExecutor,
+            blockingExecutor,
             e -> {
               setUpdateTaskCompletionErrorWithDefault(
                   e, "Failed to download APK", Status.DOWNLOAD_FAILURE);
@@ -120,14 +119,14 @@ class ApkUpdater {
         .applyToForegroundActivityTask(
             activity -> apkInstaller.installApk(file.getPath(), activity))
         .addOnSuccessListener(
-            taskExecutor,
+            blockingExecutor,
             unused -> {
               synchronized (updateTaskLock) {
                 safeSetTaskResult(cachedUpdateTask);
               }
             })
         .addOnFailureListener(
-            taskExecutor,
+            blockingExecutor,
             e -> {
               postUpdateProgress(
                   file.length(),
@@ -151,7 +150,7 @@ class ApkUpdater {
 
     downloadTaskCompletionSource = new TaskCompletionSource<>();
 
-    taskExecutor.execute(
+    blockingExecutor.execute(
         () -> {
           try {
             makeApkDownloadRequest(newRelease, showNotification);

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/AppDistributionReleaseInternal.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/AppDistributionReleaseInternal.java
@@ -21,6 +21,8 @@ import com.google.firebase.appdistribution.BinaryType;
 
 /**
  * This class represents the AppDistributionRelease object returned by the App Distribution backend.
+ *
+ * <p>TODO(lkellogg): Combine this with AppDistributionReleaseImpl
  */
 @AutoValue
 abstract class AppDistributionReleaseInternal {
@@ -64,6 +66,9 @@ abstract class AppDistributionReleaseInternal {
   /** Short-lived download URL. */
   @Nullable
   abstract String getDownloadUrl();
+
+  @NonNull
+  abstract Builder toBuilder();
 
   /** Builder for {@link AppDistributionReleaseInternal}. */
   @AutoValue.Builder

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionImpl.java
@@ -58,17 +58,13 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   private final AabUpdater aabUpdater;
   private final SignInStorage signInStorage;
 
-  private final Object updateIfNewReleaseTaskLock = new Object();
-
-  @GuardedBy("updateIfNewReleaseTaskLock")
-  private UpdateTaskImpl cachedUpdateIfNewReleaseTask;
-
   private final Object cachedNewReleaseLock = new Object();
 
   @GuardedBy("cachedNewReleaseLock")
   private AppDistributionReleaseInternal cachedNewRelease;
 
-  private Task<AppDistributionRelease> cachedCheckForNewReleaseTask;
+  private TaskCache<UpdateTask> updateIfNewReleaseAvailableTaskCache = new TaskCache<>();
+  private TaskCache<Task<AppDistributionRelease>> checkForNewReleaseTaskCache = new TaskCache<>();
   private AlertDialog updateConfirmationDialog;
   private AlertDialog signInConfirmationDialog;
   @Nullable private Activity dialogHostActivity = null;
@@ -105,54 +101,57 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   // TODO(b/261014422): Use an explicit executor in continuations.
   @SuppressLint("TaskMainThread")
   public UpdateTask updateIfNewReleaseAvailable() {
-    synchronized (updateIfNewReleaseTaskLock) {
-      if (updateIfNewReleaseAvailableIsTaskInProgress()) {
-        return cachedUpdateIfNewReleaseTask;
-      }
-      cachedUpdateIfNewReleaseTask = new UpdateTaskImpl();
-      remakeSignInConfirmationDialog = false;
-      remakeUpdateConfirmationDialog = false;
-      dialogHostActivity = null;
-    }
-    lifecycleNotifier
-        .applyToForegroundActivityTask(this::showSignInConfirmationDialog)
-        .onSuccessTask(unused -> signInTester())
-        .onSuccessTask(unused -> checkForNewRelease())
-        .continueWithTask(
-            task -> {
-              if (!task.isSuccessful()) {
-                postProgressToCachedUpdateIfNewReleaseTask(
-                    UpdateProgressImpl.builder()
-                        .setApkBytesDownloaded(UNKNOWN_RELEASE_FILE_SIZE)
-                        .setApkFileTotalBytes(UNKNOWN_RELEASE_FILE_SIZE)
-                        .setUpdateStatus(UpdateStatus.NEW_RELEASE_CHECK_FAILED)
-                        .build());
-              }
-              // if the task failed, this get() will cause the error to propagate to the handler
-              // below
-              AppDistributionRelease release = task.getResult();
-              if (release == null) {
-                postProgressToCachedUpdateIfNewReleaseTask(
-                    UpdateProgressImpl.builder()
-                        .setApkFileTotalBytes(UNKNOWN_RELEASE_FILE_SIZE)
-                        .setApkBytesDownloaded(UNKNOWN_RELEASE_FILE_SIZE)
-                        .setUpdateStatus(UpdateStatus.NEW_RELEASE_NOT_AVAILABLE)
-                        .build());
-                setCachedUpdateIfNewReleaseResult();
-                return Tasks.forResult(null);
-              }
-              return lifecycleNotifier.applyToForegroundActivityTask(
-                  activity -> showUpdateConfirmationDialog(activity, release));
-            })
-        .onSuccessTask(
-            unused ->
-                updateApp(true)
-                    .addOnProgressListener(this::postProgressToCachedUpdateIfNewReleaseTask))
-        .addOnFailureListener(this::setCachedUpdateIfNewReleaseCompletionError);
+    return updateIfNewReleaseAvailableTaskCache.getOrCreateTask(
+        () -> {
+          UpdateTaskImpl updateTask = new UpdateTaskImpl();
+          remakeSignInConfirmationDialog = false;
+          remakeUpdateConfirmationDialog = false;
+          dialogHostActivity = null;
 
-    synchronized (updateIfNewReleaseTaskLock) {
-      return cachedUpdateIfNewReleaseTask;
-    }
+          lifecycleNotifier
+              .applyToForegroundActivityTask(this::showSignInConfirmationDialog)
+              .onSuccessTask(unused -> signInTester())
+              .onSuccessTask(unused -> checkForNewRelease())
+              .continueWithTask(
+                  task -> {
+                    if (!task.isSuccessful()) {
+                      postProgressToCachedUpdateIfNewReleaseTask(
+                          updateTask,
+                          UpdateProgressImpl.builder()
+                              .setApkBytesDownloaded(UNKNOWN_RELEASE_FILE_SIZE)
+                              .setApkFileTotalBytes(UNKNOWN_RELEASE_FILE_SIZE)
+                              .setUpdateStatus(UpdateStatus.NEW_RELEASE_CHECK_FAILED)
+                              .build());
+                    }
+                    // if the task failed, this get() will cause the error to propagate to the
+                    // handler below
+                    AppDistributionRelease release = task.getResult();
+                    if (release == null) {
+                      postProgressToCachedUpdateIfNewReleaseTask(
+                          updateTask,
+                          UpdateProgressImpl.builder()
+                              .setApkFileTotalBytes(UNKNOWN_RELEASE_FILE_SIZE)
+                              .setApkBytesDownloaded(UNKNOWN_RELEASE_FILE_SIZE)
+                              .setUpdateStatus(UpdateStatus.NEW_RELEASE_NOT_AVAILABLE)
+                              .build());
+                      setCachedUpdateIfNewReleaseResult(updateTask);
+                      return Tasks.forResult(null);
+                    }
+                    return lifecycleNotifier.applyToForegroundActivityTask(
+                        activity -> showUpdateConfirmationDialog(activity, release));
+                  })
+              .onSuccessTask(
+                  unused ->
+                      updateApp(true)
+                          .addOnProgressListener(
+                              updateProgress ->
+                                  postProgressToCachedUpdateIfNewReleaseTask(
+                                      updateTask, updateProgress)))
+              .addOnFailureListener(
+                  exception -> setCachedUpdateIfNewReleaseCompletionError(updateTask, exception));
+
+          return updateTask;
+        });
   }
 
   @NonNull
@@ -224,37 +223,35 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
   // TODO(b/261014422): Use an explicit executor in continuations.
   @SuppressLint("TaskMainThread")
   public synchronized Task<AppDistributionRelease> checkForNewRelease() {
-    if (cachedCheckForNewReleaseTask != null && !cachedCheckForNewReleaseTask.isComplete()) {
-      LogWrapper.getInstance().v("Response in progress");
-      return cachedCheckForNewReleaseTask;
-    }
-    if (!isTesterSignedIn()) {
-      return Tasks.forException(
-          new FirebaseAppDistributionException("Tester is not signed in", AUTHENTICATION_FAILURE));
-    }
+    return checkForNewReleaseTaskCache.getOrCreateTask(
+        () -> {
+          if (!isTesterSignedIn()) {
+            return Tasks.forException(
+                new FirebaseAppDistributionException(
+                    "Tester is not signed in", AUTHENTICATION_FAILURE));
+          }
 
-    cachedCheckForNewReleaseTask =
-        newReleaseFetcher
-            .checkForNewRelease()
-            .onSuccessTask(
-                appDistributionReleaseInternal -> {
-                  setCachedNewRelease(appDistributionReleaseInternal);
-                  return Tasks.forResult(
-                      ReleaseUtils.convertToAppDistributionRelease(appDistributionReleaseInternal));
-                })
-            .addOnFailureListener(
-                e -> {
-                  if (e instanceof FirebaseAppDistributionException
-                      && ((FirebaseAppDistributionException) e).getErrorCode()
-                          == AUTHENTICATION_FAILURE) {
-                    // If CheckForNewRelease returns authentication error, the FID is no longer
-                    // valid or does not have access to the latest release. So sign out the tester
-                    // to force FID re-registration
-                    signOutTester();
-                  }
-                });
-
-    return cachedCheckForNewReleaseTask;
+          return newReleaseFetcher
+              .checkForNewRelease()
+              .onSuccessTask(
+                  appDistributionReleaseInternal -> {
+                    setCachedNewRelease(appDistributionReleaseInternal);
+                    return Tasks.forResult(
+                        ReleaseUtils.convertToAppDistributionRelease(
+                            appDistributionReleaseInternal));
+                  })
+              .addOnFailureListener(
+                  e -> {
+                    if (e instanceof FirebaseAppDistributionException
+                        && ((FirebaseAppDistributionException) e).getErrorCode()
+                            == AUTHENTICATION_FAILURE) {
+                      // If CheckForNewRelease returns authentication error, the FID is no longer
+                      // valid or does not have access to the latest release. So sign out the tester
+                      // to force FID re-registration
+                      signOutTester();
+                    }
+                  });
+        });
   }
 
   @Override
@@ -411,25 +408,20 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
     return showUpdateDialogTask.getTask();
   }
 
-  private void setCachedUpdateIfNewReleaseCompletionError(Exception e) {
-    synchronized (updateIfNewReleaseTaskLock) {
-      safeSetTaskException(cachedUpdateIfNewReleaseTask, e);
-    }
+  private void setCachedUpdateIfNewReleaseCompletionError(UpdateTaskImpl updateTask, Exception e) {
+    safeSetTaskException(updateTask, e);
     dismissDialogs();
   }
 
-  private void postProgressToCachedUpdateIfNewReleaseTask(UpdateProgress progress) {
-    synchronized (updateIfNewReleaseTaskLock) {
-      if (cachedUpdateIfNewReleaseTask != null && !cachedUpdateIfNewReleaseTask.isComplete()) {
-        cachedUpdateIfNewReleaseTask.updateProgress(progress);
-      }
+  private void postProgressToCachedUpdateIfNewReleaseTask(
+      UpdateTaskImpl updateTask, UpdateProgress progress) {
+    if (updateTask != null && !updateTask.isComplete()) {
+      updateTask.updateProgress(progress);
     }
   }
 
-  private void setCachedUpdateIfNewReleaseResult() {
-    synchronized (updateIfNewReleaseTaskLock) {
-      safeSetTaskResult(cachedUpdateIfNewReleaseTask);
-    }
+  private void setCachedUpdateIfNewReleaseResult(UpdateTaskImpl updateTask) {
+    safeSetTaskResult(updateTask);
     dismissDialogs();
   }
 
@@ -446,12 +438,6 @@ class FirebaseAppDistributionImpl implements FirebaseAppDistribution {
     UpdateTaskImpl updateTask = new UpdateTaskImpl();
     updateTask.setException(e);
     return updateTask;
-  }
-
-  private boolean updateIfNewReleaseAvailableIsTaskInProgress() {
-    synchronized (updateIfNewReleaseTaskLock) {
-      return cachedUpdateIfNewReleaseTask != null && !cachedUpdateIfNewReleaseTask.isComplete();
-    }
   }
 
   private boolean awaitingSignInDialogConfirmation() {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClient.java
@@ -16,7 +16,6 @@ package com.google.firebase.appdistribution.impl;
 
 import static com.google.firebase.appdistribution.impl.TaskUtils.runAsyncInTask;
 
-import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -29,7 +28,6 @@ import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
 import java.io.File;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -64,18 +62,17 @@ class FirebaseAppDistributionTesterApiClient {
   private final FirebaseApp firebaseApp;
   private final Provider<FirebaseInstallationsApi> firebaseInstallationsApiProvider;
   private final TesterApiHttpClient testerApiHttpClient;
-
-  // TODO(b/261014422): Migrate to go/firebase-android-executors
-  @SuppressLint("ThreadPoolCreation")
-  private final Executor taskExecutor = Executors.newSingleThreadExecutor();
+  private final Executor blockingExecutor;
 
   FirebaseAppDistributionTesterApiClient(
       @NonNull FirebaseApp firebaseApp,
       @NonNull Provider<FirebaseInstallationsApi> firebaseInstallationsApiProvider,
-      @NonNull TesterApiHttpClient testerApiHttpClient) {
+      @NonNull TesterApiHttpClient testerApiHttpClient,
+      @NonNull Executor blockingExecutor) {
     this.firebaseApp = firebaseApp;
     this.firebaseInstallationsApiProvider = firebaseInstallationsApiProvider;
     this.testerApiHttpClient = testerApiHttpClient;
+    this.blockingExecutor = blockingExecutor;
   }
 
   /**
@@ -265,9 +262,9 @@ class FirebaseAppDistributionTesterApiClient {
         firebaseInstallationsApiProvider.get().getToken(/* forceRefresh= */ false);
 
     return Tasks.whenAllSuccess(installationIdTask, installationAuthTokenTask)
-        .continueWithTask(taskExecutor, TaskUtils::handleTaskFailure)
+        .continueWithTask(blockingExecutor, TaskUtils::handleTaskFailure)
         .onSuccessTask(
-            taskExecutor,
+            blockingExecutor,
             resultsList -> {
               // Tasks.whenAllSuccess combines task results into a list
               if (resultsList.size() != 2) {
@@ -276,7 +273,7 @@ class FirebaseAppDistributionTesterApiClient {
               }
               String fid = (String) resultsList.get(0);
               InstallationTokenResult tokenResult = (InstallationTokenResult) resultsList.get(1);
-              return runAsyncInTask(taskExecutor, () -> job.run(fid, tokenResult.getToken()));
+              return runAsyncInTask(blockingExecutor, () -> job.run(fid, tokenResult.getToken()));
             });
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/LogWrapper.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/LogWrapper.java
@@ -80,6 +80,10 @@ class LogWrapper {
     Log.e(LOG_TAG, msg, tr);
   }
 
+  void e(@NonNull String additionalTag, @NonNull String msg) {
+    Log.e(LOG_TAG, prependTag(additionalTag, msg));
+  }
+
   void e(@NonNull String additionalTag, @NonNull String msg, @NonNull Throwable tr) {
     Log.e(LOG_TAG, prependTag(additionalTag, msg), tr);
   }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SequentialReference.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SequentialReference.java
@@ -1,0 +1,65 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.firebase.concurrent.FirebaseExecutors;
+import java.util.concurrent.Executor;
+
+/**
+ * A reference to an object that uses a sequential executor to ensure non-concurrent reads and
+ * writes while preventing lock contention.
+ */
+class SequentialReference<T> {
+
+  private final Executor sequentialExecutor;
+  private T value;
+
+  /**
+   * Constructor for a {@link SequentialReference} that controls access using its own sequential
+   * executor backed by the given base executor.
+   */
+  SequentialReference(Executor baseExecutor) {
+    this.sequentialExecutor = FirebaseExecutors.newSequentialExecutor(baseExecutor);
+  }
+
+  /**
+   * Sets the value, returning a {@link Task} will complete once it is set.
+   *
+   * <p>For convenience when chaining tasks together, the result of the returned task is the value.
+   */
+  Task<T> set(T newValue) {
+    TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<>();
+    sequentialExecutor.execute(
+        () -> {
+          value = newValue;
+          taskCompletionSource.setResult(value);
+        });
+    return taskCompletionSource.getTask();
+  }
+
+  /**
+   * Gets a {@link Task} that will complete with the value.
+   *
+   * <p>In some cases the value may have changed by the time any callbacks attached to the returned
+   * {@link Task} are called.
+   */
+  Task<T> get() {
+    TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<>();
+    sequentialExecutor.execute(() -> taskCompletionSource.setResult(value));
+    return taskCompletionSource.getTask();
+  }
+}

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
@@ -16,6 +16,7 @@ package com.google.firebase.appdistribution.impl;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import com.google.firebase.components.Lazy;
 
 /** Class that handles storage for App Distribution SignIn persistence. */
 class SignInStorage {
@@ -23,18 +24,21 @@ class SignInStorage {
   private static final String SIGNIN_PREFERENCES_NAME = "FirebaseAppDistributionSignInStorage";
   private static final String SIGNIN_TAG = "firebase_app_distribution_signin";
 
-  private final SharedPreferences signInSharedPreferences;
+  private final Lazy<SharedPreferences> signInSharedPreferences;
 
   SignInStorage(Context applicationContext) {
     this.signInSharedPreferences =
-        applicationContext.getSharedPreferences(SIGNIN_PREFERENCES_NAME, Context.MODE_PRIVATE);
+        new Lazy(
+            () ->
+                applicationContext.getSharedPreferences(
+                    SIGNIN_PREFERENCES_NAME, Context.MODE_PRIVATE));
   }
 
   void setSignInStatus(boolean testerSignedIn) {
-    this.signInSharedPreferences.edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
+    this.signInSharedPreferences.get().edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
   }
 
   boolean getSignInStatus() {
-    return signInSharedPreferences.getBoolean(SIGNIN_TAG, false);
+    return signInSharedPreferences.get().getBoolean(SIGNIN_TAG, false);
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TaskCache.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TaskCache.java
@@ -1,0 +1,48 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import com.google.android.gms.tasks.Task;
+
+/**
+ * A cache for Tasks, for use in cases where we only ever want one active task at a time for a
+ * particular operation.
+ */
+class TaskCache<T extends Task> {
+
+  /** A functional interface for a producer of a new Task. */
+  @FunctionalInterface
+  interface TaskProducer<T extends Task> {
+
+    /** Produce a new Task. */
+    T produce();
+  }
+
+  private T cachedTask;
+
+  /**
+   * Gets a cached task, if there is one and it is not completed, or else calls the given {@code
+   * producer} and caches the returned task.
+   *
+   * @return the cached task if there is one and it is not completed, or else the result from {@code
+   *     producer.produce()}
+   */
+  synchronized T getOrCreateTask(TaskProducer<T> producer) {
+    if (cachedTask == null || cachedTask.isComplete()) {
+      cachedTask = producer.produce();
+    }
+    return cachedTask;
+  }
+}

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/UpdateTaskImpl.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/UpdateTaskImpl.java
@@ -31,6 +31,7 @@ import com.google.android.gms.tasks.TaskExecutors;
 import com.google.firebase.appdistribution.OnProgressListener;
 import com.google.firebase.appdistribution.UpdateProgress;
 import com.google.firebase.appdistribution.UpdateTask;
+import com.google.firebase.concurrent.FirebaseExecutors;
 import java.util.concurrent.Executor;
 
 /** Implementation of UpdateTask, the return type of updateApp. */
@@ -62,6 +63,17 @@ class UpdateTaskImpl extends UpdateTask {
         this.listener.invoke(updateProgress);
       }
     }
+  }
+
+  /**
+   * Listen to all completion and progress events on the given {@link UpdateTask}, updating the
+   * progress or completing this task with the same changes.
+   */
+  void shadow(UpdateTask updateTask) {
+    updateTask
+        .addOnProgressListener(FirebaseExecutors.directExecutor(), this::updateProgress)
+        .addOnSuccessListener(FirebaseExecutors.directExecutor(), unused -> this.setResult())
+        .addOnFailureListener(FirebaseExecutors.directExecutor(), this::setException);
   }
 
   private Task<Void> getTask() {

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionTesterApiClientTest.java
@@ -35,6 +35,7 @@ import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.installations.InstallationTokenResult;
 import java.io.File;
+import java.util.concurrent.Executors;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -102,7 +103,10 @@ public class FirebaseAppDistributionTesterApiClientTest {
 
     firebaseAppDistributionTesterApiClient =
         new FirebaseAppDistributionTesterApiClient(
-            firebaseApp, mockFirebaseInstallationsProvider, mockTesterApiHttpClient);
+            firebaseApp,
+            mockFirebaseInstallationsProvider,
+            mockTesterApiHttpClient,
+            Executors.newSingleThreadExecutor());
   }
 
   @Test

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TestUtils.java
@@ -82,9 +82,13 @@ final class TestUtils {
     return onCompleteListener.await();
   }
 
+  static void awaitTermination(ExecutorService executorService) throws InterruptedException {
+    executorService.awaitTermination(100, TimeUnit.MILLISECONDS);
+  }
+
   static void awaitAsyncOperations(ExecutorService executorService) throws InterruptedException {
     // Await anything enqueued to the executor
-    executorService.awaitTermination(100, TimeUnit.MILLISECONDS);
+    awaitTermination(executorService);
 
     // Idle the main looper, which is also running these tests, so any Task or lifecycle callbacks
     // can be handled. See http://robolectric.org/blog/2019/06/04/paused-looper/ for more info.

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/UpdateTaskImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/UpdateTaskImplTest.java
@@ -1,0 +1,144 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.appdistribution.UpdateProgress;
+import com.google.firebase.appdistribution.UpdateStatus;
+import com.google.firebase.concurrent.FirebaseExecutors;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class UpdateTaskImplTest {
+
+  private static final UpdateProgress PROGRESS_DOWNLOADING =
+      UpdateProgressImpl.builder()
+          .setUpdateStatus(UpdateStatus.DOWNLOADING)
+          .setApkBytesDownloaded(100)
+          .setApkFileTotalBytes(123)
+          .build();
+
+  private static final UpdateProgress PROGRESS_DOWNLOADED =
+      UpdateProgressImpl.builder()
+          .setUpdateStatus(UpdateStatus.DOWNLOADED)
+          .setApkBytesDownloaded(123)
+          .setApkFileTotalBytes(123)
+          .build();
+
+  @Test
+  public void addOnProgressListener_supportsMultipleListeners() {
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+    List<UpdateProgress> progressEvents1 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents1::add);
+    List<UpdateProgress> progressEvents2 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents2::add);
+
+    updateTaskImpl.updateProgress(PROGRESS_DOWNLOADING);
+
+    assertThat(progressEvents1).containsExactly(PROGRESS_DOWNLOADING);
+    assertThat(progressEvents2).containsExactly(PROGRESS_DOWNLOADING);
+  }
+
+  @Test
+  public void setException_clearsProgressListeners() {
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+    List<UpdateProgress> progressEvents1 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents1::add);
+    List<UpdateProgress> progressEvents2 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents2::add);
+
+    // Set the result
+    updateTaskImpl.setException(new RuntimeException("Error"));
+
+    // Has no effect on the listeners after the exception is set
+    updateTaskImpl.updateProgress(PROGRESS_DOWNLOADING);
+
+    assertThat(progressEvents1).isEmpty();
+    assertThat(progressEvents2).isEmpty();
+  }
+
+  @Test
+  public void setResult_clearsProgressListeners() {
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+    List<UpdateProgress> progressEvents1 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents1::add);
+    List<UpdateProgress> progressEvents2 = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents2::add);
+
+    // Set the result
+    updateTaskImpl.setResult();
+
+    // Has no effect on the listeners after the result is set
+    updateTaskImpl.updateProgress(PROGRESS_DOWNLOADING);
+
+    assertThat(progressEvents1).isEmpty();
+    assertThat(progressEvents2).isEmpty();
+  }
+
+  @Test
+  public void shadow_completesWithShadowedException() {
+    UpdateTaskImpl taskToShadow = new UpdateTaskImpl();
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+
+    // Shadow the task
+    updateTaskImpl.shadow(taskToShadow);
+
+    // Complete the shadowed task
+    RuntimeException expectedException = new RuntimeException("Error");
+    taskToShadow.setException(expectedException);
+
+    assertThat(updateTaskImpl.isComplete()).isEqualTo(true);
+    assertThat(updateTaskImpl.isSuccessful()).isEqualTo(false);
+    assertThat(updateTaskImpl.getException()).isEqualTo(expectedException);
+  }
+
+  @Test
+  public void shadow_completesWithShadowedResult() {
+    UpdateTaskImpl taskToShadow = new UpdateTaskImpl();
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+
+    // Shadow the task
+    updateTaskImpl.shadow(taskToShadow);
+
+    // Complete the shadowed task
+    taskToShadow.setResult();
+
+    assertThat(updateTaskImpl.isComplete()).isEqualTo(true);
+    assertThat(updateTaskImpl.isSuccessful()).isEqualTo(true);
+  }
+
+  @Test
+  public void shadow_updatesWithShadowedProgress() {
+    UpdateTaskImpl taskToShadow = new UpdateTaskImpl();
+    UpdateTaskImpl updateTaskImpl = new UpdateTaskImpl();
+    List<UpdateProgress> progressEvents = new ArrayList<>();
+    updateTaskImpl.addOnProgressListener(FirebaseExecutors.directExecutor(), progressEvents::add);
+
+    // Shadow the task
+    updateTaskImpl.shadow(taskToShadow);
+
+    // Update the shadowed task
+    taskToShadow.updateProgress(PROGRESS_DOWNLOADING);
+    taskToShadow.updateProgress(PROGRESS_DOWNLOADED);
+
+    assertThat(updateTaskImpl.isComplete()).isEqualTo(false);
+    assertThat(progressEvents).containsExactly(PROGRESS_DOWNLOADING, PROGRESS_DOWNLOADED);
+  }
+}

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -35,8 +35,8 @@ import java.util.concurrent.Executors
 class MainActivity : AppCompatActivity() {
     var firebaseAppDistribution = Firebase.appDistribution
     var updateTask: Task<Void>? = null
-    var release: AppDistributionRelease? = null
     val executorService: ExecutorService = Executors.newFixedThreadPool(1)
+
     lateinit var signInButton: AppCompatButton
     lateinit var signOutButton: AppCompatButton
     lateinit var checkForUpdateButton: AppCompatButton
@@ -125,10 +125,11 @@ class MainActivity : AppCompatActivity() {
             firebaseAppDistribution
                 .checkForNewRelease()
                 .addOnSuccessListener {
-                    setupUI(
-                        isSignedIn = firebaseAppDistribution.isTesterSignedIn,
-                        isUpdateAvailable = it != null,
-                        release = it)
+                        release ->
+                            setupUI(
+                                isSignedIn = firebaseAppDistribution.isTesterSignedIn,
+                                isUpdateAvailable = release != null,
+                                release = release)
                 }
                 .addOnFailureListener { failureListener(it) }
         }
@@ -138,11 +139,11 @@ class MainActivity : AppCompatActivity() {
                 firebaseAppDistribution
                     .checkForNewRelease()
                     .addOnSuccessListener {
-                        release = it
-                        setupUI(
-                            isSignedIn = firebaseAppDistribution.isTesterSignedIn,
-                            isUpdateAvailable = release != null,
-                            release = release)
+                            release ->
+                                setupUI(
+                                    isSignedIn = firebaseAppDistribution.isTesterSignedIn,
+                                    isUpdateAvailable = release != null,
+                                    release = release)
                     }
                     .addOnFailureListener { failureListener(it) }
             }

--- a/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
+++ b/firebase-appdistribution/test-app/src/main/java/com/googletest/firebase/appdistribution/testapp/MainActivity.kt
@@ -26,13 +26,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
 import com.google.android.gms.tasks.Task
 import com.google.firebase.appdistribution.AppDistributionRelease
-import com.google.firebase.appdistribution.FirebaseAppDistribution
 import com.google.firebase.appdistribution.UpdateProgress
+import com.google.firebase.appdistribution.ktx.appDistribution
+import com.google.firebase.ktx.Firebase
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 class MainActivity : AppCompatActivity() {
-    var firebaseAppDistribution: FirebaseAppDistribution = FirebaseAppDistribution.getInstance()
+    var firebaseAppDistribution = Firebase.appDistribution
     var updateTask: Task<Void>? = null
     var release: AppDistributionRelease? = null
     val executorService: ExecutorService = Executors.newFixedThreadPool(1)

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -18,12 +18,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.googletest.firebase.appdistribution.testapp"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionName "1.0"
         versionCode 1
 
@@ -57,18 +57,18 @@ dependencies {
     // In this test project we also need to explicitly declare these dependencies
     implementation project(':firebase-appdistribution-api')
     implementation project(':firebase-common:ktx')
-    implementation "com.google.android.gms:play-services-tasks:18.0.1"
+    implementation "com.google.android.gms:play-services-tasks:18.0.2"
 
     // Debug uses the full implementation
     debugImplementation project(':firebase-appdistribution')
 
     // Other dependencies
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'androidx.core:core-ktx:1.5.0'
-    implementation "androidx.core:core:1.6.0"
-    implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation "androidx.core:core:1.9.0"
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.+'
 }
 

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -18,12 +18,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.googletest.firebase.appdistribution.testapp"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionName "1.0"
         versionCode 1
 
@@ -31,12 +31,13 @@ android {
     }
 
     buildTypes {
-        // This is so we can build the "release" variant for the "dev-app" (and the SDK) without
+        // This is so we can build the "release" variant for the "test-app" (and the SDK) without
         // needing to have the app signed.
         release {
             initWith debug
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -50,15 +51,18 @@ dependencies {
     // TODO(rachelprince): Add flag to build with public version of SDK
     println("Building with HEAD version ':firebase-appdistribution' of SDK")
 
-    // Debug variant uses full SDK
-    debugImplementation project(':firebase-appdistribution-api') // TODO(lkellogg): why doesn't this get picked up transitively?
-    debugImplementation project(':firebase-appdistribution')
+    // All variants use the API
+    implementation project(':firebase-appdistribution-api:ktx')
 
-    // Release variant just uses the API, as if publishing to Play
-    releaseImplementation project(':firebase-appdistribution-api')
-
+    // In this test project we also need to explicitly declare these dependencies
+    implementation project(':firebase-appdistribution-api')
+    implementation project(':firebase-common:ktx')
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
 
+    // Debug uses the full implementation
+    debugImplementation project(':firebase-appdistribution')
+
+    // Other dependencies
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.core:core-ktx:1.5.0'
     implementation "androidx.core:core:1.6.0"


### PR DESCRIPTION
Mostly internal cleanup with one addition to the CHANGELOG:

- [fixed] Fixed a bug where only the last listener added to an `UpdateTask` using
  `addOnProgressListener()` would receive updates.