### PR TITLE
Add common logging interface

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/logger/Level.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/logger/Level.kt
@@ -1,0 +1,12 @@
+package com.google.firebase.logger
+
+import android.util.Log
+
+/** Log levels with each [priority] that matches [Log]. */
+enum class Level(internal val priority: Int) {
+  VERBOSE(Log.VERBOSE),
+  DEBUG(Log.DEBUG),
+  INFO(Log.INFO),
+  WARN(Log.WARN),
+  ERROR(Log.ERROR),
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/logger/LogWrapper.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/logger/LogWrapper.kt
@@ -1,0 +1,58 @@
+package com.google.firebase.logger
+
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+
+/** Simple internal Kotlin wrapper around [Log]. */
+internal sealed class LogWrapper private constructor(val tag: String) {
+  abstract fun log(level: Level, format: String, vararg args: Any?, throwable: Throwable?): Int
+
+  /** Implementation of the wrapper around [Log]. */
+  internal class Android(tag: String) : LogWrapper(tag) {
+    override fun log(level: Level, format: String, vararg args: Any?, throwable: Throwable?): Int {
+      val msg = if (args.isEmpty()) format else String.format(format, args)
+      return when (level) {
+        Level.VERBOSE -> throwable?.let { Log.v(tag, msg, throwable) } ?: Log.v(tag, msg)
+        Level.DEBUG -> throwable?.let { Log.d(tag, msg, throwable) } ?: Log.d(tag, msg)
+        Level.INFO -> throwable?.let { Log.i(tag, msg, throwable) } ?: Log.i(tag, msg)
+        Level.WARN -> throwable?.let { Log.w(tag, msg, throwable) } ?: Log.w(tag, msg)
+        Level.ERROR -> throwable?.let { Log.e(tag, msg, throwable) } ?: Log.e(tag, msg)
+      }
+    }
+  }
+
+  /** Fake implementation of the log wrapper that allows recording and asserting on log messages. */
+  @VisibleForTesting
+  internal class Fake(tag: String) : LogWrapper(tag) {
+    private val record: MutableList<String> = ArrayList()
+
+    override fun log(level: Level, format: String, vararg args: Any?, throwable: Throwable?): Int {
+      val logMessage = toLogMessage(level, format, args, throwable = throwable)
+      println("Log: $logMessage")
+      record.add(logMessage)
+      return logMessage.length
+    }
+
+    /** Clear the recorded log messages. */
+    @VisibleForTesting fun clearLogMessages(): Unit = record.clear()
+
+    /** Returns if the record has any message that contains the given [message] as a substring. */
+    @VisibleForTesting
+    fun hasLogMessage(message: String): Boolean = record.any { it.contains(message) }
+
+    /** Returns if the record has any message that matches the given [predicate]. */
+    @VisibleForTesting
+    fun hasLogMessageThat(predicate: (String) -> Boolean): Boolean = record.any(predicate)
+
+    /** Builds a log message from all the log params. */
+    private fun toLogMessage(
+      level: Level,
+      format: String,
+      vararg args: Any?,
+      throwable: Throwable?,
+    ): String {
+      val msg = if (args.isEmpty()) format else String.format(format, args)
+      return throwable?.let { "$level $msg ${Log.getStackTraceString(throwable)}" } ?: "$level $msg"
+    }
+  }
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/logger/Logger.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/logger/Logger.kt
@@ -1,0 +1,73 @@
+package com.google.firebase.logger
+
+import androidx.annotation.VisibleForTesting
+import java.util.concurrent.ConcurrentHashMap
+
+/** Common logger interface that handles Android logcat logging. */
+class Logger private constructor(private val logWrapper: LogWrapper) {
+  var enabled: Boolean = true
+  var minLevel: Level = Level.INFO
+
+  @JvmOverloads
+  fun verbose(format: String, vararg args: Any?, throwable: Throwable? = null): Int =
+    log(Level.VERBOSE, format, args, throwable = throwable)
+
+  @JvmOverloads
+  fun verbose(msg: String, throwable: Throwable? = null): Int =
+    log(Level.VERBOSE, msg, throwable = throwable)
+
+  @JvmOverloads
+  fun debug(format: String, vararg args: Any?, throwable: Throwable? = null): Int =
+    log(Level.DEBUG, format, args, throwable = throwable)
+
+  @JvmOverloads
+  fun debug(msg: String, throwable: Throwable? = null): Int =
+    log(Level.DEBUG, msg, throwable = throwable)
+
+  @JvmOverloads
+  fun info(format: String, vararg args: Any?, throwable: Throwable? = null): Int =
+    log(Level.INFO, format, args, throwable = throwable)
+
+  @JvmOverloads
+  fun info(msg: String, throwable: Throwable? = null): Int =
+    log(Level.INFO, msg, throwable = throwable)
+
+  @JvmOverloads
+  fun warn(format: String, vararg args: Any?, throwable: Throwable? = null): Int =
+    log(Level.WARN, format, args, throwable = throwable)
+
+  @JvmOverloads
+  fun warn(msg: String, throwable: Throwable? = null): Int =
+    log(Level.WARN, msg, throwable = throwable)
+
+  @JvmOverloads
+  fun error(format: String, vararg args: Any?, throwable: Throwable? = null): Int =
+    log(Level.ERROR, format, args, throwable = throwable)
+
+  @JvmOverloads
+  fun error(msg: String, throwable: Throwable? = null): Int =
+    log(Level.ERROR, msg, throwable = throwable)
+
+  private fun log(level: Level, format: String, vararg args: Any?, throwable: Throwable?): Int =
+    if (enabled && level.priority >= minLevel.priority) {
+      logWrapper.log(level, format, args, throwable = throwable)
+    } else {
+      0
+    }
+
+  companion object {
+    private val loggers = ConcurrentHashMap<String, Logger>()
+
+    /** Gets (or creates) the single instance of [Logger] with the given [tag]. */
+    @JvmStatic
+    fun getLogger(tag: String): Logger = loggers.getOrPut(tag) { Logger(LogWrapper.Android(tag)) }
+
+    /** Sets (or replaces) the instance of [Logger] with the given [tag] for testing purposes. */
+    @VisibleForTesting
+    internal fun setupFakeLogger(tag: String): LogWrapper.Fake {
+      val logWrapper = LogWrapper.Fake(tag)
+      loggers[logWrapper.tag] = Logger(logWrapper)
+      return logWrapper
+    }
+  }
+}

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/logger/LoggerTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/logger/LoggerTest.kt
@@ -1,0 +1,85 @@
+package com.google.firebase.logger
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import java.io.FileNotFoundException
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LoggerTest {
+  private lateinit var fakeLogger: LogWrapper.Fake
+
+  @Before
+  fun setUp() {
+    fakeLogger = Logger.setupFakeLogger(TAG)
+  }
+
+  @Test
+  fun hasLogMessage_positive() {
+    Logger.getLogger(TAG).minLevel = Level.DEBUG
+    Logger.getLogger(TAG).debug("this is a debug log message")
+
+    assertThat(fakeLogger.hasLogMessage("this is a debug log message")).isTrue()
+  }
+
+  @Test
+  fun hasLogMessage_negative() {
+    Logger.getLogger(TAG).info("this is an info log message")
+
+    assertThat(fakeLogger.hasLogMessage("nobody logged this")).isFalse()
+  }
+
+  @Test
+  fun hasLogMessage_containsExceptionMessage() {
+    Logger.getLogger(TAG).warn("eh", RuntimeException("some exception message"))
+
+    assertThat(fakeLogger.hasLogMessage("some exception message")).isTrue()
+  }
+
+  @Test
+  fun hasLogMessage_containsExceptionType() {
+    Logger.getLogger(TAG).warn("eh", FileNotFoundException())
+
+    assertThat(fakeLogger.hasLogMessage("FileNotFoundException")).isTrue()
+  }
+
+  @Test
+  fun hasLogMessage_containsLevel() {
+    Logger.getLogger(TAG).warn("eh")
+
+    assertThat(fakeLogger.hasLogMessage("WARN")).isTrue()
+  }
+
+  @Test
+  fun hasLogMessageThat_positive() {
+    Logger.getLogger(TAG).info("this is a log message")
+
+    assertThat(fakeLogger.hasLogMessageThat { logMessage -> logMessage.endsWith("log message") })
+      .isTrue()
+  }
+
+  @Test
+  fun hasLogMessageThat_negative() {
+    Logger.getLogger(TAG).info("this is a log message")
+
+    assertThat(fakeLogger.hasLogMessageThat { logMessage -> logMessage.isEmpty() }).isFalse()
+  }
+
+  @Test
+  fun clearLogMessages() {
+    Logger.getLogger(TAG).warn("this is a log message")
+
+    assertThat(fakeLogger.hasLogMessageThat { true }).isTrue()
+
+    fakeLogger.clearLogMessages()
+
+    // The predicate will never happen on a cleared record.
+    assertThat(fakeLogger.hasLogMessageThat { true }).isFalse()
+  }
+
+  companion object {
+    private const val TAG = "tag"
+  }
+}


### PR DESCRIPTION
Add common logging interface.

This is in firebase-sessions for now, but I plan to move it to firebase-common once it's finished and after firebase-common gets Kotlin code merged into it.