### PR TITLE
Use kotlin.time.Duration instead of Long for time intervals

### DIFF
--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -1,16 +1,18 @@
-// Copyright 2023 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 plugins {
   id("firebase-library")

--- a/firebase-sessions/src/androidTest/kotlin/com/google/firebase/sessions/FirebaseSessionsTests.kt
+++ b/firebase-sessions/src/androidTest/kotlin/com/google/firebase/sessions/FirebaseSessionsTests.kt
@@ -1,16 +1,18 @@
-// Copyright 2023 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.google.firebase.sessions
 

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -1,16 +1,18 @@
-// Copyright 2023 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.google.firebase.sessions
 
@@ -23,7 +25,7 @@ import com.google.firebase.ktx.app
 
 class FirebaseSessions internal constructor(firebaseApp: FirebaseApp) {
   init {
-    val sessionInitiator = SessionInitiator(System::currentTimeMillis, this::initiateSessionStart)
+    val sessionInitiator = SessionInitiator(WallClock::elapsedRealtime, this::initiateSessionStart)
     val context = firebaseApp.applicationContext.applicationContext
     if (context is Application) {
       context.registerActivityLifecycleCallbacks(sessionInitiator.activityLifecycleCallbacks)

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionInitiator.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionInitiator.kt
@@ -19,6 +19,8 @@ package com.google.firebase.sessions
 import android.app.Activity
 import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * The [SessionInitiator] is responsible for calling the [initiateSessionStart] callback whenever a
@@ -28,23 +30,23 @@ import android.os.Bundle
  * @hide
  */
 internal class SessionInitiator(
-  private val currentTimeMs: () -> Long,
+  private val elapsedRealtime: () -> Duration,
   private val initiateSessionStart: () -> Unit
 ) {
-  private var backgroundTimeMs = currentTimeMs()
-  private val sessionTimeoutMs = 30 * 60 * 1000L // TODO(mrober): Get session timeout from settings
+  private var backgroundTime = elapsedRealtime()
+  private val sessionTimeout = 30.minutes // TODO(mrober): Get session timeout from settings
 
   init {
     initiateSessionStart()
   }
 
   fun appBackgrounded() {
-    backgroundTimeMs = currentTimeMs()
+    backgroundTime = elapsedRealtime()
   }
 
   fun appForegrounded() {
-    val intervalMs = currentTimeMs() - backgroundTimeMs
-    if (intervalMs > sessionTimeoutMs) {
+    val interval = elapsedRealtime() - backgroundTime
+    if (interval > sessionTimeout) {
       initiateSessionStart()
     }
   }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/WallClock.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/WallClock.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions
+
+import android.os.Build
+import android.os.SystemClock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
+
+/** Util object for "wall clock" time functions. */
+internal object WallClock {
+  /** Gets the [Duration] elapsed in "wall clock" time since device boot. */
+  fun elapsedRealtime(): Duration =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      SystemClock.elapsedRealtimeNanos().nanoseconds
+    } else {
+      SystemClock.elapsedRealtime().milliseconds
+    }
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/WallClock.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/WallClock.kt
@@ -16,19 +16,12 @@
 
 package com.google.firebase.sessions
 
-import android.os.Build
 import android.os.SystemClock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.nanoseconds
 
 /** Util object for "wall clock" time functions. */
 internal object WallClock {
   /** Gets the [Duration] elapsed in "wall clock" time since device boot. */
-  fun elapsedRealtime(): Duration =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      SystemClock.elapsedRealtimeNanos().nanoseconds
-    } else {
-      SystemClock.elapsedRealtime().milliseconds
-    }
+  fun elapsedRealtime(): Duration = SystemClock.elapsedRealtime().milliseconds
 }

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionInitiatorTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionInitiatorTest.kt
@@ -19,7 +19,6 @@ package com.google.firebase.sessions
 import com.google.common.truth.Truth.assertThat
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import org.junit.Test
 
 class SessionInitiatorTest {
@@ -137,7 +136,7 @@ class SessionInitiatorTest {
   }
 
   companion object {
-    private val SMALL_INTERVAL = 3.seconds // not enough time to initiate a new session
-    private val LARGE_INTERVAL = 90.minutes // enough to initiate another session
+    private val SMALL_INTERVAL = 29.minutes // not enough time to initiate a new session
+    private val LARGE_INTERVAL = 31.minutes // enough to initiate another session
   }
 }


### PR DESCRIPTION
Use `kotlin.time.Duration` instead of `Long` for time intervals.

`kotlin.time.Duration` is safe to use with min api level 16. It is `java.time.Duration` that requres api level 26. We still can't use `java.time.Instant` because of our min api level, but I avoided it by making everything `Duration`s.

Also switched to using `SystemClock.elapsedRealtime()` which is *"the time since the system was booted, and include deep sleep. This clock is guaranteed to be monotonic, and continues to tick even when the CPU is in power saving modes, so is the recommend basis for general purpose interval timing."*

Fixed the copyright format on Kotlin files so it shows collapsed by default in AS.