### PR TITLE
Allow setting impression/dismiss thresholds in FirebaseInAppMessagingDisplay

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -77,9 +77,8 @@ import javax.inject.Provider;
  */
 @FirebaseAppScope
 public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplayImpl {
-  static final long IMPRESSION_THRESHOLD_MILLIS = 5 * 1000; // 5 seconds is a valid impression
-  static final long DISMISS_THRESHOLD_MILLIS =
-      20 * 1000; // auto dismiss after 20 seconds for banner
+  static long impressionThresholdMillis = 5 * 1000; // 5 seconds is a valid impression
+  static long dismissThresholdMillis = 20 * 1000; // auto dismiss after 20 seconds for banner
   static final long INTERVAL_MILLIS = 1000;
 
   private final FirebaseInAppMessaging headlessInAppMessaging;
@@ -129,6 +128,22 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   @NonNull
   public static FirebaseInAppMessagingDisplay getInstance() {
     return FirebaseApp.getInstance().get(FirebaseInAppMessagingDisplay.class);
+  }
+
+  public static long getImpressionThresholdMillis() {
+    return impressionThresholdMillis;
+  }
+
+  public static void setImpressionThresholdMillis(long impressionThresholdMillis) {
+    FirebaseInAppMessagingDisplay.impressionThresholdMillis = impressionThresholdMillis;
+  }
+
+  public static long getDismissThresholdMillis() {
+    return dismissThresholdMillis;
+  }
+
+  public static void setDismissThresholdMillis(long dismissThresholdMillis) {
+    FirebaseInAppMessagingDisplay.dismissThresholdMillis = dismissThresholdMillis;
   }
 
   private static int getScreenOrientation(Application app) {
@@ -389,7 +404,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
                     }
                   }
                 },
-                IMPRESSION_THRESHOLD_MILLIS,
+                impressionThresholdMillis,
                 INTERVAL_MILLIS);
 
             // Setup auto dismiss timer
@@ -405,7 +420,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
                       dismissFiam(activity);
                     }
                   },
-                  DISMISS_THRESHOLD_MILLIS,
+                  dismissThresholdMillis,
                   INTERVAL_MILLIS);
             }
 

--- a/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
+++ b/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
@@ -455,7 +455,7 @@ public class FirebaseInAppMessagingDisplayTest {
             any(RenewableTimer.Callback.class),
             ArgumentMatchers.eq(
                 com.google.firebase.inappmessaging.display.FirebaseInAppMessagingDisplay
-                    .IMPRESSION_THRESHOLD_MILLIS),
+                    .impressionThresholdMillis),
             ArgumentMatchers.eq(
                 com.google.firebase.inappmessaging.display.FirebaseInAppMessagingDisplay
                     .INTERVAL_MILLIS));
@@ -473,7 +473,7 @@ public class FirebaseInAppMessagingDisplayTest {
             any(RenewableTimer.Callback.class),
             ArgumentMatchers.eq(
                 com.google.firebase.inappmessaging.display.FirebaseInAppMessagingDisplay
-                    .DISMISS_THRESHOLD_MILLIS),
+                    .dismissThresholdMillis),
             ArgumentMatchers.eq(
                 com.google.firebase.inappmessaging.display.FirebaseInAppMessagingDisplay
                     .INTERVAL_MILLIS));


### PR DESCRIPTION
Currently, the impression and dismiss thresholds are constant and can't be changed. This set of changes makes those values modifiable.

Related issue https://github.com/firebase/firebase-android-sdk/issues/4727