### PR TITLE
Bump AXT dependencies to 1.5.0

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
+++ b/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-appcheck-interop:17.0.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation 'androidx.test:core:1.2.0'
+    implementation "androidx.test:core:$androidxTestCoreVersion"
 
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
@@ -61,13 +61,13 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation project(':appcheck:firebase-appcheck-safetynet')
 
     androidTestImplementation project(':firebase-storage')
     androidTestImplementation 'junit:junit:4.13-beta-2'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
 }

--- a/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
+++ b/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
@@ -57,6 +57,6 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'androidx.test:rules:1.2.0'
 }

--- a/appcheck/firebase-appcheck-interop/firebase-appcheck-interop.gradle
+++ b/appcheck/firebase-appcheck-interop/firebase-appcheck-interop.gradle
@@ -50,6 +50,6 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'androidx.test:rules:1.2.0'
 }

--- a/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
+++ b/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
@@ -58,5 +58,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.4.6'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/appcheck/firebase-appcheck-safetynet/firebase-appcheck-safetynet.gradle
+++ b/appcheck/firebase-appcheck-safetynet/firebase-appcheck-safetynet.gradle
@@ -57,6 +57,6 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'androidx.test:rules:1.2.0'
 }

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -59,12 +59,12 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'androidx.test:rules:1.2.0'
 
     androidTestImplementation project(':appcheck:firebase-appcheck')
     androidTestImplementation project(':integ-testing')
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'junit:junit:4.12'

