### PR TITLE
Changing Fireperf's SDK Floats to Doubles

### DIFF
--- a/firebase-perf/CHANGELOG.md
+++ b/firebase-perf/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * [changed] Updated javalite, protoc, protobufjavautil to 3.21.11.
+* [changed] Updated [perfmon] to use Double precision for sampling.
 
 # 20.3.1
 * [changed] Migrated [perfmon] to use standard Firebase executors.

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigResolver.java
@@ -286,7 +286,7 @@ public class ConfigResolver {
   }
 
   /** Returns what percentage of Traces should be collected, range is [0.00f, 1.00f]. */
-  public float getTraceSamplingRate() {
+  public double getTraceSamplingRate() {
     // Order of precedence is:
     // 1. If the value exists through Firebase Remote Config, cache and return this value.
     // 2. If the value exists in device cache, return this value.
@@ -294,14 +294,14 @@ public class ConfigResolver {
     TraceSamplingRate config = TraceSamplingRate.getInstance();
 
     // 1. Reads value from Firebase Remote Config, saves this value in cache layer if valid.
-    Optional<Float> rcValue = getRemoteConfigFloat(config);
+    Optional<Double> rcValue = getRemoteConfigDouble(config);
     if (rcValue.isAvailable() && isSamplingRateValid(rcValue.get())) {
       deviceCacheManager.setValue(config.getDeviceCacheFlag(), rcValue.get());
       return rcValue.get();
     }
 
     // 2. Reads value from cache layer.
-    Optional<Float> deviceCacheValue = getDeviceCacheFloat(config);
+    Optional<Double> deviceCacheValue = getDeviceCacheDouble(config);
     if (deviceCacheValue.isAvailable() && isSamplingRateValid(deviceCacheValue.get())) {
       return deviceCacheValue.get();
     }
@@ -311,7 +311,7 @@ public class ConfigResolver {
   }
 
   /** Returns what percentage of NetworkRequest should be collected, range is [0.00f, 1.00f]. */
-  public float getNetworkRequestSamplingRate() {
+  public double getNetworkRequestSamplingRate() {
     // Order of precedence is:
     // 1. If the value exists through Firebase Remote Config, cache and return this value.
     // 2. If the value exists in device cache, return this value.
@@ -319,14 +319,14 @@ public class ConfigResolver {
     NetworkRequestSamplingRate config = NetworkRequestSamplingRate.getInstance();
 
     // 1. Reads value from Firebase Remote Config, saves this value in cache layer if valid.
-    Optional<Float> rcValue = getRemoteConfigFloat(config);
+    Optional<Double> rcValue = getRemoteConfigDouble(config);
     if (rcValue.isAvailable() && isSamplingRateValid(rcValue.get())) {
       deviceCacheManager.setValue(config.getDeviceCacheFlag(), rcValue.get());
       return rcValue.get();
     }
 
     // 2. Reads value from cache layer.
-    Optional<Float> deviceCacheValue = getDeviceCacheFloat(config);
+    Optional<Double> deviceCacheValue = getDeviceCacheDouble(config);
     if (deviceCacheValue.isAvailable() && isSamplingRateValid(deviceCacheValue.get())) {
       return deviceCacheValue.get();
     }
@@ -336,7 +336,7 @@ public class ConfigResolver {
   }
 
   /** Returns what percentage of Session gauge should be collected, range is [0.00f, 1.00f]. */
-  public float getSessionsSamplingRate() {
+  public double getSessionsSamplingRate() {
     // Order of precedence is:
     // 1. If the value exists in Android Manifest, convert from [0.00f, 100.00f] to [0.00f, 1.00f]
     // and return this value.
@@ -346,24 +346,24 @@ public class ConfigResolver {
     SessionsSamplingRate config = SessionsSamplingRate.getInstance();
 
     // 1. Reads value in Android Manifest (it is set by developers during build time).
-    Optional<Float> metadataValue = getMetadataFloat(config);
+    Optional<Double> metadataValue = getMetadataDouble(config);
     if (metadataValue.isAvailable()) {
       // Sampling percentage from metadata needs to convert from [0.00f, 100.00f] to [0.00f, 1.00f].
-      float samplingRate = metadataValue.get() / 100.0f;
+      double samplingRate = metadataValue.get() / 100;
       if (isSamplingRateValid(samplingRate)) {
         return samplingRate;
       }
     }
 
     // 2. Reads value from Firebase Remote Config, saves this value in cache layer if valid.
-    Optional<Float> rcValue = getRemoteConfigFloat(config);
+    Optional<Double> rcValue = getRemoteConfigDouble(config);
     if (rcValue.isAvailable() && isSamplingRateValid(rcValue.get())) {
       deviceCacheManager.setValue(config.getDeviceCacheFlag(), rcValue.get());
       return rcValue.get();
     }
 
     // 3. Reads value from cache layer.
-    Optional<Float> deviceCacheValue = getDeviceCacheFloat(config);
+    Optional<Double> deviceCacheValue = getDeviceCacheDouble(config);
     if (deviceCacheValue.isAvailable() && isSamplingRateValid(deviceCacheValue.get())) {
       return deviceCacheValue.get();
     }
@@ -732,7 +732,7 @@ public class ConfigResolver {
   }
 
   /** Returns what percentage of fragment traces should be collected, range is [0.00f, 1.00f]. */
-  public float getFragmentSamplingRate() {
+  public double getFragmentSamplingRate() {
     // Order of precedence is:
     // 1. If the value exists in Android Manifest, convert from [0.00f, 100.00f] to [0.00f, 1.00f]
     // and return this value.
@@ -742,24 +742,24 @@ public class ConfigResolver {
     FragmentSamplingRate config = FragmentSamplingRate.getInstance();
 
     // 1. Reads value in Android Manifest (it is set by developers during build time).
-    Optional<Float> metadataValue = getMetadataFloat(config);
+    Optional<Double> metadataValue = getMetadataDouble(config);
     if (metadataValue.isAvailable()) {
       // Sampling percentage from metadata needs to convert from [0.00f, 100.00f] to [0.00f, 1.00f].
-      float samplingRate = metadataValue.get() / 100.0f;
+      double samplingRate = metadataValue.get() / 100.0f;
       if (isSamplingRateValid(samplingRate)) {
         return samplingRate;
       }
     }
 
     // 2. Reads value from Firebase Remote Config, saves this value in cache layer if valid.
-    Optional<Float> rcValue = getRemoteConfigFloat(config);
+    Optional<Double> rcValue = getRemoteConfigDouble(config);
     if (rcValue.isAvailable() && isSamplingRateValid(rcValue.get())) {
       deviceCacheManager.setValue(config.getDeviceCacheFlag(), rcValue.get());
       return rcValue.get();
     }
 
     // 3. Reads value from cache layer.
-    Optional<Float> deviceCacheValue = getDeviceCacheFloat(config);
+    Optional<Double> deviceCacheValue = getDeviceCacheDouble(config);
     if (deviceCacheValue.isAvailable() && isSamplingRateValid(deviceCacheValue.get())) {
       return deviceCacheValue.get();
     }
@@ -807,8 +807,8 @@ public class ConfigResolver {
     return metadataBundle.getBoolean(config.getMetadataFlag());
   }
 
-  private Optional<Float> getMetadataFloat(ConfigurationFlag<Float> config) {
-    return metadataBundle.getFloat(config.getMetadataFlag());
+  private Optional<Double> getMetadataDouble(ConfigurationFlag<Double> config) {
+    return metadataBundle.getDouble(config.getMetadataFlag());
   }
 
   private Optional<Long> getMetadataLong(ConfigurationFlag<Long> config) {
@@ -816,8 +816,8 @@ public class ConfigResolver {
   }
 
   // Helper functions for interaction with Firebase Remote Config.
-  private Optional<Float> getRemoteConfigFloat(ConfigurationFlag<Float> config) {
-    return remoteConfigManager.getFloat(config.getRemoteConfigFlag());
+  private Optional<Double> getRemoteConfigDouble(ConfigurationFlag<Double> config) {
+    return remoteConfigManager.getDouble(config.getRemoteConfigFlag());
   }
 
   private Optional<Long> getRemoteConfigLong(ConfigurationFlag<Long> config) {
@@ -841,8 +841,8 @@ public class ConfigResolver {
   }
 
   // Helper functions for interaction with Device Caching layer.
-  private Optional<Float> getDeviceCacheFloat(ConfigurationFlag<Float> config) {
-    return deviceCacheManager.getFloat(config.getDeviceCacheFlag());
+  private Optional<Double> getDeviceCacheDouble(ConfigurationFlag<Double> config) {
+    return deviceCacheManager.getDouble(config.getDeviceCacheFlag());
   }
 
   private Optional<Long> getDeviceCacheLong(ConfigurationFlag<Long> config) {
@@ -858,7 +858,7 @@ public class ConfigResolver {
   }
 
   // Helper functions for config value validation.
-  private boolean isSamplingRateValid(float samplingRate) {
+  private boolean isSamplingRateValid(double samplingRate) {
     return MIN_SAMPLING_RATE <= samplingRate && samplingRate <= MAX_SAMPLING_RATE;
   }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/ConfigurationConstants.java
@@ -130,7 +130,7 @@ final class ConfigurationConstants {
     }
   }
 
-  protected static final class TraceSamplingRate extends ConfigurationFlag<Float> {
+  protected static final class TraceSamplingRate extends ConfigurationFlag<Double> {
     private static TraceSamplingRate instance;
 
     private TraceSamplingRate() {
@@ -145,11 +145,11 @@ final class ConfigurationConstants {
     }
 
     @Override
-    protected Float getDefault() {
+    protected Double getDefault() {
       // Sampling rate range is [0.00f, 1.00f]. By default, sampling rate is 1.00f, which is 100%.
       // 0.00f means 0%, Fireperf will not capture any event for trace from the device,
       // 1.00f means 100%, Fireperf will capture all events for trace from the device.
-      return 1.00f;
+      return 1.0;
     }
 
     @Override
@@ -163,7 +163,7 @@ final class ConfigurationConstants {
     }
   }
 
-  protected static final class NetworkRequestSamplingRate extends ConfigurationFlag<Float> {
+  protected static final class NetworkRequestSamplingRate extends ConfigurationFlag<Double> {
     private static NetworkRequestSamplingRate instance;
 
     private NetworkRequestSamplingRate() {
@@ -178,11 +178,11 @@ final class ConfigurationConstants {
     }
 
     @Override
-    protected Float getDefault() {
+    protected Double getDefault() {
       // Sampling rate range is [0.00f, 1.00f]. By default, sampling rate is 1.00f, which is 100%.
       // 0.00f means 0%, Fireperf will not capture any event for trace from the device,
       // 1.00f means 100%, Fireperf will capture all events for trace from the device.
-      return 1.00f;
+      return 1.0;
     }
 
     @Override
@@ -534,7 +534,7 @@ final class ConfigurationConstants {
     }
   }
 
-  protected static final class SessionsSamplingRate extends ConfigurationFlag<Float> {
+  protected static final class SessionsSamplingRate extends ConfigurationFlag<Double> {
     private static SessionsSamplingRate instance;
 
     private SessionsSamplingRate() {
@@ -549,8 +549,8 @@ final class ConfigurationConstants {
     }
 
     @Override
-    protected Float getDefault() {
-      return 0.01f;
+    protected Double getDefault() {
+      return 0.01;
     }
 
     @Override
@@ -624,7 +624,7 @@ final class ConfigurationConstants {
     }
   }
 
-  protected static final class FragmentSamplingRate extends ConfigurationFlag<Float> {
+  protected static final class FragmentSamplingRate extends ConfigurationFlag<Double> {
     private static FragmentSamplingRate instance;
 
     private FragmentSamplingRate() {
@@ -639,11 +639,11 @@ final class ConfigurationConstants {
     }
 
     @Override
-    protected Float getDefault() {
+    protected Double getDefault() {
       // Sampling rate range is [0.00f, 1.00f]. By default, sampling rate is 0.00f, which is 0%.
       // 0.00f means 0%, Fireperf will not capture any event for fragment trace from the device,
       // 1.00f means 100%, Fireperf will capture all events for fragment trace from the device.
-      return 0.00f;
+      return 0.00;
     }
 
     @Override

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/DeviceCacheManager.java
@@ -230,6 +230,8 @@ public class DeviceCacheManager {
     try {
       // Default value should never be used because key existence is checked above.
       long defaultValue = Double.doubleToLongBits(0.0);
+      // SharedPreferences does not allow storing a Double directly. We store the double's bits as a
+      // long so here we convert that back to a double.
       return Optional.of(Double.longBitsToDouble(sharedPref.getLong(key, defaultValue)));
     } catch (ClassCastException e) {
       logger.debug(
@@ -257,6 +259,9 @@ public class DeviceCacheManager {
         return false;
       }
     }
+    // SharedPreferences does not allow storing a Double directly. The main way to store it without
+    // losing precision is to store the double's bits as a long so it can then be converted back to
+    // a double.
     sharedPref.edit().putLong(key, Double.doubleToRawLongBits(value)).apply();
     return true;
   }

--- a/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/config/RemoteConfigManager.java
@@ -139,23 +139,23 @@ public class RemoteConfigManager {
   }
 
   /**
-   * Retrieves the double value of the given key from the remote config, converts to float type and
+   * Retrieves the double value of the given key from the remote config, converts to double type and
    * returns this value.
    *
    * @implNote Triggers a remote config fetch on a background thread if it hasn't yet been fetched.
    * @param key The key to fetch the double value for.
-   * @return The float value of the key or not present.
+   * @return The double value of the key or not present.
    */
-  public Optional<Float> getFloat(String key) {
+  public Optional<Double> getDouble(String key) {
     if (key == null) {
-      logger.debug("The key to get Remote Config float value is null.");
+      logger.debug("The key to get Remote Config double value is null.");
       return Optional.absent();
     }
 
     FirebaseRemoteConfigValue rcValue = getRemoteConfigValue(key);
     if (rcValue != null) {
       try {
-        return Optional.of(Double.valueOf(rcValue.asDouble()).floatValue());
+        return Optional.of(rcValue.asDouble());
       } catch (IllegalArgumentException e) {
         if (!rcValue.asString().isEmpty()) {
           logger.debug("Could not parse value: '%s' for key: '%s'.", rcValue.asString(), key);
@@ -260,8 +260,8 @@ public class RemoteConfigManager {
         if (defaultValue instanceof Boolean) {
           valueToReturn = rcValue.asBoolean();
 
-        } else if (defaultValue instanceof Float) {
-          valueToReturn = Double.valueOf(rcValue.asDouble()).floatValue();
+        } else if (defaultValue instanceof Double) {
+          valueToReturn = rcValue.asDouble();
 
         } else if (defaultValue instanceof Long || defaultValue instanceof Integer) {
           valueToReturn = rcValue.asLong();

--- a/firebase-perf/src/main/java/com/google/firebase/perf/transport/RateLimiter.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/transport/RateLimiter.java
@@ -46,10 +46,10 @@ final class RateLimiter {
 
   /** Gets the sampling and rate limiting configs. */
   private final ConfigResolver configResolver;
-  /** The app's bucket ID for sampling, a number in [0.0f, 1.0f). */
-  private final float samplingBucketId;
+  /** The app's bucket ID for sampling, a number in [0.0, 1.0). */
+  private final double samplingBucketId;
 
-  private final float fragmentBucketId;
+  private final double fragmentBucketId;
 
   private RateLimiterImpl traceLimiter = null;
   private RateLimiterImpl networkLimiter = null;
@@ -77,23 +77,23 @@ final class RateLimiter {
 
   /** Generates a bucket id between [0.0f, 1.0f) for sampling, it is sticky across app lifecycle. */
   @VisibleForTesting
-  static float getSamplingBucketId() {
-    return new Random().nextFloat();
+  static double getSamplingBucketId() {
+    return new Random().nextDouble();
   }
 
   RateLimiter(
       final Rate rate,
       final long capacity,
       final Clock clock,
-      float samplingBucketId,
-      float fragmentBucketId,
+      double samplingBucketId,
+      double fragmentBucketId,
       ConfigResolver configResolver) {
     Utils.checkArgument(
-        0.0f <= samplingBucketId && samplingBucketId < 1.0f,
-        "Sampling bucket ID should be in range [0.0f, 1.0f).");
+        0.0 <= samplingBucketId && samplingBucketId < 1.0,
+        "Sampling bucket ID should be in range [0.0, 1.0).");
     Utils.checkArgument(
-        0.0f <= fragmentBucketId && fragmentBucketId < 1.0f,
-        "Fragment sampling bucket ID should be in range [0.0f, 1.0f).");
+        0.0 <= fragmentBucketId && fragmentBucketId < 1.0,
+        "Fragment sampling bucket ID should be in range [0.0, 1.0).");
     this.samplingBucketId = samplingBucketId;
     this.fragmentBucketId = fragmentBucketId;
     this.configResolver = configResolver;
@@ -107,13 +107,13 @@ final class RateLimiter {
 
   /** Returns whether device is allowed to send trace events based on trace sampling rate. */
   private boolean isDeviceAllowedToSendTraces() {
-    float validTraceSamplingBucketIdThreshold = configResolver.getTraceSamplingRate();
+    double validTraceSamplingBucketIdThreshold = configResolver.getTraceSamplingRate();
     return samplingBucketId < validTraceSamplingBucketIdThreshold;
   }
 
   /** Returns whether device is allowed to send network events based on network sampling rate. */
   private boolean isDeviceAllowedToSendNetworkEvents() {
-    float validNetworkSamplingBucketIdThreshold = configResolver.getNetworkRequestSamplingRate();
+    double validNetworkSamplingBucketIdThreshold = configResolver.getNetworkRequestSamplingRate();
     return samplingBucketId < validNetworkSamplingBucketIdThreshold;
   }
 
@@ -122,7 +122,7 @@ final class RateLimiter {
    * trace sampling rate.
    */
   private boolean isDeviceAllowedToSendFragmentScreenTraces() {
-    float validFragmentSamplingBucketIdThreshold = configResolver.getFragmentSamplingRate();
+    double validFragmentSamplingBucketIdThreshold = configResolver.getFragmentSamplingRate();
     return fragmentBucketId < validFragmentSamplingBucketIdThreshold;
   }
 

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/Constants.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/Constants.java
@@ -22,8 +22,8 @@ public class Constants {
   public static final String PREFS_NAME = "FirebasePerfSharedPrefs";
   public static final String ENABLE_DISABLE = "isEnabled";
 
-  public static final float MIN_SAMPLING_RATE = 0.00f;
-  public static final float MAX_SAMPLING_RATE = 1.00f;
+  public static final double MIN_SAMPLING_RATE = 0.0;
+  public static final double MAX_SAMPLING_RATE = 1.0;
 
   // Max length of URL.
   public static final int MAX_URL_LENGTH = 2000;

--- a/firebase-perf/src/main/java/com/google/firebase/perf/util/ImmutableBundle.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/util/ImmutableBundle.java
@@ -68,21 +68,26 @@ public final class ImmutableBundle {
   }
 
   /**
-   * Returns float value associated with the given key, or not present if no mapping of the desired
+   * Returns double value associated with the given key, or not present if no mapping of the desired
    * type exists for the given key.
    */
-  public Optional<Float> getFloat(String key) {
+  public Optional<Double> getDouble(String key) {
     if (!containsKey(key)) {
       return Optional.absent();
     }
 
-    try {
-      Object o = bundle.get(key);
-      return Optional.fromNullable((Float) o);
-    } catch (ClassCastException e) {
-      logger.debug("Metadata key %s contains type other than float: %s", key, e.getMessage());
+    Object o = bundle.get(key);
+    if (o == null) {
+      return Optional.absent();
+    }
+    if (o instanceof Float) {
+      return Optional.of(((Float) o).doubleValue());
+    }
+    if (o instanceof Double) {
+      return Optional.of((Double) o);
     }
 
+    logger.debug("Metadata key %s contains type other than double: %s", key);
     return Optional.absent();
   }
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigResolverTest.java
@@ -1645,358 +1645,357 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
 
   @Test
   public void getTraceSamplingRate_noRemoteConfig_returnsDefault() {
-    when(mockRemoteConfigManager.getFloat(TRACE_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(TRACE_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
-    when(mockDeviceCacheManager.getFloat(TRACE_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(1.00f));
+    when(mockDeviceCacheManager.getDouble(TRACE_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(1.00));
 
-    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(1.00f);
+    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(1.00);
   }
 
   @Test
   public void getTraceSamplingRate_noRemoteConfigHasCache_returnsCache() {
-    when(mockRemoteConfigManager.getFloat(TRACE_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(TRACE_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
-    when(mockDeviceCacheManager.getFloat(TRACE_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.01f));
+    when(mockDeviceCacheManager.getDouble(TRACE_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.01));
 
-    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(0.01);
   }
 
   @Test
   public void getTraceSamplingRate_validRemoteConfig_returnsRemoteConfigValue() {
-    when(mockRemoteConfigManager.getFloat(TRACE_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.01f));
-    when(mockDeviceCacheManager.getFloat(TRACE_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.02f));
+    when(mockRemoteConfigManager.getDouble(TRACE_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.01));
+    when(mockDeviceCacheManager.getDouble(TRACE_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.02));
 
-    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(0.01f);
-    verify(mockDeviceCacheManager, times(1)).setValue(eq(TRACE_SAMPLING_RATE_CACHE_KEY), eq(0.01f));
+    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(0.01);
+    verify(mockDeviceCacheManager, times(1)).setValue(eq(TRACE_SAMPLING_RATE_CACHE_KEY), eq(0.01));
   }
 
   @Test
   public void getTraceSamplingRate_remoteConfigValueTooHigh_returnsDefaultValue() {
-    when(mockRemoteConfigManager.getFloat(TRACE_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(1.01f));
-    when(mockDeviceCacheManager.getFloat(TRACE_SAMPLING_RATE_CACHE_KEY))
+    when(mockRemoteConfigManager.getDouble(TRACE_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(1.01));
+    when(mockDeviceCacheManager.getDouble(TRACE_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(1.00f);
+    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(1.00);
     verify(mockDeviceCacheManager, never()).setValue(anyString(), anyLong());
   }
 
   @Test
   public void getTraceSamplingRate_remoteConfigValueTooLow_returnsDefaultValue() {
-    when(mockRemoteConfigManager.getFloat(TRACE_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(-0.01f));
-    when(mockDeviceCacheManager.getFloat(TRACE_SAMPLING_RATE_CACHE_KEY))
+    when(mockRemoteConfigManager.getDouble(TRACE_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(-0.01));
+    when(mockDeviceCacheManager.getDouble(TRACE_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(1.00f);
+    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(1.00);
     verify(mockDeviceCacheManager, never()).setValue(anyString(), anyLong());
   }
 
   @Test
   public void getTraceSamplingRate_10digitRemoteConfig_returnsRemoteConfigValue() {
-    when(mockRemoteConfigManager.getFloat(TRACE_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.0000000001f));
+    when(mockRemoteConfigManager.getDouble(TRACE_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.0000000001));
 
-    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(0.0000000001f);
+    assertThat(testConfigResolver.getTraceSamplingRate()).isEqualTo(0.0000000001);
   }
 
   @Test
   public void getNetworkRequestSamplingRate_noRemoteConfig_returnsDefault() {
-    when(mockRemoteConfigManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
-    when(mockDeviceCacheManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
+    when(mockDeviceCacheManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(1.00f);
+    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(1.00);
   }
 
   @Test
   public void getNetworkRequestSamplingRate_noRemoteConfigHasCache_returnsCache() {
-    when(mockRemoteConfigManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
-    when(mockDeviceCacheManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.01f));
+    when(mockDeviceCacheManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.01));
 
-    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(0.01);
   }
 
   @Test
   public void getNetworkRequestSamplingRate_validRemoteConfig_returnsRemoteConfigValue() {
-    when(mockRemoteConfigManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.01f));
-    when(mockDeviceCacheManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
+    when(mockRemoteConfigManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.01));
+    when(mockDeviceCacheManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(0.01);
     verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY), eq(0.01f));
+        .setValue(eq(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY), eq(0.01));
   }
 
   @Test
   public void getNetworkRequestSamplingRate_remoteConfigValueTooHigh_returnsDefaultValue() {
-    when(mockRemoteConfigManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(1.01f));
-    when(mockDeviceCacheManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
+    when(mockRemoteConfigManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(1.01));
+    when(mockDeviceCacheManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(1.00f);
+    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(1.00);
     verify(mockDeviceCacheManager, never()).setValue(anyString(), anyLong());
   }
 
   @Test
   public void getNetworkRequestSamplingRate_remoteConfigValueTooLow_returnsDefaultValue() {
-    when(mockDeviceCacheManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
+    when(mockDeviceCacheManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
-    when(mockRemoteConfigManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(-0.01f));
+    when(mockRemoteConfigManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(-0.01));
 
-    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(1.00f);
+    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(1.00);
     verify(mockDeviceCacheManager, never()).setValue(anyString(), anyLong());
   }
 
   @Test
   public void getNetworkRequestSamplingRate_10digitRemoteConfig_returnsRemoteConfigValue() {
-    when(mockRemoteConfigManager.getFloat(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.0000000001f));
+    when(mockRemoteConfigManager.getDouble(NETWORK_REQUEST_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.0000000001));
 
-    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(0.0000000001f);
+    assertThat(testConfigResolver.getNetworkRequestSamplingRate()).isEqualTo(0.0000000001);
   }
 
   @Test
   public void getSessionsSamplingRate_validMetadata_returnsMetadata() {
     // #1 pass: Validate that method returns Remote Config Value when there is no metadata value.
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.01f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.01));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01);
 
     // #2 pass: Validate that method returns Metadata value which takes higher precedence.
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 20.0f);
+    bundle.putDouble("sessions_sampling_percentage", 20.0);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.2);
   }
 
   @Test
   public void getSessionsSamplingRate_validMetadata_notSaveMetadataInCache() {
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 20.0f);
+    bundle.putDouble("sessions_sampling_percentage", 20.0);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.2);
 
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }
 
   @Test
   public void getSessionsSamplingRate_invalidAndroidMetadataBundle_returnDefaultValue() {
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01);
 
     // Case #1: Android Metadata bundle value is too high.
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 200.00f);
+    bundle.putDouble("sessions_sampling_percentage", 200.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01);
 
     // Case #2: Android Metadata bundle value is too low.
     bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", -1.00f);
+    bundle.putDouble("sessions_sampling_percentage", -1.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01);
   }
 
   @Test
   public void getSessionsSamplingRate_invalidAndroidMetadataBundle_returnRemoteConfigValue() {
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.25f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.25));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25);
 
     // Case #1: Android Metadata bundle value is too high.
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 200.00f);
+    bundle.putDouble("sessions_sampling_percentage", 200.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25);
 
     // Case #2: Android Metadata bundle value is too low.
     bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", -1.00f);
+    bundle.putDouble("sessions_sampling_percentage", -1.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25);
   }
 
   @Test
   public void getSessionsSamplingRate_invalidMetadataBundle_returnCacheValue() {
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(1.0f));
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(1.0));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(1.0);
 
     // Case #1: Android Metadata bundle value is too high.
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 200.00f);
+    bundle.putDouble("sessions_sampling_percentage", 200.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(1.0);
 
     // Case #2: Android Metadata bundle value is too low.
     bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", -1.00f);
+    bundle.putDouble("sessions_sampling_percentage", -1.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(1.0);
   }
 
   @Test
   public void getSessionsSamplingRate_validRemoteConfig_returnRemoteConfigValue() {
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.25f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.25));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25);
     verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(SESSION_SAMPLING_RATE_CACHE_KEY), eq(0.25f));
+        .setValue(eq(SESSION_SAMPLING_RATE_CACHE_KEY), eq(0.25));
 
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.0f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.0));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.0f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.0);
+    verify(mockDeviceCacheManager, times(1)).setValue(eq(SESSION_SAMPLING_RATE_CACHE_KEY), eq(0.0));
+
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.00005));
+
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.00005);
     verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(SESSION_SAMPLING_RATE_CACHE_KEY), eq(0.0f));
+        .setValue(eq(SESSION_SAMPLING_RATE_CACHE_KEY), eq(0.00005));
 
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.00005f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.0000000001));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.00005f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.0000000001);
     verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(SESSION_SAMPLING_RATE_CACHE_KEY), eq(0.00005f));
-
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.0000000001f));
-
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.0000000001f);
-    verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(SESSION_SAMPLING_RATE_CACHE_KEY), eq(0.0000000001f));
+        .setValue(eq(SESSION_SAMPLING_RATE_CACHE_KEY), eq(0.0000000001));
   }
 
   @Test
   public void getSessionsSamplingRate_invalidRemoteConfig_returnDefaultValue() {
     // Mock behavior that device cache doesn't have session sampling rate value.
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
     // Case #1: Firebase Remote Config value is too high.
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(1.01f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(1.01));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
 
     // Case #2: Firebase Remote Config value is too low.
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(-0.1f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(-0.1));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }
 
   @Test
   public void getSessionsSamplingRate_invalidRemoteConfig_returnCacheValue() {
     // Mock behavior that device cache doesn't have session sampling rate value.
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.25f));
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.25));
 
     // Case #1: Firebase Remote Config value is too high.
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(1.01f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(1.01));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
 
     // Case #2: Firebase Remote Config value is too low.
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(-0.1f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(-0.1));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.25);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }
 
   @Test
   public void getSessionsSamplingRate_validCache_returnCacheValue() {
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(1.0f));
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(1.0));
 
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(1.0);
   }
 
   @Test
   public void getSessionsSamplingRate_invalidCache_returnDefaultValue() {
     // Mock behavior that remote config doesn't have session sampling rate value.
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
 
     // Case #1: Device Cache value is too high.
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(10.0f));
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(10.0));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01);
 
     // Case #2: Device Cache value is too low.
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(-1.0f));
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(-1.0));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.01);
   }
 
   @Test
   public void
       getSessionsSamplingRate_metadataAndRemoteConfigAndCacheAreSet_metadataHasHighestConfigPrecedence() {
     // Set cache value.
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.2f));
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.2));
 
     // Set remote config value.
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.3f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.3));
 
     // Set Android Manifest value.
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 4.0f);
+    bundle.putDouble("sessions_sampling_percentage", 4.0);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.04f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.04);
   }
 
   @Test
   public void
       getSessionsSamplingRate_remoteConfigAndCacheAreSet_remoteConfigHasHighestConfigPrecedence() {
     // Set cache value.
-    when(mockDeviceCacheManager.getFloat(SESSION_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.2f));
+    when(mockDeviceCacheManager.getDouble(SESSION_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.2));
 
     // Set remote config value.
-    when(mockRemoteConfigManager.getFloat(SESSION_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.3f));
+    when(mockRemoteConfigManager.getDouble(SESSION_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.3));
 
-    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.3f);
+    assertThat(testConfigResolver.getSessionsSamplingRate()).isEqualTo(0.3);
   }
 
   @Test
@@ -2491,50 +2490,50 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
   @Test
   public void getFragmentSamplingRate_validMetadata_returnsMetadata() {
     // #1 pass: Validate that method returns Remote Config Value when there is no metadata value.
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.01f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.01));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.01f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.01);
 
     // #2 pass: Validate that method returns Metadata value which takes higher precedence.
     Bundle bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", 20.0f);
+    bundle.putDouble("fragment_sampling_percentage", 20.0);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2);
   }
 
   @Test
   public void getFragmentSamplingRate_validMetadata_notSaveMetadataInCache() {
     Bundle bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", 20.0f);
+    bundle.putDouble("fragment_sampling_percentage", 20.0);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.2);
 
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }
 
   @Test
   public void getFragmentSamplingRate_invalidAndroidMetadataBundle_returnDefaultValue() {
-    Float defaultValue = ConfigurationConstants.FragmentSamplingRate.getInstance().getDefault();
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+    double defaultValue = ConfigurationConstants.FragmentSamplingRate.getInstance().getDefault();
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
     assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(defaultValue);
 
     // Case #1: Android Metadata bundle value is too high.
     Bundle bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", 200.00f);
+    bundle.putDouble("fragment_sampling_percentage", 200.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
     assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(defaultValue);
 
     // Case #2: Android Metadata bundle value is too low.
     bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", -1.00f);
+    bundle.putDouble("fragment_sampling_percentage", -1.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
     assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(defaultValue);
@@ -2542,98 +2541,98 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
 
   @Test
   public void getFragmentSamplingRate_invalidAndroidMetadataBundle_returnRemoteConfigValue() {
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.25f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.25));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25);
 
     // Case #1: Android Metadata bundle value is too high.
     Bundle bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", 200.00f);
+    bundle.putDouble("fragment_sampling_percentage", 200.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25);
 
     // Case #2: Android Metadata bundle value is too low.
     bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", -1.00f);
+    bundle.putDouble("fragment_sampling_percentage", -1.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25);
   }
 
   @Test
   public void getFragmentSamplingRate_invalidMetadataBundle_returnCacheValue() {
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(1.0f));
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(1.0));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0);
 
     // Case #1: Android Metadata bundle value is too high.
     Bundle bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", 200.00f);
+    bundle.putDouble("fragment_sampling_percentage", 200.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0);
 
     // Case #2: Android Metadata bundle value is too low.
     bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", -1.00f);
+    bundle.putDouble("fragment_sampling_percentage", -1.00);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0);
   }
 
   @Test
   public void getFragmentSamplingRate_validRemoteConfig_returnRemoteConfigValue() {
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.25f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.25));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25);
     verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(FRAGMENT_SAMPLING_RATE_CACHE_KEY), eq(0.25f));
