### PR TITLE
Fix behaviour with multiple subscribers

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -180,25 +180,26 @@ public class FirebaseCrashlytics {
         });
 
     // TODO(mrober): Replace with a real session implementation.
-    firebaseSessions.register(new SessionSubscriber() {
-      @Override
-      public void onSessionChanged(@NonNull SessionDetails sessionDetails) {
-        Logger.getLogger().d("onSessionChanged: " + sessionDetails);
-        // TODO(mrober): Set new field in report and remove this.
-        core.setInternalKey("sessionId", sessionDetails.getSessionId());
-      }
+    firebaseSessions.register(
+        new SessionSubscriber() {
+          @Override
+          public void onSessionChanged(@NonNull SessionDetails sessionDetails) {
+            Logger.getLogger().d("onSessionChanged: " + sessionDetails);
+            // TODO(mrober): Set new field in report and remove this.
+            core.setInternalKey("sessionId", sessionDetails.getSessionId());
+          }
 
-      @Override
-      public boolean isDataCollectionEnabled() {
-        return arbiter.isAutomaticDataCollectionEnabled();
-      }
+          @Override
+          public boolean isDataCollectionEnabled() {
+            return arbiter.isAutomaticDataCollectionEnabled();
+          }
 
-      @NonNull
-      @Override
-      public SessionSubscriber.Name getSessionSubscriberName() {
-        return SessionSubscriber.Name.CRASHLYTICS;
-      }
-    });
+          @NonNull
+          @Override
+          public SessionSubscriber.Name getSessionSubscriberName() {
+            return SessionSubscriber.Name.CRASHLYTICS;
+          }
+        });
 
     return new FirebaseCrashlytics(core);
   }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -78,6 +78,14 @@ internal constructor(
       "Registering Sessions SDK subscriber with name: ${subscriber.sessionSubscriberName}, " +
         "data collection enabled: ${subscriber.isDataCollectionEnabled}"
     )
+
+    // Immediately call the callback if Sessions generated a session before the
+    // subscriber subscribed, otherwise subscribers might miss the first session.
+    if (sessionGenerator.hasGenerateSession) {
+      subscriber.onSessionChanged(
+        SessionSubscriber.SessionDetails(sessionGenerator.currentSession.sessionId)
+      )
+    }
   }
 
   private fun initiateSessionStart() {

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionGenerator.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionGenerator.kt
@@ -46,6 +46,10 @@ internal class SessionGenerator(
   lateinit var currentSession: SessionDetails
     private set
 
+  /** Returns if a session has been generated. */
+  val hasGenerateSession: Boolean
+    get() = ::currentSession.isInitialized
+
   /** Generates a new session. The first session's sessionId will match firstSessionId. */
   fun generateNewSession(): SessionDetails {
     sessionIndex++

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionGeneratorTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionGeneratorTest.kt
@@ -44,6 +44,22 @@ class SessionGeneratorTest {
   }
 
   @Test
+  fun hasGenerateSession_beforeGenerate_returnsFalse() {
+    val sessionGenerator = SessionGenerator(collectEvents = false)
+
+    assertThat(sessionGenerator.hasGenerateSession).isFalse()
+  }
+
+  @Test
+  fun hasGenerateSession_afterGenerate_returnsTrue() {
+    val sessionGenerator = SessionGenerator(collectEvents = false)
+
+    sessionGenerator.generateNewSession()
+
+    assertThat(sessionGenerator.hasGenerateSession).isTrue()
+  }
+
+  @Test
   fun generateNewSession_generatesValidSessionIds() {
     val sessionGenerator = SessionGenerator(collectEvents = true) // defaults to UUID::randomUUID
 


### PR DESCRIPTION
Immediately call the callback if Sessions generated a session before the subscriber subscribed. iOS does this too. This will fix the `FirebaseSessionsTest` when having multiple subscribers in the test app.