### PR TITLE
Merge sessions-e2e.yml from firebase-sessions so it can run on schedule

### DIFF
--- a/.github/workflows/sessions-e2e.yml
+++ b/.github/workflows/sessions-e2e.yml
@@ -1,7 +1,9 @@
 name: Firebase Sessions E2E Tests
 
 on:
-  workflow_dispatch: # allow triggering the workflow manually
+  schedule:
+    - cron: 24 */4 * * *  # every 4 hours at 24 minutes past the hour
+  workflow_dispatch:     # allow triggering the workflow manually
 
 concurrency:
   group: ${{ github.workflow }}
@@ -10,29 +12,34 @@ env:
   SESSIONS_E2E_GOOGLE_SERVICES: ${{ secrets.SESSIONS_E2E_GOOGLE_SERVICES }}
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout firebase-sessions
-      uses: actions/checkout@v3
-      with:
-        ref: 'firebase-sessions'
+      - name: Checkout firebase-sessions
+        uses: actions/checkout@v3
+        with:
+          ref: 'firebase-sessions'
 
-    - name: set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: gradle
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
 
-    - name: Add google-services.json
-      run: |
-        echo $SESSIONS_E2E_GOOGLE_SERVICES | base64 -d > google-services.json
+      - name: Add google-services.json
+        run: |
+          echo $SESSIONS_E2E_GOOGLE_SERVICES | base64 -d > google-services.json
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-
-    - name: Run sessions end-to-end tests
-      run: ./gradlew firebase-sessions:deviceCheck withErrorProne -PtargetBackend="prod"
+      - uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/setup-gcloud@v0
+      - name: Run sessions end-to-end tests
+        env:
+          FTL_RESULTS_BUCKET: fireescape
+          FIREBASE_APP_CHECK_DEBUG_SECRET: ${{ secrets.FIREBASE_APP_CHECK_DEBUG_SECRET }}
+        run: |
+          ./gradlew :firebase-sessions:test-app:deviceCheck withErrorProne -PtargetBackend="prod"

--- a/.github/workflows/sessions-e2e.yml
+++ b/.github/workflows/sessions-e2e.yml
@@ -40,6 +40,5 @@ jobs:
       - name: Run sessions end-to-end tests
         env:
           FTL_RESULTS_BUCKET: fireescape
-          FIREBASE_APP_CHECK_DEBUG_SECRET: ${{ secrets.FIREBASE_APP_CHECK_DEBUG_SECRET }}
         run: |
           ./gradlew :firebase-sessions:test-app:deviceCheck withErrorProne -PtargetBackend="prod"


### PR DESCRIPTION
This workflow will still checkout firebase-sessions and run the test on that branch. But for it to run every 4 hours, we need to merge it into master.