### PR TITLE
Extract an action handler for FIAM clicks

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -19,10 +19,7 @@ import static com.google.firebase.inappmessaging.display.internal.FiamAnimator.P
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
-import android.content.Intent;
-import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
-import android.net.Uri;
 import android.text.TextUtils;
 import android.view.MotionEvent;
 import android.view.View;
@@ -30,7 +27,6 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.browser.customtabs.CustomTabsIntent;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.inappmessaging.FirebaseInAppMessaging;
 import com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplayCallbacks;
@@ -96,6 +92,8 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   private FiamListener fiamListener;
   private InAppMessage inAppMessage;
   private FirebaseInAppMessagingDisplayCallbacks callbacks;
+  private FirebaseInAppMessagingDisplayActionHandler actionHandler =
+      new FirebaseInAppMessagingDisplayDefaultActionHandler();
 
   @VisibleForTesting @Nullable String currentlyBoundActivityName;
 
@@ -165,6 +163,13 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
    */
   public void clearFiamListener() {
     this.fiamListener = null;
+  }
+
+  /**
+   * Sets the action handler used when one of the message elements is clicked.
+   */
+  public void setActionHandler(@NonNull FirebaseInAppMessagingDisplayActionHandler actionHandler) {
+    this.actionHandler = actionHandler;
   }
 
   /**
@@ -324,7 +329,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
                   Logging.logi("Calling callback for click action");
                   callbacks.messageClicked(action);
                 }
-                launchUriIntent(activity, Uri.parse(action.getActionUrl()));
+                actionHandler.handleAction(activity, action);
                 notifyFiamClick();
                 // Ensure that we remove the displayed FIAM, and ensure that on re-load, the message
                 // isn't re-displayed
@@ -539,44 +544,5 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     if (fiamListener != null) {
       fiamListener.onFiamDismiss();
     }
-  }
-
-  private void launchUriIntent(Activity activity, Uri uri) {
-    if (ishttpOrHttpsUri(uri) && supportsCustomTabs(activity)) {
-      // If we can launch a chrome view, try that.
-      CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
-      Intent intent = customTabsIntent.intent;
-      intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      customTabsIntent.launchUrl(activity, uri);
-    } else {
-      // If we can't launch a chrome view try to launch anything that can handle a URL.
-      Intent browserIntent = new Intent(Intent.ACTION_VIEW, uri);
-      ResolveInfo info = activity.getPackageManager().resolveActivity(browserIntent, 0);
-      browserIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-      browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      if (info != null) {
-        activity.startActivity(browserIntent);
-      } else {
-        // If the device can't resolve a url then log, but don't crash.
-        Logging.loge("Device cannot resolve intent for: " + Intent.ACTION_VIEW);
-      }
-    }
-  }
-
-  private boolean supportsCustomTabs(Activity activity) {
-    Intent customTabIntent = new Intent("android.support.customtabs.action.CustomTabsService");
-    customTabIntent.setPackage("com.android.chrome");
-    List<ResolveInfo> resolveInfos =
-        activity.getPackageManager().queryIntentServices(customTabIntent, 0);
-    return resolveInfos != null && !resolveInfos.isEmpty();
-  }
-
-  private boolean ishttpOrHttpsUri(Uri uri) {
-    if (uri == null) {
-      return false;
-    }
-    String scheme = uri.getScheme();
-    return scheme != null && (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"));
   }
 }

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayActionHandler.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayActionHandler.java
@@ -1,0 +1,12 @@
+package com.google.firebase.inappmessaging.display;
+
+import android.app.Activity;
+import androidx.annotation.NonNull;
+import com.google.firebase.inappmessaging.model.Action;
+
+/**
+ * Handles message element (image, button) clicks.
+ */
+public interface FirebaseInAppMessagingDisplayActionHandler {
+  void handleAction(@NonNull Activity activity, @NonNull Action action);
+}

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayDefaultActionHandler.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayDefaultActionHandler.java
@@ -1,0 +1,58 @@
+package com.google.firebase.inappmessaging.display;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabsIntent;
+import com.google.firebase.inappmessaging.display.internal.Logging;
+import com.google.firebase.inappmessaging.model.Action;
+import java.util.List;
+
+/**
+ * The default handler of message actions. It opens a Custom Tab with the link if possible or tries to find an Activity
+ * that can handle the action URL
+ */
+public class FirebaseInAppMessagingDisplayDefaultActionHandler implements FirebaseInAppMessagingDisplayActionHandler {
+  @Override
+  public void handleAction(@NonNull Activity activity, @NonNull Action action) {
+    Uri uri = Uri.parse(action.getActionUrl());
+    if (ishttpOrHttpsUri(uri) && supportsCustomTabs(activity)) {
+      // If we can launch a chrome view, try that.
+      CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
+      Intent intent = customTabsIntent.intent;
+      intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      customTabsIntent.launchUrl(activity, uri);
+    } else {
+      // If we can't launch a chrome view try to launch anything that can handle a URL.
+      Intent browserIntent = new Intent(Intent.ACTION_VIEW, uri);
+      ResolveInfo info = activity.getPackageManager().resolveActivity(browserIntent, 0);
+      browserIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+      browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      if (info != null) {
+        activity.startActivity(browserIntent);
+      } else {
+        // If the device can't resolve a url then log, but don't crash.
+        Logging.loge("Device cannot resolve intent for: " + Intent.ACTION_VIEW);
+      }
+    }
+  }
+
+  private boolean supportsCustomTabs(Activity activity) {
+    Intent customTabIntent = new Intent("android.support.customtabs.action.CustomTabsService");
+    customTabIntent.setPackage("com.android.chrome");
+    List<ResolveInfo> resolveInfos =
+        activity.getPackageManager().queryIntentServices(customTabIntent, 0);
+    return !resolveInfos.isEmpty();
+  }
+
+  private boolean ishttpOrHttpsUri(Uri uri) {
+    if (uri == null) {
+      return false;
+    }
+    String scheme = uri.getScheme();
+    return scheme != null && (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"));
+  }
+}


### PR DESCRIPTION
Allow for setting a custom action handler in `FirebaseInAppMessagingDisplay`. This way you can handle the action however you like. The default behavior doesn't handle deep links correctly.

Related issue https://github.com/firebase/firebase-android-sdk/issues/4726
These changes would also fix https://github.com/firebase/firebase-android-sdk/issues/3056

An alternative fix is here, but I prefer this one https://github.com/firebase/firebase-android-sdk/pull/4728