### PR TITLE
Diff ABT Experiments for real-time RC

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
@@ -93,12 +93,22 @@ public final class RemoteConfigConstants {
    */
   @StringDef({
     ExperimentDescriptionFieldKey.EXPERIMENT_ID,
-    ExperimentDescriptionFieldKey.VARIANT_ID
+    ExperimentDescriptionFieldKey.VARIANT_ID,
+    ExperimentDescriptionFieldKey.TRIGGER_EVENT,
+    ExperimentDescriptionFieldKey.EXPERIMENT_START_TIME,
+    ExperimentDescriptionFieldKey.TRIGGER_TIMEOUT_MILLIS,
+    ExperimentDescriptionFieldKey.TIME_TO_LIVE_MILLIS,
+    ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEY
   })
   @Retention(RetentionPolicy.SOURCE)
   public @interface ExperimentDescriptionFieldKey {
     String EXPERIMENT_ID = "experimentId";
     String VARIANT_ID = "variantId";
+    String TRIGGER_EVENT = "triggerEvent";
+    String EXPERIMENT_START_TIME = "experimentStartTime";
+    String TRIGGER_TIMEOUT_MILLIS = "triggetTimeoutMillis";
+    String TIME_TO_LIVE_MILLIS = "timeToLiveMillis";
+    String AFFECTED_PARAMETER_KEY = "affectedParameterKey";
   }
 
   private RemoteConfigConstants() {}

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -15,7 +15,12 @@
 package com.google.firebase.remoteconfig.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEY;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_ID;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_START_TIME;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TIME_TO_LIVE_MILLIS;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TRIGGER_EVENT;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.TRIGGER_TIMEOUT_MILLIS;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.VARIANT_ID;
 import static com.google.firebase.remoteconfig.internal.Personalization.ARM_INDEX;
 import static com.google.firebase.remoteconfig.internal.Personalization.CHOICE_ID;
@@ -23,6 +28,7 @@ import static com.google.firebase.remoteconfig.internal.Personalization.GROUP;
 import static com.google.firebase.remoteconfig.internal.Personalization.PERSONALIZATION_ID;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Date;
 import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -138,21 +144,168 @@ public class ConfigContainerTest {
   }
 
   @Test
-  public void getChangedParams_changedExperimentsMetadata_returnsNoParamKeys() throws Exception {
+  public void getChangedParams_sameExperimentsMetadata_returnsEmptySet() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
     ConfigContainer config =
         ConfigContainer.newBuilder()
             .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
             .build();
 
     ConfigContainer other =
         ConfigContainer.newBuilder()
             .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
-            .withAbtExperiments(generateAbtExperiments(1))
+            .withAbtExperiments(fetchedExperiments)
             .build();
 
     Set<String> changedParams = config.getChangedParams(other);
 
     assertThat(changedParams).isEmpty();
+  }
+
+  @Test
+  public void getChangedParams_changedExperimentsMetadata_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    activeExperiments.getJSONObject(0).put(VARIANT_ID, "32");
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_newExperiments_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(2);
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_deletedExperiment_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = new JSONArray();
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_changedExperimentsKeys_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    fetchedExperiments.getJSONObject(0).getJSONArray(AFFECTED_PARAMETER_KEY).put("abt_test_key_2");
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_2");
+  }
+
+  @Test
+  public void getChangedParams_changedExperimentsStartTime_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    fetchedExperiments.getJSONObject(0).put(EXPERIMENT_START_TIME, new Date(2089));
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_changedExperimentsNoTriggerEvent_returnsUpdatedKey()
+      throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    fetchedExperiments.getJSONObject(0).remove(TRIGGER_EVENT);
+
+    fetchedExperiments.getJSONObject(0).put(EXPERIMENT_START_TIME, new Date(2089));
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
   }
 
   @Test
@@ -272,9 +425,18 @@ public class ConfigContainerTest {
 
   private static JSONArray generateAbtExperiments(int numExperiments) throws JSONException {
     JSONArray experiments = new JSONArray();
+    JSONArray experimentKeys = new JSONArray();
+    experimentKeys.put("abt_test_key_1");
     for (int experimentNum = 1; experimentNum <= numExperiments; experimentNum++) {
       experiments.put(
-          new JSONObject().put(EXPERIMENT_ID, "exp" + experimentNum).put(VARIANT_ID, "var1"));
+          new JSONObject()
+              .put(EXPERIMENT_ID, "exp" + experimentNum)
+              .put(VARIANT_ID, "var1")
+              .put(TRIGGER_EVENT, "event")
+              .put(EXPERIMENT_START_TIME, new Date(1))
+              .put(TRIGGER_TIMEOUT_MILLIS, 1L)
+              .put(TIME_TO_LIVE_MILLIS, 1L)
+              .put(AFFECTED_PARAMETER_KEY, experimentKeys));
     }
     return experiments;
   }


### PR DESCRIPTION
Adds diffing logic between experiments fetched via real-time and experiments active on the device. The config keys that have been affected by the differences will be added to ConfigUpdate.