### PR TITLE
Diff ABT Experiments for real-time RC

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
@@ -93,12 +93,22 @@ public final class RemoteConfigConstants {
    */
   @StringDef({
     ExperimentDescriptionFieldKey.EXPERIMENT_ID,
-    ExperimentDescriptionFieldKey.VARIANT_ID
+    ExperimentDescriptionFieldKey.VARIANT_ID,
+    ExperimentDescriptionFieldKey.TRIGGER_EVENT,
+    ExperimentDescriptionFieldKey.EXPERIMENT_START_TIME,
+    ExperimentDescriptionFieldKey.TRIGGER_TIMEOUT_MILLIS,
+    ExperimentDescriptionFieldKey.TIME_TO_LIVE_MILLIS,
+    ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEY
   })
   @Retention(RetentionPolicy.SOURCE)
   public @interface ExperimentDescriptionFieldKey {
     String EXPERIMENT_ID = "experimentId";
     String VARIANT_ID = "variantId";
+    String TRIGGER_EVENT = "triggerEvent";
+    String EXPERIMENT_START_TIME = "experimentStartTime";
+    String TRIGGER_TIMEOUT_MILLIS = "triggetTimeoutMillis";
+    String TIME_TO_LIVE_MILLIS = "timeToLiveMillis";
+    String AFFECTED_PARAMETER_KEY = "affectedParameterKey";
   }
 
   private RemoteConfigConstants() {}

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -221,11 +221,11 @@ public class ConfigContainer {
 
   private Set<String> getChangedExperimentConfigKeys(
       Set<String> activeKeys, Set<String> fetchedKeys) throws JSONException {
-    Set<String> changed = new HashSet<>();
-    changed.addAll(activeKeys);
-    changed.addAll(fetchedKeys);
+    Set<String> allKeys = new HashSet<>();
+    allKeys.addAll(activeKeys);
+    allKeys.addAll(fetchedKeys);
 
-    Set<String> allKeys = new HashSet<>(changed);
+    Set<String> changed = new HashSet<>(allKeys);
     // Iterate through all possible keys.
     for (String key : allKeys) {
       // If fetchedKeys and activeKeys contains the config key, remove it from `changed`.

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -16,11 +16,6 @@ package com.google.firebase.remoteconfig.internal;
 
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEY;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_ID;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_START_TIME;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TIME_TO_LIVE_MILLIS;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TRIGGER_EVENT;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TRIGGER_TIMEOUT_MILLIS;
-import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.VARIANT_ID;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -191,17 +186,17 @@ public class ConfigContainer {
 
   private boolean isExperimentMetadataSame(
       JSONObject activeExperiment, JSONObject fetchedExperiment) throws JSONException {
-    return activeExperiment.getString(VARIANT_ID).equals(fetchedExperiment.getString(VARIANT_ID))
-        && activeExperiment
-            .getString(TRIGGER_EVENT)
-            .equals(fetchedExperiment.getString(TRIGGER_EVENT))
-        && activeExperiment
-            .getString(EXPERIMENT_START_TIME)
-            .equals(fetchedExperiment.getString(EXPERIMENT_START_TIME))
-        && activeExperiment.getLong(TRIGGER_TIMEOUT_MILLIS)
-            == fetchedExperiment.getLong(TRIGGER_TIMEOUT_MILLIS)
-        && activeExperiment.getLong(TIME_TO_LIVE_MILLIS)
-            == fetchedExperiment.getLong(TIME_TO_LIVE_MILLIS);
+    JSONObject activeExperimentCopy = new JSONObject(activeExperiment.toString());
+    JSONObject fetchedExperimentCopy = new JSONObject(fetchedExperiment.toString());
+
+    if (activeExperimentCopy.has(AFFECTED_PARAMETER_KEY)) {
+      activeExperimentCopy.remove(AFFECTED_PARAMETER_KEY);
+    }
+    if (fetchedExperimentCopy.has(AFFECTED_PARAMETER_KEY)) {
+      fetchedExperimentCopy.remove(AFFECTED_PARAMETER_KEY);
+    }
+
+    return activeExperimentCopy.toString().equals(fetchedExperimentCopy.toString());
   }
 
   private void compareExperimentConfigKeys(JSONArray active, JSONArray fetched, Set<String> changed)

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -220,7 +220,7 @@ public class ConfigContainer {
 
     // Iterate through all possible keys.
     for (String key : allKeys) {
-      // If fetchedKeys or activeKeys does not contain the config key, add it to changed.
+      // If fetchedKeys or activeKeys does not contain the config key, add it to `changed`.
       if (!activeKeys.contains(key) || !fetchedKeys.contains(key)) {
         changed.add(key);
       }
@@ -248,8 +248,9 @@ public class ConfigContainer {
 
     // Iterate through all experiment IDs
     for (String experimentId : allExperimentIds) {
-      // If one of the maps does not contain the experiment ID, add that experiments' config keys to
-      // changed.
+      // If one of the maps does not contain the experiment ID, it must have been added or removed.
+      // Add that experiments' config keys to
+      // `changed`.
       if (!activeExperimentsMap.containsKey(experimentId)
           || !fetchedExperimentsMap.containsKey(experimentId)) {
         // Get the experiment that was added/removed.
@@ -268,7 +269,7 @@ public class ConfigContainer {
         }
       } else {
         // Fetched and Active contain the experiment ID. The metadata needs to be compared to see if
-        // anything has changed.
+        // they're still the same.
         JSONObject activeExperiment = activeExperimentsMap.get(experimentId);
         JSONObject fetchedExperiment = fetchedExperimentsMap.get(experimentId);
         boolean experimentsMetadataSame =

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -172,12 +172,12 @@ public class ConfigContainer {
     return containerJson.toString().equals(that.toString());
   }
 
-  // Map experiments to their experiment IDs.
   private Map<String, JSONObject> getExperimentsMap(JSONArray experiments) throws JSONException {
     Map<String, JSONObject> experimentsMap = new HashMap<>();
     for (int i = 0; i < experiments.length(); i++) {
       JSONObject experiment = experiments.getJSONObject(i);
       String experimentID = experiment.getString(EXPERIMENT_ID);
+      // Map experiments to their experiment IDs.
       experimentsMap.put(experimentID, experiment);
     }
 
@@ -186,9 +186,11 @@ public class ConfigContainer {
 
   private boolean isExperimentMetadataSame(
       JSONObject activeExperiment, JSONObject fetchedExperiment) throws JSONException {
+    // Create copies of active and fetched experiments.
     JSONObject activeExperimentCopy = new JSONObject(activeExperiment.toString());
     JSONObject fetchedExperimentCopy = new JSONObject(fetchedExperiment.toString());
 
+    // Remove config parameter keys from object since they don't show up in consistent order.
     if (activeExperimentCopy.has(AFFECTED_PARAMETER_KEY)) {
       activeExperimentCopy.remove(AFFECTED_PARAMETER_KEY);
     }
@@ -249,8 +251,7 @@ public class ConfigContainer {
     // Iterate through all experiment IDs
     for (String experimentId : allExperimentIds) {
       // If one of the maps does not contain the experiment ID, it must have been added or removed.
-      // Add that experiments' config keys to
-      // `changed`.
+      // Add that experiments' config keys to `changed`.
       if (!activeExperimentsMap.containsKey(experimentId)
           || !fetchedExperimentsMap.containsKey(experimentId)) {
         // Get the experiment that was added/removed.
@@ -260,7 +261,8 @@ public class ConfigContainer {
         } else {
           changedExperiment = fetchedExperimentsMap.get(experimentId);
         }
-        // Check if changed experiment has param keys.
+
+        // Check if changed experiment has param keys and add them to `changed` if present.
         if (changedExperiment.has(AFFECTED_PARAMETER_KEY)) {
           JSONArray experimentKeys = changedExperiment.getJSONArray(AFFECTED_PARAMETER_KEY);
           for (int i = 0; i < experimentKeys.length(); i++) {

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -219,8 +219,8 @@ public class ConfigContainer {
     return keys;
   }
 
-  private Set<String> compareExperimentConfigKeys(Set<String> activeKeys, Set<String> fetchedKeys)
-      throws JSONException {
+  private Set<String> getChangedExperimentConfigKeys(
+      Set<String> activeKeys, Set<String> fetchedKeys) throws JSONException {
     Set<String> changed = new HashSet<>();
     changed.addAll(activeKeys);
     changed.addAll(fetchedKeys);
@@ -278,7 +278,7 @@ public class ConfigContainer {
           changed.addAll(fetchedExperimentKeys);
         } else {
           // Compare config keys from either experiment.
-          return compareExperimentConfigKeys(activeExperimentKeys, fetchedExperimentKeys);
+          return getChangedExperimentConfigKeys(activeExperimentKeys, fetchedExperimentKeys);
         }
       }
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -278,7 +278,7 @@ public class ConfigContainer {
           changed.addAll(fetchedExperimentKeys);
         } else {
           // Compare config keys from either experiment.
-          return getChangedExperimentConfigKeys(activeExperimentKeys, fetchedExperimentKeys);
+          changed.addAll(getChangedExperimentConfigKeys(activeExperimentKeys, fetchedExperimentKeys));
         }
       }
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -228,7 +228,7 @@ public class ConfigContainer {
     Set<String> allKeys = new HashSet<>(changed);
     // Iterate through all possible keys.
     for (String key : allKeys) {
-      // If fetchedKeys or activeKeys does not contain the config key, add it to `changed`.
+      // If fetchedKeys and activeKeys contains the config key, remove it from `changed`.
       if (activeKeys.contains(key) && fetchedKeys.contains(key)) {
         changed.remove(key);
       }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -188,7 +188,7 @@ public class ConfigContainer {
     return experimentsMap;
   }
 
-  private boolean isExperimentMetadataSame(
+  private boolean isExperimentMetadataUnchanged(
       JSONObject activeExperiment, JSONObject fetchedExperiment) throws JSONException {
     // Create copies of active and fetched experiments.
     JSONObject activeExperimentCopy = new JSONObject(activeExperiment.toString());
@@ -237,7 +237,8 @@ public class ConfigContainer {
     return changed;
   }
 
-  private Set<String> getChangedABTExperiments(JSONArray otherExperiment) throws JSONException {
+  private Set<String> getKeysAffectedByChangedExperiments(JSONArray otherExperiment)
+      throws JSONException {
     Set<String> changed = new HashSet<>();
     Map<String, JSONObject> fetchedExperimentsMap = getExperimentsMap(this.abtExperiments);
     Map<String, JSONObject> activeExperimentsMap = getExperimentsMap(otherExperiment);
@@ -272,7 +273,7 @@ public class ConfigContainer {
         Set<String> activeExperimentKeys = extractConfigKeysFromExperiment(activeExperiment);
         Set<String> fetchedExperimentKeys = extractConfigKeysFromExperiment(fetchedExperiment);
 
-        if (!isExperimentMetadataSame(activeExperiment, fetchedExperiment)) {
+        if (!isExperimentMetadataUnchanged(activeExperiment, fetchedExperiment)) {
           // Add in all keys from both sides if the experiments metadata has changed.
           changed.addAll(activeExperimentKeys);
           changed.addAll(fetchedExperimentKeys);
@@ -341,7 +342,7 @@ public class ConfigContainer {
     while (remainingOtherKeys.hasNext()) {
       changed.add(remainingOtherKeys.next());
     }
-    changed.addAll(getChangedABTExperiments(other.getAbtExperiments()));
+    changed.addAll(getKeysAffectedByChangedExperiments(other.getAbtExperiments()));
 
     return changed;
   }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -16,6 +16,7 @@ package com.google.firebase.remoteconfig.internal;
 
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEY;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_ID;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_START_TIME;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TIME_TO_LIVE_MILLIS;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TRIGGER_EVENT;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TRIGGER_TIMEOUT_MILLIS;
@@ -194,6 +195,9 @@ public class ConfigContainer {
         && activeExperiment
             .getString(TRIGGER_EVENT)
             .equals(fetchedExperiment.getString(TRIGGER_EVENT))
+        && activeExperiment
+            .getString(EXPERIMENT_START_TIME)
+            .equals(fetchedExperiment.getString(EXPERIMENT_START_TIME))
         && activeExperiment.getLong(TRIGGER_TIMEOUT_MILLIS)
             == fetchedExperiment.getLong(TRIGGER_TIMEOUT_MILLIS)
         && activeExperiment.getLong(TIME_TO_LIVE_MILLIS)

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -278,7 +278,8 @@ public class ConfigContainer {
           changed.addAll(fetchedExperimentKeys);
         } else {
           // Compare config keys from either experiment.
-          changed.addAll(getChangedExperimentConfigKeys(activeExperimentKeys, fetchedExperimentKeys));
+          changed.addAll(
+              getChangedExperimentConfigKeys(activeExperimentKeys, fetchedExperimentKeys));
         }
       }
     }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -15,7 +15,11 @@
 package com.google.firebase.remoteconfig.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEY;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_ID;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TIME_TO_LIVE_MILLIS;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TRIGGER_EVENT;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TRIGGER_TIMEOUT_MILLIS;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.VARIANT_ID;
 import static com.google.firebase.remoteconfig.internal.Personalization.ARM_INDEX;
 import static com.google.firebase.remoteconfig.internal.Personalization.CHOICE_ID;
@@ -138,10 +142,11 @@ public class ConfigContainerTest {
   }
 
   @Test
-  public void getChangedParams_changedExperimentsMetadata_returnsNoParamKeys() throws Exception {
+  public void getChangedParams_sameExperimentsMetadata_returnsEmptySet() throws Exception {
     ConfigContainer config =
         ConfigContainer.newBuilder()
             .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(generateAbtExperiments(1))
             .build();
 
     ConfigContainer other =
@@ -153,6 +158,98 @@ public class ConfigContainerTest {
     Set<String> changedParams = config.getChangedParams(other);
 
     assertThat(changedParams).isEmpty();
+  }
+
+  @Test
+  public void getChangedParams_changedExperimentsMetadata_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    activeExperiments.getJSONObject(0).put(VARIANT_ID, "32");
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_newExperiments_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(2);
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_deletedExperiment_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = new JSONArray();
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_changedExperimentsKeys_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    fetchedExperiments.getJSONObject(0).getJSONArray(AFFECTED_PARAMETER_KEY).put("abt_test_key_2");
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_2");
   }
 
   @Test
@@ -272,9 +369,17 @@ public class ConfigContainerTest {
 
   private static JSONArray generateAbtExperiments(int numExperiments) throws JSONException {
     JSONArray experiments = new JSONArray();
+    JSONArray experimentKeys = new JSONArray();
+    experimentKeys.put("abt_test_key_1");
     for (int experimentNum = 1; experimentNum <= numExperiments; experimentNum++) {
       experiments.put(
-          new JSONObject().put(EXPERIMENT_ID, "exp" + experimentNum).put(VARIANT_ID, "var1"));
+          new JSONObject()
+              .put(EXPERIMENT_ID, "exp" + experimentNum)
+              .put(VARIANT_ID, "var1")
+              .put(AFFECTED_PARAMETER_KEY, experimentKeys)
+              .put(TRIGGER_EVENT, "event")
+              .put(TRIGGER_TIMEOUT_MILLIS, 1L)
+              .put(TIME_TO_LIVE_MILLIS, 1L));
     }
     return experiments;
   }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -282,6 +282,33 @@ public class ConfigContainerTest {
   }
 
   @Test
+  public void getChangedParams_changedExperimentsNoTriggerEvent_returnsUpdatedKey()
+      throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    fetchedExperiments.getJSONObject(0).remove(TRIGGER_EVENT);
+
+    fetchedExperiments.getJSONObject(0).put(EXPERIMENT_START_TIME, new Date(2089));
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
   public void getChangedParams_noChanges_returnsEmptySet() throws Exception {
     ConfigContainer config =
         ConfigContainer.newBuilder()


### PR DESCRIPTION
Adds diffing logic between experiments fetched via real-time and experiments active on the device. The config keys that have been affected by the differences will be added to ConfigUpdate.