### PR TITLE
Mitigation for issue 5024

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettingsFetcher.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettingsFetcher.kt
@@ -46,12 +46,12 @@ internal class RemoteSettingsFetcher(
     onFailure: suspend (String) -> Unit
   ) =
     withContext(blockingDispatcher) {
-      val connection = settingsUrl().openConnection() as HttpsURLConnection
-      connection.requestMethod = "GET"
-      connection.setRequestProperty("Accept", "application/json")
-      headerOptions.forEach { connection.setRequestProperty(it.key, it.value) }
-
       try {
+        val connection = settingsUrl().openConnection() as HttpsURLConnection
+        connection.requestMethod = "GET"
+        connection.setRequestProperty("Accept", "application/json")
+        headerOptions.forEach { connection.setRequestProperty(it.key, it.value) }
+
         val responseCode = connection.responseCode
         if (responseCode == HttpsURLConnection.HTTP_OK) {
           val inputStream = connection.inputStream


### PR DESCRIPTION
The crashing in #5024, reveals that the stacktrace points to `RemoteSettingsFetcher$doConfigFetch`. The issue is due to the `openConnection()`.  I'm guessing that this is somewhat being triggered when the user has VPN or unstable internet connection. Including this inside the try catch should resolve the issue.

```
Fatal Exception: java.lang.SecurityException: Unknown calling package name 'xxx'.
       at android.os.Parcel.createExceptionOrNull(Parcel.java:3011)
       at android.os.Parcel.createException(Parcel.java:2995)
       at android.os.Parcel.readException(Parcel.java:2978)
       at android.os.Parcel.readException(Parcel.java:2920)
       at com.google.android.gms.common.internal.zzac.getService(zzac.java:31)
       at com.google.android.gms.common.internal.BaseGmsClient.getRemoteService(BaseGmsClient.java:109)
       at com.google.android.gms.common.internal.BaseGmsClient$LegacyClientCallbackAdapter.onReportServiceBinding(BaseGmsClient.java:109)
       at com.google.android.gms.common.internal.zzg.zzd(zzg.java:8)
       at com.google.android.gms.common.internal.zza.ʿʽʼˆˈˆ(zza.java:9)
       at com.google.android.gms.common.internal.zzc.zze(zzc.java:342)
       at com.google.android.gms.common.internal.zzb.handleMessage(zzb.java:342)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:210)
       at android.os.Looper.loop(Looper.java:299)
       at android.app.ActivityThread.main(ActivityThread.java:8247)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:559)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:954)

Firebase Blocking Thread #1:
       at java.net.SocketInputStream.socketRead0(SocketInputStream.java)
       at java.net.SocketInputStream.socketRead(SocketInputStream.java:118)
       at java.net.SocketInputStream.read(SocketInputStream.java:173)
       at java.net.SocketInputStream.read(SocketInputStream.java:143)
       at com.android.org.conscrypt.ConscryptEngineSocket$SSLInputStream.readFromSocket(ConscryptEngineSocket.java:945)
       at com.android.org.conscrypt.ConscryptEngineSocket$SSLInputStream.processDataFromSocket(ConscryptEngineSocket.java:909)
       at com.android.org.conscrypt.ConscryptEngineSocket$SSLInputStream.readUntilDataAvailable(ConscryptEngineSocket.java:824)
       at com.android.org.conscrypt.ConscryptEngineSocket$SSLInputStream.read(ConscryptEngineSocket.java:797)
       at com.android.okhttp.okio.Okio$2.read(Okio.java:138)
       at com.android.okhttp.okio.AsyncTimeout$2.read(AsyncTimeout.java:213)
       at com.android.okhttp.okio.RealBufferedSource.indexOf(RealBufferedSource.java:307)
       at com.android.okhttp.okio.RealBufferedSource.indexOf(RealBufferedSource.java:301)
       at com.android.okhttp.okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.java:197)
       at com.android.okhttp.internal.http.Http1xStream.readResponse(Http1xStream.java:188)
       at com.android.okhttp.internal.http.Http1xStream.readResponseHeaders(Http1xStream.java:129)
       at com.android.okhttp.internal.http.HttpEngine.readNetworkResponse(HttpEngine.java:750)
       at com.android.okhttp.internal.http.HttpEngine.readResponse(HttpEngine.java:622)
       at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:475)
       at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:411)
       at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:542)
       at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getResponseCode(DelegatingHttpsURLConnection.java:106)
       at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:30)
       at com.google.firebase.sessions.settings.RemoteSettingsFetcher$doConfigFetch$2.invokeSuspend(RemoteSettingsFetcher.java:200)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:8)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.java:100)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
       at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0(CustomThreadFactory.java:27)
       at java.lang.Thread.run(Thread.java:1012)
```