+        .setValue(eq(FRAGMENT_SAMPLING_RATE_CACHE_KEY), eq(0.25));
 
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.0f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.0));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.0f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.0);
     verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(FRAGMENT_SAMPLING_RATE_CACHE_KEY), eq(0.0f));
+        .setValue(eq(FRAGMENT_SAMPLING_RATE_CACHE_KEY), eq(0.0));
 
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.00005f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.00005));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.00005f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.00005);
     verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(FRAGMENT_SAMPLING_RATE_CACHE_KEY), eq(0.00005f));
+        .setValue(eq(FRAGMENT_SAMPLING_RATE_CACHE_KEY), eq(0.00005));
 
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.0000000001f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.0000000001));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.0000000001f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.0000000001);
     verify(mockDeviceCacheManager, times(1))
-        .setValue(eq(FRAGMENT_SAMPLING_RATE_CACHE_KEY), eq(0.0000000001f));
+        .setValue(eq(FRAGMENT_SAMPLING_RATE_CACHE_KEY), eq(0.0000000001));
   }
 
   @Test
   public void getFragmentSamplingRate_invalidRemoteConfig_returnDefaultValue() {
-    Float defaultValue = ConfigurationConstants.FragmentSamplingRate.getInstance().getDefault();
+    double defaultValue = ConfigurationConstants.FragmentSamplingRate.getInstance().getDefault();
     // Mock behavior that device cache doesn't have session sampling rate value.
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
         .thenReturn(Optional.absent());
 
     // Case #1: Firebase Remote Config value is too high.
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(1.01f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(1.01));
 
     assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(defaultValue);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
 
     // Case #2: Firebase Remote Config value is too low.
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(-0.1f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(-0.1));
 
     assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(defaultValue);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
@@ -2642,51 +2641,51 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
   @Test
   public void getFragmentSamplingRate_invalidRemoteConfig_returnCacheValue() {
     // Mock behavior that device cache doesn't have session sampling rate value.
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.25f));
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.25));
 
     // Case #1: Firebase Remote Config value is too high.
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(1.01f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(1.01));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
 
     // Case #2: Firebase Remote Config value is too low.
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(-0.1f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(-0.1));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.25);
     verify(mockDeviceCacheManager, never()).setValue(any(), any());
   }
 
   @Test
   public void getFragmentSamplingRate_validCache_returnCacheValue() {
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(1.0f));
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(1.0));
 
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(1.0);
   }
 
   @Test
   public void getFragmentSamplingRate_invalidCache_returnDefaultValue() {
-    Float defaultValue = ConfigurationConstants.FragmentSamplingRate.getInstance().getDefault();
+    double defaultValue = ConfigurationConstants.FragmentSamplingRate.getInstance().getDefault();
     // Mock behavior that remote config doesn't have session sampling rate value.
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
         .thenReturn(Optional.absent());
 
     // Case #1: Device Cache value is too high.
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(10.0f));
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(10.0));
 
     assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(defaultValue);
 
     // Case #2: Device Cache value is too low.
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(-1.0f));
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(-1.0));
 
     assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(defaultValue);
   }
