### PR TITLE
Firestore: Update test bloomFilterShouldCorrectlyEncodeComplexUnicodeCharacters() in QueryTest.java

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -1220,109 +1220,104 @@ public class QueryTest {
       testDocs.put(docId, map("foo", 42));
     }
 
-    // Each iteration of the "while" loop below runs a single iteration of the test. The test will
-    // be run multiple times only if a bloom filter false positive occurs.
-    int attemptNumber = 0;
-    while (true) {
-      attemptNumber++;
+    // Create the documents whose names contain complex Unicode characters in a new collection.
+    CollectionReference collection = testCollectionWithDocs(testDocs);
 
-      // Create the documents whose names contain complex Unicode characters in a new collection.
-      CollectionReference collection = testCollectionWithDocs(testDocs);
-
-      // Run a query to populate the local cache with documents that have names with complex Unicode
-      // characters.
-      List<DocumentReference> createdDocuments = new ArrayList<>();
-      {
-        QuerySnapshot querySnapshot1 = waitFor(collection.get());
-        for (DocumentSnapshot documentSnapshot : querySnapshot1.getDocuments()) {
-          createdDocuments.add(documentSnapshot.getReference());
-        }
-        HashSet<String> createdDocumentIds = new HashSet<>();
-        for (DocumentSnapshot documentSnapshot : querySnapshot1.getDocuments()) {
-          createdDocumentIds.add(documentSnapshot.getId());
-        }
-        assertWithMessage("createdDocumentIds")
-            .that(createdDocumentIds)
-            .containsExactlyElementsIn(testDocIds);
+    // Run a query to populate the local cache with documents that have names with complex Unicode
+    // characters.
+    List<DocumentReference> createdDocuments = new ArrayList<>();
+    {
+      QuerySnapshot querySnapshot1 = waitFor(collection.get());
+      for (DocumentSnapshot documentSnapshot : querySnapshot1.getDocuments()) {
+        createdDocuments.add(documentSnapshot.getReference());
       }
-
-      // Delete one of the documents so that the next call to getDocs() will
-      // experience an existence filter mismatch. Do this deletion in a
-      // transaction, rather than using deleteDoc(), to avoid affecting the
-      // local cache.
-      waitFor(
-          collection
-              .getFirestore()
-              .runTransaction(
-                  transaction -> {
-                    DocumentReference documentToDelete = collection.document("DocumentToDelete");
-                    DocumentSnapshot documentToDeleteSnapshot = transaction.get(documentToDelete);
-                    assertWithMessage("documentToDeleteSnapshot.exists()")
-                        .that(documentToDeleteSnapshot.exists())
-                        .isTrue();
-                    transaction.delete(documentToDelete);
-                    return null;
-                  }));
-
-      // Wait for 10 seconds, during which Watch will stop tracking the query and will send an
-      // existence filter rather than "delete" events when the query is resumed.
-      Thread.sleep(10000);
-
-      // Resume the query and save the resulting snapshot for verification. Use some internal
-      // testing hooks to "capture" the existence filter mismatches.
-      AtomicReference<QuerySnapshot> querySnapshot2Ref = new AtomicReference<>();
-      ArrayList<ExistenceFilterMismatchInfo> existenceFilterMismatches =
-          captureExistenceFilterMismatches(
-              () -> {
-                QuerySnapshot querySnapshot = waitFor(collection.get());
-                querySnapshot2Ref.set(querySnapshot);
-              });
-      QuerySnapshot querySnapshot2 = querySnapshot2Ref.get();
-
-      // Verify that the snapshot from the resumed query contains the expected documents; that is,
-      // that it contains the documents whose names contain complex Unicode characters and _not_ the
-      // document that was deleted.
-      HashSet<String> querySnapshot2DocumentIds = new HashSet<>();
-      for (DocumentSnapshot documentSnapshot : querySnapshot2.getDocuments()) {
-        querySnapshot2DocumentIds.add(documentSnapshot.getId());
+      HashSet<String> createdDocumentIds = new HashSet<>();
+      for (DocumentSnapshot documentSnapshot : querySnapshot1.getDocuments()) {
+        createdDocumentIds.add(documentSnapshot.getId());
       }
-      HashSet<String> querySnapshot2ExpectedDocumentIds = new HashSet<>(testDocIds);
-      querySnapshot2ExpectedDocumentIds.remove("DocumentToDelete");
-      assertWithMessage("querySnapshot2DocumentIds")
-          .that(querySnapshot2DocumentIds)
-          .containsExactlyElementsIn(querySnapshot2ExpectedDocumentIds);
+      assertWithMessage("createdDocumentIds")
+          .that(createdDocumentIds)
+          .containsExactlyElementsIn(testDocIds);
+    }
 
-      // Verify that Watch sent an existence filter with the correct counts.
-      assertWithMessage("Watch should have sent exactly 1 existence filter")
-          .that(existenceFilterMismatches)
-          .hasSize(1);
-      ExistenceFilterMismatchInfo existenceFilterMismatchInfo = existenceFilterMismatches.get(0);
-      assertWithMessage("localCacheCount")
-          .that(existenceFilterMismatchInfo.localCacheCount())
-          .isEqualTo(testDocIds.size());
-      assertWithMessage("existenceFilterCount")
-          .that(existenceFilterMismatchInfo.existenceFilterCount())
-          .isEqualTo(testDocIds.size() - 1);
+    // Delete one of the documents so that the next call to getDocs() will experience an existence
+    // filter mismatch. Do this deletion in a transaction, rather than using deleteDoc(), to avoid
+    // affecting the local cache.
+    DocumentReference documentToDelete = collection.document("DocumentToDelete");
+    waitFor(
+        collection
+            .getFirestore()
+            .runTransaction(
+                transaction -> {
+                  DocumentSnapshot documentToDeleteSnapshot = transaction.get(documentToDelete);
+                  assertWithMessage("documentToDeleteSnapshot.exists()")
+                      .that(documentToDeleteSnapshot.exists())
+                      .isTrue();
+                  transaction.delete(documentToDelete);
+                  return null;
+                }));
 
-      // Verify that Watch sent a valid bloom filter.
-      ExistenceFilterBloomFilterInfo bloomFilter = existenceFilterMismatchInfo.bloomFilter();
-      assertWithMessage("The bloom filter specified in the existence filter")
-          .that(bloomFilter)
-          .isNotNull();
+    // Wait for 10 seconds, during which Watch will stop tracking the query and will send an
+    // existence filter rather than "delete" events when the query is resumed.
+    Thread.sleep(10000);
 
-      // Verify that the bloom filter was successfully used to avert a full requery. If a false
-      // positive occurred, which is statistically rare, but technically possible, then retry the
-      // entire test.
-      if (attemptNumber == 1 && !bloomFilter.applied()) {
-        continue;
-      }
+    // Resume the query and save the resulting snapshot for verification. Use some internal testing
+    // hooks to "capture" the existence filter mismatches.
+    AtomicReference<QuerySnapshot> querySnapshot2Ref = new AtomicReference<>();
+    ArrayList<ExistenceFilterMismatchInfo> existenceFilterMismatches =
+        captureExistenceFilterMismatches(
+            () -> {
+              QuerySnapshot querySnapshot = waitFor(collection.get());
+              querySnapshot2Ref.set(querySnapshot);
+            });
+    QuerySnapshot querySnapshot2 = querySnapshot2Ref.get();
 
-      assertWithMessage("bloom filter successfully applied with attemptNumber=" + attemptNumber)
-          .that(bloomFilter.applied())
+    // Verify that the snapshot from the resumed query contains the expected documents; that is,
+    // that it contains the documents whose names contain complex Unicode characters and _not_ the
+    // document that was deleted.
+    HashSet<String> querySnapshot2DocumentIds = new HashSet<>();
+    for (DocumentSnapshot documentSnapshot : querySnapshot2.getDocuments()) {
+      querySnapshot2DocumentIds.add(documentSnapshot.getId());
+    }
+    HashSet<String> querySnapshot2ExpectedDocumentIds = new HashSet<>(testDocIds);
+    querySnapshot2ExpectedDocumentIds.remove("DocumentToDelete");
+    assertWithMessage("querySnapshot2DocumentIds")
+        .that(querySnapshot2DocumentIds)
+        .containsExactlyElementsIn(querySnapshot2ExpectedDocumentIds);
+
+    // Verify that Watch sent an existence filter with the correct counts.
+    assertWithMessage("Watch should have sent exactly 1 existence filter")
+        .that(existenceFilterMismatches)
+        .hasSize(1);
+    ExistenceFilterMismatchInfo existenceFilterMismatchInfo = existenceFilterMismatches.get(0);
+    assertWithMessage("localCacheCount")
+        .that(existenceFilterMismatchInfo.localCacheCount())
+        .isEqualTo(testDocIds.size());
+    assertWithMessage("existenceFilterCount")
+        .that(existenceFilterMismatchInfo.existenceFilterCount())
+        .isEqualTo(testDocIds.size() - 1);
+
+    // Verify that Watch sent a valid bloom filter.
+    ExistenceFilterBloomFilterInfo bloomFilter = existenceFilterMismatchInfo.bloomFilter();
+    assertWithMessage("The bloom filter specified in the existence filter")
+        .that(bloomFilter)
+        .isNotNull();
+
+    // The bloom filter application should statistically be successful almost every time; the _only_
+    // time when it would _not_ be successful is if there is a false positive when testing for
+    // 'DocumentToDelete' in the bloom filter. So verify that the bloom filter application is
+    // successful, unless there was a false positive.
+    boolean isFalsePositive = bloomFilter.mightContain(documentToDelete);
+    assertWithMessage("bloomFilter.applied()")
+        .that(bloomFilter.applied())
+        .isEqualTo(!isFalsePositive);
+
+    // Verify that the bloom filter contains the document paths with complex Unicode characters.
+    for (DocumentSnapshot documentSnapshot : querySnapshot2.getDocuments()) {
+      DocumentReference documentReference = documentSnapshot.getReference();
+      assertWithMessage("bloomFilter.mightContain() for " + documentReference.getPath())
+          .that(bloomFilter.mightContain(documentReference))
           .isTrue();
-
-      // Break out of the test loop now that the test passes.
-      break;
     }
   }
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/BloomFilter.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/BloomFilter.java
@@ -16,7 +16,6 @@ package com.google.firebase.firestore.remote;
 
 import android.util.Base64;
 import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -93,7 +92,6 @@ public final class BloomFilter {
     }
   }
 
-  @VisibleForTesting
   int getBitCount() {
     return this.bitCount;
   }

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/TestingHooks.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/TestingHooks.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.auto.value.AutoValue;
 import com.google.firebase.firestore.ListenerRegistration;
+import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firestore.v1.BloomFilter;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
@@ -128,9 +129,11 @@ final class TestingHooks {
     static ExistenceFilterMismatchInfo create(
         int localCacheCount,
         int existenceFilterCount,
+        String projectId,
+        String databaseId,
         @Nullable ExistenceFilterBloomFilterInfo bloomFilter) {
       return new AutoValue_TestingHooks_ExistenceFilterMismatchInfo(
-          localCacheCount, existenceFilterCount, bloomFilter);
+          localCacheCount, existenceFilterCount, projectId, databaseId, bloomFilter);
     }
 
     /** Returns the number of documents that matched the query in the local cache. */
@@ -141,6 +144,12 @@ final class TestingHooks {
      * ExistenceFilter message's `count` field.
      */
     abstract int existenceFilterCount();
+
+    /** The projectId used when checking documents for membership in the bloom filter. */
+    abstract String projectId();
+
+    /** The databaseId used when checking documents for membership in the bloom filter. */
+    abstract String databaseId();
 
     /**
      * Returns information about the bloom filter provided by Watch in the ExistenceFilter message's
@@ -155,11 +164,17 @@ final class TestingHooks {
      * with the values taken from the given arguments.
      */
     static ExistenceFilterMismatchInfo from(
-        boolean bloomFilterApplied, int localCacheCount, ExistenceFilter existenceFilter) {
+        int localCacheCount,
+        ExistenceFilter existenceFilter,
+        DatabaseId databaseId,
+        @Nullable com.google.firebase.firestore.remote.BloomFilter bloomFilter,
+        boolean bloomFilterApplied) {
       return create(
           localCacheCount,
           existenceFilter.getCount(),
-          ExistenceFilterBloomFilterInfo.from(bloomFilterApplied, existenceFilter));
+          databaseId.getProjectId(),
+          databaseId.getDatabaseId(),
+          ExistenceFilterBloomFilterInfo.from(bloomFilter, bloomFilterApplied, existenceFilter));
     }
   }
 
