### PR TITLE
Have Perf report data collection disabled to Sessions

### DIFF
--- a/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/FirebasePerfEarly.java
@@ -69,7 +69,8 @@ public class FirebasePerfEarly {
 
           @Override
           public boolean isDataCollectionEnabled() {
-            return configResolver.isPerformanceMonitoringEnabled();
+            // TODO(b/289036760): Get configResolver to read metadata by here.
+            return false;
           }
 
           @NonNull


### PR DESCRIPTION
Have Perf report data collection disabled to Sessions until the metadata issue is resolved. This is to prevent Sessions from thinking Perf data collection is enabled when it was disabled in metadata.