### PR TITLE
Fix firebase-crashlytics-ktx instrumented tests

### DIFF
--- a/firebase-crashlytics/ktx/ktx.gradle
+++ b/firebase-crashlytics/ktx/ktx.gradle
@@ -53,14 +53,14 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation 'org.mockito:mockito-core:3.4.3'
 
-    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:core:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation 'androidx.test:core:1.4.0'
 }
 
 // ==========================================================================

--- a/firebase-crashlytics/ktx/ktx.gradle
+++ b/firebase-crashlytics/ktx/ktx.gradle
@@ -30,6 +30,7 @@ android {
     minSdk 16
     multiDexEnabled true
     targetSdk 33
+    versionName version
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   compileOptions {

--- a/firebase-crashlytics/ktx/ktx.gradle
+++ b/firebase-crashlytics/ktx/ktx.gradle
@@ -13,59 +13,43 @@
 // limitations under the License.
 
 plugins {
-    id 'firebase-library'
-    id 'kotlin-android'
+  id "firebase-library"
+  id "kotlin-android"
 }
 
 firebaseLibrary {
-    libraryGroup "crashlytics"
-    testLab.enabled = true
-    publishJavadoc = true
-    publishSources = true
+  libraryGroup "crashlytics"
+  testLab.enabled = true
+  publishJavadoc = true
+  publishSources = true
 }
 
 android {
-    compileSdkVersion 33
-    defaultConfig {
-        minSdk 16
-        multiDexEnabled true
-        targetSdk 33
-        versionName version
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-    sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-        test.java {
-            srcDir 'src/test/kotlin'
-        }
-        androidTest.java.srcDirs += 'src/androidTest/kotlin'
-    }
-    testOptions.unitTests.includeAndroidResources = true
+  compileSdk 33
+  defaultConfig {
+    minSdk 16
+    multiDexEnabled true
+    targetSdk 33
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+  }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+  kotlinOptions {
+    jvmTarget = '1.8'
+  }
+  testOptions.unitTests.includeAndroidResources = true
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+  implementation "com.google.firebase:firebase-common-ktx:20.3.2"
+  implementation "com.google.firebase:firebase-common:20.3.2"
+  implementation "com.google.firebase:firebase-components:17.1.0"
+  implementation(libs.androidx.annotation)
+  implementation project(":firebase-crashlytics")
 
-    implementation 'com.google.firebase:firebase-common:20.3.1'
-    implementation 'com.google.firebase:firebase-components:17.1.0'
-    implementation 'com.google.firebase:firebase-common-ktx:20.3.1'
-    implementation project(':firebase-crashlytics')
-    implementation 'androidx.annotation:annotation:1.1.0'
-
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'org.mockito:mockito-core:3.4.3'
-
-    androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test:core:1.4.0'
+  androidTestImplementation(libs.androidx.test.junit)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.truth)
 }
-
-// ==========================================================================
-// Copy from here down if you want to use the google-services plugin in your
-// androidTest integration tests.
-// ==========================================================================
-ext.packageName = "com.google.firebase.crashlytics.ktx"
-apply from: '../../gradle/googleServices.gradle'

--- a/firebase-crashlytics/ktx/src/androidTest/AndroidManifest.xml
+++ b/firebase-crashlytics/ktx/src/androidTest/AndroidManifest.xml
@@ -1,13 +1,27 @@
+<!--
+  ~ Copyright 2023 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.google.firebase.crashlytics.ktx">
-  <!--Although the *SdkVersion is captured in gradle build files, this is required for non gradle builds-->
-  <!--<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="23" />-->
-  <uses-permission android:name="android.permission.INTERNET"/>
+  package="com.google.firebase.crashlytics.ktx"
+  android:versionCode="1"
+  android:versionName="1.0.0">
+
   <application>
-    <uses-library android:name="android.test.runner" />
+
   </application>
 
-  <instrumentation
-    android:name="androidx.test.runner.AndroidJUnitRunner"
-    android:targetPackage="com.google.firebase.crashlytics.ktx" />
+  <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/firebase-crashlytics/ktx/src/androidTest/kotlin/com/google/firebase/crashlytics/ktx/CrashlyticsTests.kt
+++ b/firebase-crashlytics/ktx/src/androidTest/kotlin/com/google/firebase/crashlytics/ktx/CrashlyticsTests.kt
@@ -14,36 +14,38 @@
 
 package com.google.firebase.crashlytics.ktx
 
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.ktx.app
 import com.google.firebase.ktx.initialize
 import com.google.firebase.platforminfo.UserAgentPublisher
-import org.junit.AfterClass
-import org.junit.BeforeClass
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class CrashlyticsTests {
-  companion object {
-    lateinit var app: FirebaseApp
+  @Before
+  fun setUp() {
+    Firebase.initialize(
+      ApplicationProvider.getApplicationContext(),
+      FirebaseOptions.Builder()
+        .setApplicationId(APP_ID)
+        .setApiKey(API_KEY)
+        .setProjectId(PROJECT_ID)
+        .build()
+    )
+  }
 
-    @BeforeClass
-    @JvmStatic
-    fun setup() {
-      app = Firebase.initialize(InstrumentationRegistry.getContext())!!
-    }
-
-    @AfterClass
-    @JvmStatic
-    fun cleanup() {
-      app.delete()
-    }
+  @After
+  fun cleanUp() {
+    FirebaseApp.clearInstancesForTest()
   }
 
   @Test
@@ -52,32 +54,14 @@ class CrashlyticsTests {
   }
 
   @Test
-  fun testDataCall() {
-    assertThat("hola").isEqualTo("hola")
-  }
-}
-
-@RunWith(AndroidJUnit4::class)
-class LibraryVersionTest {
-  companion object {
-    lateinit var app: FirebaseApp
-
-    @BeforeClass
-    @JvmStatic
-    fun setup() {
-      app = Firebase.initialize(InstrumentationRegistry.getContext())!!
-    }
-
-    @AfterClass
-    @JvmStatic
-    fun cleanup() {
-      app.delete()
-    }
-  }
-
-  @Test
   fun libraryRegistrationAtRuntime() {
     val publisher = Firebase.app.get(UserAgentPublisher::class.java)
-    assertThat(publisher.userAgent).contains(LIBRARY_NAME)
+    assertThat(publisher.userAgent).contains(FirebaseCrashlyticsKtxRegistrar.LIBRARY_NAME)
+  }
+
+  companion object {
+    private const val APP_ID = "1:1:android:1a"
+    private const val API_KEY = "API-KEY-API-KEY-API-KEY-API-KEY-API-KEY"
+    private const val PROJECT_ID = "PROJECT-ID"
   }
 }

--- a/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
+++ b/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
@@ -32,11 +32,13 @@ fun FirebaseCrashlytics.setCustomKeys(init: KeyValueBuilder.() -> Unit) {
   builder.init()
 }
 
-internal const val LIBRARY_NAME: String = "fire-cls-ktx"
-
 /** @suppress */
 @Keep
 class FirebaseCrashlyticsKtxRegistrar : ComponentRegistrar {
   override fun getComponents(): List<Component<*>> =
     listOf(LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME))
+
+  companion object {
+    internal const val LIBRARY_NAME: String = "fire-cls-ktx"
+  }
 }

--- a/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
+++ b/firebase-crashlytics/ktx/src/main/kotlin/com/google/firebase/crashlytics/ktx/FirebaseCrashlytics.kt
@@ -34,7 +34,7 @@ fun FirebaseCrashlytics.setCustomKeys(init: KeyValueBuilder.() -> Unit) {
 
 /** @suppress */
 @Keep
-class FirebaseCrashlyticsKtxRegistrar : ComponentRegistrar {
+internal class FirebaseCrashlyticsKtxRegistrar : ComponentRegistrar {
   override fun getComponents(): List<Component<*>> =
     listOf(LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME))
 

--- a/health-metrics/apk-size/app/default.gradle
+++ b/health-metrics/apk-size/app/default.gradle
@@ -25,13 +25,13 @@ android {
         abortOnError false
         checkReleaseBuilds false
     }
-    compileSdkVersion project.targetSdkVersion
+    compileSdk 33
 
     defaultConfig {
         applicationId 'com.google.apksize'
         minSdkVersion project.targetSdkVersion
         multiDexEnabled true
-        targetSdkVersion project.targetSdkVersion
+        targetSdkVersion 33
         versionCode 1
         versionName '1.0'
     }


### PR DESCRIPTION
This is needed because we upped the target sdk and firebase-crashlytics-ktx had been using some deprecated apis.