@@ -2695,32 +2694,32 @@ public class ConfigResolverTest extends FirebasePerformanceTestBase {
   public void
       getFragmentSamplingRate_metadataAndRemoteConfigAndCacheAreSet_metadataHasHighestConfigPrecedence() {
     // Set cache value.
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.2f));
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.2));
 
     // Set remote config value.
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.3f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.3));
 
     // Set Android Manifest value.
     Bundle bundle = new Bundle();
-    bundle.putFloat("fragment_sampling_percentage", 4.0f);
+    bundle.putDouble("fragment_sampling_percentage", 4.0);
     testConfigResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.04f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.04);
   }
 
   @Test
   public void
       getFragmentSamplingRate_remoteConfigAndCacheAreSet_remoteConfigHasHighestConfigPrecedence() {
     // Set cache value.
-    when(mockDeviceCacheManager.getFloat(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
-        .thenReturn(Optional.of(0.2f));
+    when(mockDeviceCacheManager.getDouble(FRAGMENT_SAMPLING_RATE_CACHE_KEY))
+        .thenReturn(Optional.of(0.2));
 
     // Set remote config value.
-    when(mockRemoteConfigManager.getFloat(FRAGMENT_SAMPLING_RATE_FRC_KEY))
-        .thenReturn(Optional.of(0.3f));
+    when(mockRemoteConfigManager.getDouble(FRAGMENT_SAMPLING_RATE_FRC_KEY))
+        .thenReturn(Optional.of(0.3));
 
-    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.3f);
+    assertThat(testConfigResolver.getFragmentSamplingRate()).isEqualTo(0.3);
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigurationConstantsTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/ConfigurationConstantsTest.java
@@ -152,7 +152,7 @@ public class ConfigurationConstantsTest {
   public void getInstance_TraceSamplingRate_validateConstants() {
     TraceSamplingRate configFlag = TraceSamplingRate.getInstance();
 
-    assertThat(configFlag.getDefault()).isEqualTo(1.00f);
+    assertThat(configFlag.getDefault()).isEqualTo(1.00);
     assertThat(configFlag.getDeviceCacheFlag())
         .isEqualTo("com.google.firebase.perf.TraceSamplingRate");
     assertThat(configFlag.getRemoteConfigFlag()).isEqualTo("fpr_vc_trace_sampling_rate");
@@ -163,7 +163,7 @@ public class ConfigurationConstantsTest {
   public void getInstance_NetworkRequestSamplingRate_validateConstants() {
     NetworkRequestSamplingRate configFlag = NetworkRequestSamplingRate.getInstance();
 
-    assertThat(configFlag.getDefault()).isEqualTo(1.00f);
+    assertThat(configFlag.getDefault()).isEqualTo(1.00);
     assertThat(configFlag.getDeviceCacheFlag())
         .isEqualTo("com.google.firebase.perf.NetworkRequestSamplingRate");
     assertThat(configFlag.getRemoteConfigFlag()).isEqualTo("fpr_vc_network_request_sampling_rate");
@@ -174,7 +174,7 @@ public class ConfigurationConstantsTest {
   public void getInstance_SessionsSamplingRate_validateConstants() {
     SessionsSamplingRate configFlag = SessionsSamplingRate.getInstance();
 
-    assertThat(configFlag.getDefault()).isEqualTo(0.01f);
+    assertThat(configFlag.getDefault()).isEqualTo(0.01);
     assertThat(configFlag.getDeviceCacheFlag())
         .isEqualTo("com.google.firebase.perf.SessionSamplingRate");
     assertThat(configFlag.getRemoteConfigFlag()).isEqualTo("fpr_vc_session_sampling_rate");
@@ -259,7 +259,7 @@ public class ConfigurationConstantsTest {
   public void getInstance_FragmentSamplingRate_validateConstants() {
     FragmentSamplingRate configFlag = FragmentSamplingRate.getInstance();
 
-    assertThat(configFlag.getDefault()).isEqualTo(0.0f);
+    assertThat(configFlag.getDefault()).isEqualTo(0.0);
     assertThat(configFlag.getDeviceCacheFlag())
         .isEqualTo("com.google.firebase.perf.FragmentSamplingRate");
     assertThat(configFlag.getRemoteConfigFlag()).isEqualTo("fpr_vc_fragment_sampling_rate");

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
@@ -16,8 +16,12 @@ package com.google.firebase.perf.config;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
+import com.google.firebase.perf.util.Constants;
 import com.google.testing.timing.FakeScheduledExecutorService;
 import org.junit.Before;
 import org.junit.Test;
@@ -194,6 +198,19 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
     deviceCacheManager.setValue("some_key", 1.2);
 
     assertThat(deviceCacheManager.getDouble("some_key").get()).isEqualTo(1.2);
+  }
+
+  @Test
+  public void getDouble_valueIsSetAsFloat_returnsSetValue() {
+    deviceCacheManager.setContext(appContext);
+    fakeScheduledExecutorService.runAll();
+
+    // Manually setting a Float to simulate it being cached from a previous SDK version.
+    SharedPreferences sharedPreferences =
+        appContext.getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE);
+    sharedPreferences.edit().putFloat("some_key", 1.2f).apply();
+
+    assertThat(deviceCacheManager.getDouble("some_key").get()).isWithin(0.001).of(1.2);
   }
 
   @Test

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.perf.FirebasePerformanceTestBase;
 import com.google.firebase.perf.util.Constants;

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
@@ -224,7 +224,7 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void setValueFloat_setTwice_canGetLatestValue() {
+  public void setValueDouble_setTwice_canGetLatestValue() {
     deviceCacheManager.setContext(appContext);
     fakeScheduledExecutorService.runAll();
     deviceCacheManager.setValue("some_key", 1.01);
@@ -235,13 +235,27 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void setValueFloat_contextNotSet_returnsEmpty() {
+  public void setValueDouble_wasSetAsFloat_canGetLatestValue() {
+    deviceCacheManager.setContext(appContext);
+    fakeScheduledExecutorService.runAll();
+
+    // Manually setting a Float to simulate it being cached from a previous SDK version.
+    SharedPreferences sharedPreferences =
+        appContext.getSharedPreferences(Constants.PREFS_NAME, Context.MODE_PRIVATE);
+    sharedPreferences.edit().putFloat("some_key", 1.2f).apply();
+
+    deviceCacheManager.setValue("some_key", 0.01);
+    assertThat(deviceCacheManager.getDouble("some_key").get()).isEqualTo(0.01);
+  }
+
+  @Test
+  public void setValueDouble_contextNotSet_returnsEmpty() {
     deviceCacheManager.setValue("some_key", 100.0);
     assertThat(deviceCacheManager.getDouble("some_key").isAvailable()).isFalse();
   }
 
   @Test
-  public void setValueFloat_keyIsNull_returnsFalse() {
+  public void setValueDouble_keyIsNull_returnsFalse() {
     deviceCacheManager.setContext(appContext);
     fakeScheduledExecutorService.runAll();
     assertThat(deviceCacheManager.setValue(null, 10.0)).isFalse();

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/DeviceCacheManagerTest.java
@@ -171,64 +171,64 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getFloat_valueIsNotSet_returnsEmpty() {
+  public void getDouble_valueIsNotSet_returnsEmpty() {
     deviceCacheManager.setContext(appContext);
     fakeScheduledExecutorService.runAll();
 
-    assertThat(deviceCacheManager.getFloat("some_key").isAvailable()).isFalse();
+    assertThat(deviceCacheManager.getDouble("some_key").isAvailable()).isFalse();
   }
 
   @Test
-  public void getFloat_contextAndValueNotSet_returnsEmpty() {
+  public void getDouble_contextAndValueNotSet_returnsEmpty() {
     DeviceCacheManager.clearInstance();
     deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
 
     assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
-    assertThat(deviceCacheManager.getFloat("some_key").isAvailable()).isFalse();
+    assertThat(deviceCacheManager.getDouble("some_key").isAvailable()).isFalse();
   }
 
   @Test
-  public void getFloat_valueIsSet_returnsSetValue() {
+  public void getDouble_valueIsSet_returnsSetValue() {
     deviceCacheManager.setContext(appContext);
     fakeScheduledExecutorService.runAll();
-    deviceCacheManager.setValue("some_key", 1.2f);
+    deviceCacheManager.setValue("some_key", 1.2);
 
-    assertThat(deviceCacheManager.getFloat("some_key").get()).isEqualTo(1.2f);
+    assertThat(deviceCacheManager.getDouble("some_key").get()).isEqualTo(1.2);
   }
 
   @Test
-  public void getFloat_firebaseAppNotExist_returnsEmpty() {
+  public void getDouble_firebaseAppNotExist_returnsEmpty() {
     DeviceCacheManager.clearInstance();
     FirebaseApp.clearInstancesForTest();
     deviceCacheManager = new DeviceCacheManager(fakeScheduledExecutorService);
-    deviceCacheManager.setValue("some_key", 1.2f);
+    deviceCacheManager.setValue("some_key", 1.2);
 
     assertThat(fakeScheduledExecutorService.isEmpty()).isTrue();
-    assertThat(deviceCacheManager.getFloat("some_key").isAvailable()).isFalse();
+    assertThat(deviceCacheManager.getDouble("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueFloat_setTwice_canGetLatestValue() {
     deviceCacheManager.setContext(appContext);
     fakeScheduledExecutorService.runAll();
-    deviceCacheManager.setValue("some_key", 1.01f);
-    assertThat(deviceCacheManager.getFloat("some_key").get()).isEqualTo(1.01f);
+    deviceCacheManager.setValue("some_key", 1.01);
+    assertThat(deviceCacheManager.getDouble("some_key").get()).isEqualTo(1.01);
 
-    deviceCacheManager.setValue("some_key", 0.01f);
-    assertThat(deviceCacheManager.getFloat("some_key").get()).isEqualTo(0.01f);
+    deviceCacheManager.setValue("some_key", 0.01);
+    assertThat(deviceCacheManager.getDouble("some_key").get()).isEqualTo(0.01);
   }
 
   @Test
   public void setValueFloat_contextNotSet_returnsEmpty() {
-    deviceCacheManager.setValue("some_key", 100.0f);
-    assertThat(deviceCacheManager.getFloat("some_key").isAvailable()).isFalse();
+    deviceCacheManager.setValue("some_key", 100.0);
+    assertThat(deviceCacheManager.getDouble("some_key").isAvailable()).isFalse();
   }
 
   @Test
   public void setValueFloat_keyIsNull_returnsFalse() {
     deviceCacheManager.setContext(appContext);
     fakeScheduledExecutorService.runAll();
-    assertThat(deviceCacheManager.setValue(null, 10.0f)).isFalse();
+    assertThat(deviceCacheManager.setValue(null, 10.0)).isFalse();
   }
 
   @Test
@@ -292,6 +292,6 @@ public final class DeviceCacheManagerTest extends FirebasePerformanceTestBase {
   public void setValueLong_keyIsNull_returnsFalse() {
     deviceCacheManager.setContext(appContext);
     fakeScheduledExecutorService.runAll();
-    assertThat(deviceCacheManager.setValue(null, 10.0f)).isFalse();
+    assertThat(deviceCacheManager.setValue(null, 10.0)).isFalse();
   }
 }

--- a/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/config/RemoteConfigManagerTest.java
@@ -85,24 +85,24 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   // region Tests that verify output of valid/invalid Firebase Remote Config values.
 
   @Test
-  public void getFloat_keyIsNull_returnsEmpty() {
+  public void getDouble_keyIsNull_returnsEmpty() {
     RemoteConfigManager testRemoteConfigManager =
         setupTestRemoteConfigManager(createDefaultRcConfigMap());
 
-    assertThat(testRemoteConfigManager.getFloat(null).isAvailable()).isFalse();
+    assertThat(testRemoteConfigManager.getDouble(null).isAvailable()).isFalse();
   }
 
   @Test
-  public void getFloat_invalidFrcType_returnsEmpty() {
+  public void getDouble_invalidFrcType_returnsEmpty() {
     Map<String, FirebaseRemoteConfigValue> configs = createDefaultRcConfigMap();
     configs.put("some_key", new RemoteConfigValueImplForTest(/* throwsException= */ true));
     RemoteConfigManager testRemoteConfigManager = setupTestRemoteConfigManager(configs);
 
-    assertThat(testRemoteConfigManager.getFloat("some_key").isAvailable()).isFalse();
+    assertThat(testRemoteConfigManager.getDouble("some_key").isAvailable()).isFalse();
   }
 
   @Test
-  public void getFloat_validFrcValue_returnsValue() {
+  public void getDouble_validFrcValue_returnsValue() {
     Map<String, FirebaseRemoteConfigValue> configs = createDefaultRcConfigMap();
     configs.put("some_key1", new RemoteConfigValueImplForTest("100.0f"));
     configs.put("some_key2", new RemoteConfigValueImplForTest("1.0f"));
@@ -112,12 +112,12 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
     configs.put("some_key6", new RemoteConfigValueImplForTest("0.01f"));
     RemoteConfigManager testRemoteConfigManager = setupTestRemoteConfigManager(configs);
 
-    assertThat(testRemoteConfigManager.getFloat("some_key1").get()).isEqualTo(100.0f);
-    assertThat(testRemoteConfigManager.getFloat("some_key2").get()).isEqualTo(1.0f);
-    assertThat(testRemoteConfigManager.getFloat("some_key3").get()).isEqualTo(0.0f);
-    assertThat(testRemoteConfigManager.getFloat("some_key4").get()).isEqualTo(0.001f);
-    assertThat(testRemoteConfigManager.getFloat("some_key5").get()).isEqualTo(0.123f);
-    assertThat(testRemoteConfigManager.getFloat("some_key6").get()).isEqualTo(0.01f);
+    assertThat(testRemoteConfigManager.getDouble("some_key1").get()).isEqualTo(100.0);
+    assertThat(testRemoteConfigManager.getDouble("some_key2").get()).isEqualTo(1.0);
+    assertThat(testRemoteConfigManager.getDouble("some_key3").get()).isEqualTo(0.0);
+    assertThat(testRemoteConfigManager.getDouble("some_key4").get()).isEqualTo(0.001);
+    assertThat(testRemoteConfigManager.getDouble("some_key5").get()).isEqualTo(0.123);
+    assertThat(testRemoteConfigManager.getDouble("some_key6").get()).isEqualTo(0.01);
   }
 
   @Test
@@ -271,15 +271,15 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_invalidFrcValue_returnsDefaultValue() {
+  public void getRemoteConfigValueOrDefaultDouble_invalidFrcValue_returnsDefaultValue() {
     Map<String, FirebaseRemoteConfigValue> configs = createDefaultRcConfigMap();
     configs.put("some_key", new RemoteConfigValueImplForTest(/* throwsException= */ true));
     RemoteConfigManager testRemoteConfigManager = setupTestRemoteConfigManager(configs);
 
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isEqualTo(5.0f);
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 7.0f))
-        .isEqualTo(7.0f);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isEqualTo(5.0);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 7.0))
+        .isEqualTo(7.0);
   }
 
   @Test
@@ -301,13 +301,13 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_nullFrc_returnsDefaultValue() {
+  public void getRemoteConfigValueOrDefaultDouble_nullFrc_returnsDefaultValue() {
     RemoteConfigManager testRemoteConfigManager =
         setupRemoteConfigManagerWithUninitializedFirebaseRemoteConfigAndFirebaseApp(
             createDefaultRcConfigMap());
 
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isEqualTo(5.0f);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isEqualTo(5.0);
   }
 
   @Test
@@ -344,15 +344,15 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_frcInjectedAfterInit_returnsFrcValue() {
+  public void getRemoteConfigValueOrDefaultDouble_frcInjectedAfterInit_returnsFrcValue() {
     Map<String, FirebaseRemoteConfigValue> configs = createDefaultRcConfigMap();
     RemoteConfigManager testRemoteConfigManager =
         setupRemoteConfigManagerWithUninitializedFirebaseRemoteConfigAndFirebaseApp(configs);
-    configs.put("some_key", new RemoteConfigValueImplForTest("25.0f"));
+    configs.put("some_key", new RemoteConfigValueImplForTest("25.0"));
     testRemoteConfigManager.setFirebaseRemoteConfigProvider(mockFirebaseRemoteConfigProvider);
 
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isEqualTo(25.0f);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isEqualTo(25.0);
   }
 
   @Test
@@ -392,13 +392,13 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_frcValueSourceIsRemote_returnsFrcValue() {
+  public void getRemoteConfigValueOrDefaultDouble_frcValueSourceIsRemote_returnsFrcValue() {
     Map<String, FirebaseRemoteConfigValue> configs = createDefaultRcConfigMap();
-    configs.put("some_key", new RemoteConfigValueImplForTest("4.0f"));
+    configs.put("some_key", new RemoteConfigValueImplForTest("4.0"));
     RemoteConfigManager testRemoteConfigManager = setupTestRemoteConfigManager(configs);
 
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isEqualTo(4.0f);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isEqualTo(4.0);
   }
 
   @Test
@@ -457,25 +457,25 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_frcValueSourceIsNotRemote_returnsDefaultValue() {
+  public void getRemoteConfigValueOrDefaultDouble_frcValueSourceIsNotRemote_returnsDefaultValue() {
     Map<String, FirebaseRemoteConfigValue> configs = createDefaultRcConfigMap();
     RemoteConfigManager testRemoteConfigManager = setupTestRemoteConfigManager(configs);
 
     // Pass 1: Test with VALUE_SOURCE_DEFAULT
     configs.put(
         "some_key",
-        new RemoteConfigValueImplForTest("4.0f", FirebaseRemoteConfig.VALUE_SOURCE_DEFAULT));
+        new RemoteConfigValueImplForTest("4.0", FirebaseRemoteConfig.VALUE_SOURCE_DEFAULT));
 
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isEqualTo(5.0f);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isEqualTo(5.0);
 
     // Pass 2: Test with VALUE_SOURCE_STATIC
     configs.put(
         "some_key",
-        new RemoteConfigValueImplForTest("4.0f", FirebaseRemoteConfig.VALUE_SOURCE_STATIC));
+        new RemoteConfigValueImplForTest("4.0", FirebaseRemoteConfig.VALUE_SOURCE_STATIC));
 
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isEqualTo(5.0f);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isEqualTo(5.0);
   }
 
   @Test
@@ -573,8 +573,8 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_triggersRcFetchOnceAndOnlyOnce() {
-    verifyRcTriggersFetchOnceAndOnlyOnceFor(5.0f);
+  public void getRemoteConfigValueOrDefaultDouble_triggersRcFetchOnceAndOnlyOnce() {
+    verifyRcTriggersFetchOnceAndOnlyOnceFor(5.0);
   }
 
   @Test
@@ -621,8 +621,8 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_triggersOneRcFetchIfPreviousFetchWasTooLongAgo() {
-    verifyRcTriggersOneFetchIfPreviousFetchWasTooLongAgoFor(5.0f);
+  public void getRemoteConfigValueOrDefaultDouble_triggersOneRcFetchIfPreviousFetchWasTooLongAgo() {
+    verifyRcTriggersOneFetchIfPreviousFetchWasTooLongAgoFor(5.0);
   }
 
   @Test
@@ -696,25 +696,25 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_scalesFrcValue() {
+  public void getRemoteConfigValueOrDefaultDouble_scalesFrcValue() {
     Map<String, FirebaseRemoteConfigValue> configs = createDefaultRcConfigMap();
-    configs.put("some_key", new RemoteConfigValueImplForTest("0.5f"));
+    configs.put("some_key", new RemoteConfigValueImplForTest("0.5"));
     RemoteConfigManager testRemoteConfigManager = setupTestRemoteConfigManager(configs);
 
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isEqualTo(0.5f);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isEqualTo(0.5);
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_scalesVerySmallFrcValue() {
+  public void getRemoteConfigValueOrDefaultDouble_scalesVerySmallFrcValue() {
     Map<String, FirebaseRemoteConfigValue> configs = createDefaultRcConfigMap();
-    configs.put("some_key", new RemoteConfigValueImplForTest("0.000005f"));
+    configs.put("some_key", new RemoteConfigValueImplForTest("0.000005"));
     RemoteConfigManager testRemoteConfigManager = setupTestRemoteConfigManager(configs);
 
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isAtMost(0.000005f);
-    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0f))
-        .isAtLeast(0.0000049f);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isAtMost(0.000005);
+    assertThat(testRemoteConfigManager.getRemoteConfigValueOrDefault("some_key", 5.0))
+        .isAtLeast(0.0000049);
   }
 
   @Test
@@ -723,8 +723,8 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
   }
 
   @Test
-  public void getRemoteConfigValueOrDefaultFloat_allowsRefetchOnFailure() {
-    verifyRcAllowsRefetchOnFailureFor(5.0f);
+  public void getRemoteConfigValueOrDefaultDouble_allowsRefetchOnFailure() {
+    verifyRcAllowsRefetchOnFailureFor(5.0);
   }
 
   @Test
@@ -846,7 +846,7 @@ public final class RemoteConfigManagerTest extends FirebasePerformanceTestBase {
     simulateFirebaseRemoteConfigLastFetchStatus(
         FirebaseRemoteConfig.LAST_FETCH_STATUS_NO_FETCH_YET);
     remoteConfigManagerPartialMock.getRemoteConfigValueOrDefault("some_key", 5L);
-    remoteConfigManagerPartialMock.getRemoteConfigValueOrDefault("some_other_key", 5.0f);
+    remoteConfigManagerPartialMock.getRemoteConfigValueOrDefault("some_other_key", 5.0);
     remoteConfigManagerPartialMock.getRemoteConfigValueOrDefault("some_other_key_2", true);
     remoteConfigManagerPartialMock.getRemoteConfigValueOrDefault("some_other_key_3", "1.0.0");
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/session/PerfSessionTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/session/PerfSessionTest.java
@@ -74,7 +74,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
   public void shouldCollectGaugesAndEvents_perfMonDisabledAtRuntime_sessionNotVerbose() {
     ConfigResolver configResolver = ConfigResolver.getInstance();
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 100f);
+    bundle.putFloat("sessions_sampling_percentage", 100);
     configResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
     // By default, session is verbose if developer has set 100% of session verbosity.
@@ -96,7 +96,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
     ConfigResolver configResolver = ConfigResolver.getInstance();
     // Developer disables Performance collection at AndroidManifest.
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 100f);
+    bundle.putFloat("sessions_sampling_percentage", 100);
     bundle.putBoolean("firebase_performance_collection_enabled", false);
     configResolver.setMetadataBundle(new ImmutableBundle(bundle));
 
@@ -119,7 +119,7 @@ public class PerfSessionTest extends FirebasePerformanceTestBase {
   public void shouldCollectGaugesAndEvents_perfMonDeactivated_sessionNotVerbose() {
     ConfigResolver configResolver = ConfigResolver.getInstance();
     Bundle bundle = new Bundle();
-    bundle.putFloat("sessions_sampling_percentage", 100f);
+    bundle.putFloat("sessions_sampling_percentage", 100);
     bundle.putBoolean("firebase_performance_collection_deactivated", true);
     configResolver.setMetadataBundle(new ImmutableBundle(bundle));
 

--- a/firebase-perf/src/test/java/com/google/firebase/perf/transport/RateLimiterTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/transport/RateLimiterTest.java
@@ -62,7 +62,6 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   private static final Rate FOUR_TOKENS_PER_MINUTE = new Rate(4, 1, MINUTES);
   private static final Rate TWO_TOKENS_PER_SECOND = new Rate(2, 1, SECONDS);
   private static final Rate THREE_TOKENS_PER_SECOND = new Rate(3, 1, SECONDS);
-  private static final Rate TEN_TOKENS_PER_SECOND = new Rate(10, 1, SECONDS);
 
   @Before
   public void setUp() {
@@ -85,8 +84,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
 
     // Make Config Resolver returns default value for resource sampling rate.
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0);
 
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
@@ -129,8 +128,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
 
     // Make Config Resolver returns default value for resource sampling rate.
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0);
 
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0s, token count is 2.0.
@@ -170,8 +169,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
 
     // Make Config Resolver returns default value for resource sampling rate.
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0);
 
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
@@ -212,8 +211,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
 
     // Make Config Resolver returns default value for resource sampling rate.
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0);
 
     // allow 3 logs per second. token bucket capacity is 4.
     RateLimiterImpl limiterImpl =
@@ -260,8 +259,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
 
     // Make Config Resolver returns default value for resource sampling rate.
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0);
 
     // allow 3 logs per second. token bucket capacity is 2.
     RateLimiterImpl limiterImpl =
@@ -308,8 +307,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
     makeConfigResolverReturnDefaultValues();
 
     // Make Config Resolver returns default value for resource sampling rate.
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(1.0);
 
     // allow 2 logs every minute. token bucket capacity is 2.
     // clock is 0, token count is 2.
@@ -372,8 +371,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_tracesEnabledButNetworkDisabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.02f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.02);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, 0, mockConfigResolver);
@@ -385,8 +384,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_tracesDisabledButNetworkEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.02f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.02);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, 0, mockConfigResolver);
@@ -398,8 +397,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_tracesEnabledButFragmentDisabled_dropsFragmentTrace() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.02f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.02);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, 0.49f, mockConfigResolver);
@@ -434,8 +433,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_tracesDisabledButFragmentEnabled_dropsFragmentTrace() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.02f);
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.5f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.02);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.5);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, 0.49f, mockConfigResolver);
@@ -459,7 +458,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void getIsDeviceAllowedToSendTraces_8digitSamplingRate_traceIsEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.00000001f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.00000001);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.000000005f, 0, mockConfigResolver);
@@ -470,7 +469,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void getIsDeviceAllowedToSendTraces_8digitSamplingRate_traceIsDisabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.00000001f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.00000001);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.000000011f, 0, mockConfigResolver);
@@ -481,7 +480,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void getIsDeviceAllowedToSendNetwork_8digitSamplingRate_networkIsEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.00000001f);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.00000001);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.000000005f, 0, mockConfigResolver);
@@ -492,7 +491,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void getIsDeviceAllowedToSendNetwork_8digitSamplingRate_networkIsDisabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.00000001f);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.00000001);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.000000011f, 0, mockConfigResolver);
@@ -503,7 +502,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void getIsDeviceAllowedToSendFragmentScreenTraces_8digitSamplingRate_fragmentIsEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.00000001f);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.00000001);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.99f, 0.000000005f, mockConfigResolver);
@@ -514,7 +513,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void getIsDeviceAllowedToSendFragmentScreenTraces_8digitSamplingRate_fragmentIsDisabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.00000001f);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.00000001);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0, 0.000000011f, mockConfigResolver);
@@ -525,8 +524,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_bothTracesAndNetworkEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, 0, mockConfigResolver);
@@ -538,8 +537,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_bothTracesAndNetworkDisabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.51f, 0, mockConfigResolver);
@@ -551,8 +550,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_bothTracesAndFragmentEnabled_acceptsFragmentTrace() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.5f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.5);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.49f, 0.49f, mockConfigResolver);
@@ -575,14 +574,14 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_changeInTraceSamplingRateIsImmediatelyEffective() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.5);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.51f, 0, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isFalse();
 
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.75f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.75);
 
     assertThat(limiter.getIsDeviceAllowedToSendTraces()).isTrue();
   }
