### PR TITLE
Use actual version for androidx.core.test inside smoke-tests

### DIFF
--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   implementation "androidx.test:runner:1.4.0"
   implementation "com.google.truth:truth:1.0.1"
   implementation "junit:junit:4.13.2"
-  implementation "androidx.test:core:$androidxTestCoreVersion"
+  implementation "androidx.test:core:1.5.0"
 
   // Common utilities (instrumentation side)
   androidTestImplementation "androidx.test:runner:1.4.0"


### PR DESCRIPTION
It doesn't import the main build file, thus cannot find the variable.