### PR TITLE
Add the integration test's google-services.json file to unit tests

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -56,6 +56,12 @@ jobs:
           distribution: temurin
           cache: gradle
 
+      - name: Add google-services.json
+        env:
+          INTEG_TESTS_GOOGLE_SERVICES: ${{ secrets.INTEG_TESTS_GOOGLE_SERVICES }}
+        run: |
+          echo $INTEG_TESTS_GOOGLE_SERVICES | base64 -d > google-services.json
+
       - name: ${{ matrix.module }} Unit Tests
         env:
           FIREBASE_CI: 1

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -48,5 +48,6 @@ dependencies {
   implementation("com.google.android.material:material:1.8.0")
 }
 
-// extra["packageName"] = "com.google.firebase.testing.sessions"
-// apply(from = "../../gradle/googleServices.gradle")
+extra["packageName"] = "com.google.firebase.testing.sessions"
+
+apply(from = "../../gradle/googleServices.gradle")


### PR DESCRIPTION
Add the integration test's google-services.json file to unit tests so unit tests can use the google services plugin too.