### PR TITLE
Use >API30 for crashlytics ndk device testing

### DIFF
--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -18,7 +18,10 @@ plugins {
 }
 
 firebaseLibrary {
-    testLab.enabled = true
+    testLab {
+        enabled = true
+        device 'model=panther,version=33' // Pixel7
+    }
     publishJavadoc = false
 }
 


### PR DESCRIPTION
Fixes instrumentation tests for crashlytics-ndk