### PR TITLE
Add NumberedEnum interface

### DIFF
--- a/encoders/firebase-encoders-json/firebase-encoders-json.gradle
+++ b/encoders/firebase-encoders-json/firebase-encoders-json.gradle
@@ -14,6 +14,7 @@
 
 plugins {
     id 'firebase-library'
+    id 'kotlin-android'
 }
 
 firebaseLibrary {
@@ -24,15 +25,18 @@ firebaseLibrary {
 android {
     compileSdkVersion project.targetSdkVersion
     defaultConfig {
-      minSdkVersion project.minSdkVersion
-      targetSdkVersion project.targetSdkVersion
-      versionName version
-      testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        minSdkVersion project.minSdkVersion
+        targetSdkVersion project.targetSdkVersion
+        versionName version
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
     testOptions {
         unitTests {

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContext.java
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContext.java
@@ -317,7 +317,11 @@ final class JsonValueObjectEncoderContext implements ObjectEncoderContext, Value
 
     // Process enum last if it does not have a custom encoder registered.
     if (o instanceof Enum) {
-      add(((Enum) o).name());
+      if (o instanceof NumberedEnum) {
+        add(((NumberedEnum) o).getNumber());
+      } else {
+        add(((Enum<?>) o).name());
+      }
       return this;
     }
 

--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/json/NumberedEnum.kt
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/json/NumberedEnum.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.encoders.json
+
+/** Represents an explicitly numbered enum for json serialization. */
+internal interface NumberedEnum {
+  val number: Int
+}

--- a/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/DummyEnum.kt
+++ b/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/DummyEnum.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.encoders.json
+
+internal enum class DummyEnum(override val number: Int) : NumberedEnum {
+  VALUE_1(1),
+  VALUE_2(2),
+}

--- a/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContextTest.java
+++ b/encoders/firebase-encoders-json/src/test/java/com/google/firebase/encoders/json/JsonValueObjectEncoderContextTest.java
@@ -220,6 +220,18 @@ public class JsonValueObjectEncoderContextTest {
   }
 
   @Test
+  public void testEncodingNumberedEnum() {
+    String result =
+        new JsonDataEncoderBuilder()
+            .build()
+            .encode(
+                new DummyEnum[] {
+                  DummyEnum.VALUE_1, DummyEnum.VALUE_2, DummyEnum.VALUE_1, DummyEnum.VALUE_1
+                });
+    assertThat(result).isEqualTo("[1,2,1,1]");
+  }
+
+  @Test
   public void testEncodingCollection() throws IOException {
     ObjectEncoder<InnerDummyClass> anotherObjectEncoder =
         (o, ctx) -> {


### PR DESCRIPTION
Add NumberedEnum interface.

This is useful for when we want enums to have explicit numbers, and serialize as the number, instead of the enum name.
This is in Kotlin so we can take advantage of the nice syntax to override it in the primary ctor of an enum class.