### PR TITLE
Firestore: add a Kotlin unit test for PropertyName

### DIFF
--- a/firebase-firestore/ktx/src/test/kotlin/com/google/firebase/firestore/ktx/FirestoreTests.kt
+++ b/firebase-firestore/ktx/src/test/kotlin/com/google/firebase/firestore/ktx/FirestoreTests.kt
@@ -118,9 +118,7 @@ data class Room(var a: Int = 0, var b: Int = 0)
 // Also, the properties need to be mutable; that is, declared with `var` and not `val`.
 // See https://github.com/firebase/firebase-android-sdk/issues/4822
 data class DataClassWithPropertyName(
-    @get:PropertyName("dbName")
-    @set:PropertyName("dbName")
-    var objName: String = "DefaultObjName"
+  @get:PropertyName("dbName") @set:PropertyName("dbName") var objName: String = "DefaultObjName"
 )
 
 @RunWith(RobolectricTestRunner::class)

--- a/firebase-firestore/ktx/src/test/kotlin/com/google/firebase/firestore/ktx/FirestoreTests.kt
+++ b/firebase-firestore/ktx/src/test/kotlin/com/google/firebase/firestore/ktx/FirestoreTests.kt
@@ -22,6 +22,7 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldPath
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreSettings
+import com.google.firebase.firestore.PropertyName
 import com.google.firebase.firestore.TestUtil
 import com.google.firebase.firestore.model.ObjectValue
 import com.google.firebase.firestore.testutil.TestUtil.wrap
@@ -113,6 +114,15 @@ class LibraryVersionTest : BaseTestCase() {
 
 data class Room(var a: Int = 0, var b: Int = 0)
 
+// NOTE: When Kotlin properties are annotated with `PropertyName` they need to use @get and @set.
+// Also, the properties need to be mutable; that is, declared with `var` and not `val`.
+// See https://github.com/firebase/firebase-android-sdk/issues/4822
+data class DataClassWithPropertyName(
+    @get:PropertyName("dbName")
+    @set:PropertyName("dbName")
+    var objName: String = "DefaultObjName"
+)
+
 @RunWith(RobolectricTestRunner::class)
 class DocumentSnapshotTests {
   @Before
@@ -154,6 +164,15 @@ class DocumentSnapshotTests {
     assertThat(room).isEqualTo(Room(1, 2))
     assertThat(room)
       .isEqualTo(ds.toObject(Room::class.java, DocumentSnapshot.ServerTimestampBehavior.ESTIMATE))
+  }
+
+  @Test
+  fun `PropertyName annotation works on data classes`() {
+    val ds = TestUtil.documentSnapshot("foo/bar", mapOf("dbName" to "CustomValue"), false)
+
+    val toObjectReturnValue = ds.toObject<DataClassWithPropertyName>()
+
+    assertThat(toObjectReturnValue).isEqualTo(DataClassWithPropertyName("CustomValue"))
   }
 }
 


### PR DESCRIPTION
Add a unit test for Firestore's `@PropertyName` annotation on Kotlin data class properties. This test both (a) verifies that the annotation actually works and (b) showcases how to use the property in Kotlin, which can easily trip up users (e.g. https://github.com/firebase/firebase-android-sdk/issues/4822).