### PR TITLE
Add and populate appQualitySessionId in Crashlytics reports

### DIFF
--- a/firebase-crashlytics/ktx/ktx.gradle
+++ b/firebase-crashlytics/ktx/ktx.gradle
@@ -25,11 +25,11 @@ firebaseLibrary {
 }
 
 android {
-    compileSdkVersion project.targetSdkVersion
+    compileSdkVersion 33
     defaultConfig {
-        minSdkVersion 16
+        minSdk 16
         multiDexEnabled true
-        targetSdkVersion project.targetSdkVersion
+        targetSdk 33
         versionName version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -69,4 +69,3 @@ dependencies {
 // ==========================================================================
 ext.packageName = "com.google.firebase.crashlytics.ktx"
 apply from: '../../gradle/googleServices.gradle'
-

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -136,7 +136,8 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
           new DisabledBreadcrumbSource(),
           new UnavailableAnalyticsEventLogger(),
           fileStore,
-          crashHandlerExecutor);
+          crashHandlerExecutor,
+          mock(CrashlyticsAppQualitySessionsSubscriber.class));
     }
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -426,7 +426,8 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
               breadcrumbSource,
               new UnavailableAnalyticsEventLogger(),
               new FileStore(context),
-              new SameThreadExecutorService());
+              new SameThreadExecutorService(),
+              mock(CrashlyticsAppQualitySessionsSubscriber.class));
       return crashlyticsCore;
     }
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistenceTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistenceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
+import com.google.firebase.crashlytics.internal.common.CrashlyticsAppQualitySessionsSubscriber;
 import com.google.firebase.crashlytics.internal.common.CrashlyticsReportWithSessionId;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session;
@@ -42,8 +43,8 @@ import java.util.SortedSet;
 import org.mockito.internal.util.collections.Sets;
 
 public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
-
   private static final int VERY_LARGE_UPPER_LIMIT = 9999;
+  private static final String APP_QUALITY_SESSION_ID = "9";
 
   private CrashlyticsReportPersistence reportPersistence;
   private FileStore fileStore;
@@ -62,12 +63,22 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     return settingsProvider;
   }
 
+  private static CrashlyticsAppQualitySessionsSubscriber createSessionsSubscriberMock(
+      String appQualitySessionId) {
+    CrashlyticsAppQualitySessionsSubscriber sessionsSubscriber =
+        mock(CrashlyticsAppQualitySessionsSubscriber.class);
+    when(sessionsSubscriber.getAppQualitySessionId()).thenReturn(appQualitySessionId);
+    return sessionsSubscriber;
+  }
+
   @Override
   public void setUp() throws Exception {
     fileStore = new FileStore(getContext());
     reportPersistence =
         new CrashlyticsReportPersistence(
-            fileStore, createSettingsProviderMock(VERY_LARGE_UPPER_LIMIT, VERY_LARGE_UPPER_LIMIT));
+            fileStore,
+            createSettingsProviderMock(VERY_LARGE_UPPER_LIMIT, VERY_LARGE_UPPER_LIMIT),
+            createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
   }
 
   public void testListSortedOpenSessionIds() {
@@ -147,6 +158,7 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     assertEquals(
         testReport
             .withSessionEndFields(endedAt, false, null)
+            .withAppQualitySessionId(APP_QUALITY_SESSION_ID)
             .withEvents(ImmutableList.from(testEvent)),
         finalizedReport);
   }
@@ -172,6 +184,7 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     assertEquals(
         testReport
             .withSessionEndFields(endedAt, false, null)
+            .withAppQualitySessionId(APP_QUALITY_SESSION_ID)
             .withEvents(ImmutableList.from(testEvent, testEvent2)),
         finalizedReport);
   }
@@ -201,12 +214,14 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     assertEquals(
         testReport1
             .withSessionEndFields(endedAt, false, null)
+            .withAppQualitySessionId(APP_QUALITY_SESSION_ID)
             .withEvents(ImmutableList.from(testEvent1)),
         finalizedReport1);
     final CrashlyticsReport finalizedReport2 = finalizedReports.get(0).getReport();
     assertEquals(
         testReport2
             .withSessionEndFields(endedAt, false, null)
+            .withAppQualitySessionId(APP_QUALITY_SESSION_ID)
             .withEvents(ImmutableList.from(testEvent2)),
         finalizedReport2);
   }
