### PR TITLE
Default template_version_number_key to 0 when it is not cached.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -107,7 +107,8 @@ public class ConfigContainer {
         new Date(containerJson.getLong(FETCH_TIME_KEY)),
         containerJson.getJSONArray(ABT_EXPERIMENTS_KEY),
         personalizationMetadataJSON,
-        containerJson.getLong(TEMPLATE_VERSION_NUMBER_KEY));
+        // Default to 0 if template_version_number_key has not been cached yet.
+        containerJson.optLong(TEMPLATE_VERSION_NUMBER_KEY));
   }
 
   /**

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -255,6 +255,21 @@ public class ConfigContainerTest {
     assertThat(other.getConfigs().toString()).isEqualTo(configsString);
   }
 
+  @Test
+  public void copyOf_missingTemplateVersionNumber_defaultsToZero() throws Exception {
+    ConfigContainer config =
+            ConfigContainer.newBuilder()
+                    .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+                    .withTemplateVersionNumber(2L)
+                    .build();
+    JSONObject containerJson = new JSONObject(config.toString());
+    containerJson.remove(ConfigContainer.TEMPLATE_VERSION_NUMBER_KEY);
+
+    ConfigContainer configWithoutTemplateVersion = ConfigContainer.copyOf(containerJson);
+
+    assertThat(configWithoutTemplateVersion.getTemplateVersionNumber()).isEqualTo(0L);
+  }
+
   private static JSONArray generateAbtExperiments(int numExperiments) throws JSONException {
     JSONArray experiments = new JSONArray();
     for (int experimentNum = 1; experimentNum <= numExperiments; experimentNum++) {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -258,10 +258,10 @@ public class ConfigContainerTest {
   @Test
   public void copyOf_missingTemplateVersionNumber_defaultsToZero() throws Exception {
     ConfigContainer config =
-            ConfigContainer.newBuilder()
-                    .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
-                    .withTemplateVersionNumber(2L)
-                    .build();
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withTemplateVersionNumber(2L)
+            .build();
     JSONObject containerJson = new JSONObject(config.toString());
     containerJson.remove(ConfigContainer.TEMPLATE_VERSION_NUMBER_KEY);
 


### PR DESCRIPTION
Fixes a bug reading from the cache after upgrading to this version.

* Before upgrading, the cached config does not contain `template_version_number_key`.
* After upgrading, calling `containerJson.getLong(TEMPLATE_VERSION_NUMBER_KEY)` throws a `JSONException`, which is [caught](https://github.com/firebase/firebase-android-sdk/blob/dfe71a9b2b1067dbee7b8b6f204e07b68d45c549/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigStorageClient.java#L106) (since it's expected the cache may not have been written yet) and [a default value is returned](https://github.com/firebase/firebase-android-sdk/blob/dfe71a9b2b1067dbee7b8b6f204e07b68d45c549/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandler.java#L233-L247).

To repro:

1. Run an app with a pre-realtime version. Fetch and activate. `get` a fetched value.
2. See the remote value.
3. Update to this version. Fetch and activate.
4. See the remote value cannot be found (warning is logged) and a static default is returned. 