### PR TITLE
Move currentTimeUs into WallClock

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
@@ -103,7 +103,7 @@ internal object SessionEvents {
   fun startSession(
     firebaseApp: FirebaseApp,
     sessionDetails: SessionDetails,
-    currentTimeUs: Long = System.currentTimeMillis() * 1000
+    currentTimeUs: Long = WallClock.currentTimeUs(),
   ) =
     SessionEvent(
       eventType = EventType.SESSION_START,

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/WallClock.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/WallClock.kt
@@ -24,4 +24,12 @@ import kotlin.time.Duration.Companion.milliseconds
 internal object WallClock {
   /** Gets the [Duration] elapsed in "wall clock" time since device boot. */
   fun elapsedRealtime(): Duration = SystemClock.elapsedRealtime().milliseconds
+
+  /**
+   * Gets the current time in microseconds. The clock can be set by the user or phone network so it
+   * is not universally accurate or increasing.
+   */
+  fun currentTimeUs(): Long {
+    return System.currentTimeMillis() * 1000
+  }
 }


### PR DESCRIPTION
Follow up from https://github.com/firebase/firebase-android-sdk/pull/4870#discussion_r1162805177