### PR TITLE
Initial commit for Firebase Sessions SDK

### DIFF
--- a/firebase-sessions/api.txt
+++ b/firebase-sessions/api.txt
@@ -1,0 +1,19 @@
+// Signature format: 2.0
+package com.google.firebase.sessions {
+
+  public final class FirebaseSessions {
+    method @NonNull public static com.google.firebase.sessions.FirebaseSessions getInstance();
+    method @NonNull public static com.google.firebase.sessions.FirebaseSessions getInstance(@NonNull com.google.firebase.FirebaseApp app);
+    method @Discouraged(message="This will be replaced with a real API.") @NonNull public String greeting();
+    property @NonNull public static final com.google.firebase.sessions.FirebaseSessions instance;
+    field @NonNull public static final com.google.firebase.sessions.FirebaseSessions.Companion Companion;
+  }
+
+  public static final class FirebaseSessions.Companion {
+    method @NonNull public com.google.firebase.sessions.FirebaseSessions getInstance();
+    method @NonNull public com.google.firebase.sessions.FirebaseSessions getInstance(@NonNull com.google.firebase.FirebaseApp app);
+    property @NonNull public final com.google.firebase.sessions.FirebaseSessions instance;
+  }
+
+}
+

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -40,6 +40,7 @@ android {
 }
 
 dependencies {
+  implementation(project(":firebase-common"))
   implementation(project(":firebase-common:ktx"))
   implementation(project(":firebase-components"))
   implementation(libs.androidx.annotation)

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+plugins {
+  id("firebase-library")
+  id("kotlin-android")
+}
+
+firebaseLibrary {
+  testLab.enabled = true
+  publishSources = true
+}
+
+android {
+  val targetSdkVersion: Int by rootProject
+  compileSdk = targetSdkVersion
+  defaultConfig {
+    minSdk = 16
+    targetSdk = targetSdkVersion
+    multiDexEnabled = true
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+  kotlinOptions { jvmTarget = "1.8" }
+  testOptions.unitTests.isIncludeAndroidResources = true
+}
+
+dependencies {
+  implementation(project(":firebase-common"))
+  implementation(project(":firebase-common:ktx"))
+  implementation(project(":firebase-components"))
+  implementation(libs.androidx.annotation)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+
+  androidTestImplementation(libs.androidx.test.junit)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.truth)
+}

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -40,7 +40,6 @@ android {
 }
 
 dependencies {
-  implementation(project(":firebase-common"))
   implementation(project(":firebase-common:ktx"))
   implementation(project(":firebase-components"))
   implementation(libs.androidx.annotation)

--- a/firebase-sessions/gradle.properties
+++ b/firebase-sessions/gradle.properties
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version=0.1.0

--- a/firebase-sessions/src/androidTest/kotlin/com/google/firebase/sessions/FirebaseSessionsTests.kt
+++ b/firebase-sessions/src/androidTest/kotlin/com/google/firebase/sessions/FirebaseSessionsTests.kt
@@ -1,0 +1,40 @@
+package com.google.firebase.sessions
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.ktx.initialize
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class FirebaseSessionsTests {
+  @Before
+  fun setUp() {
+    Firebase.initialize(
+      ApplicationProvider.getApplicationContext(),
+      FirebaseOptions.Builder().setApplicationId("APP_ID").build()
+    )
+  }
+
+  @After
+  fun cleanUp() {
+    FirebaseApp.clearInstancesForTest()
+  }
+
+  @Test
+  fun mattDoesDayHi() {
+    // This will be replaced with real tests.
+    assertThat(FirebaseSessions.instance.greeting()).isEqualTo("Matt says hi!")
+  }
+}

--- a/firebase-sessions/src/androidTest/kotlin/com/google/firebase/sessions/FirebaseSessionsTests.kt
+++ b/firebase-sessions/src/androidTest/kotlin/com/google/firebase/sessions/FirebaseSessionsTests.kt
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.sessions
 
 import androidx.test.core.app.ApplicationProvider

--- a/firebase-sessions/src/main/AndroidManifest.xml
+++ b/firebase-sessions/src/main/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2023 Google LLC -->
+<!-- -->
+<!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
+<!-- you may not use this file except in compliance with the License. -->
+<!-- You may obtain a copy of the License at -->
+<!-- -->
+<!--      http://www.apache.org/licenses/LICENSE-2.0 -->
+<!-- -->
+<!-- Unless required by applicable law or agreed to in writing, software -->
+<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
+<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
+<!-- See the License for the specific language governing permissions and -->
+<!-- limitations under the License. -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.google.firebase.sessions">
+  <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
+  <!--<uses-sdk android:minSdkVersion="16"/>-->
+
+  <application>
+    <service android:name="com.google.firebase.components.ComponentDiscoveryService"
+      android:exported="false">
+      <meta-data
+        android:name="com.google.firebase.components:com.google.firebase.sessions.FirebaseSessionsRegistrar"
+        android:value="com.google.firebase.components.ComponentRegistrar" />
+    </service>
+  </application>
+</manifest>

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -1,0 +1,20 @@
+package com.google.firebase.sessions
+
+import androidx.annotation.Discouraged
+import com.google.firebase.FirebaseApp
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.ktx.app
+
+class FirebaseSessions internal constructor() {
+  @Discouraged(message = "This will be replaced with a real API.")
+  fun greeting(): String = "Matt says hi!"
+
+  companion object {
+    @JvmStatic
+    val instance: FirebaseSessions
+      get() = getInstance(Firebase.app)
+
+    @JvmStatic
+    fun getInstance(app: FirebaseApp): FirebaseSessions = app.get(FirebaseSessions::class.java)
+  }
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.sessions
 
 import androidx.annotation.Discouraged

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.sessions
 
 import androidx.annotation.Keep

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -1,0 +1,27 @@
+package com.google.firebase.sessions
+
+import androidx.annotation.Keep
+import com.google.firebase.components.Component
+import com.google.firebase.components.ComponentRegistrar
+import com.google.firebase.platforminfo.LibraryVersionComponent
+
+/**
+ * [ComponentRegistrar] for setting up [FirebaseSessions].
+ *
+ * @hide
+ */
+@Keep
+internal class FirebaseSessionsRegistrar : ComponentRegistrar {
+  override fun getComponents() =
+    listOf(
+      Component.builder(FirebaseSessions::class.java)
+        .name(LIBRARY_NAME)
+        .factory { FirebaseSessions() }
+        .build(),
+      LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME)
+    )
+
+  companion object {
+    private const val LIBRARY_NAME = "fire-ses"
+  }
+}

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/FirebaseSessionsTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/FirebaseSessionsTest.kt
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.sessions
 
 import com.google.common.truth.Truth.assertThat

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/FirebaseSessionsTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/FirebaseSessionsTest.kt
@@ -1,0 +1,17 @@
+package com.google.firebase.sessions
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Example local unit test, which will execute on the development machine (host).
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+class FirebaseSessionsTest {
+  @Test
+  fun mattDoesDayHi() {
+    // This will be replaced with real tests.
+    assertThat(FirebaseSessions().greeting()).isEqualTo("Matt says hi!")
+  }
+}

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -51,6 +51,7 @@ firebase-perf:ktx
 firebase-perf:dev-app
 firebase-perf:e2e-app
 # firebase-segmentation
+firebase-sessions
 firebase-storage
 firebase-storage:ktx
 protolite-well-known-types


### PR DESCRIPTION
Initial commit for Firebase Sessions SDK

- Setup subproject, including test structure with a place holder api
- Source code and gradle build files are all in Kotlin
- Set min sdk level to 16, which is what Crashlytics and Fireperf are