### PR TITLE
Store rollouts state in cache

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
@@ -14,15 +14,19 @@
 
 package com.google.firebase.crashlytics.internal.metadata;
 
+import com.google.common.truth.Truth;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
 import com.google.firebase.crashlytics.internal.common.CrashlyticsBackgroundWorker;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.junit.Test;
 
 @SuppressWarnings("ResultOfMethodCallIgnored") // Convenient use of files.
 public class MetaDataStoreTest extends CrashlyticsTestCase {
@@ -42,6 +46,14 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
   private static final String UNICODE = "あいうえおかきくけ";
 
   private static final String ESCAPED = "\ttest\nvalue";
+
+  private static final List<RolloutAssignment> ROLLOUTS_STATE = new ArrayList<>();
+
+  static {
+    RolloutAssignment assignment =
+        RolloutAssignment.create("rollout_1", "my_feature", "false", "control", 1);
+    ROLLOUTS_STATE.add(assignment);
+  }
 
   private FileStore fileStore;
   private final CrashlyticsBackgroundWorker worker = new CrashlyticsBackgroundWorker(Runnable::run);
@@ -280,6 +292,14 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
   public void testReadKeys_noStoredData() {
     final Map<String, String> readKeys = storeUnderTest.readKeyData(SESSION_ID_1);
     assertEquals(0, readKeys.size());
+  }
+
+  @Test
+  public void testWriteReadRolloutState() throws Exception {
+    storeUnderTest.writeRolloutState(SESSION_ID_1, ROLLOUTS_STATE);
+    List<RolloutAssignment> readRolloutsState = storeUnderTest.readRolloutsState(SESSION_ID_1);
+
+    Truth.assertThat(readRolloutsState).isEqualTo(ROLLOUTS_STATE);
   }
 
   public static void assertEqualMaps(Map<String, String> expected, Map<String, String> actual) {

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/RolloutAssignmentListTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/RolloutAssignmentListTest.java
@@ -1,0 +1,137 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.metadata;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
+import com.google.firebase.encoders.DataEncoder;
+import com.google.firebase.encoders.json.JsonDataEncoderBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONException;
+import org.junit.Test;
+
+public class RolloutAssignmentListTest extends CrashlyticsTestCase {
+  private static final String ROLLOUTS_STATE_JSON_1 =
+      "[{"
+          + "\"rolloutId\":\"rollout_1\","
+          + "\"variantId\":\"control\","
+          + "\"parameterKey\":\"my_feature\","
+          + "\"parameterValue\":\"false\","
+          + "\"templateVersion\":1"
+          + "}]";
+
+  private static final String ROLLOUTS_STATE_JSON_2 =
+      "["
+          + "{"
+          + "\"rolloutId\":\"rollout_1\","
+          + "\"variantId\":\"control\","
+          + "\"parameterKey\":\"my_feature\","
+          + "\"parameterValue\":\"false\","
+          + "\"templateVersion\":1"
+          + "},"
+          + "{"
+          + "\"rollout_id\":\"rollout_2\""
+          + "\"variantId\":\"control\","
+          + "\"parameterKey\":\"color_feature\","
+          + "\"parameterValue\":\"blue\","
+          + "\"templateVersion\":2"
+          + "}]";
+
+  private static List<RolloutAssignment> ROLLOUTS_STATE_1;
+
+  static {
+    ROLLOUTS_STATE_1 = new ArrayList<>();
+    ROLLOUTS_STATE_1.add(
+        RolloutAssignment.create("rollout_1", "my_feature", "false", "control", 1));
+  }
+
+  private static List<RolloutAssignment> ROLLOUTS_STATE_2;
+
+  static {
+    ROLLOUTS_STATE_2 = new ArrayList<>();
+    ROLLOUTS_STATE_2.add(
+        RolloutAssignment.create("rollout_1", "my_feature", "false", "control", 1));
+    ROLLOUTS_STATE_2.add(
+        RolloutAssignment.create("rollout_2", "color_feature", "false", "control", 2));
+  }
+
+  private static final String ROLLOUT_ASSIGNMENT_JSON =
+      "{"
+          + "\"rolloutId\":\"rollout_1\","
+          + "\"variantId\":\"control\","
+          + "\"parameterKey\":\"my_feature\","
+          + "\"parameterValue\":\"false\","
+          + "\"templateVersion\":1"
+          + "}";
+
+  private static final int MAX_ENTRIES = 64;
+
+  private final RolloutAssignmentList rolloutAssignmentList =
+      new RolloutAssignmentList(MAX_ENTRIES);
+
+  @Test
+  public void testRollAssignmentInit_json() throws JSONException {
+    RolloutAssignment expected =
+        RolloutAssignment.create("rollout_1", "my_feature", "false", "control", 1);
+    RolloutAssignment rolloutAssignmentInitFromJson =
+        RolloutAssignment.create(ROLLOUT_ASSIGNMENT_JSON);
+
+    assertThat(rolloutAssignmentInitFromJson).isEqualTo(expected);
+  }
+
+  @Test
+  public void testRolloutAssignment_encodeJSON() {
+    RolloutAssignment rolloutAssignment =
+        RolloutAssignment.create("rollout_1", "my_feature", "false", "control", 1);
+    DataEncoder encoder =
+        new JsonDataEncoderBuilder().configureWith(AutoRolloutAssignmentEncoder.CONFIG).build();
+    String data = encoder.encode(rolloutAssignment);
+
+    assertThat(data).isNotEmpty();
+  }
+
+  @Test
+  public void testUpdateRolloutAssignmentList() throws Exception {
+    final List<String> changed = new ArrayList<String>();
+
+    rolloutAssignmentList.updateMapList(ROLLOUTS_STATE_1);
+
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                changed.add("changed");
+                rolloutAssignmentList.updateMapList(ROLLOUTS_STATE_2);
+              }
+            })
+        .start();
+
+    new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                List<RolloutAssignment> list = rolloutAssignmentList.getKeysMapList();
+                if (changed.isEmpty()) {
+                  assertThat(rolloutAssignmentList.getKeysMapList().size()).isEqualTo(1);
+                } else {
+                  assertThat(rolloutAssignmentList.getKeysMapList().size()).isEqualTo(2);
+                }
+              }
+            })
+        .start();
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/RolloutAssignment.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/RolloutAssignment.java
@@ -1,0 +1,64 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.metadata;
+
+import com.google.auto.value.AutoValue;
+import com.google.firebase.encoders.DataEncoder;
+import com.google.firebase.encoders.annotations.Encodable;
+import com.google.firebase.encoders.json.JsonDataEncoderBuilder;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * model used in user metadata context which make rollout assignment serialize, deserialize easier
+ */
+@Encodable
+@AutoValue
+public abstract class RolloutAssignment {
+
+  public abstract String getRolloutId();
+
+  public abstract String getParameterKey();
+
+  public abstract String getParameterValue();
+
+  public abstract String getVariantId();
+
+  public abstract long getTemplateVersion();
+
+  static RolloutAssignment create(
+      String rolloutId,
+      String parameterKey,
+      String parameterValue,
+      String variantId,
+      long templateVersion) {
+    return new AutoValue_RolloutAssignment(
+        rolloutId, parameterKey, parameterValue, variantId, templateVersion);
+  }
+
+  public static final DataEncoder ROLLOUT_ASSIGNMENT_JSON_ENCODER =
+      new JsonDataEncoderBuilder().configureWith(AutoRolloutAssignmentEncoder.CONFIG).build();
+
+  static RolloutAssignment create(String json) throws JSONException {
+    final JSONObject dataObj = new JSONObject(json);
+    String rolloutId = dataObj.getString("rolloutId");
+    String parameterKey = dataObj.getString("parameterKey");
+    String parameterValue = dataObj.getString("parameterValue");
+    String variantId = dataObj.getString("variantId");
+    long templateVersion = dataObj.getLong("templateVersion");
+    return new AutoValue_RolloutAssignment(
+        rolloutId, parameterKey, parameterValue, variantId, templateVersion);
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/RolloutAssignmentList.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/RolloutAssignmentList.java
@@ -1,0 +1,55 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal.metadata;
+
+import com.google.firebase.crashlytics.internal.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Handles RolloutsState for metadata */
+public class RolloutAssignmentList {
+  // Sync on list itself rather than the elements, this is because for Rollout
+  // we only care about the snapshot of the state for all assignments
+  private final List<RolloutAssignment> rolloutsState = new ArrayList<>();
+  private final int maxEntries;
+
+  // init
+  public RolloutAssignmentList(int maxEntries) {
+    this.maxEntries = maxEntries;
+  }
+
+  public synchronized List<RolloutAssignment> getKeysMapList() {
+    return Collections.unmodifiableList(new ArrayList<RolloutAssignment>(rolloutsState));
+  }
+
+  public synchronized boolean updateMapList(List<RolloutAssignment> newMapList) {
+    rolloutsState.clear();
+    int nOverLimit = 0;
+
+    if (newMapList.size() > maxEntries) {
+      Logger.getLogger()
+          .w(
+              "Ignored "
+                  + nOverLimit
+                  + " entries when adding rollout assignments. "
+                  + "Maximum allowable: "
+                  + maxEntries);
+      List<RolloutAssignment> maxAllowedNewMapList = newMapList.subList(0, maxEntries);
+      return rolloutsState.addAll(maxAllowedNewMapList);
+    }
+    return rolloutsState.addAll(newMapList);
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -35,6 +35,8 @@ public class UserMetadata {
   public static final String KEYDATA_FILENAME = "keys";
   public static final String INTERNAL_KEYDATA_FILENAME = "internal-keys";
 
+  public static final String ROLLOUTS_STATE_FILENAME = "rollouts-state";
+
   @VisibleForTesting public static final int MAX_ATTRIBUTES = 64;
   @VisibleForTesting public static final int MAX_ATTRIBUTE_SIZE = 1024;
   @VisibleForTesting public static final int MAX_INTERNAL_KEY_SIZE = 8192;


### PR DESCRIPTION
Create a `RolloutAssignment` model for storing the instance at UserMetadata in memory.
Implemented serialization and  de-serialization from json to data model and vice-versa (this is used for file read and write).

`RolloutAssignment` will not become a part of the proto in CrashlyticsReport because we might later port it to Interop SDK so both RC and Crash can leverage on.

#no-changelog