### PR TITLE
ci: Migrate set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,7 +31,7 @@ jobs:
       - id: changed-modules
         run: |
           git diff --name-only HEAD~1 | xargs printf -- '--changed-git-paths %s\n' | xargs ./gradlew writeChangedProjects --output-file-path=modules.json
-          echo ::set-output name=modules::$(cat modules.json)
+          echo modules=$(cat modules.json) >> $GITHUB_OUTPUT
 
   unit_tests:
     name: "Unit Tests"

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -35,7 +35,7 @@ jobs:
           # Query the git history for all gradle.properties files changed by this push.
           # Then, check the diff to see if any "latestReleasedVersion=" lines changed.
           if (git diff '${{ github.event.before }}' -- '**/gradle.properties' | grep -q '^[-+]latestReleasedVersion='); then
-            echo "::set-output name=released_version_changed::1"
+            echo "released_version_changed=1" >> $GITHUB_OUTPUT
           else
             echo "No change to latestReleasedVersion detected since ${{ github.event.before }}"
           fi


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/