### PR TITLE
Integrate firebase-sessions with GoogleDataTransport

### DIFF
--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -47,9 +47,11 @@ dependencies {
   implementation("com.google.firebase:firebase-encoders-json:18.0.1")
   implementation("com.google.firebase:firebase-encoders:17.0.0")
   implementation("com.google.firebase:firebase-installations-interop:17.1.0")
+  implementation("com.google.android.datatransport:transport-api:3.0.0")
   implementation(libs.androidx.annotation)
 
   runtimeOnly("com.google.firebase:firebase-installations:17.1.3")
+  runtimeOnly(project(":firebase-datatransport"))
 
   testImplementation(libs.androidx.test.junit)
   testImplementation(libs.androidx.test.runner)

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/EventGDTLogger.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/EventGDTLogger.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions
+
+import com.google.android.datatransport.*
+import com.google.android.datatransport.TransportFactory
+import com.google.firebase.inject.Provider
+
+/**
+ * The [EventGDTLoggerInterface] is for testing purposes so that we can mock EventGDTLogger in other
+ * classes that depend on it.
+ *
+ * @hide
+ */
+internal interface EventGDTLoggerInterface {
+  fun log(sessionEvent: SessionEvent)
+}
+
+/**
+ * The [EventGDTLogger] is responsible for encoding and logging events to the Google Data Transport
+ * library.
+ *
+ * @hide
+ */
+internal class EventGDTLogger(private val transportFactoryProvider: Provider<TransportFactory>) :
+  EventGDTLoggerInterface {
+
+  // Logs a [SessionEvent] to FireLog
+  override fun log(sessionEvent: SessionEvent) {
+    transportFactoryProvider
+      .get()
+      .getTransport(
+        EventGDTLogger.AQS_LOG_SOURCE,
+        SessionEvent::class.java,
+        Encoding.of("json"),
+        this::encode,
+      )
+      .send(Event.ofData(sessionEvent))
+  }
+
+  private fun encode(value: SessionEvent): ByteArray {
+    return SessionEvents.SESSION_EVENT_ENCODER.encode(value).toByteArray()
+  }
+
+  companion object {
+    // TODO What do we put for the AQS Log Source
+    private const val AQS_LOG_SOURCE = "FIREBASE_APPQUALITY_SESSION"
+  }
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -19,7 +19,9 @@ package com.google.firebase.sessions
 import android.app.Application
 import android.util.Log
 import androidx.annotation.Discouraged
+import com.google.android.datatransport.TransportFactory
 import com.google.firebase.FirebaseApp
+import com.google.firebase.inject.Provider
 import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.ktx.app
@@ -29,10 +31,13 @@ class FirebaseSessions
 internal constructor(
   private val firebaseApp: FirebaseApp,
   firebaseInstallations: FirebaseInstallationsApi,
-  backgroundDispatcher: CoroutineDispatcher
+  backgroundDispatcher: CoroutineDispatcher,
+  transportFactoryProvider: Provider<TransportFactory>,
 ) {
   private val sessionGenerator = SessionGenerator(collectEvents = true)
-  private val sessionCoordinator = SessionCoordinator(firebaseInstallations, backgroundDispatcher)
+  private val eventGDTLogger = EventGDTLogger(transportFactoryProvider)
+  private val sessionCoordinator =
+    SessionCoordinator(firebaseInstallations, backgroundDispatcher, eventGDTLogger)
 
   init {
     val sessionInitiator = SessionInitiator(WallClock::elapsedRealtime, this::initiateSessionStart)

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsEarly.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsEarly.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions
+
+/**
+ * The Firebase Sessions early initialization.
+ *
+ * @hide
+ *
+ * TODO: This should handle generating the Session ID and communicating with subscribers.
+ */
+class FirebaseSessionsEarly {}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionCoordinator.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionCoordinator.kt
@@ -31,7 +31,8 @@ import kotlinx.coroutines.tasks.await
  */
 internal class SessionCoordinator(
   private val firebaseInstallations: FirebaseInstallationsApi,
-  backgroundDispatcher: CoroutineDispatcher
+  backgroundDispatcher: CoroutineDispatcher,
+  private val eventGDTLogger: EventGDTLoggerInterface,
 ) {
   private val scope = CoroutineScope(backgroundDispatcher)
 
@@ -46,7 +47,13 @@ internal class SessionCoordinator(
           ""
         }
 
-      Log.i(TAG, "Initiate session start: $sessionEvent")
+      try {
+        eventGDTLogger.log(sessionEvent)
+
+        Log.i(TAG, "Logged Session Start event: $sessionEvent")
+      } catch (e: RuntimeException) {
+        Log.w(TAG, "Failed to log Session Start event: ", e)
+      }
     }
 
   companion object {

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionCoordinatorTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionCoordinatorTest.kt
@@ -18,6 +18,7 @@ package com.google.firebase.sessions
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.google.firebase.sessions.testing.FakeEventGDTLogger
 import com.google.firebase.sessions.testing.FakeFirebaseInstallations
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -31,10 +32,12 @@ import org.junit.runner.RunWith
 class SessionCoordinatorTest {
   @Test
   fun attemptLoggingSessionEvent_populatesFid() = runTest {
+    val fakeEventGDTLogger = FakeEventGDTLogger()
     val sessionCoordinator =
       SessionCoordinator(
         firebaseInstallations = FakeFirebaseInstallations("FaKeFiD"),
         backgroundDispatcher = StandardTestDispatcher(testScheduler),
+        eventGDTLogger = fakeEventGDTLogger,
       )
 
     // Construct an event with no fid set.
@@ -62,5 +65,7 @@ class SessionCoordinatorTest {
     runCurrent()
 
     assertThat(sessionEvent.sessionData.firebaseInstallationId).isEqualTo("FaKeFiD")
+    assertThat(fakeEventGDTLogger.loggedEvent!!.sessionData.firebaseInstallationId)
+      .isEqualTo("FaKeFiD")
   }
 }

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeEventGDTLogger.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeEventGDTLogger.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions.testing
+
+import com.google.firebase.sessions.EventGDTLogger
+import com.google.firebase.sessions.EventGDTLoggerInterface
+import com.google.firebase.sessions.SessionEvent
+
+/**
+ * The [FakeEventGDTLogger] is for mocking [EventGDTLogger].
+ *
+ * @hide
+ */
+internal class FakeEventGDTLogger : EventGDTLoggerInterface {
+
+  // Lets tests assert the right event was logged.
+  var loggedEvent: SessionEvent? = null
+
+  override fun log(sessionEvent: SessionEvent) {
+    loggedEvent = sessionEvent
+  }
+}

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeProvider.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions.testing
+
+import com.google.firebase.inject.Provider
+
+class FakeProvider<T>(private val instance: T) : Provider<T> {
+  override fun get(): T {
+    return instance
+  }
+}

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeTransportFactory.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeTransportFactory.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions.testing
+
+import com.google.android.datatransport.*
+import com.google.firebase.sessions.SessionEvent
+
+/** Fake [Transport] that implements [send]. */
+internal class FakeTransport<T>() : Transport<T> {
+
+  var sentEvent: Event<T>? = null
+
+  override fun send(event: Event<T>?) {
+    this.sentEvent = event
+  }
+
+  override fun schedule(p0: Event<T>?, p1: TransportScheduleCallback?) {
+    return
+  }
+}
+
+/** Fake [TransportFactory] that implements [getTransport]. */
+internal class FakeTransportFactory() : TransportFactory {
+
+  var name: String? = null
+  var payloadEncoding: Encoding? = null
+  var fakeTransport: FakeTransport<SessionEvent>? = null
+
+  override fun <T> getTransport(
+    name: String?,
+    payloadType: java.lang.Class<T>?,
+    payloadEncoding: Encoding?,
+    payloadTransformer: Transformer<T, ByteArray?>?
+  ): Transport<T>? {
+    this.name = name
+    this.payloadEncoding = payloadEncoding
+    val fakeTransport = FakeTransport<T>()
+    @Suppress("UNCHECKED_CAST")
+    this.fakeTransport = fakeTransport as FakeTransport<SessionEvent>
+    return fakeTransport
+  }
+
+  @Deprecated("This is deprecated in the API. Don't use or expect on this function.")
+  override fun <T> getTransport(
+    name: String?,
+    payloadType: java.lang.Class<T>?,
+    payloadTransformer: Transformer<T, ByteArray?>?
+  ): Transport<T>? {
+    return null
+  }
+}

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions.testing
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.firebase.sessions.*
+
+internal object TestSessionEventData {
+  val TEST_SESSION_DETAILS =
+    SessionDetails(
+      sessionId = "a1b2c3",
+      firstSessionId = "a1a1a1",
+      collectEvents = true,
+      sessionIndex = 3,
+    )
+
+  val EXPECTED_DEFAULT_SESSION_EVENT =
+    SessionEvent(
+      eventType = EventType.SESSION_START,
+      sessionData =
+        SessionInfo(
+          sessionId = "a1b2c3",
+          firstSessionId = "a1a1a1",
+          sessionIndex = 3,
+        ),
+      applicationInfo =
+        ApplicationInfo(
+          appId = FakeFirebaseApp.MOCK_APP_ID,
+          deviceModel = "",
+          sessionSdkVersion = BuildConfig.VERSION_NAME,
+          logEnvironment = LogEnvironment.LOG_ENVIRONMENT_PROD,
+          AndroidApplicationInfo(
+            packageName = ApplicationProvider.getApplicationContext<Context>().packageName,
+            versionName = FakeFirebaseApp.MOCK_APP_VERSION
+          ),
+        )
+    )
+}


### PR DESCRIPTION
 - Adds a dependency on data-transport
 - Adds TestSessionEventData.kt to store Session Event objects used for testing

#no-changelog 