### PR TITLE
Firestore Spec Tests: Port JS PR 7372 (remove no-ios tag from bloom filter tests)

### DIFF
--- a/firebase-firestore/src/test/resources/json/existence_filter_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/existence_filter_spec_test.json
@@ -3,7 +3,6 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter can process special characters in document name",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -207,7 +206,6 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter fills in default values for undefined padding and hashCount",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -394,7 +392,6 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter is handled at global snapshot",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -633,7 +630,6 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter limbo resolution is denied",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -893,7 +889,6 @@
     "describeName": "Existence Filters:",
     "itName": "Bloom filter with large size works as expected",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -6517,7 +6512,6 @@
     "describeName": "Existence Filters:",
     "itName": "Full re-query is skipped when bloom filter can identify documents deleted",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -6977,7 +6971,6 @@
     "describeName": "Existence Filters:",
     "itName": "Full re-query is triggered when bloom filter can not identify documents deleted",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -7190,7 +7183,6 @@
     "describeName": "Existence Filters:",
     "itName": "Full re-query is triggered when bloom filter hashCount is invalid",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -7379,7 +7371,6 @@
     "describeName": "Existence Filters:",
     "itName": "Full re-query is triggered when bloom filter is empty",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -7568,7 +7559,6 @@
     "describeName": "Existence Filters:",
     "itName": "Same documents can have different bloom filters",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,

--- a/firebase-firestore/src/test/resources/json/limbo_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/limbo_spec_test.json
@@ -7956,7 +7956,6 @@
     "describeName": "Limbo Documents:",
     "itName": "Limbo resolution throttling with bloom filter application",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "maxConcurrentLimboResolutions": 2,

--- a/firebase-firestore/src/test/resources/json/listen_spec_test.json
+++ b/firebase-firestore/src/test/resources/json/listen_spec_test.json
@@ -3385,7 +3385,6 @@
     "describeName": "Listens:",
     "itName": "ExpectedCount in listen request should work after coming back online",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -12745,7 +12744,6 @@
     "describeName": "Listens:",
     "itName": "Resuming a query should specify expectedCount that does not include pending mutations",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,
@@ -12947,7 +12945,6 @@
     "describeName": "Listens:",
     "itName": "Resuming a query should specify expectedCount when adding the target",
     "tags": [
-      "no-ios"
     ],
     "config": {
       "numClients": 1,


### PR DESCRIPTION
Sync spec tests with changes from https://github.com/firebase/firebase-js-sdk/pull/7372: "Remove the no-ios tag from bloom filter spec tests".

The changes in this PR have no effect on this SDK, but serves to keep the spec tests in sync for easier updating in the future.

#no-changelog