### PR TITLE
Fill in device_model field for AQS

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.sessions
 
+import android.os.Build
 import com.google.firebase.FirebaseApp
 import com.google.firebase.encoders.DataEncoder
 import com.google.firebase.encoders.FieldDescriptor
@@ -127,7 +128,7 @@ internal object SessionEvents {
 
     return ApplicationInfo(
       appId = firebaseApp.options.applicationId,
-      deviceModel = "",
+      deviceModel = Build.MODEL,
       sessionSdkVersion = BuildConfig.VERSION_NAME,
       logEnvironment = LogEnvironment.LOG_ENVIRONMENT_PROD,
       androidAppInfo =

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/ApplicationInfoTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/ApplicationInfoTest.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.sessions
 
 import android.content.Context
+import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
@@ -36,7 +37,7 @@ class ApplicationInfoTest {
       .isEqualTo(
         ApplicationInfo(
           appId = FakeFirebaseApp.MOCK_APP_ID,
-          deviceModel = "robolectric",
+          deviceModel = Build.MODEL,
           sessionSdkVersion = BuildConfig.VERSION_NAME,
           logEnvironment = LogEnvironment.LOG_ENVIRONMENT_PROD,
           AndroidApplicationInfo(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/ApplicationInfoTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/ApplicationInfoTest.kt
@@ -36,7 +36,7 @@ class ApplicationInfoTest {
       .isEqualTo(
         ApplicationInfo(
           appId = FakeFirebaseApp.MOCK_APP_ID,
-          deviceModel = "",
+          deviceModel = "robolectric",
           sessionSdkVersion = BuildConfig.VERSION_NAME,
           logEnvironment = LogEnvironment.LOG_ENVIRONMENT_PROD,
           AndroidApplicationInfo(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
@@ -68,7 +68,7 @@ class SessionEventEncoderTest {
             },
             "application_info":{
               "app_id":"1:12345:android:app",
-              "device_model":"",
+              "device_model":"robolectric",
               "session_sdk_version":"0.1.0",
               "log_environment":3,
               "android_app_info":{

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
@@ -16,6 +16,7 @@
 
 package com.google.firebase.sessions
 
+import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
@@ -68,7 +69,7 @@ class SessionEventEncoderTest {
             },
             "application_info":{
               "app_id":"1:12345:android:app",
-              "device_model":"robolectric",
+              "device_model":"${Build.MODEL}",
               "session_sdk_version":"0.1.0",
               "log_environment":3,
               "android_app_info":{

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
@@ -55,7 +55,7 @@ internal object TestSessionEventData {
       applicationInfo =
         ApplicationInfo(
           appId = FakeFirebaseApp.MOCK_APP_ID,
-          deviceModel = "",
+          deviceModel = "robolectric",
           sessionSdkVersion = BuildConfig.VERSION_NAME,
           logEnvironment = LogEnvironment.LOG_ENVIRONMENT_PROD,
           AndroidApplicationInfo(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.sessions.testing
 
 import android.content.Context
+import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.firebase.sessions.*
 
@@ -55,7 +56,7 @@ internal object TestSessionEventData {
       applicationInfo =
         ApplicationInfo(
           appId = FakeFirebaseApp.MOCK_APP_ID,
-          deviceModel = "robolectric",
+          deviceModel = Build.MODEL,
           sessionSdkVersion = BuildConfig.VERSION_NAME,
           logEnvironment = LogEnvironment.LOG_ENVIRONMENT_PROD,
           AndroidApplicationInfo(


### PR DESCRIPTION


I assume this needs to be consistent with the Crashlytics Device Model: https://github.com/firebase/firebase-android-sdk/blob/master/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java#L220