@@ -590,14 +589,14 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_changeInNetworkSamplingRateIsImmediatelyEffective() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5f);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.5);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0.51f, 0, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isFalse();
 
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.75f);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.75);
 
     assertThat(limiter.getIsDeviceAllowedToSendNetworkEvents()).isTrue();
   }
@@ -605,14 +604,14 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testDeviceSampling_changeInFragmentSamplingRateIsImmediatelyEffective() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.5f);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.5);
 
     RateLimiter limiter =
         new RateLimiter(TWO_TOKENS_PER_MINUTE, 2, mClock, 0, 0.51f, mockConfigResolver);
 
     assertThat(limiter.getIsDeviceAllowedToSendFragmentScreenTraces()).isFalse();
 
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.75f);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.75);
 
     assertThat(limiter.getIsDeviceAllowedToSendFragmentScreenTraces()).isTrue();
   }
@@ -897,7 +896,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testTracesAreNotSampledWhenSessionIsVerboseAndSamplingEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.70f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.70);
 
     // Passing a value for samplingBucketId which is greater than the sampling rate ensures that
     // the sampling will be enabled causing all the metrics to be dropped
@@ -924,7 +923,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testNetworkRequestsAreNotSampledWhenSessionIsVerboseAndSamplingEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.70f);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.70);
 
     // Passing a value for samplingBucketId which is greater than the sampling rate ensures that
     // the sampling will be enabled causing all the metrics to be dropped
