### PR TITLE
Refactor PomValidator

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
@@ -78,7 +78,7 @@ abstract class BaseFirebaseLibraryPlugin : Plugin<Project> {
 
   protected fun getIsPomValidTask(project: Project, firebaseLibrary: FirebaseLibraryExtension) {
     project.tasks.register<PomValidator>("isPomDependencyValid") {
-      pomFilePath.value(project.file("build/publications/mavenAar/pom-default.xml"))
+      pomFile.value(project.file("build/publications/mavenAar/pom-default.xml"))
       groupId.value(firebaseLibrary.groupId.get())
       artifactId.value(firebaseLibrary.artifactId.get())
       dependsOn("generatePomFileForMavenAarPublication")

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
@@ -78,9 +78,9 @@ abstract class BaseFirebaseLibraryPlugin : Plugin<Project> {
 
   protected fun getIsPomValidTask(project: Project, firebaseLibrary: FirebaseLibraryExtension) {
     project.tasks.register<PomValidator>("isPomDependencyValid") {
-      pomFile.value(project.file("build/publications/mavenAar/pom-default.xml"))
-      groupId.value(firebaseLibrary.groupId.get())
-      artifactId.value(firebaseLibrary.artifactId.get())
+      pomFile.set(project.layout.buildDirectory.file("publications/mavenAar/pom-default.xml"))
+      groupId.set(firebaseLibrary.groupId.get())
+      artifactId.set(firebaseLibrary.artifactId.get())
       dependsOn("generatePomFileForMavenAarPublication")
     }
   }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PomValidator.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PomValidator.kt
@@ -18,7 +18,7 @@ import java.net.URL
 import javax.xml.parsers.DocumentBuilderFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -37,7 +37,7 @@ import org.w3c.dom.Element
  * @throws GradleException if a dependency is found with a degraded version
  */
 abstract class PomValidator : DefaultTask() {
-  @get:InputFile abstract val pomFile: Property<RegularFile>
+  @get:InputFile abstract val pomFile: RegularFileProperty
   @get:Input abstract val artifactId: Property<String>
   @get:Input abstract val groupId: Property<String>
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PomValidator.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PomValidator.kt
@@ -16,7 +16,6 @@ package com.google.firebase.gradle.plugins
 
 import java.io.File
 import java.net.URL
-import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -24,55 +23,70 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
-import org.w3c.dom.Document
 import org.w3c.dom.Element
-import org.w3c.dom.Node
-import org.w3c.dom.NodeList
 
+/**
+ * Ensures that pom dependencies are not accidently downgraded.
+ *
+ * Compares the latest pom at gmaven for the given artifact with the one generate for the current
+ * release.
+ *
+ * @throws GradleException if a dependency is found with a degraded version
+ *
+ * @property pomFile The pom file for the current release
+ * @property artifactId The artifactId for the pom parent
+ * @property groupId The groupId for the pom parent
+ */
 abstract class PomValidator : DefaultTask() {
-  @get:InputFile abstract val pomFilePath: Property<File>
+  @get:InputFile abstract val pomFile: Property<File>
   @get:Input abstract val artifactId: Property<String>
   @get:Input abstract val groupId: Property<String>
 
   @TaskAction
   fun run() {
-    val gMavenHelper = GmavenHelper(groupId.get(), artifactId.get())
-    val latestReleasedVersion = gMavenHelper.getLatestReleasedVersion()
-    val releasedVersionPomUrl = gMavenHelper.getPomFileForVersion(latestReleasedVersion)
-    var output: String = diffWithPomFileUrl(releasedVersionPomUrl).trim()
-    if (output.isNotEmpty()) {
-      throw GradleException("${output}\nPlease fix the above errors")
+    var diff = diffWithPomFromURL(getLatestReleasePomUrl())
+
+    if (diff.isNotEmpty()) {
+      throw GradleException("Dependency version errors found:\n${diff}")
     }
   }
 
-  fun getMapFromXml(pomNodeList: NodeList): Map<String, String> {
-    val pomMap = mutableMapOf<String, String>()
-    for (i in 0..pomNodeList.length - 1) {
-      val node: Node = pomNodeList.item(i)
-      if (node.getNodeType() == Node.ELEMENT_NODE) {
-        val element = node as Element
-        val artifact = element.getElementsByTagName("artifactId").item(0).getTextContent()
-        val version = element.getElementsByTagName("version").item(0).getTextContent()
-        pomMap[artifact] = version
-      }
+  private fun getLatestReleasePomUrl() =
+    with(GmavenHelper(groupId.get(), artifactId.get())) {
+      getPomFileForVersion(getLatestReleasedVersion())
     }
-    return pomMap
-  }
 
-  fun diffWithPomFileUrl(pomUrl: String): String {
-    val factory: DocumentBuilderFactory = DocumentBuilderFactory.newInstance()
-    val oldPomBuilder: DocumentBuilder = factory.newDocumentBuilder()
-    val oldPomDoc: Document = oldPomBuilder.parse(URL(pomUrl).openStream())
-    val currentPomBuilder: DocumentBuilder = factory.newDocumentBuilder()
-    val currentPomDoc: Document = currentPomBuilder.parse(pomFilePath.get())
-    val oldPomMap = getMapFromXml(oldPomDoc.getElementsByTagName("dependency"))
-    val currentPomMap = getMapFromXml(currentPomDoc.getElementsByTagName("dependency"))
-
-    return currentPomMap
-      .filter {
-        (oldPomMap.get(it.key) != null) && (oldPomMap.get(it.key)!!.trim()) > it.value.trim()
+  private fun getMapOfDependencies(doc: Element) =
+    doc
+      .findElementsByTag("dependency")
+      .associate { it.textByTag("artifactId") to it.textByTag("version") }
+      .filter { it.key != "javax.inject" } // javax.inject doesn't respect SemVer and doesn't update
+      .mapValues {
+        ModuleVersion.fromStringOrNull(it.value)
+          ?: throw RuntimeException("Invalid module version found for '${it.key}': ${it.value}")
       }
-      .map { "Artifacts ${it.key} has been degraded to ${it.value} from ${oldPomMap.get(it.key)}" }
+
+  data class DependencyDiff(
+    val artifactId: String,
+    val oldVersion: ModuleVersion,
+    val currentVersion: ModuleVersion
+  )
+
+  fun diffWithPomFromURL(url: String): String {
+    val documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+
+    val oldPom = documentBuilder.parse(URL(url).openStream())
+    val currentPom = documentBuilder.parse(pomFile.get())
+
+    val oldDependencies = getMapOfDependencies(oldPom.documentElement)
+    val currentDependencies = getMapOfDependencies(currentPom.documentElement)
+
+    return currentDependencies
+      .map { DependencyDiff(it.key, oldDependencies.getOrDefault(it.key, it.value), it.value) }
+      .filter { it.oldVersion > it.currentVersion }
+      .map {
+        "Dependency on ${it.artifactId} has been degraded from ${it.oldVersion} to ${it.currentVersion}"
+      }
       .joinToString("\n")
   }
 }


### PR DESCRIPTION
Per [b/279212956](https://b.corp.google.com/issues/279212956),

This takes advantage of the new extension methods provided in the recently merged #4879, and refactors the `PomValidator` task to take advantage of them.

Additionally, this fixes [b/279212781](https://b.corp.google.com/issues/279212781) - providing documentation for the `PomValidator` task.