### PR TITLE
Store dev mode sign in state separately

### DIFF
--- a/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
+++ b/firebase-appdistribution/src/main/java/com/google/firebase/appdistribution/impl/TesterSignInManager.java
@@ -56,6 +56,7 @@ class TesterSignInManager {
   private final SignInStorage signInStorage;
   private final FirebaseAppDistributionLifecycleNotifier lifecycleNotifier;
 
+  private final DevModeDetector devModeDetector;
   @Lightweight private final Executor lightweightExecutor;
   private final TaskCompletionSourceCache<Void> signInTaskCompletionSourceCache;
 
@@ -68,12 +69,14 @@ class TesterSignInManager {
       Provider<FirebaseInstallationsApi> firebaseInstallationsApiProvider,
       SignInStorage signInStorage,
       FirebaseAppDistributionLifecycleNotifier lifecycleNotifier,
+      DevModeDetector devModeDetector,
       @Lightweight Executor lightweightExecutor) {
     this.applicationContext = applicationContext;
     this.firebaseOptions = firebaseOptions;
     this.firebaseInstallationsApiProvider = firebaseInstallationsApiProvider;
     this.signInStorage = signInStorage;
     this.lifecycleNotifier = lifecycleNotifier;
+    this.devModeDetector = devModeDetector;
     this.lightweightExecutor = lightweightExecutor;
     this.signInTaskCompletionSourceCache = new TaskCompletionSourceCache<>(lightweightExecutor);
 
@@ -133,6 +136,11 @@ class TesterSignInManager {
   }
 
   private Task<Void> doSignInTester() {
+    if (devModeDetector.isDevModeEnabled()) {
+      LogWrapper.w(TAG, "Skipping actual tester sign in because dev mode is enabled");
+      signInStorage.setSignInStatus(true);
+      return Tasks.forResult(null);
+    }
     return signInTaskCompletionSourceCache.getOrCreateTaskFromCompletionSource(
         () -> {
           TaskCompletionSource<Void> signInTaskCompletionSource = new TaskCompletionSource<>();

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/FirebaseAppDistributionServiceImplTest.java
@@ -905,6 +905,6 @@ public class FirebaseAppDistributionServiceImplTest {
     SharedPreferences sharedPreferences =
         ApplicationProvider.getApplicationContext()
             .getSharedPreferences(SignInStorage.SIGNIN_PREFERENCES_NAME, MODE_PRIVATE);
-    sharedPreferences.edit().putBoolean(SignInStorage.SIGNIN_TAG, testerSignedIn).commit();
+    sharedPreferences.edit().putBoolean(SignInStorage.SIGN_IN_KEY, testerSignedIn).commit();
   }
 }

--- a/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterSignInManagerTest.java
+++ b/firebase-appdistribution/src/test/java/com/google/firebase/appdistribution/impl/TesterSignInManagerTest.java
@@ -154,6 +154,7 @@ public class TesterSignInManagerTest {
             mockFirebaseInstallationsProvider,
             signInStorage,
             mockLifecycleNotifier,
+            devModeDetector,
             lightweightExecutor);
   }
 
@@ -281,12 +282,13 @@ public class TesterSignInManagerTest {
   }
 
   @Test
-  public void signInTester_devModeEnabled_doesNothing()
+  public void signInTester_devModeEnabled_immediatelySignsIn()
       throws FirebaseAppDistributionException, ExecutionException, InterruptedException {
     when(devModeDetector.isDevModeEnabled()).thenReturn(true);
 
     awaitTask(testerSignInManager.signInTester());
 
+    assertThat(awaitTask(signInStorage.getSignInStatus())).isTrue();
     verifyNoInteractions(mockFirebaseInstallationsProvider);
     verifyNoInteractions(mockFirebaseInstallations);
   }


### PR DESCRIPTION
In dev mode, instead of just always having the tester be signed in, actually allow the developer to use `signInTester()`, `signOutTester()`, `isTesterSignedIn()`, etc., but just skip the actual sign in flow. This will be a more realistic way to text the SDK out using dev mode. Expands on https://github.com/firebase/firebase-android-sdk/pull/5078.

Stores the sign in state separately from non-dev mode, so that they don't sign in during dev mode and then try to use the SDK for real after setting dev mode to false.