### PR TITLE
Do not require sign in to use developer mode

### DIFF
--- a/firebase-appdistribution/CHANGELOG.md
+++ b/firebase-appdistribution/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [feature] Improved development mode to allow all API calls to be made without having to sign in.
 
 # 16.0.0-beta08
 * [fixed] Fixed an issue where a crash happened whenever a feedback

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/DevModeDetector.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/DevModeDetector.java
@@ -1,0 +1,50 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.appdistribution.impl;
+
+import androidx.annotation.Nullable;
+import java.lang.reflect.Method;
+import javax.inject.Inject;
+
+/**
+ * A detector to recognize when the SDK is in development mode, which disables any functionality
+ * that requires the tester to have signed in.
+ */
+class DevModeDetector {
+
+  @Inject
+  DevModeDetector() {}
+
+  boolean isDevModeEnabled() {
+    return Boolean.valueOf(getSystemProperty("debug.firebase.appdistro.devmode"));
+  }
+
+  @Nullable
+  @SuppressWarnings({"unchecked", "PrivateApi"})
+  private static String getSystemProperty(String propertyName) {
+    String className = "android.os.SystemProperties";
+    try {
+      Class<?> sysProps = Class.forName(className);
+      Method method = sysProps.getDeclaredMethod("get", String.class);
+      Object result = method.invoke(null, propertyName);
+      if (result != null && String.class.isAssignableFrom(result.getClass())) {
+        return (String) result;
+      }
+    } catch (Exception e) {
+      // do nothing
+    }
+    return null;
+  }
+}

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/FeedbackActivity.java
@@ -198,8 +198,8 @@ public class FeedbackActivity extends AppCompatActivity {
   public void submitFeedback(View view) {
     setSubmittingStateEnabled(true);
     if (releaseName == null) {
-      // Don't actually send feedback in development-mode
       Toast.makeText(this, R.string.feedback_no_release, Toast.LENGTH_LONG).show();
+      LogWrapper.w(TAG, "Not submitting feedback because development mode is enabled.");
       finish();
       return;
     }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ReleaseIdentifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ReleaseIdentifier.java
@@ -76,8 +76,8 @@ class ReleaseIdentifier {
   /**
    * Identify the currently installed release, returning the release name.
    *
-   * <p>Will return {@code Task} with a {@code null} result in "development mode" which allows the UI
-   * to be used, but no actual feedback to be submitted.
+   * <p>Will return {@code Task} with a {@code null} result in "development mode" which allows the
+   * UI to be used, but no actual feedback to be submitted.
    */
   Task<String> identifyRelease() {
     if (devModeDetector.isDevModeEnabled()) {

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ReleaseIdentifier.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/ReleaseIdentifier.java
@@ -30,7 +30,6 @@ import com.google.firebase.appdistribution.FirebaseAppDistributionException;
 import com.google.firebase.appdistribution.FirebaseAppDistributionException.Status;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -56,6 +55,7 @@ class ReleaseIdentifier {
   private final Context applicationContext;
   private final FirebaseAppDistributionTesterApiClient testerApiClient;
 
+  private final DevModeDetector devModeDetector;
   @Background private final Executor backgroundExecutor;
   @Lightweight private final Executor lightweightExecutor;
 
@@ -63,10 +63,12 @@ class ReleaseIdentifier {
   ReleaseIdentifier(
       Context applicationContext,
       FirebaseAppDistributionTesterApiClient testerApiClient,
+      DevModeDetector devModeDetector,
       @Background Executor backgroundExecutor,
       @Lightweight Executor lightweightExecutor) {
     this.applicationContext = applicationContext;
     this.testerApiClient = testerApiClient;
+    this.devModeDetector = devModeDetector;
     this.backgroundExecutor = backgroundExecutor;
     this.lightweightExecutor = lightweightExecutor;
   }
@@ -74,11 +76,11 @@ class ReleaseIdentifier {
   /**
    * Identify the currently installed release, returning the release name.
    *
-   * <p>Will return {@code Task} with a {@code null} result in "developer mode" which allows the UI
+   * <p>Will return {@code Task} with a {@code null} result in "development mode" which allows the UI
    * to be used, but no actual feedback to be submitted.
    */
   Task<String> identifyRelease() {
-    if (developmentModeEnabled()) {
+    if (devModeDetector.isDevModeEnabled()) {
       return Tasks.forResult(null);
     }
 
@@ -212,26 +214,5 @@ class ReleaseIdentifier {
       result[i] = list.get(i);
     }
     return result;
-  }
-
-  private static boolean developmentModeEnabled() {
-    return Boolean.valueOf(getSystemProperty("debug.firebase.appdistro.devmode"));
-  }
-
-  @Nullable
-  @SuppressWarnings({"unchecked", "PrivateApi"})
-  private static String getSystemProperty(String propertyName) {
-    String className = "android.os.SystemProperties";
-    try {
-      Class<?> sysProps = Class.forName(className);
-      Method method = sysProps.getDeclaredMethod("get", String.class);
-      Object result = method.invoke(null, propertyName);
-      if (result != null && String.class.isAssignableFrom(result.getClass())) {
-        return (String) result;
-      }
-    } catch (Exception e) {
-      // do nothing
-    }
-    return null;
   }
 }

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
@@ -30,6 +30,7 @@ import javax.inject.Singleton;
 @Singleton
 class SignInStorage {
   static final String TAG = "SignInStorage";
+
   @VisibleForTesting
   static final String SIGNIN_PREFERENCES_NAME = "FirebaseAppDistributionSignInStorage";
 
@@ -68,7 +69,8 @@ class SignInStorage {
 
   Task<Boolean> getSignInStatus() {
     if (devModeDetector.isDevModeEnabled()) {
-      LogWrapper.w(TAG, "Returning tester sign in status 'true' because development mode is enabled");
+      LogWrapper.w(
+          TAG, "Returning tester sign in status 'true' because development mode is enabled");
       return Tasks.forResult(true);
     }
     return applyToSharedPreferences(
@@ -77,7 +79,8 @@ class SignInStorage {
 
   boolean getSignInStatusBlocking() {
     if (devModeDetector.isDevModeEnabled()) {
-      LogWrapper.w(TAG, "Returning tester sign in status 'true' because development mode is enabled");
+      LogWrapper.w(
+          TAG, "Returning tester sign in status 'true' because development mode is enabled");
       return true;
     }
     return getAndCacheSharedPreferences().getBoolean(SIGNIN_TAG, false);

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/SignInStorage.java
@@ -29,12 +29,14 @@ import javax.inject.Singleton;
 // TODO(b/266704696): This currently only supports one FirebaseAppDistribution instance app-wide
 @Singleton
 class SignInStorage {
+  static final String TAG = "SignInStorage";
   @VisibleForTesting
   static final String SIGNIN_PREFERENCES_NAME = "FirebaseAppDistributionSignInStorage";
 
   @VisibleForTesting static final String SIGNIN_TAG = "firebase_app_distribution_signin";
 
   private final Context applicationContext;
+  private final DevModeDetector devModeDetector;
   @Background private final Executor backgroundExecutor;
   private SharedPreferences sharedPreferences;
 
@@ -43,12 +45,20 @@ class SignInStorage {
   }
 
   @Inject
-  SignInStorage(Context applicationContext, @Background Executor backgroundExecutor) {
+  SignInStorage(
+      Context applicationContext,
+      DevModeDetector devModeDetector,
+      @Background Executor backgroundExecutor) {
     this.applicationContext = applicationContext;
+    this.devModeDetector = devModeDetector;
     this.backgroundExecutor = backgroundExecutor;
   }
 
   Task<Void> setSignInStatus(boolean testerSignedIn) {
+    if (devModeDetector.isDevModeEnabled()) {
+      LogWrapper.w(TAG, "Not signing out tester because development mode is enabled");
+      return Tasks.forResult(null);
+    }
     return applyToSharedPreferences(
         sharedPreferences -> {
           sharedPreferences.edit().putBoolean(SIGNIN_TAG, testerSignedIn).apply();
@@ -57,11 +67,19 @@ class SignInStorage {
   }
 
   Task<Boolean> getSignInStatus() {
+    if (devModeDetector.isDevModeEnabled()) {
+      LogWrapper.w(TAG, "Returning tester sign in status 'true' because development mode is enabled");
+      return Tasks.forResult(true);
+    }
     return applyToSharedPreferences(
         sharedPreferences -> sharedPreferences.getBoolean(SIGNIN_TAG, false));
   }
 
   boolean getSignInStatusBlocking() {
+    if (devModeDetector.isDevModeEnabled()) {
+      LogWrapper.w(TAG, "Returning tester sign in status 'true' because development mode is enabled");
+      return true;
+    }
     return getAndCacheSharedPreferences().getBoolean(SIGNIN_TAG, false);
   }
 

--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
@@ -56,6 +56,7 @@ class TesterSignInManager {
   private final SignInStorage signInStorage;
   private final FirebaseAppDistributionLifecycleNotifier lifecycleNotifier;
 
+  private final DevModeDetector devModeDetector;
   @Lightweight private final Executor lightweightExecutor;
   private final TaskCompletionSourceCache<Void> signInTaskCompletionSourceCache;
 
@@ -68,12 +69,14 @@ class TesterSignInManager {
       Provider<FirebaseInstallationsApi> firebaseInstallationsApiProvider,
       SignInStorage signInStorage,
       FirebaseAppDistributionLifecycleNotifier lifecycleNotifier,
+      DevModeDetector devModeDetector,
       @Lightweight Executor lightweightExecutor) {
     this.applicationContext = applicationContext;
     this.firebaseOptions = firebaseOptions;
     this.firebaseInstallationsApiProvider = firebaseInstallationsApiProvider;
     this.signInStorage = signInStorage;
     this.lifecycleNotifier = lifecycleNotifier;
+    this.devModeDetector = devModeDetector;
     this.lightweightExecutor = lightweightExecutor;
     this.signInTaskCompletionSourceCache = new TaskCompletionSourceCache<>(lightweightExecutor);
 
@@ -133,6 +136,11 @@ class TesterSignInManager {
   }
 
   private Task<Void> doSignInTester() {
+    if (devModeDetector.isDevModeEnabled()) {
+      LogWrapper.w(TAG, "Skipping actual tester sign in because dev mode is enabled");
+      signInStorage.setSignInStatus(true);
+      return Tasks.forResult(null);
+    }
     return signInTaskCompletionSourceCache.getOrCreateTaskFromCompletionSource(
         () -> {
           TaskCompletionSource<Void> signInTaskCompletionSource = new TaskCompletionSource<>();

--- a/firebase-appdistribution/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
   <string name="update_release_notes" translation_description="Text prefixing release notes">Release notes:</string>
   <string name="update_yes_button" translation_description="Text on button to start update">Update</string>
   <string name="update_no_button" translation_description="Text on button to cancel update">Cancel</string>
+  <string name="update_dev_mode_enabled" translation_description="Toast explaining that the SDK did not check for a new release since development mode was active">Not checking for update due to development mode.</string>
   <string name="downloading_app_update" translation_description="Title of the notification showing during download of update">Downloading in-app update…</string>
   <string name="download_completed" translation_description="Title of notification when download of update has completed">Download complete</string>
   <string name="download_failed" translation_description="Title of notification when download of update has failed">Download failed</string>

--- a/firebase-appdistribution/src/main/res/values/strings.xml
+++ b/firebase-appdistribution/src/main/res/values/strings.xml
@@ -23,7 +23,6 @@
   <string name="update_release_notes" translation_description="Text prefixing release notes">Release notes:</string>
   <string name="update_yes_button" translation_description="Text on button to start update">Update</string>
   <string name="update_no_button" translation_description="Text on button to cancel update">Cancel</string>
-  <string name="update_dev_mode_enabled" translation_description="Toast explaining that the SDK did not check for a new release since development mode was active">Not checking for update due to development mode.</string>
   <string name="downloading_app_update" translation_description="Title of the notification showing during download of update">Downloading in-app update…</string>
   <string name="download_completed" translation_description="Title of notification when download of update has completed">Download complete</string>
   <string name="download_failed" translation_description="Title of notification when download of update has failed">Download failed</string>

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -168,18 +168,21 @@ public class FirebaseAppDistributionServiceImplTest {
   @Mock private FirebaseAppDistributionLifecycleNotifier mockLifecycleNotifier;
   @Mock private ReleaseIdentifier mockReleaseIdentifier;
   @Mock private ScreenshotTaker mockScreenshotTaker;
+  @Mock private DevModeDetector mockDevModeDetector;
 
   static class TestActivity extends Activity {}
 
   @Before
   public void setup() throws FirebaseAppDistributionException {
-
     MockitoAnnotations.initMocks(this);
-
     FirebaseApp.clearInstancesForTest();
 
     signInStorage =
-        spy(new SignInStorage(ApplicationProvider.getApplicationContext(), backgroundExecutor));
+        spy(
+            new SignInStorage(
+                ApplicationProvider.getApplicationContext(),
+                mockDevModeDetector,
+                backgroundExecutor));
 
     FirebaseApp firebaseApp =
         FirebaseApp.initializeApp(
@@ -213,8 +216,9 @@ public class FirebaseAppDistributionServiceImplTest {
 
     when(mockTesterSignInManager.signInTester()).thenReturn(Tasks.forResult(null));
     setSignInStatusSharedPreference(true);
-
     when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
+    when(mockScreenshotTaker.takeScreenshot()).thenReturn(Tasks.forResult(TEST_SCREENSHOT_URI));
+    when(mockDevModeDetector.isDevModeEnabled()).thenReturn(false);
 
     ShadowPackageManager shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
@@ -237,7 +241,6 @@ public class FirebaseAppDistributionServiceImplTest {
     activity = spy(activityController.get());
     mockForegroundActivity(mockLifecycleNotifier, activity);
 
-    when(mockScreenshotTaker.takeScreenshot()).thenReturn(Tasks.forResult(TEST_SCREENSHOT_URI));
   }
 
   @After

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -240,7 +240,6 @@ public class FirebaseAppDistributionServiceImplTest {
     activityController = Robolectric.buildActivity(TestActivity.class).setup();
     activity = spy(activityController.get());
     mockForegroundActivity(mockLifecycleNotifier, activity);
-
   }
 
   @After

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -905,6 +905,6 @@ public class FirebaseAppDistributionServiceImplTest {
     SharedPreferences sharedPreferences =
         ApplicationProvider.getApplicationContext()
             .getSharedPreferences(SignInStorage.SIGNIN_PREFERENCES_NAME, MODE_PRIVATE);
-    sharedPreferences.edit().putBoolean(SignInStorage.SIGNIN_TAG, testerSignedIn).commit();
+    sharedPreferences.edit().putBoolean(SignInStorage.SIGN_IN_KEY, testerSignedIn).commit();
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/NewReleaseFetcherTest.java
@@ -20,7 +20,6 @@ import static com.google.firebase.appdistribution.BinaryType.APK;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitAsyncOperations;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitTask;
 import static com.google.firebase.appdistribution.impl.TestUtils.awaitTaskFailure;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterSignInManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterSignInManagerTest.java
@@ -23,6 +23,7 @@ import static com.google.firebase.appdistribution.impl.TestUtils.awaitTaskFailur
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -96,6 +97,7 @@ public class TesterSignInManagerTest {
   @Mock private InstallationTokenResult mockInstallationTokenResult;
   @Mock private FirebaseAppDistributionLifecycleNotifier mockLifecycleNotifier;
   @Mock private SignInResultActivity mockSignInResultActivity;
+  @Mock private DevModeDetector devModeDetector;
 
   @Before
   public void setUp() {
@@ -116,11 +118,13 @@ public class TesterSignInManagerTest {
     when(mockFirebaseInstallations.getId()).thenReturn(Tasks.forResult(TEST_FID_1));
     when(mockFirebaseInstallations.getToken(false))
         .thenReturn(Tasks.forResult(mockInstallationTokenResult));
-
     when(mockInstallationTokenResult.getToken()).thenReturn(TEST_AUTH_TOKEN);
+    when(devModeDetector.isDevModeEnabled()).thenReturn(false);
 
     signInStorage =
-        spy(new SignInStorage(ApplicationProvider.getApplicationContext(), backgroundExecutor));
+        spy(
+            new SignInStorage(
+                ApplicationProvider.getApplicationContext(), devModeDetector, backgroundExecutor));
 
     shadowPackageManager =
         shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
@@ -251,8 +255,9 @@ public class TesterSignInManagerTest {
   public void signInTester_whenStorageFailsToRecordSignInStatus_taskFails()
       throws InterruptedException {
     Exception expectedException = new RuntimeException("Error");
-    when(signInStorage.setSignInStatus(anyBoolean()))
-        .thenReturn(Tasks.forException(expectedException));
+    doReturn(Tasks.forException(expectedException))
+        .when(signInStorage)
+        .setSignInStatus(anyBoolean());
     Task signInTask = testerSignInManager.signInTester();
     awaitAsyncOperations(backgroundExecutor);
     awaitAsyncOperations(lightweightExecutor);
@@ -273,5 +278,16 @@ public class TesterSignInManagerTest {
     testerSignInManager.onActivityResumed(activity);
 
     awaitTaskFailure(signInTask, AUTHENTICATION_CANCELED, ErrorMessages.AUTHENTICATION_CANCELED);
+  }
+
+  @Test
+  public void signInTester_devModeEnabled_doesNothing()
+      throws FirebaseAppDistributionException, ExecutionException, InterruptedException {
+    when(devModeDetector.isDevModeEnabled()).thenReturn(true);
+
+    awaitTask(testerSignInManager.signInTester());
+
+    verifyNoInteractions(mockFirebaseInstallationsProvider);
+    verifyNoInteractions(mockFirebaseInstallations);
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterSignInManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterSignInManagerTest.java
@@ -154,6 +154,7 @@ public class TesterSignInManagerTest {
             mockFirebaseInstallationsProvider,
             signInStorage,
             mockLifecycleNotifier,
+            devModeDetector,
             lightweightExecutor);
   }
 
@@ -281,12 +282,13 @@ public class TesterSignInManagerTest {
   }
 
   @Test
-  public void signInTester_devModeEnabled_doesNothing()
+  public void signInTester_devModeEnabled_immediatelySignsIn()
       throws FirebaseAppDistributionException, ExecutionException, InterruptedException {
     when(devModeDetector.isDevModeEnabled()).thenReturn(true);
 
     awaitTask(testerSignInManager.signInTester());
 
+    assertThat(awaitTask(signInStorage.getSignInStatus())).isTrue();
     verifyNoInteractions(mockFirebaseInstallationsProvider);
     verifyNoInteractions(mockFirebaseInstallations);
   }


### PR DESCRIPTION
The docs say that dev mode allows you to test in-app feedback without actually distributing your app. However that's not true because you still have to sign into the SDK.

This expands dev mode to allow testing the SDK in a signed in state without actually signing in:
- `signInTester()` skips opening the browser and immediately marks the tester as signed in
- Sign in state is managed using a separate key in app storage

Also, this expands dev mode to cover the in-app update functionality as well. It simply disables the check for new release and prints a log message instead.