@@ -167,10 +182,18 @@ final class TestingHooks {
   abstract static class ExistenceFilterBloomFilterInfo {
 
     static ExistenceFilterBloomFilterInfo create(
-        boolean applied, int hashCount, int bitmapLength, int padding) {
+        @Nullable com.google.firebase.firestore.remote.BloomFilter bloomFilter,
+        boolean applied,
+        int hashCount,
+        int bitmapLength,
+        int padding) {
       return new AutoValue_TestingHooks_ExistenceFilterBloomFilterInfo(
-          applied, hashCount, bitmapLength, padding);
+          bloomFilter, applied, hashCount, bitmapLength, padding);
     }
+
+    /** The BloomFilter created from the existence filter; may be null if creating it failed. */
+    @Nullable
+    abstract com.google.firebase.firestore.remote.BloomFilter bloomFilter();
 
     /**
      * Returns whether a full requery was averted by using the bloom filter. If false, then
@@ -188,13 +211,17 @@ final class TestingHooks {
     /** Returns the number of bits of padding in the last byte of the bloom filter. */
     abstract int padding();
 
+    @Nullable
     static ExistenceFilterBloomFilterInfo from(
-        boolean bloomFilterApplied, ExistenceFilter existenceFilter) {
+        @Nullable com.google.firebase.firestore.remote.BloomFilter bloomFilter,
+        boolean bloomFilterApplied,
+        ExistenceFilter existenceFilter) {
       BloomFilter unchangedNames = existenceFilter.getUnchangedNames();
       if (unchangedNames == null) {
         return null;
       }
       return create(
+          bloomFilter,
           bloomFilterApplied,
           unchangedNames.getHashCount(),
           unchangedNames.getBits().getBitmap().size(),

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/WatchChangeAggregator.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/WatchChangeAggregator.java
@@ -216,7 +216,11 @@ public class WatchChangeAggregator {
         if (currentSize != expectedCount) {
 
           // Apply bloom filter to identify and mark removed documents.
-          BloomFilterApplicationStatus status = this.applyBloomFilter(watchChange, currentSize);
+          BloomFilter bloomFilter = this.parseBloomFilter(watchChange);
+          BloomFilterApplicationStatus status =
+              bloomFilter == null
+                  ? BloomFilterApplicationStatus.SKIPPED
+                  : this.applyBloomFilter(bloomFilter, watchChange, currentSize);
 
           if (status != BloomFilterApplicationStatus.SUCCESS) {
             // If bloom filter application fails, we reset the mapping and
@@ -234,28 +238,27 @@ public class WatchChangeAggregator {
           TestingHooks.getInstance()
               .notifyOnExistenceFilterMismatch(
                   TestingHooks.ExistenceFilterMismatchInfo.from(
-                      status == BloomFilterApplicationStatus.SUCCESS,
                       currentSize,
-                      watchChange.getExistenceFilter()));
+                      watchChange.getExistenceFilter(),
+                      targetMetadataProvider.getDatabaseId(),
+                      bloomFilter,
+                      /*bloomFilterApplied=*/ status == BloomFilterApplicationStatus.SUCCESS));
         }
       }
     }
   }
 
-  /** Apply bloom filter to remove the deleted documents, and return the application status. */
-  private BloomFilterApplicationStatus applyBloomFilter(
-      ExistenceFilterWatchChange watchChange, int currentCount) {
-    int expectedCount = watchChange.getExistenceFilter().getCount();
+  /** Parse the bloom filter from the "unchanged_names" field of an existence filter. */
+  @Nullable
+  private BloomFilter parseBloomFilter(ExistenceFilterWatchChange watchChange) {
     com.google.firestore.v1.BloomFilter unchangedNames =
         watchChange.getExistenceFilter().getUnchangedNames();
-
     if (unchangedNames == null || !unchangedNames.hasBits()) {
-      return BloomFilterApplicationStatus.SKIPPED;
+      return null;
     }
 
     ByteString bitmap = unchangedNames.getBits().getBitmap();
     BloomFilter bloomFilter;
-
     try {
       bloomFilter =
           BloomFilter.create(
@@ -266,20 +269,26 @@ public class WatchChangeAggregator {
           "Applying bloom filter failed: ("
               + e.getMessage()
               + "); ignoring the bloom filter and falling back to full re-query.");
-      return BloomFilterApplicationStatus.SKIPPED;
+      return null;
     }
 
     if (bloomFilter.getBitCount() == 0) {
-      return BloomFilterApplicationStatus.SKIPPED;
+      return null;
     }
+
+    return bloomFilter;
+  }
+
+  /** Apply bloom filter to remove the deleted documents, and return the application status. */
+  private BloomFilterApplicationStatus applyBloomFilter(
+      BloomFilter bloomFilter, ExistenceFilterWatchChange watchChange, int currentCount) {
+    int expectedCount = watchChange.getExistenceFilter().getCount();
 
     int removedDocumentCount = this.filterRemovedDocuments(bloomFilter, watchChange.getTargetId());
 
-    if (expectedCount != (currentCount - removedDocumentCount)) {
-      return BloomFilterApplicationStatus.FALSE_POSITIVE;
-    }
-
-    return BloomFilterApplicationStatus.SUCCESS;
+    return (expectedCount == (currentCount - removedDocumentCount))
+        ? BloomFilterApplicationStatus.SUCCESS
+        : BloomFilterApplicationStatus.FALSE_POSITIVE;
   }
 
   /**


### PR DESCRIPTION
Modify the test `bloomFilterShouldCorrectlyEncodeComplexUnicodeCharacters()` in `QueryTest.java`, that was added by the recent PR https://github.com/firebase/firebase-android-sdk/pull/5135, to directly check the bloom filter for containing the document paths with complex Unicode characters. Previously, it was indirectly checking this via the other properties of the existence filter. As a result, the "retry" logic was removed, since it doesn't matter if there is a false positive.

To add the ability to directly interrogate the bloom filter, the testing hooks needed to be augmented to expose the  `BloomFilter`, projectId, and databaseId.

This is a port of https://github.com/firebase/firebase-js-sdk/pull/7413