### PR TITLE
Connect PostReleasePlugin with PublishingPlugin

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.kt
@@ -54,7 +54,6 @@ class FirebaseLibraryPlugin : BaseFirebaseLibraryPlugin() {
 
     project.apply<DackkaPlugin>()
     project.apply<GitSubmodulePlugin>()
-    project.apply<PostReleasePlugin>()
     project.tasks.getByName("preBuild").dependsOn("updateGitSubmodules")
   }
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GradleUtils.kt
@@ -58,6 +58,38 @@ fun Provider<File>.childFile(path: String) = map { File("${it.path}/$path") }
 fun File.childFile(childPath: String) = File("$path/$childPath")
 
 /**
+ * Rewrites the lines of a file.
+ *
+ * The lines of the file are first read and then transformed by the provided `block` function. The
+ * transformed lines are then joined together with a newline character and written back to the file.
+ *
+ * If the `terminateWithNewline` parameter is set to `false`, the file will not be terminated with a
+ * newline character.
+ *
+ * @param terminateWithNewline Whether to terminate the file with a newline character. Defaults to
+ * `true`.
+ * @param block A function that takes a string as input and returns a new string. This function is
+ * used to transform the lines of the file before they are rewritten.
+ *
+ * ```
+ * val file = File("my-file.txt")
+ *
+ * // Rewrite the lines of the file, replacing all spaces with tabs.
+ * file.rewriteLines { it.replace(" ", "\t") }
+ *
+ * // Rewrite the lines of the file, capitalizing the first letter of each word.
+ * file.rewriteLines { it.capitalizeWords() }
+ * ```
+ *
+ * @see [readLines]
+ * @see [writeText]
+ */
+fun File.rewriteLines(terminateWithNewline: Boolean = true, block: (String) -> String) {
+  val newLines = readLines().map(block)
+  writeText(newLines.joinToString("\n").let { if (terminateWithNewline) it + "\n" else it })
+}
+
+/**
  * Provides a temporary file for use during the task.
  *
  * Creates a file under the [temporaryDir][DefaultTask.getTemporaryDir] of the task, and should be

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -30,6 +30,7 @@ import org.gradle.api.Project
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.bundling.Zip
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 
@@ -60,6 +61,9 @@ import org.gradle.kotlin.dsl.register
  * - [PUBLISH_RELEASING_LIBS_TO_LOCAL_TASK][registerPublishReleasingLibrariesToMavenLocalTask]
  * - [SEMVER_CHECK_TASK][registerSemverCheckForReleaseTask]
  * - [PUBLISH_ALL_TO_BUILD_TASK][registerPublishAllToBuildDir]
+ *
+ * Additionally, this plugin registers the [PostReleasePlugin] via [registerPostReleasePlugin] for
+ * each releasing library.
  */
 abstract class PublishingPlugin : Plugin<Project> {
   override fun apply(project: Project) {
@@ -91,6 +95,7 @@ abstract class PublishingPlugin : Plugin<Project> {
       registerPublishReleasingLibrariesToMavenLocalTask(project, releasingProjects)
       registerSemverCheckForReleaseTask(project, releasingProjects)
       registerPublishAllToBuildDir(project, allFirebaseLibraries)
+      registerPostReleasePlugin(releasingProjects)
 
       val buildMavenZip =
         project.tasks.register<Zip>(BUILD_MAVEN_ZIP_TASK) {
@@ -444,6 +449,13 @@ abstract class PublishingPlugin : Plugin<Project> {
       }
     }
 
+  /** Registers the [PostReleasePlugin] to each releaing project. */
+  private fun registerPostReleasePlugin(releasingProjects: List<Project>) {
+    for (releasingProject in releasingProjects) {
+      releasingProject.apply<PostReleasePlugin>()
+    }
+  }
+
   companion object {
     const val RELEASE_CONFIG_FILE = "release.json"
     const val RELEASE_REPORT_MD_FILE = "release_report.md"
@@ -476,7 +488,6 @@ abstract class PublishingPlugin : Plugin<Project> {
  *
  * @property releasingLibraries A list of libraries that should be released
  * @property name The name of the release (such as `m123`)
- *
  * @see computeReleaseMetadata
  */
 data class ReleaseMetadata(

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VersionBumpTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VersionBumpTask.kt
@@ -49,10 +49,8 @@ abstract class VersionBumpTask : DefaultTask() {
 
   @TaskAction
   fun build() {
-    with(versionFile.get()) {
-      readLines()
-        .map { it.takeUnless { it.startsWith("version=") } ?: "version=${newVersion.get()}" }
-        .also { writeText(it.joinToString("\n") + '\n') }
+    versionFile.get().rewriteLines {
+      if (it.startsWith("version=")) "version=${newVersion.get()}" else it
     }
   }
 


### PR DESCRIPTION
Per [b/274794264](https://b.corp.google.com/issues/274794264),

This connects the `PostReleasePlugin` plugin with releasing libraries, such that tasks like `VersionBumpTask` can be executed from the root directory- while only applying to releasing libraries.