### PR TITLE
Firestore Spec Tests: Port JS PR 7257 (use strings for `targetPurpose`)

### DIFF
--- a/firebase-firestore/src/test/resources/json/bundle_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/bundle_spec_test.json
@@ -1179,7 +1179,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [

--- a/firebase-firestore/src/test/resources/json/existence_filter_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/existence_filter_spec_test.json
@@ -185,7 +185,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -385,7 +385,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -613,7 +613,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -818,7 +818,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3529,7 +3529,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "11": {
               "queries": [
@@ -3542,7 +3542,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "13": {
               "queries": [
@@ -3555,7 +3555,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "15": {
               "queries": [
@@ -3568,7 +3568,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "17": {
               "queries": [
@@ -3581,7 +3581,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "19": {
               "queries": [
@@ -3594,7 +3594,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3619,7 +3619,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "23": {
               "queries": [
@@ -3632,7 +3632,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "25": {
               "queries": [
@@ -3645,7 +3645,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "27": {
               "queries": [
@@ -3658,7 +3658,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "29": {
               "queries": [
@@ -3671,7 +3671,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "3": {
               "queries": [
@@ -3684,7 +3684,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "31": {
               "queries": [
@@ -3697,7 +3697,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "33": {
               "queries": [
@@ -3710,7 +3710,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "35": {
               "queries": [
@@ -3723,7 +3723,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "37": {
               "queries": [
@@ -3736,7 +3736,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "39": {
               "queries": [
@@ -3749,7 +3749,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "41": {
               "queries": [
@@ -3762,7 +3762,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "43": {
               "queries": [
@@ -3775,7 +3775,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "45": {
               "queries": [
@@ -3788,7 +3788,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "47": {
               "queries": [
@@ -3801,7 +3801,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "49": {
               "queries": [
@@ -3814,7 +3814,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "5": {
               "queries": [
@@ -3827,7 +3827,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "51": {
               "queries": [
@@ -3840,7 +3840,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "53": {
               "queries": [
@@ -3853,7 +3853,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "55": {
               "queries": [
@@ -3866,7 +3866,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "57": {
               "queries": [
@@ -3879,7 +3879,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "59": {
               "queries": [
@@ -3892,7 +3892,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "61": {
               "queries": [
@@ -3905,7 +3905,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "63": {
               "queries": [
@@ -3918,7 +3918,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "65": {
               "queries": [
@@ -3931,7 +3931,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "67": {
               "queries": [
@@ -3944,7 +3944,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "69": {
               "queries": [
@@ -3957,7 +3957,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "7": {
               "queries": [
@@ -3970,7 +3970,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "71": {
               "queries": [
@@ -3983,7 +3983,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "73": {
               "queries": [
@@ -3996,7 +3996,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "75": {
               "queries": [
@@ -4009,7 +4009,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "77": {
               "queries": [
@@ -4022,7 +4022,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "79": {
               "queries": [
@@ -4035,7 +4035,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "81": {
               "queries": [
@@ -4048,7 +4048,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "83": {
               "queries": [
@@ -4061,7 +4061,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "85": {
               "queries": [
@@ -4074,7 +4074,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "87": {
               "queries": [
@@ -4087,7 +4087,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "89": {
               "queries": [
@@ -4100,7 +4100,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "9": {
               "queries": [
@@ -4113,7 +4113,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "91": {
               "queries": [
@@ -4126,7 +4126,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "93": {
               "queries": [
@@ -4139,7 +4139,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "95": {
               "queries": [
@@ -4152,7 +4152,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "97": {
               "queries": [
@@ -4165,7 +4165,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "99": {
               "queries": [
@@ -4178,7 +4178,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -4360,7 +4360,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -4632,7 +4632,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5144,7 +5144,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5212,7 +5212,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5225,7 +5225,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5282,7 +5282,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5729,7 +5729,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5797,7 +5797,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5810,7 +5810,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5877,7 +5877,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6088,7 +6088,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6156,7 +6156,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -6169,7 +6169,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6236,7 +6236,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6511,7 +6511,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -6704,7 +6704,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -6972,7 +6972,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -7186,7 +7186,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 2
+              "targetPurpose": "TargetPurposeExistenceFilterMismatchBloom"
             }
           }
         }
@@ -7376,7 +7376,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -7566,7 +7566,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -7953,7 +7953,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -8051,7 +8051,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -8081,7 +8081,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [

--- a/firebase-firestore/src/test/resources/json/limbo_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/limbo_spec_test.json
@@ -238,7 +238,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -284,7 +284,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -411,7 +411,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -495,7 +495,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -578,7 +578,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -682,7 +682,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "10": {
               "queries": [
@@ -782,7 +782,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "10": {
               "queries": [
@@ -873,7 +873,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -947,7 +947,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1212,7 +1212,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1258,7 +1258,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1385,7 +1385,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1469,7 +1469,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1552,7 +1552,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -1656,7 +1656,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "10": {
               "queries": [
@@ -1756,7 +1756,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "10": {
               "queries": [
@@ -2055,7 +2055,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -2141,7 +2141,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -2224,7 +2224,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -2442,7 +2442,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -2862,7 +2862,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -3152,7 +3152,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3422,7 +3422,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3672,7 +3672,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -3965,7 +3965,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4081,7 +4081,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4345,7 +4345,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4697,7 +4697,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5082,7 +5082,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5173,7 +5173,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5553,7 +5553,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5578,7 +5578,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -5690,7 +5690,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5715,7 +5715,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -5770,7 +5770,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -5890,7 +5890,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -6332,7 +6332,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -6870,7 +6870,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -7203,7 +7203,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -7288,7 +7288,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -7618,7 +7618,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -7643,7 +7643,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -7754,7 +7754,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "7": {
               "queries": [
@@ -7767,7 +7767,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -7875,7 +7875,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -8313,7 +8313,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -8338,7 +8338,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -8681,7 +8681,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -8774,7 +8774,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -8787,7 +8787,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             },
             "3": {
               "queries": [
@@ -8800,7 +8800,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -8896,7 +8896,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             },
             "5": {
               "queries": [
@@ -8909,7 +8909,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -8978,7 +8978,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           },
           "enqueuedLimboDocs": [
@@ -9250,7 +9250,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -9275,7 +9275,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -9366,7 +9366,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "5": {
               "queries": [
@@ -9379,7 +9379,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -9464,7 +9464,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "7": {
               "queries": [
@@ -9477,7 +9477,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -9561,7 +9561,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "9": {
               "queries": [
@@ -9574,7 +9574,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -9656,7 +9656,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           },
           "enqueuedLimboDocs": [
@@ -10038,7 +10038,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [

--- a/firebase-firestore/src/test/resources/json/limit_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/limit_spec_test.json
@@ -220,7 +220,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4461,7 +4461,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -4488,7 +4488,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -4625,7 +4625,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -4650,7 +4650,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -4794,7 +4794,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "7": {
               "queries": [
@@ -4807,7 +4807,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -4950,7 +4950,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             }
           }
         }
@@ -5449,7 +5449,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -5645,7 +5645,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5713,7 +5713,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -5732,7 +5732,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }
@@ -5825,7 +5825,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 1
+              "targetPurpose": "TargetPurposeExistenceFilterMismatch"
             }
           }
         }

--- a/firebase-firestore/src/test/resources/json/offline_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/offline_spec_test.json
@@ -1156,7 +1156,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [
@@ -1194,7 +1194,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "2": {
               "queries": [

--- a/firebase-firestore/src/test/resources/json/recovery_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/recovery_spec_test.json
@@ -3133,7 +3133,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -3223,7 +3223,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -3613,7 +3613,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [
@@ -3673,7 +3673,7 @@
                 }
               ],
               "resumeToken": "",
-              "targetPurpose": 3
+              "targetPurpose": "TargetPurposeLimboResolution"
             },
             "4": {
               "queries": [


### PR DESCRIPTION
Port spec test changes from https://github.com/firebase/firebase-js-sdk/pull/7257 (Firestore: use string values for TargetPurpose enum).