### PR TITLE
Update target to SDK 33

### DIFF
--- a/sdkProperties.gradle
+++ b/sdkProperties.gradle
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 ext {
-    targetSdkVersion = 29
+    targetSdkVersion = 33
     minSdkVersion = 14
 }


### PR DESCRIPTION
We need to update AXT core and AndroidX ext JUnit version to ensure using proper AXT dependency that export necessary Activities for higher target SDKs.

This CL also disables lint for some sub-projets and anyone can remove it and fix warnings.