### PR TITLE
Removing former team members from the Fireperf e2e assignee list

### DIFF
--- a/.github/workflows/fireperf-e2e.yml
+++ b/.github/workflows/fireperf-e2e.yml
@@ -93,7 +93,7 @@ jobs:
                 title: 'FirePerf E2E Test Failures',
                 body: text,
                 labels: ['fireperf-e2e-tests'],
-                assignees: ['jeremyjiang-dev', 'leotianlizhan', 'raymondlam', 'visumickey']
+                assignees: ['raymondlam', 'visumickey']
               });
             }
       - name: Upload test artifacts


### PR DESCRIPTION
Removing Jeremy and Leo from the Fireperf e2e test assignee list.