### PR TITLE
Make NumberedEnum public, not internal

### DIFF
--- a/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/json/NumberedEnum.kt
+++ b/encoders/firebase-encoders-json/src/main/java/com/google/firebase/encoders/json/NumberedEnum.kt
@@ -17,6 +17,6 @@
 package com.google.firebase.encoders.json
 
 /** Represents an explicitly numbered enum for json serialization. */
-internal interface NumberedEnum {
+interface NumberedEnum {
   val number: Int
 }


### PR DESCRIPTION
Make `NumberedEnum` public, not internal. This is needed to use it in other Firebase libraries.