### PR TITLE
Ignore invalidations and stop listening when there are no listeners.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -83,8 +83,8 @@ public class ConfigAutoFetch {
     }
   }
 
-  private synchronized Set<ConfigUpdateListener> getEventListeners() {
-    return this.eventListeners;
+  private synchronized boolean isEventListenersEmpty() {
+    return this.eventListeners.isEmpty();
   }
 
   private String parseAndValidateConfigUpdateMessage(String message) {
@@ -159,7 +159,7 @@ public class ConfigAutoFetch {
           // In effect, stop listening when the last listener is removed. This works around
           // URLConnection.disconnect() being called by ConfigAutoFetch rather than
           // ConfigRealtimeHttpClient.
-          if (this.getEventListeners().isEmpty()) {
+          if (this.isEventListenersEmpty()) {
             break;
           }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -83,6 +83,10 @@ public class ConfigAutoFetch {
     }
   }
 
+  private synchronized Set<ConfigUpdateListener> getEventListeners() {
+    return this.eventListeners;
+  }
+
   private String parseAndValidateConfigUpdateMessage(String message) {
     int left = message.indexOf('{');
     int right = message.lastIndexOf('}');
@@ -155,7 +159,7 @@ public class ConfigAutoFetch {
           // In effect, stop listening when the last listener is removed. This works around
           // URLConnection.disconnect() being called by ConfigAutoFetch rather than
           // ConfigRealtimeHttpClient.
-          if (eventListeners.isEmpty()) {
+          if (this.getEventListeners().isEmpty()) {
             break;
           }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -147,6 +147,18 @@ public class ConfigAutoFetch {
                     FirebaseRemoteConfigException.Code.CONFIG_UPDATE_UNAVAILABLE));
             break;
           }
+
+          // If there's an invalidation message and no listeners, ignore the message and close the
+          // realtime stream connection. The next time the realtime connection is opened, the client
+          // will receive the same invalidation message and call any registered listeners.
+          //
+          // In effect, stop listening when the last listener is removed. This works around
+          // URLConnection.disconnect() being called by ConfigAutoFetch rather than
+          // ConfigRealtimeHttpClient.
+          if (eventListeners.isEmpty()) {
+            break;
+          }
+
           if (jsonObject.has(TEMPLATE_VERSION_KEY)) {
             long oldTemplateVersion = configFetchHandler.getTemplateVersionNumber();
             long targetTemplateVersion = jsonObject.getLong(TEMPLATE_VERSION_KEY);


### PR DESCRIPTION
As noted in the comment, if there's an invalidation message and no listeners, ignore the message and close the realtime stream connection. The next time the realtime connection is opened, the client will receive the same invalidation message and call any registered listeners.

In effect, this stops listening when the last listener is removed. This works around `URLConnection.disconnect()` being called in `ConfigAutoFetch` rather than `ConfigRealtimeHttpClient`. Since the connection is cleaned up in `ConfigAutoFetch`, terminating it early in `ConfigRealtimeHttpClient` involves significant refactoring to avoid calling multiple connection lifecycle methods twice.