### PR TITLE
Fix various issues and inconsistencies in the Remote Config ref docs.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -51,9 +51,9 @@ import org.json.JSONObject;
  * Entry point for the Firebase Remote Config API.
  *
  * <p>Callers should first get the singleton object using {@link #getInstance()}, and then call
- * operations on that singleton object. The singleton contains the complete set of Remote Config parameter
- * values available to your app. The singleton also stores values fetched from the Remote Config Server until
- * they are made available for use with a call to {@link #activate()}.
+ * operations on that singleton object. The singleton contains the complete set of Remote Config
+ * parameter values available to your app. The singleton also stores values fetched from the Remote
+ * Config Server until they are made available for use with a call to {@link #activate()}.
  */
 public class FirebaseRemoteConfig {
   // -------------------------------------------------------------------------------

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -48,14 +48,12 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * Entry point for the Firebase Remote Config (FRC) API.
+ * Entry point for the Firebase Remote Config API.
  *
  * <p>Callers should first get the singleton object using {@link #getInstance()}, and then call
- * operations on that singleton object. The singleton contains the complete set of FRC parameter
- * values available to your app. The singleton also stores values fetched from the FRC Server until
+ * operations on that singleton object. The singleton contains the complete set of Remote Config parameter
+ * values available to your app. The singleton also stores values fetched from the Remote Config Server until
  * they are made available for use with a call to {@link #activate()}.
- *
- * @author Miraziz Yusupov
  */
 public class FirebaseRemoteConfig {
   // -------------------------------------------------------------------------------
@@ -557,8 +555,8 @@ public class FirebaseRemoteConfig {
    * re-use the same connection to the backend.
    *
    * <p>Note: Real-time Remote Config requires the Firebase Remote Config Realtime API. See the <a
-   * href="https://firebase.google.com/docs/remote-config/get-started#add-real-time-listener">Remote
-   * Config Get Started </a> guide to enable the API.
+   * href="https://firebase.google.com/docs/remote-config/get-started?platform=android#add-real-time-listener">Remote
+   * Config Get Started</a> guide to enable the API.
    *
    * @param configUpdateListener A {@link ConfigUpdateListener} that can be used to respond to
    *     config updates when they're fetched.

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientException.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientException.java
@@ -34,8 +34,8 @@ public class FirebaseRemoteConfigClientException extends FirebaseRemoteConfigExc
   }
 
   /**
-   * Creates a Firebase Remote Config client exception with the given message and
-   * {@code FirebaseRemoteConfigException} code.
+   * Creates a Firebase Remote Config client exception with the given message and {@code
+   * FirebaseRemoteConfigException} code.
    */
   public FirebaseRemoteConfigClientException(@NonNull String detailMessage, @NonNull Code code) {
     super(detailMessage, code);

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientException.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientException.java
@@ -20,8 +20,6 @@ import androidx.annotation.Nullable;
 /**
  * A Firebase Remote Config internal issue that isn't caused by an interaction with the Firebase
  * Remote Config server.
- *
- * @author Miraziz Yusupov
  */
 public class FirebaseRemoteConfigClientException extends FirebaseRemoteConfigException {
   /** Creates a Firebase Remote Config client exception with the given message. */
@@ -37,7 +35,7 @@ public class FirebaseRemoteConfigClientException extends FirebaseRemoteConfigExc
 
   /**
    * Creates a Firebase Remote Config client exception with the given message and
-   * FirebaseRemoteConfigException code.
+   * {@code FirebaseRemoteConfigException} code.
    */
   public FirebaseRemoteConfigClientException(@NonNull String detailMessage, @NonNull Code code) {
     super(detailMessage, code);

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigException.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigException.java
@@ -77,6 +77,7 @@ public class FirebaseRemoteConfigException extends FirebaseException {
 
   /**
    * Gets the {@link Code} representing the type of exception.
+   *
    * @return A {@link Code} representing the type of exception.
    */
   @NonNull

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigException.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigException.java
@@ -75,6 +75,10 @@ public class FirebaseRemoteConfigException extends FirebaseException {
     }
   }
 
+  /**
+   * Gets the {@link Code} representing the type of exception.
+   * @return A {@link Code} representing the type of exception.
+   */
   @NonNull
   public Code getCode() {
     return code;

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigInfo.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigInfo.java
@@ -16,7 +16,7 @@ package com.google.firebase.remoteconfig;
 
 import androidx.annotation.NonNull;
 
-/** Wraps the current state of the FirebaseRemoteConfig singleton object. */
+/** Wraps the current state of the {@link FirebaseRemoteConfig} singleton object. */
 public interface FirebaseRemoteConfigInfo {
   /**
    * Gets the timestamp (milliseconds since epoch) of the last successful fetch, regardless of
@@ -38,7 +38,7 @@ public interface FirebaseRemoteConfigInfo {
   int getLastFetchStatus();
 
   /**
-   * Gets the current settings of the FirebaseRemoteConfig singleton object.
+   * Gets the current settings of the {@link FirebaseRemoteConfig} singleton object.
    *
    * @return A {@link FirebaseRemoteConfigSettings} object indicating the current settings.
    */

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigServerException.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigServerException.java
@@ -21,8 +21,6 @@ import javax.annotation.Nonnull;
 /**
  * A Firebase Remote Config internal issue caused by an interaction with the Firebase Remote Config
  * server.
- *
- * @author Miraziz Yusupov
  */
 public class FirebaseRemoteConfigServerException extends FirebaseRemoteConfigException {
   private final int httpStatusCode;

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
@@ -21,8 +21,6 @@ import androidx.annotation.NonNull;
 
 /**
  * Wraps the settings for {@link FirebaseRemoteConfig} operations.
- *
- * @author Lucas Png
  */
 public class FirebaseRemoteConfigSettings {
   private final long fetchTimeoutInSeconds;
@@ -37,7 +35,7 @@ public class FirebaseRemoteConfigSettings {
    * Returns the fetch timeout in seconds.
    *
    * <p>The timeout specifies how long the client should wait for a connection to the Firebase
-   * Remote Config servers.
+   * Remote Config server.
    */
   public long getFetchTimeoutInSeconds() {
     return fetchTimeoutInSeconds;
@@ -48,7 +46,7 @@ public class FirebaseRemoteConfigSettings {
     return minimumFetchInterval;
   }
 
-  /** Constructs a builder initialized with the current FirebaseRemoteConfigSettings. */
+  /** Constructs a builder initialized with the current {@link FirebaseRemoteConfigSettings}. */
   @NonNull
   public FirebaseRemoteConfigSettings.Builder toBuilder() {
     FirebaseRemoteConfigSettings.Builder frcBuilder = new FirebaseRemoteConfigSettings.Builder();
@@ -68,7 +66,7 @@ public class FirebaseRemoteConfigSettings {
      * servers in seconds.
      *
      * <p>A fetch call will fail if it takes longer than the specified timeout to connect to or read
-     * from the Remote Config servers.
+     * from the Remote Config server.
      *
      * @param duration Timeout duration in seconds. Should be a non-negative number.
      */
@@ -109,7 +107,7 @@ public class FirebaseRemoteConfigSettings {
      * Returns the fetch timeout in seconds.
      *
      * <p>The timeout specifies how long the client should wait for a connection to the Firebase
-     * Remote Config servers.
+     * Remote Config server.
      */
     public long getFetchTimeoutInSeconds() {
       return fetchTimeoutInSeconds;

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigSettings.java
@@ -19,9 +19,7 @@ import static com.google.firebase.remoteconfig.internal.ConfigFetchHandler.DEFAU
 
 import androidx.annotation.NonNull;
 
-/**
- * Wraps the settings for {@link FirebaseRemoteConfig} operations.
- */
+/** Wraps the settings for {@link FirebaseRemoteConfig} operations. */
 public class FirebaseRemoteConfigSettings {
   private final long fetchTimeoutInSeconds;
   private final long minimumFetchInterval;


### PR DESCRIPTION
* Use "Remote Config" instead of "FRC"
* Remove many `@author` tags (all can be removed, starting with documented classes). This doesn't show up in the docs, but we typically don't use it in the Firebase repo.
* Use platform-specific link for https://firebase.google.com/docs/remote-config/get-started?platform=android#add-real-time-listener
* Document `getCode()` in `FirebaseRemoteConfigException`
* Add various `@code` and `@link` references
* Remote Config Servers -> Remote Config Server (singular)

Internal b/274648602