--- a/appcheck/firebase-appcheck/ktx/ktx.gradle
+++ b/appcheck/firebase-appcheck/ktx/ktx.gradle
@@ -69,5 +69,5 @@ dependencies {
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:core:1.2.0'
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ ext {
     googleTruthVersion = libs.versions.truth.get()
     grpcVersion = libs.versions.grpc.get()
     robolectricVersion = libs.versions.robolectric.get()
+    androidxTestCoreVersion = libs.versions.androidx.test.core.get()
+    androidxTestJUnitVersion = libs.versions.androidx.test.junit.get()
     protocVersion = libs.versions.protoc.get()
     javaliteVersion = libs.versions.javalite.get()
     protobufJavaUtilVersion = libs.versions.protobufjavautil.get()

--- a/encoders/firebase-decoders-json/firebase-decoders-json.gradle
+++ b/encoders/firebase-decoders-json/firebase-decoders-json.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.13-rc-1'
     testImplementation "com.google.truth:truth:$googleTruthVersion"

--- a/encoders/firebase-encoders-json/firebase-encoders-json.gradle
+++ b/encoders/firebase-encoders-json/firebase-encoders-json.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-encoders:17.0.0'
 
     testImplementation 'androidx.test:runner:1.3.0'
-    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.13'
     testImplementation "com.google.truth:truth:1.0.1"

--- a/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
+++ b/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-encoders-json:18.0.0'
 
     testImplementation 'androidx.test:runner:1.3.0'
-    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.13'
     testImplementation 'com.google.truth:truth:1.0.1'

--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -49,7 +49,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'org.mockito:mockito-inline:3.4.0'
     testImplementation project(':firebase-appdistribution-api')
     androidTestImplementation "org.mockito:mockito-android:3.4.0"

--- a/firebase-appdistribution-api/ktx/ktx.gradle
+++ b/firebase-appdistribution-api/ktx/ktx.gradle
@@ -68,5 +68,5 @@ dependencies {
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:core:1.2.0'
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -65,7 +65,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-inline:3.4.0'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
 
@@ -76,7 +76,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
 
     androidTestImplementation project(':integ-testing')
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'junit:junit:4.12'

--- a/firebase-config/firebase-config.gradle
+++ b/firebase-config/firebase-config.gradle
@@ -74,7 +74,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "org.skyscreamer:jsonassert:1.5.0"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'

--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -59,5 +59,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -116,7 +116,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.4.3'
 
     androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test:core:1.4.0'
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
     androidTestImplementation 'org.mockito:mockito-core:3.4.3'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -80,7 +80,7 @@ dependencies {
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 
     testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.3'
@@ -88,8 +88,8 @@ dependencies {
 
     androidTestImplementation 'com.google.firebase:firebase-encoders-json:18.0.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test:core:1.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'org.mockito:mockito-core:3.4.3'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -57,5 +57,5 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -74,7 +74,7 @@ dependencies {
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'androidx.test:core:1.3.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'com.android.support.test:runner:1.0.2'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/firebase-dynamic-links/ktx/ktx.gradle
+++ b/firebase-dynamic-links/ktx/ktx.gradle
@@ -56,5 +56,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -145,7 +145,7 @@ dependencies {
 
     testImplementation project(':firebase-firestore')
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
@@ -163,7 +163,7 @@ dependencies {
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
 }
 
 gradle.projectsEvaluated {

--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -68,5 +68,5 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -101,11 +101,11 @@ dependencies {
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.25.0"
     testImplementation "com.google.truth:truth:1.0"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'com.google.guava:guava:30.1-android'
 
     androidTestImplementation project(':integ-testing')
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation "androidx.annotation:annotation:1.0.0"
     androidTestImplementation "org.mockito:mockito-core:2.25.0"
     androidTestImplementation "com.google.dexmaker:dexmaker:1.2"

--- a/firebase-inappmessaging-display/ktx/ktx.gradle
+++ b/firebase-inappmessaging-display/ktx/ktx.gradle
@@ -60,5 +60,5 @@ dependencies {
     testImplementation ("com.google.firebase:firebase-analytics:17.0.0") {
         exclude group: "com.google.firebase", module: "firebase-common"
     }
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -138,17 +138,17 @@ dependencies {
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test:runner:1.3.0'
-    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation ("org.robolectric:robolectric:$robolectricVersion") {
         exclude group: 'com.google.protobuf', module: 'protobuf-java'
     }
     testImplementation "io.grpc:grpc-testing:$grpcVersion"
     testImplementation 'com.google.guava:guava:30.1-android'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation project(":integ-testing")
 
     androidTestImplementation project(':integ-testing')
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation "androidx.annotation:annotation:1.0.0"
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/firebase-inappmessaging/ktx/ktx.gradle
+++ b/firebase-inappmessaging/ktx/ktx.gradle
@@ -55,5 +55,5 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -56,7 +56,7 @@ dependencies {
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"
 
     testImplementation project(':integ-testing')
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
@@ -64,7 +64,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:2.25.0'
 
     androidTestImplementation project(':integ-testing')
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'junit:junit:4.12'

--- a/firebase-installations/ktx/ktx.gradle
+++ b/firebase-installations/ktx/ktx.gradle
@@ -53,5 +53,5 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.13'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -105,7 +105,7 @@ dependencies {
 
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'com.google.android.gms:play-services-cloud-messaging:17.0.1'
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'androidx.test:runner:1.2.0'
@@ -131,7 +131,7 @@ dependencies {
     testImplementation 'androidx.core:core:1.6.0'
 
     androidTestImplementation project(':integ-testing')
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'junit:junit:4.12'

--- a/firebase-messaging/ktx/ktx.gradle
+++ b/firebase-messaging/ktx/ktx.gradle
@@ -53,5 +53,5 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
+++ b/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
@@ -91,7 +91,7 @@ dependencies {
     annotationProcessor project(":encoders:firebase-encoders-processor")
 
     testImplementation(project(":integ-testing"))
-    testImplementation 'androidx.test:core:1.3.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'com.github.tomakehurst:wiremock-standalone:2.26.3'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
@@ -106,7 +106,7 @@ dependencies {
     androidTestImplementation 'junit:junit:4.13.1'
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
 }
 

--- a/firebase-ml-modeldownloader/ktx/ktx.gradle
+++ b/firebase-ml-modeldownloader/ktx/ktx.gradle
@@ -54,5 +54,5 @@ dependencies {
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:3.6.0'
     testImplementation 'androidx.test:runner:1.5.1'
-    testImplementation 'androidx.test.ext:junit:1.1.4'
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
 }

--- a/firebase-ml-modeldownloader/ml-data-collection-tests/ml-data-collection-tests.gradle
+++ b/firebase-ml-modeldownloader/ml-data-collection-tests/ml-data-collection-tests.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-common:20.3.1'
     implementation project(':firebase-ml-modeldownloader')
     testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"

--- a/firebase-perf/e2e-app/e2e-app.gradle
+++ b/firebase-perf/e2e-app/e2e-app.gradle
@@ -102,8 +102,8 @@ dependencies {
 
     // Integration Test Deps
     androidTestImplementation 'junit:junit:4.13.1'
-    androidTestImplementation "androidx.test.ext:junit:1.1.2"
-    androidTestImplementation "androidx.test:core:1.3.0"
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -127,6 +127,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'androidx.test:rules:1.2.0'
 }

--- a/firebase-perf/ktx/ktx.gradle
+++ b/firebase-perf/ktx/ktx.gradle
@@ -56,5 +56,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/firebase-segmentation/firebase-segmentation.gradle
+++ b/firebase-segmentation/firebase-segmentation.gradle
@@ -51,7 +51,7 @@ dependencies {
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
 
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -102,7 +102,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation project(':appcheck:firebase-appcheck')
 }
 

--- a/firebase-storage/ktx/ktx.gradle
+++ b/firebase-storage/ktx/ktx.gradle
@@ -74,5 +74,5 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ truth = "1.1.2"
 protobufjavautil = "3.21.11"
 kotest = "5.5.5"
 quickcheck = "0.6"
+androidx-test-core="1.5.0"
+androidx-test-junit="1.1.5"
 
 [libraries]
 android-lint = { module = "com.android.tools.lint:lint", version.ref = "android-lint" }
@@ -42,9 +44,9 @@ playservices-basement = { module = "com.google.android.gms:play-services-basemen
 playservices-tasks = { module = "com.google.android.gms:play-services-tasks", version = "18.0.2" }
 
 # Test libs
-androidx-test-core = { module = "androidx.test:core", version = "1.5.0" }
-androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.1.4" }
-androidx-test-rules = { module = "androidx.test:rules", version = "1.5.0" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
+androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-core" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.5.2" }
 junit = { module = "junit:junit", version = "4.13.2" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }

--- a/health-metrics/benchmark/template/app/build.gradle.mustache
+++ b/health-metrics/benchmark/template/app/build.gradle.mustache
@@ -71,6 +71,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/health-metrics/benchmark/template/macrobenchmark/build.gradle
+++ b/health-metrics/benchmark/template/macrobenchmark/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.test.ext:junit:1.1.3'
+    implementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     implementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     implementation 'androidx.benchmark:benchmark-macro-junit4:1.1.0'

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   implementation "androidx.test:runner:1.4.0"
   implementation "com.google.truth:truth:1.0.1"
   implementation "junit:junit:4.13.2"
-  implementation "androidx.test:core:1.4.0"
+  implementation "androidx.test:core:$androidxTestCoreVersion"
 
   // Common utilities (instrumentation side)
   androidTestImplementation "androidx.test:runner:1.4.0"

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -65,7 +65,7 @@ dependencies {
     annotationProcessor project(':encoders:firebase-encoders-processor')
 
     testImplementation "com.google.protobuf:protobuf-java-util:$protobufJavaUtilVersion"
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
     testImplementation 'com.github.tomakehurst:wiremock:2.26.3'

--- a/transport/transport-runtime-testing/transport-runtime-testing.gradle
+++ b/transport/transport-runtime-testing/transport-runtime-testing.gradle
@@ -43,6 +43,6 @@ dependencies {
     androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test:rules:1.4.0'
 }

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -123,15 +123,15 @@ dependencies {
 
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'androidx.test:core:1.2.0'
-    testImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'org.mockito:mockito-core:2.25.0'
 
     androidTestImplementation 'junit:junit:4.13-beta-3'
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation 'org.mockito:mockito-android:2.25.0'


### PR DESCRIPTION
It is prepared for SDK 31+ to make test Activity exported. See https://github.com/firebase/firebase-android-sdk/pull/5150.