### PR TITLE
Include Kotlin directories in the Dackka plugin

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -174,7 +174,9 @@ abstract class DackkaPlugin : Plugin<Project> {
             val classpath =
               compileConfiguration.jars + project.javadocConfig.jars + project.files(bootClasspath)
 
-            val sourceDirectories = sourceSets.flatMap { it.javaDirectories }
+            val sourceDirectories =
+              sourceSets.flatMap { it.javaDirectories } +
+                sourceSets.flatMap { it.kotlinDirectories }
 
             val packageLists = fetchPackageLists(project)
             val excludedFiles = projectSpecificSuppressedFiles(project)


### PR DESCRIPTION
Include Kotlin directories in the Dackka plugin.

The `generateDackkaDocumentation` task was not outputting anything on `firebase-sessions` because it was ignoring the `main/kotlin/` src dir, it only looked at `main/java/` before. This was causing some workflows to fail on every PR since sessions is entirely written in Kotlin.