### PR TITLE
Finish background FCM broadcasts after handling the message.

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -3,6 +3,11 @@
   [FAQ](https://firebase.google.com/support/faq#fcm-23-deprecation) for more
   details.
 
+* [changed] Changed to finish a background broadcast after the message has been
+  handled, subject to a timeout. This keeps the `FirebaseMessagingService`'s
+  process in an active state while it is handling an FCM message, up to the
+  20 seconds allowed.
+
 # 23.1.2
 * [fixed] Fixed a breakage related to Jetpack core library related to an
   [upstream update](https://android-review.googlesource.com/c/platform/frameworks/support/+/2399893).

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/EnhancedIntentService.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/EnhancedIntentService.java
@@ -36,6 +36,10 @@ import java.util.concurrent.ExecutorService;
  */
 @SuppressLint("UnwrappedWakefulBroadcastReceiver") // Not used within GmsCore
 public abstract class EnhancedIntentService extends Service {
+
+  // Allow apps 20 seconds to handle a message.
+  static final long MESSAGE_TIMEOUT_S = 20;
+
   private static final String TAG = "EnhancedIntentService";
 
   // Use a different thread per service instance, so it can be reclaimed once the service is done.

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmBroadcastProcessor.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FcmBroadcastProcessor.java
@@ -87,7 +87,7 @@ public class FcmBroadcastProcessor {
     boolean isHighPriority = (intent.getFlags() & Intent.FLAG_RECEIVER_FOREGROUND) != 0;
 
     if (subjectToBackgroundCheck && !isHighPriority) {
-      return bindToMessagingService(context, intent);
+      return bindToMessagingService(context, intent, isHighPriority);
     }
 
     // If app isn't subject to background check or if message is high priority, use startService
@@ -106,7 +106,7 @@ public class FcmBroadcastProcessor {
           // On O, if we're not able to start the service fall back to binding. This could happen if
           // the app isn't targeting O, but the user manually applied restrictions, or if the temp
           // whitelist has already expired.
-          return bindToMessagingService(context, intent)
+          return bindToMessagingService(context, intent, isHighPriority)
               .continueWith(
                   // ok to use direct executor because we're just immediately returning an int
                   Runnable::run,
@@ -114,20 +114,32 @@ public class FcmBroadcastProcessor {
         });
   }
 
-  private static Task<Integer> bindToMessagingService(Context context, Intent intent) {
+  private static Task<Integer> bindToMessagingService(
+      Context context, Intent intent, boolean isForegroundBroadcast) {
     if (Log.isLoggable(TAG, Log.DEBUG)) {
       Log.d(TAG, "Binding to service");
     }
-    if (ServiceStarter.getInstance().hasWakeLockPermission(context)) {
-      WakeLockHolder.sendWakefulServiceIntent(
-          context, getServiceConnection(context, ServiceStarter.ACTION_MESSAGING_EVENT), intent);
-    } else {
-      // Ignore result since we're no longer blocking on the service handling the intent.
-      Task<Void> unused =
-          getServiceConnection(context, ServiceStarter.ACTION_MESSAGING_EVENT).sendIntent(intent);
-    }
 
-    return Tasks.forResult(ServiceStarter.SUCCESS);
+    WithinAppServiceConnection connection =
+        getServiceConnection(context, ServiceStarter.ACTION_MESSAGING_EVENT);
+
+    if (isForegroundBroadcast) {
+      // Foreground broadcast queue, finish the broadcast immediately
+      // (by returning a completed Task) to avoid ANRs.
+      if (ServiceStarter.getInstance().hasWakeLockPermission(context)) {
+        WakeLockHolder.sendWakefulServiceIntent(context, connection, intent);
+      } else {
+        connection.sendIntent(intent);
+      }
+      return Tasks.forResult(ServiceStarter.SUCCESS);
+    } else {
+      // Background broadcast queue, finish the broadcast after the message has been handled
+      // (which times out after 20 seconds to avoid ANRs and to limit how long the app is active).
+      return connection
+          .sendIntent(intent)
+          // ok to use direct executor because we're just immediately returning an int
+          .continueWith(Runnable::run, t -> ServiceStarter.SUCCESS);
+    }
   }
 
   /** Connect to a service via bind. This is used to process intents in Android O+ */
@@ -149,6 +161,18 @@ public class FcmBroadcastProcessor {
   public static void reset() {
     synchronized (lock) {
       fcmServiceConn = null;
+    }
+  }
+
+  /**
+   * Sets WithinAppServiceConnection for testing.
+   *
+   * @hide
+   */
+  @VisibleForTesting
+  public static void setServiceConnection(WithinAppServiceConnection connection) {
+    synchronized (lock) {
+      fcmServiceConn = connection;
     }
   }
 }

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/WithinAppServiceConnectionRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/WithinAppServiceConnectionRoboTest.java
@@ -44,10 +44,7 @@ public class WithinAppServiceConnectionRoboTest {
   private static final String TEST_BIND_ACTION = "testBindAction";
 
   // The amount of time that a broadcast receiver takes to time out
-  private static final long RECEIVER_TIMEOUT_S = 10;
-
-  // The amount of time to allow a foreground broadcast's service to run.
-  private static final long FOREGROUND_RECEIVER_TIMEOUT_S = 60;
+  private static final long RECEIVER_TIMEOUT_S = 20;
 
   private Application context;
   private FakeScheduledExecutorService fakeExecutor;
@@ -71,27 +68,7 @@ public class WithinAppServiceConnectionRoboTest {
 
     // Check the runnable doesn't run early, and that after it should have run the pending
     // result is finished.
-    fakeExecutor.simulateNormalOperationFor(RECEIVER_TIMEOUT_S - 2, TimeUnit.SECONDS);
-    assertThat(pendingResult.isComplete()).isFalse();
-    fakeExecutor.simulateNormalOperationFor(1, TimeUnit.SECONDS);
-    assertThat(pendingResult.isComplete()).isTrue();
-  }
-
-  @Test
-  public void testReceiverTimesOut_ForegroundBroadcast() {
-    WithinAppServiceConnection connection =
-        new WithinAppServiceConnection(context, TEST_BIND_ACTION, fakeExecutor);
-    setMockBinder(TEST_BIND_ACTION);
-
-    // Send a foreground broadcst intent, verify the pending result isn't finished
-    Intent foregroundBroadcastIntent = new Intent();
-    foregroundBroadcastIntent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
-    Task<Void> pendingResult = connection.sendIntent(foregroundBroadcastIntent);
-    assertThat(pendingResult.isComplete()).isFalse();
-
-    // Check the runnable doesn't run early, and that after it should have run the pending
-    // result is finished.
-    fakeExecutor.simulateNormalOperationFor(FOREGROUND_RECEIVER_TIMEOUT_S - 1, TimeUnit.SECONDS);
+    fakeExecutor.simulateNormalOperationFor(RECEIVER_TIMEOUT_S - 1, TimeUnit.SECONDS);
     assertThat(pendingResult.isComplete()).isFalse();
     fakeExecutor.simulateNormalOperationFor(1, TimeUnit.SECONDS);
     assertThat(pendingResult.isComplete()).isTrue();


### PR DESCRIPTION
* Changed to finish a background broadcast after the message has been handled, subject to a timeout. This keeps the `FirebaseMessagingService`'s process in an active state while it is handling an FCM message, up to the 20 seconds allowed.
* Removed acquiring a WakeLock for background broadcasts as one is held for the app until the broadcast is finished.