### PR TITLE
Remove irrelevant exceptions and update tests

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -105,6 +105,7 @@ public class ConfigAutoFetch {
         handleNotifications(inputStream);
         inputStream.close();
       } catch (IOException ex) {
+        // Stream was interrupted due to a transient issue and the system will retry the connection.
         Log.d(TAG, "Stream was cancelled due to an exception: " + ex.toString());
       } finally {
         httpURLConnection.disconnect();
@@ -151,6 +152,8 @@ public class ConfigAutoFetch {
               }
             }
           } catch (JSONException ex) {
+            // Message was mangled up and so it was unable to be parsed. User is notified of this
+            // because it there could be a new configuration that needs to be fetched.
             propagateErrors(
                 new FirebaseRemoteConfigClientException(
                     "Unable to parse config update message.",

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -106,7 +106,11 @@ public class ConfigAutoFetch {
         inputStream.close();
       } catch (IOException ex) {
         // Stream was interrupted due to a transient issue and the system will retry the connection.
-        Log.d(TAG, "Stream was cancelled due to an exception: " + ex.toString());
+        Log.d(
+            TAG,
+            String.format(
+                "Stream was cancelled due to an exception: %s. Retrying the connection...",
+                ex.toString()));
       } finally {
         httpURLConnection.disconnect();
       }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -106,11 +106,7 @@ public class ConfigAutoFetch {
         inputStream.close();
       } catch (IOException ex) {
         // Stream was interrupted due to a transient issue and the system will retry the connection.
-        Log.d(
-            TAG,
-            String.format(
-                "Stream was cancelled due to an exception: %s. Retrying the connection...",
-                ex.toString()));
+        Log.d(TAG, "Stream was cancelled due to an exception. Retrying the connection...", ex);
       } finally {
         httpURLConnection.disconnect();
       }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -159,7 +159,7 @@ public class ConfigAutoFetch {
                     "Unable to parse config update message.",
                     ex.getCause(),
                     FirebaseRemoteConfigException.Code.CONFIG_UPDATE_MESSAGE_INVALID));
-            Log.e(TAG, "Unable to parse latest config update message." + ex.toString());
+            Log.e(TAG, "Unable to parse latest config update message.", ex);
           }
 
           currentConfigUpdateMessage = "";

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -105,11 +105,7 @@ public class ConfigAutoFetch {
         handleNotifications(inputStream);
         inputStream.close();
       } catch (IOException ex) {
-        propagateErrors(
-            new FirebaseRemoteConfigClientException(
-                "Unable to parse config update message.",
-                ex.getCause(),
-                FirebaseRemoteConfigException.Code.CONFIG_UPDATE_MESSAGE_INVALID));
+        Log.d(TAG, "Stream was cancelled due to an exception: " + ex.toString());
       } finally {
         httpURLConnection.disconnect();
       }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -151,6 +151,11 @@ public class ConfigAutoFetch {
               }
             }
           } catch (JSONException ex) {
+            propagateErrors(
+                new FirebaseRemoteConfigClientException(
+                    "Unable to parse config update message.",
+                    ex.getCause(),
+                    FirebaseRemoteConfigException.Code.CONFIG_UPDATE_MESSAGE_INVALID));
             Log.e(TAG, "Unable to parse latest config update message." + ex.toString());
           }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -472,11 +472,6 @@ public class ConfigRealtimeHttpClient {
       }
     } catch (IOException e) {
       Log.d(TAG, "Exception connecting to realtime stream. Retrying the connection...");
-      propagateErrors(
-          new FirebaseRemoteConfigServerException(
-              "Unable to connect to the server. Try again in a few minutes.",
-              e.getCause(),
-              FirebaseRemoteConfigException.Code.CONFIG_UPDATE_STREAM_ERROR));
     } finally {
       closeRealtimeHttpStream(httpURLConnection);
       setIsHttpConnectionRunning(false);

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -473,7 +473,7 @@ public class ConfigRealtimeHttpClient {
     } catch (IOException e) {
       // Stream could not be open due to a transient issue and the system will retry the connection
       // without user intervention.
-      Log.d(TAG, "Exception connecting to realtime stream. Retrying the connection...");
+      Log.d(TAG, "Exception connecting to realtime stream. Retrying the connection...", e);
     } finally {
       closeRealtimeHttpStream(httpURLConnection);
       setIsHttpConnectionRunning(false);

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -471,6 +471,8 @@ public class ConfigRealtimeHttpClient {
         configAutoFetch.listenForNotifications();
       }
     } catch (IOException e) {
+      // Stream could not be open due to a transient issue and the system will retry the connection
+      // without user intervention.
       Log.d(TAG, "Exception connecting to realtime stream. Retrying the connection...");
     } finally {
       closeRealtimeHttpStream(httpURLConnection);

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1223,14 +1223,6 @@ public final class FirebaseRemoteConfigTest {
   }
 
   @Test
-  public void realtime_stream_listen_fail() throws Exception {
-    when(mockHttpURLConnection.getInputStream()).thenThrow(IOException.class);
-    configAutoFetch.listenForNotifications();
-
-    verify(mockInvalidMessageEventListener).onError(any(FirebaseRemoteConfigClientException.class));
-  }
-
-  @Test
   public void realtime_redirectStatusCode_noRetries() throws Exception {
     ConfigRealtimeHttpClient configRealtimeHttpClientSpy = spy(configRealtimeHttpClient);
     doReturn(mockHttpURLConnection).when(configRealtimeHttpClientSpy).createRealtimeConnection();
@@ -1415,7 +1407,7 @@ public final class FirebaseRemoteConfigTest {
         .thenReturn(Tasks.forResult(realtimeFetchedContainerResponse));
     configAutoFetch.listenForNotifications();
 
-    verify(mockInvalidMessageEventListener).onError(any(FirebaseRemoteConfigClientException.class));
+    verify(mockHttpURLConnection).disconnect();
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1398,6 +1398,23 @@ public final class FirebaseRemoteConfigTest {
   }
 
   @Test
+  public void realtimeStreamListen_andUnableToParseMessage() throws Exception {
+    when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
+    when(mockHttpURLConnection.getInputStream())
+        .thenReturn(
+            new ByteArrayInputStream(
+                "{ \"featureDisabled\": false,  \"latestTemplateVersionNumber: 2 } }"
+                    .getBytes(StandardCharsets.UTF_8)));
+    when(mockFetchHandler.getTemplateVersionNumber()).thenReturn(1L);
+    when(mockFetchHandler.fetchNowWithTypeAndAttemptNumber(
+            ConfigFetchHandler.FetchType.REALTIME, 1))
+        .thenReturn(Tasks.forResult(realtimeFetchedContainerResponse));
+    configAutoFetch.listenForNotifications();
+
+    verify(mockInvalidMessageEventListener).onError(any(FirebaseRemoteConfigClientException.class));
+  }
+
+  @Test
   public void realtime_stream_listen_get_inputstream_fail() throws Exception {
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
     when(mockHttpURLConnection.getInputStream()).thenThrow(IOException.class);


### PR DESCRIPTION
- Remove exceptions that users can't do anything about and that don't break Realtime
- Remote duplicate test and update test to not rely on exception