### PR TITLE
Allow disabling Custom Tabs when handling In-App Message click actions

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -82,8 +82,6 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
       20 * 1000; // auto dismiss after 20 seconds for banner
   static final long INTERVAL_MILLIS = 1000;
 
-  public boolean useCustomTabs = true;
-
   private final FirebaseInAppMessaging headlessInAppMessaging;
 
   private final Map<String, Provider<InAppMessageLayoutConfig>> layoutConfigs;
@@ -98,6 +96,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   private FiamListener fiamListener;
   private InAppMessage inAppMessage;
   private FirebaseInAppMessagingDisplayCallbacks callbacks;
+  private boolean useCustomTabs = true;
 
   @VisibleForTesting @Nullable String currentlyBoundActivityName;
 
@@ -167,6 +166,22 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
    */
   public void clearFiamListener() {
     this.fiamListener = null;
+  }
+
+  /**
+   * Gets whether the action link should be handled by opening a Custom Tab.
+   */
+  public boolean getUseCustomTabs() {
+    return useCustomTabs;
+  }
+
+  /**
+   * Sets whether the action link should be handled by opening a Custom Tab.
+   *
+   * @hide
+   */
+  public void setUseCustomTabs(boolean useCustomTabs) {
+    this.useCustomTabs = useCustomTabs;
   }
 
   /**

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -82,6 +82,8 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
       20 * 1000; // auto dismiss after 20 seconds for banner
   static final long INTERVAL_MILLIS = 1000;
 
+  public boolean useCustomTabs = true;
+
   private final FirebaseInAppMessaging headlessInAppMessaging;
 
   private final Map<String, Provider<InAppMessageLayoutConfig>> layoutConfigs;
@@ -542,7 +544,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   }
 
   private void launchUriIntent(Activity activity, Uri uri) {
-    if (ishttpOrHttpsUri(uri) && supportsCustomTabs(activity)) {
+    if (useCustomTabs && ishttpOrHttpsUri(uri) && supportsCustomTabs(activity)) {
       // If we can launch a chrome view, try that.
       CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
       Intent intent = customTabsIntent.intent;


### PR DESCRIPTION
By default, In-App Message links are handled by opening a Custom Tab. This behavior might be undesirable because deep links don't open in the app. It would be great if there was a way of disabling Custom Tabs.

Related issue https://github.com/firebase/firebase-android-sdk/issues/4726

I implemented an alternative (arguably better) solution here https://github.com/firebase/firebase-android-sdk/pull/4729