@@ -274,7 +289,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
   public void testFinalizeReports_capsReports() {
     reportPersistence =
         new CrashlyticsReportPersistence(
-            fileStore, createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT));
+            fileStore,
+            createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT),
+            createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
     for (int i = 0; i < 10; i++) {
       persistReportWithEvent(reportPersistence, "testSession" + i, true);
     }
@@ -298,7 +315,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
         new Settings(0, sessionData2, new FeatureFlagData(true, true, false), 3, 0, 1.0, 1.0, 1);
 
     when(settingsProvider.getSettingsSync()).thenReturn(settings1);
-    reportPersistence = new CrashlyticsReportPersistence(fileStore, settingsProvider);
+    reportPersistence =
+        new CrashlyticsReportPersistence(
+            fileStore, settingsProvider, createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
 
     DecimalFormat format = new DecimalFormat("00");
     for (int i = 0; i < 16; i++) {
@@ -324,7 +343,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
   public void testFinalizeReports_removesLowPriorityReportsFirst() throws IOException {
     reportPersistence =
         new CrashlyticsReportPersistence(
-            fileStore, createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT));
+            fileStore,
+            createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT),
+            createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
 
     for (int i = 0; i < 10; i++) {
       boolean priority = i >= 3 && i <= 8;
@@ -347,7 +368,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     CrashlyticsReport.FilesPayload filesPayload = makeFilePayload();
     reportPersistence =
         new CrashlyticsReportPersistence(
-            fileStore, createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT));
+            fileStore,
+            createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT),
+            createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
 
     persistReportWithEvent(reportPersistence, "testSession1", true);
     reportPersistence.finalizeSessionWithNativeEvent("testSession1", filesPayload, null);
