### PR TITLE
Firestore: Internal method AggregateQuerySnapshot.createWithCount() added for CPP SDK

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateQuerySnapshot.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/AggregateQuerySnapshot.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import com.google.firestore.v1.Value;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -41,6 +42,16 @@ public class AggregateQuerySnapshot {
     checkNotNull(query);
     this.query = query;
     this.data = data;
+  }
+
+  // Convenience function to create an AggregateQuerySnapshot instance whose only aggregation is a
+  // "count" with the given value. This method only exists for use by the CPP SDK; when the CPP SDK
+  // implements generic aggregations and migrates away from this method then it can be removed.
+  static AggregateQuerySnapshot createWithCount(@NonNull AggregateQuery query, long count) {
+    return new AggregateQuerySnapshot(
+        query,
+        Collections.singletonMap(
+            AggregateField.count().getAlias(), Value.newBuilder().setIntegerValue(count).build()));
   }
 
   /** Returns the query that was executed to produce this result. */

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/AggregateQuerySnapshotTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/AggregateQuerySnapshotTest.java
@@ -1,0 +1,36 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.firestore;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.firestore.TestUtil.collectionReference;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class AggregateQuerySnapshotTest {
+
+  @Test
+  public void createWithCountShouldReturnInstanceWithTheGivenQueryAndCount() {
+    AggregateQuery query = collectionReference("foo/bar/baz").count();
+    AggregateQuerySnapshot snapshot = AggregateQuerySnapshot.createWithCount(query, 42);
+    assertThat(snapshot.getQuery()).isSameInstanceAs(query);
+    assertThat(snapshot.getCount()).isEqualTo(42);
+  }
+}


### PR DESCRIPTION
See https://github.com/firebase/firebase-cpp-sdk/pull/1283