### PR TITLE
Add JSON encoder for SessionEvents

### DIFF
--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -42,11 +42,10 @@ android {
 }
 
 dependencies {
-  implementation(project(":encoders:firebase-encoders"))
+  implementation("com.google.firebase:firebase-encoders:17.0.0")
   implementation(project(":encoders:firebase-encoders-json"))
-  implementation(project(":firebase-common"))
-  implementation(project(":firebase-common:ktx"))
-  implementation(project(":firebase-components"))
+  implementation("com.google.firebase:firebase-common-ktx:20.3.1")
+  implementation("com.google.firebase:firebase-components:17.1.0")
   implementation(libs.androidx.annotation)
 
   testImplementation(libs.androidx.test.junit)

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -42,12 +42,17 @@ android {
 }
 
 dependencies {
+  implementation(project(":encoders:firebase-encoders"))
+  implementation(project(":encoders:firebase-encoders-json"))
   implementation(project(":firebase-common"))
   implementation(project(":firebase-common:ktx"))
   implementation(project(":firebase-components"))
   implementation(libs.androidx.annotation)
 
+  testImplementation(libs.androidx.test.junit)
+  testImplementation(libs.androidx.test.runner)
   testImplementation(libs.junit)
+  testImplementation(libs.robolectric)
   testImplementation(libs.truth)
 
   androidTestImplementation(libs.androidx.test.junit)

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -40,8 +40,8 @@ class FirebaseSessions internal constructor(firebaseApp: FirebaseApp) {
   fun greeting(): String = "Matt says hi!"
 
   private fun initiateSessionStart() {
-    val sessionState = sessionGenerator.generateNewSession()
-    val sessionEvent = SessionEvents.sessionStart(sessionState)
+    val sessionDetails = sessionGenerator.generateNewSession()
+    val sessionEvent = SessionEvents.startSession(sessionDetails)
 
     Log.i(TAG, "Initiate session start: $sessionEvent")
   }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -41,7 +41,7 @@ class FirebaseSessions internal constructor(firebaseApp: FirebaseApp) {
 
   private fun initiateSessionStart() {
     val sessionState = sessionGenerator.generateNewSession()
-    val sessionEvent = SessionEvent.sessionStart(sessionState)
+    val sessionEvent = SessionEvents.sessionStart(sessionState)
 
     Log.i(TAG, "Initiate session start: $sessionEvent")
   }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvent.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvent.kt
@@ -16,6 +16,8 @@
 
 package com.google.firebase.sessions
 
+import com.google.firebase.encoders.json.NumberedEnum
+
 /**
  * Contains the relevant information around a Firebase Session Event.
  *
@@ -29,23 +31,10 @@ internal data class SessionEvent(
 
   /** Information about the session triggering the event. */
   val sessionData: SessionInfo,
-) {
-  companion object {
-    fun sessionStart(sessionDetails: SessionDetails) =
-      SessionEvent(
-        eventType = EventType.SESSION_START,
-        sessionData =
-          SessionInfo(
-            sessionDetails.sessionId,
-            sessionDetails.firstSessionId,
-            sessionDetails.sessionIndex,
-          ),
-      )
-  }
-}
+)
 
 /** Enum denoting all possible session event types. */
-internal enum class EventType(val number: Int) {
+internal enum class EventType(override val number: Int) : NumberedEnum {
   EVENT_TYPE_UNKNOWN(0),
 
   /** This event type is fired as soon as a new session begins. */

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions
+
+import com.google.firebase.encoders.DataEncoder
+import com.google.firebase.encoders.FieldDescriptor
+import com.google.firebase.encoders.ObjectEncoderContext
+import com.google.firebase.encoders.json.JsonDataEncoderBuilder
+
+/**
+ * Contains functions for [SessionEvent]s.
+ *
+ * @hide
+ */
+internal object SessionEvents {
+  /** JSON [DataEncoder] for [SessionEvent]s. */
+  // TODO(mrober): Replace with firebase-encoders-processor when it can encode Kotlin data classes.
+  internal val SESSION_EVENT_ENCODER: DataEncoder =
+    JsonDataEncoderBuilder()
+      .configureWith {
+        it.registerEncoder(SessionEvent::class.java) {
+          sessionEvent: SessionEvent,
+          ctx: ObjectEncoderContext ->
+          run {
+            ctx.add(FieldDescriptor.of("event_type"), sessionEvent.eventType)
+            ctx.add(FieldDescriptor.of("session_data"), sessionEvent.sessionData)
+          }
+        }
+
+        it.registerEncoder(SessionInfo::class.java) {
+          sessionInfo: SessionInfo,
+          ctx: ObjectEncoderContext ->
+          run {
+            ctx.add(FieldDescriptor.of("session_id"), sessionInfo.sessionId)
+            ctx.add(FieldDescriptor.of("first_session_id"), sessionInfo.firstSessionId)
+            ctx.add(FieldDescriptor.of("session_index"), sessionInfo.sessionIndex)
+          }
+        }
+      }
+      .build()
+
+  /** Construct a Session Start event */
+  fun sessionStart(sessionDetails: SessionDetails) =
+    SessionEvent(
+      eventType = EventType.SESSION_START,
+      sessionData =
+        SessionInfo(
+          sessionDetails.sessionId,
+          sessionDetails.firstSessionId,
+          sessionDetails.sessionIndex,
+        ),
+    )
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
@@ -54,7 +54,7 @@ internal object SessionEvents {
       .build()
 
   /** Construct a Session Start event */
-  fun sessionStart(sessionDetails: SessionDetails) =
+  fun startSession(sessionDetails: SessionDetails) =
     SessionEvent(
       eventType = EventType.SESSION_START,
       sessionData =

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
@@ -57,6 +57,38 @@ class SessionEventEncoderTest {
   }
 
   @Test
+  fun sessionEvent_emptyValues_encodesToJson() {
+    val sessionEvent =
+      SessionEvent(
+        eventType = EventType.EVENT_TYPE_UNKNOWN,
+        sessionData =
+          SessionInfo(
+            sessionId = "",
+            firstSessionId = "",
+            sessionIndex = 0,
+          ),
+      )
+
+    val json = SESSION_EVENT_ENCODER.encode(sessionEvent)
+
+    assertThat(json)
+      .isEqualTo(
+        """
+        {
+          "event_type":0,
+          "session_data":{
+            "session_id":"",
+            "first_session_id":"",
+            "session_index":0
+          }
+        }
+        """
+          .lines()
+          .joinToString("") { it.trim() }
+      )
+  }
+
+  @Test
   fun eventType_numberedEnum_encodesToJson() {
     val json =
       SESSION_EVENT_ENCODER.encode(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.google.firebase.sessions.SessionEvents.SESSION_EVENT_ENCODER
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SessionEventEncoderTest {
+  @Test
+  fun sessionEvent_encodesToJson() {
+    val sessionEvent =
+      SessionEvent(
+        eventType = EventType.SESSION_START,
+        sessionData =
+          SessionInfo(
+            sessionId = "id",
+            firstSessionId = "first",
+            sessionIndex = 9,
+          ),
+      )
+
+    val json = SESSION_EVENT_ENCODER.encode(sessionEvent)
+
+    assertThat(json)
+      .isEqualTo(
+        """
+        {
+          "event_type":1,
+          "session_data":{
+            "session_id":"id",
+            "first_session_id":"first",
+            "session_index":9
+          }
+        }
+        """
+          .lines()
+          .joinToString("") { it.trim() }
+      )
+  }
+
+  @Test
+  fun eventType_numberedEnum_encodesToJson() {
+    val json =
+      SESSION_EVENT_ENCODER.encode(
+        arrayOf(
+          EventType.SESSION_START,
+          EventType.EVENT_TYPE_UNKNOWN,
+          EventType.SESSION_START,
+          EventType.SESSION_START
+        )
+      )
+
+    assertThat(json).isEqualTo("[1,0,1,1]")
+  }
+}

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventTest.kt
@@ -30,7 +30,7 @@ class SessionEventTest {
         sessionIndex = 3,
       )
 
-    val sessionEvent = SessionEvents.sessionStart(sessionDetails)
+    val sessionEvent = SessionEvents.startSession(sessionDetails)
 
     assertThat(sessionEvent)
       .isEqualTo(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventTest.kt
@@ -30,7 +30,7 @@ class SessionEventTest {
         sessionIndex = 3,
       )
 
-    val sessionEvent = SessionEvent.sessionStart(sessionDetails)
+    val sessionEvent = SessionEvents.sessionStart(sessionDetails)
 
     assertThat(sessionEvent)
       .isEqualTo(


### PR DESCRIPTION
Add JSON encoder for `SessionEvent`s.

Also moved the logic to construct a Session Start event out of the data class, this is to make the data class cleaner and easier to read.