### PR TITLE
Update App Distro API CHANGELOG.md

### DIFF
--- a/firebase-appdistribution-api/CHANGELOG.md
+++ b/firebase-appdistribution-api/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 * [feature] Improved development mode to allow all API calls to be made without having to sign in.
 
+
 # 16.0.0-beta08
 * [fixed] Fixed an issue where a crash happened whenever a feedback
   notification was shown on devices running Android 4.4 and lower.

--- a/firebase-appdistribution-api/CHANGELOG.md
+++ b/firebase-appdistribution-api/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [feature] Improved development mode to allow all API calls to be made without having to sign in.
 
 # 16.0.0-beta08
 * [fixed] Fixed an issue where a crash happened whenever a feedback


### PR DESCRIPTION
Copies the CHANGELOG from https://github.com/firebase/firebase-android-sdk/pull/5078 since we want to keep `firebase-appdistribution` and `firebase-appdistribution-api` to stay on the same version and include the same release notes for new changes.