### PR TITLE
Fixes fireperf e2e tests

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     // resolution works, otherwise it breaks Fireperf Test Apps.
     // See https://github.com/gradle/gradle/issues/12286
     implementation("com.google.firebase:perf-plugin:$perfPluginVersion")
-
+    implementation("org.ow2.asm", "asm-tree", "9.5")
     implementation("com.google.auto.value:auto-value-annotations:1.8.1")
     annotationProcessor("com.google.auto.value:auto-value:1.6.5")
     implementation(kotlin("gradle-plugin", "1.7.10"))


### PR DESCRIPTION
Perf plugin depends on asm which is not being pulled in transitively in snapshot build which is why we need a direct dependency on asm