@@ -370,7 +393,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
   public void testFinalizeReports_removesOldestReportsFirst() throws IOException {
     reportPersistence =
         new CrashlyticsReportPersistence(
-            fileStore, createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT));
+            fileStore,
+            createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT),
+            createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
     for (int i = 0; i < 8; i++) {
       String sessionId = "testSession" + i;
       persistReportWithEvent(reportPersistence, sessionId, true);
@@ -519,7 +544,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
   public void testPersistEvent_keepsAppropriateNumberOfMostRecentEvents() throws IOException {
     reportPersistence =
         new CrashlyticsReportPersistence(
-            fileStore, createSettingsProviderMock(VERY_LARGE_UPPER_LIMIT, 4));
+            fileStore,
+            createSettingsProviderMock(VERY_LARGE_UPPER_LIMIT, 4),
+            createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
     final String sessionId = "testSession";
     final CrashlyticsReport testReport = makeTestReport(sessionId);
     final CrashlyticsReport.Session.Event testEvent1 = makeTestEvent("type1", "reason1");
@@ -547,6 +574,7 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     assertEquals(
         testReport
             .withSessionEndFields(endedAt, false, null)
+            .withAppQualitySessionId(APP_QUALITY_SESSION_ID)
             .withEvents(ImmutableList.from(testEvent2, testEvent3, testEvent4, testEvent5)),
         finalizedReport);
   }
@@ -563,7 +591,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
         new Settings(0, sessionData2, new FeatureFlagData(true, true, false), 3, 0, 1.0, 1.0, 1);
 
     when(settingsProvider.getSettingsSync()).thenReturn(settings1);
-    reportPersistence = new CrashlyticsReportPersistence(fileStore, settingsProvider);
+    reportPersistence =
+        new CrashlyticsReportPersistence(
+            fileStore, settingsProvider, createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
 
     final String sessionId = "testSession";
     final CrashlyticsReport testReport = makeTestReport(sessionId);
@@ -592,6 +622,7 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     assertEquals(
         testReport
             .withSessionEndFields(endedAt, false, null)
+            .withAppQualitySessionId(APP_QUALITY_SESSION_ID)
             .withEvents(ImmutableList.from(testEvent2, testEvent3, testEvent4, testEvent5)),
         finalizedReport);
 
@@ -629,6 +660,7 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     assertEquals(
         testReport2
             .withSessionEndFields(endedAt, false, null)
+            .withAppQualitySessionId(APP_QUALITY_SESSION_ID)
             .withEvents(
                 ImmutableList.from(
                     testEvent3,
@@ -645,7 +677,9 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
   public void testPersistReportWithAnrEvent() throws IOException {
     reportPersistence =
         new CrashlyticsReportPersistence(
-            fileStore, createSettingsProviderMock(VERY_LARGE_UPPER_LIMIT, 4));
+            fileStore,
+            createSettingsProviderMock(VERY_LARGE_UPPER_LIMIT, 4),
+            createSessionsSubscriberMock(APP_QUALITY_SESSION_ID));
     final String sessionId = "testSession";
     final CrashlyticsReport testReport = makeTestReport(sessionId);
     final Event testEvent = makeTestAnrEvent();
@@ -661,6 +695,81 @@ public class CrashlyticsReportPersistenceTest extends CrashlyticsTestCase {
     assertEquals(1, finalizedReports.size());
     final CrashlyticsReport finalizedReport = finalizedReports.get(0).getReport();
     assertEquals(1, finalizedReport.getSession().getEvents().size());
+  }
+
+  public void testFinalizeReports_missingAppQualitySessionId() {
+    reportPersistence =
+        new CrashlyticsReportPersistence(
+            fileStore,
+            createSettingsProviderMock(4, VERY_LARGE_UPPER_LIMIT),
+            // Simulate Sessions subscriber failure by setting appQualitySessionId to null.
+            createSessionsSubscriberMock(/* appQualitySessionId= */ null));
+
+    String sessionId = "testSession";
+    CrashlyticsReport testReport = makeTestReport(sessionId);
+    CrashlyticsReport.Session.Event testEvent = makeTestEvent();
+
+    reportPersistence.persistReport(testReport);
+    reportPersistence.persistEvent(testEvent, sessionId);
+
+    long endedAt = System.currentTimeMillis();
+
+    reportPersistence.finalizeReports("skippedSession", endedAt);
+
+    List<CrashlyticsReportWithSessionId> finalizedReports =
+        reportPersistence.loadFinalizedReports();
+    assertEquals(1, finalizedReports.size());
+    CrashlyticsReport finalizedReport = finalizedReports.get(0).getReport();
+    assertNotNull(finalizedReport.getSession());
+    assertEquals(
+        testReport
+            .withSessionEndFields(endedAt, false, null)
+            .withEvents(ImmutableList.from(testEvent)),
+        finalizedReport);
+
+    // getAppQualitySessionId should return null since sessions subscriber never got an id.
+    assertNull(finalizedReport.getSession().getAppQualitySessionId());
+  }
+
+  public void testPersistEvent_updatesLatestAppQualitySession() {
+    CrashlyticsAppQualitySessionsSubscriber mockSessionsSubscriber =
+        createSessionsSubscriberMock(APP_QUALITY_SESSION_ID);
+    CrashlyticsReportPersistence reportPersistence =
+        new CrashlyticsReportPersistence(
+            fileStore,
+            createSettingsProviderMock(VERY_LARGE_UPPER_LIMIT, VERY_LARGE_UPPER_LIMIT),
+            mockSessionsSubscriber);
+
+    String sessionId = "testSession";
+    CrashlyticsReport testReport = makeTestReport(sessionId);
+    CrashlyticsReport.Session.Event testEvent1 = makeTestEvent("type1", "reason1");
+    CrashlyticsReport.Session.Event testEvent2 = makeTestEvent("type2", "reason2");
+    CrashlyticsReport.Session.Event testEvent3 = makeTestEvent("type3", "reason3");
+
+    reportPersistence.persistReport(testReport);
+    reportPersistence.persistEvent(testEvent1, sessionId);
+    reportPersistence.persistEvent(testEvent2, sessionId);
+
+    // Simulate a new app quality sessions session before the last event.
+    String latestAppQualitySessionId = "300";
+    when(mockSessionsSubscriber.getAppQualitySessionId()).thenReturn(latestAppQualitySessionId);
+    reportPersistence.persistEvent(testEvent3, sessionId);
+
+    long endedAt = System.currentTimeMillis();
+
+    reportPersistence.finalizeReports("skippedSession", endedAt);
+
+    List<CrashlyticsReportWithSessionId> finalizedReports =
+        reportPersistence.loadFinalizedReports();
+    assertEquals(1, finalizedReports.size());
+    CrashlyticsReport finalizedReport = finalizedReports.get(0).getReport();
+    assertNotNull(finalizedReport.getSession());
+    assertEquals(
+        testReport
+            .withSessionEndFields(endedAt, false, null)
+            .withAppQualitySessionId(latestAppQualitySessionId)
+            .withEvents(ImmutableList.from(testEvent1, testEvent2, testEvent3)),
+        finalizedReport);
   }
 
   private static void persistReportWithEvent(

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsAppQualitySessionsSubscriber.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsAppQualitySessionsSubscriber.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.crashlytics.internal.common;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.firebase.crashlytics.internal.Logger;
+import com.google.firebase.sessions.api.SessionSubscriber;
+
+/**
+ * App Quality Sessions subscriber for Crashlytics to subscribe to and store the
+ * appQualitySessionId, which is different than the Crashlytics sessionId.
+ */
+public class CrashlyticsAppQualitySessionsSubscriber implements SessionSubscriber {
+  private final DataCollectionArbiter dataCollectionArbiter;
+
+  @Nullable private String appQualitySessionId = null;
+
+  public CrashlyticsAppQualitySessionsSubscriber(DataCollectionArbiter dataCollectionArbiter) {
+    this.dataCollectionArbiter = dataCollectionArbiter;
+  }
+
+  /**
+   * Gets the App Quality Sessions session id (which is different than the Crashlytics session id).
+   */
+  @Nullable
+  public String getAppQualitySessionId() {
+    return appQualitySessionId;
+  }
+
+  @Override
+  public void onSessionChanged(@NonNull SessionDetails sessionDetails) {
+    Logger.getLogger().d("App Quality Sessions session changed: " + sessionDetails);
+    appQualitySessionId = sessionDetails.getSessionId();
+  }
+
+  @Override
+  public boolean isDataCollectionEnabled() {
+    return dataCollectionArbiter.isAutomaticDataCollectionEnabled();
+  }
+
+  @NonNull
+  @Override
+  public SessionSubscriber.Name getSessionSubscriberName() {
+    return SessionSubscriber.Name.CRASHLYTICS;
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -90,6 +90,7 @@ public class CrashlyticsCore {
 
   private final ExecutorService crashHandlerExecutor;
   private final CrashlyticsBackgroundWorker backgroundWorker;
+  private final CrashlyticsAppQualitySessionsSubscriber sessionsSubscriber;
 
   private final CrashlyticsNativeComponent nativeComponent;
 
@@ -103,7 +104,8 @@ public class CrashlyticsCore {
       BreadcrumbSource breadcrumbSource,
       AnalyticsEventLogger analyticsEventLogger,
       FileStore fileStore,
-      ExecutorService crashHandlerExecutor) {
+      ExecutorService crashHandlerExecutor,
+      CrashlyticsAppQualitySessionsSubscriber sessionsSubscriber) {
     this.app = app;
     this.dataCollectionArbiter = dataCollectionArbiter;
     this.context = app.getApplicationContext();
@@ -114,6 +116,7 @@ public class CrashlyticsCore {
     this.crashHandlerExecutor = crashHandlerExecutor;
     this.fileStore = fileStore;
     this.backgroundWorker = new CrashlyticsBackgroundWorker(crashHandlerExecutor);
+    this.sessionsSubscriber = sessionsSubscriber;
 
     startTime = System.currentTimeMillis();
     onDemandCounter = new OnDemandCounter();
@@ -158,7 +161,8 @@ public class CrashlyticsCore {
               userMetadata,
               stackTraceTrimmingStrategy,
               settingsProvider,
-              onDemandCounter);
+              onDemandCounter,
+              sessionsSubscriber);
 
       controller =
           new CrashlyticsController(

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -68,12 +68,13 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
       UserMetadata userMetadata,
       StackTraceTrimmingStrategy stackTraceTrimmingStrategy,
       SettingsProvider settingsProvider,
-      OnDemandCounter onDemandCounter) {
+      OnDemandCounter onDemandCounter,
+      CrashlyticsAppQualitySessionsSubscriber sessionsSubscriber) {
     final CrashlyticsReportDataCapture dataCapture =
         new CrashlyticsReportDataCapture(
             context, idManager, appData, stackTraceTrimmingStrategy, settingsProvider);
     final CrashlyticsReportPersistence reportPersistence =
-        new CrashlyticsReportPersistence(fileStore, settingsProvider);
+        new CrashlyticsReportPersistence(fileStore, settingsProvider, sessionsSubscriber);
     final DataTransportCrashlyticsReportSender reportSender =
         DataTransportCrashlyticsReportSender.create(context, settingsProvider, onDemandCounter);
     return new SessionReportingCoordinator(

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -179,6 +179,16 @@ public abstract class CrashlyticsReport {
     return builder.build();
   }
 
+  /** Augment an existing {@link CrashlyticsReport} with the given app quality session id. */
+  @NonNull
+  public CrashlyticsReport withAppQualitySessionId(@Nullable String appQualitySessionId) {
+    Builder builder = toBuilder();
+    if (getSession() != null) {
+      builder.setSession(getSession().withAppQualitySessionId(appQualitySessionId));
+    }
+    return builder.build();
+  }
+
   @AutoValue
   public abstract static class FilesPayload {
 
@@ -283,6 +293,10 @@ public abstract class CrashlyticsReport {
       return getIdentifier().getBytes(UTF_8);
     }
 
+    /** The last FirebaseSessions Session ID associated with the crash. */
+    @Nullable
+    public abstract String getAppQualitySessionId();
+
     public abstract long getStartedAt();
 
     @Nullable
@@ -332,6 +346,11 @@ public abstract class CrashlyticsReport {
       return builder.build();
     }
 
+    @NonNull
+    Session withAppQualitySessionId(@Nullable String appQualitySessionId) {
+      return toBuilder().setAppQualitySessionId(appQualitySessionId).build();
+    }
+
     /** Builder for {@link Session}. */
     @AutoValue.Builder
     public abstract static class Builder {
@@ -346,6 +365,9 @@ public abstract class CrashlyticsReport {
       public Builder setIdentifierFromUtf8Bytes(@NonNull byte[] utf8Bytes) {
         return setIdentifier(new String(utf8Bytes, UTF_8));
       }
+
+      @NonNull
+      public abstract Builder setAppQualitySessionId(@Nullable String appQualitySessionId);
 
       @NonNull
       public abstract Builder setStartedAt(long startedAt);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
@@ -142,6 +142,9 @@ public class CrashlyticsReportJsonTransform {
           builder.setIdentifierFromUtf8Bytes(
               Base64.decode(jsonReader.nextString(), Base64.NO_WRAP));
           break;
+        case "appQualitySessionId":
+          builder.setAppQualitySessionId(jsonReader.nextString());
+          break;
         case "startedAt":
           builder.setStartedAt(jsonReader.nextLong());
           break;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/CrashlyticsReportPersistence.java
@@ -142,7 +142,9 @@ public class CrashlyticsReportPersistence {
       writeTextFile(fileStore.getSessionFile(sessionId, fileName), json);
 
       String appQualitySessionId = sessionsSubscriber.getAppQualitySessionId();
-      if (appQualitySessionId != null) {
+      if (appQualitySessionId == null) {
+        Logger.getLogger().w("Missing AQS session id for Crashlytics session " + sessionId);
+      } else {
         writeTextFile(
             fileStore.getSessionFile(sessionId, AQS_SESSION_ID_FILENAME), appQualitySessionId);
       }


### PR DESCRIPTION
Add and populate appQualitySessionId in Crashlytics reports. This works by saving the latest AQS session id to disk on every event, which is slightly different than iOS which saves it on every session change. The JVM can save to disk in the exception handler, so it's ok to do it this way for Android. Then when a report is finalized, take the most recent AQS session id for that Crashlytics session and include it in the report.