### PR TITLE
Fix pom dependencies

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
@@ -189,7 +189,7 @@ abstract class BaseFirebaseLibraryPlugin : Plugin<Project> {
   // TODO(b/277607560): Remove when Gradle's MavenPublishPlugin adds functionality for aar types
   private fun addTypeWithAARSupport(dependency: Element, androidLibraries: List<String>) {
     dependency.findOrCreate("type").apply {
-      textContent = if (androidLibraries.contains(dependency.toArtifactString())) "aar" else "jar"
+      textContent = if (androidLibraries.contains(dependency.toMavenName())) "aar" else "jar"
     }
   }
 }
@@ -200,7 +200,7 @@ abstract class BaseFirebaseLibraryPlugin : Plugin<Project> {
  * This is collected via the [runtimeClasspath][FirebaseLibraryExtension.getRuntimeClasspath], and
  * includes project level dependencies as well as external dependencies.
  *
- * The dependencies are mapped to their [artifactName].
+ * The dependencies are mapped to their [mavenName][toMavenName].
  *
  * @see resolveProjectLevelDependencies
  * @see resolveExternalAndroidLibraries
@@ -208,9 +208,7 @@ abstract class BaseFirebaseLibraryPlugin : Plugin<Project> {
 // TODO(b/277607560): Remove when Gradle's MavenPublishPlugin adds functionality for aar types
 fun FirebaseLibraryExtension.resolveAndroidDependencies() =
   resolveExternalAndroidLibraries() +
-    resolveProjectLevelDependencies()
-      .filter { it.type == LibraryType.ANDROID }
-      .map { it.artifactName }
+    resolveProjectLevelDependencies().filter { it.type == LibraryType.ANDROID }.map { it.mavenName }
 
 /**
  * A list of project level dependencies.
@@ -239,9 +237,9 @@ fun FirebaseLibraryExtension.resolveProjectLevelDependencies() =
  * This is collected via the [runtimeClasspath][FirebaseLibraryExtension.getRuntimeClasspath], using
  * an [ArtifactView][org.gradle.api.artifacts.ArtifactView] that filters for `aar` artifactType.
  *
- * Artifacts are mapped to their respective display name:
+ * Artifacts are mapped to their respective maven name:
  * ```
- * groupId:artifactId:version
+ * groupId:artifactId
  * ```
  */
 // TODO(b/277607560): Remove when Gradle's MavenPublishPlugin adds functionality for aar types
@@ -251,7 +249,7 @@ fun FirebaseLibraryExtension.resolveExternalAndroidLibraries() =
     .incoming
     .artifactView { attributes { attribute("artifactType", "aar") } }
     .artifacts
-    .map { it.variant.displayName.substringBefore(" ") }
+    .map { it.variant.displayName.substringBefore(" ").substringBeforeLast(":") }
 
 /**
  * The name provided to this artifact when published.

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/KotlinUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/KotlinUtils.kt
@@ -59,6 +59,27 @@ fun Element.toArtifactString() =
   "${textByTag("groupId")}:${textByTag("artifactId")}:${textByTag("version")}"
 
 /**
+ * Converts an [Element] to a Maven name
+ *
+ * A Maven name can be defined as a dependency with the following format:
+ * ```
+ * groupId:artifactId
+ * ```
+ *
+ * For example, the following would be a valid [Element]:
+ * ```
+ * <mySuperCoolElement>
+ *   <groupId>com.google.firebase</groupId>
+ *   <artifactId>firebase-common</artifactId>
+ * </mySuperCoolElement>
+ * ```
+ *
+ * @throws NoSuchElementException if the [Element] does not have descendant [Element]s with tags
+ * that match the components of an Artifact string; groupId, artifactId, version.
+ */
+fun Element.toMavenName() = "${textByTag("groupId")}:${textByTag("artifactId")}"
+
+/**
  * Finds a descendant [Element] by a given [tag], and returns the [textContent]
  * [Element.getTextContent] of it.
  *


### PR DESCRIPTION
Per [b/280087461](https://b.corp.google.com/issues/280087461),

This fixes an issue where some dependencies were being marked as `jar` when they should've been marked as `aar`. This occurred due to the fact that we were comparing based on artifact names (which include the version) instead of the maven name (just the groupId and artifactId).