@@ -951,8 +950,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void isEventSampled_fragmentWithVerboseSessionEnabled_returnsTrue() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.70f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.70);
 
     // Passing a value for samplingBucketId which is greater than the sampling rate means that
     // the sampling dice roll failed causing all the metrics to be dropped
@@ -982,7 +981,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testTracesAreSampledWhenSessionIsNonVerboseAndSamplingEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.70f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.70);
 
     // Passing a value for samplingBucketId which is greater than the sampling rate ensures that
     // the sampling will be enabled causing all the metrics to be dropped
@@ -1009,7 +1008,7 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testNetworkRequestsAreSampledWhenSessionIsNonVerboseAndSamplingEnabled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.70f);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.70);
 
     // Passing a value for samplingBucketId which is greater than the sampling rate ensures that
     // the sampling will be enabled causing all the metrics to be dropped
@@ -1036,8 +1035,8 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void isEventSampled_fragmentWithVerboseSessionDisabled_returnsFalse() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.70f);
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0f);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.70);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(1.0);
 
     // Passing a value for samplingBucketId which is greater than the sampling rate means that
     // the sampling dice roll failed causing all the metrics to be dropped
@@ -1067,9 +1066,9 @@ public class RateLimiterTest extends FirebasePerformanceTestBase {
   @Test
   public void testGaugesAreNeverSampled() {
     makeConfigResolverReturnDefaultValues();
-    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.70f);
-    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.70f);
-    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.70f);
+    when(mockConfigResolver.getTraceSamplingRate()).thenReturn(0.70);
+    when(mockConfigResolver.getNetworkRequestSamplingRate()).thenReturn(0.70);
+    when(mockConfigResolver.getFragmentSamplingRate()).thenReturn(0.70);
 
     // Passing a value for samplingBucketId which is greater than the sampling rate ensures that
     // the sampling will be enabled causing all the metrics to be dropped

