### PR TITLE
Firestore: remove unused compareTo() computation

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/core/View.java
@@ -287,7 +287,6 @@ public class View {
         viewChanges,
         (DocumentViewChange o1, DocumentViewChange o2) -> {
           int typeComp = compareIntegers(View.changeTypeOrder(o1), View.changeTypeOrder(o2));
-          o1.getType().compareTo(o2.getType());
           if (typeComp != 0) {
             return typeComp;
           }


### PR DESCRIPTION
Remove a useless invocation of compareTo() whose result was being ignored. It appears that this useless compareTo() call was accidentally left behind from some previous refactor. Comparing it to the JS and iOS implementations, https://github.com/firebase/firebase-js-sdk/blob/aea4a4471306b089a02b207d2df285dfc71666c7/packages/firestore/src/core/view.ts#L295-L300 and https://github.com/firebase/firebase-ios-sdk/blob/876b9624e490cfc9451250d1a02eb959f6746927/Firestore/core/src/core/view.cc#L266-L275, respectively, it appears that the desired logic omits this useless compareTo() call.

This "bug" was detected by static analysis of https://errorprone.info/bugpattern/CheckReturnValue in google3 (Googlers see cl/544688630 and cl/544704978).