--- a/firebase-perf/src/test/java/com/google/firebase/perf/util/ImmutableBundleTest.java
+++ b/firebase-perf/src/test/java/com/google/firebase/perf/util/ImmutableBundleTest.java
@@ -93,48 +93,48 @@ public final class ImmutableBundleTest {
   }
 
   @Test
-  public void getFloatOptional_noValueFound_returnsEmpty() {
+  public void getDoubleOptional_noValueFound_returnsEmpty() {
     Bundle testBundle = new Bundle();
     testBundle.putFloat("testKey", 25.0f);
 
     ImmutableBundle testImmutableBundle = new ImmutableBundle(testBundle);
-    assertThat(testImmutableBundle.getFloat("notPresentKey").isAvailable()).isFalse();
+    assertThat(testImmutableBundle.getDouble("notPresentKey").isAvailable()).isFalse();
   }
 
   @Test
-  public void getFloatOptional_valueFound_returnsValue() {
+  public void getDoubleOptional_valueFound_returnsValue() {
     Bundle testBundle = new Bundle();
     testBundle.putFloat("testKey", 25.0f);
 
     ImmutableBundle testImmutableBundle = new ImmutableBundle(testBundle);
-    assertThat(testImmutableBundle.getFloat("testKey").get()).isEqualTo(25.0f);
+    assertThat(testImmutableBundle.getDouble("testKey").get()).isEqualTo(25.0);
   }
 
   @Test
-  public void getFloatOptional_keyIsNull_returnsEmpty() {
+  public void getDoubleOptional_keyIsNull_returnsEmpty() {
     Bundle testBundle = new Bundle();
     testBundle.putFloat("testKey", 25.0f);
 
     ImmutableBundle testImmutableBundle = new ImmutableBundle(testBundle);
-    assertThat(testImmutableBundle.getFloat(null).isAvailable()).isFalse();
+    assertThat(testImmutableBundle.getDouble(null).isAvailable()).isFalse();
   }
 
   @Test
-  public void getFloatOptional_valueTypeNotMatch_returnsEmpty() {
+  public void getDoubleOptional_valueTypeNotMatch_returnsEmpty() {
     Bundle testBundle = new Bundle();
     testBundle.putBoolean("testKey", true);
 
     ImmutableBundle testImmutableBundle = new ImmutableBundle(testBundle);
-    assertThat(testImmutableBundle.getFloat("testKey").isAvailable()).isFalse();
+    assertThat(testImmutableBundle.getDouble("testKey").isAvailable()).isFalse();
   }
 
   @Test
-  public void getFloatOptional_valueIsNull_returnsEmpty() {
+  public void getDoubleOptional_valueIsNull_returnsEmpty() {
     Bundle testBundle = new Bundle();
     testBundle.putString("testKey", null);
 
     ImmutableBundle testImmutableBundle = new ImmutableBundle(testBundle);
-    assertThat(testImmutableBundle.getFloat("testKey").isAvailable()).isFalse();
+    assertThat(testImmutableBundle.getDouble("testKey").isAvailable()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
RC Flags are stored as Double and our SDK loses precision when converting back to Float. This causes sampling rates to not behave as expected.