### PR TITLE
Fix NPE when no version name is set

### DIFF
--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* [fixed] Fixed NPE when no version code is set.
+* [fixed] Fixed NPE when no version name is set.
 
 # 1.0.0
 

--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Unreleased
 
+* [fixed] Fixed NPE when no version code is set.
+
+# 1.0.0
+
 * [feature] Initial Firebase sessions library.

--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-* [fixed] Fixed NPE when no version name is set.
+* [fixed] Fixed NPE when no version name is
+  set ([#5195](//github.com/firebase/firebase-android-sdk/issues/5195)).
 
 # 1.0.0
 

--- a/firebase-sessions/gradle.properties
+++ b/firebase-sessions/gradle.properties
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=1.0.0
+version=1.0.1
+latestReleasedVersion=1.0.0

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
@@ -16,7 +16,6 @@
 
 package com.google.firebase.sessions
 
-import android.content.pm.PackageInfo
 import android.os.Build
 import com.google.firebase.FirebaseApp
 import com.google.firebase.encoders.DataEncoder
@@ -76,19 +75,10 @@ internal object SessionEvents {
       androidAppInfo =
         AndroidApplicationInfo(
           packageName = packageName,
-          versionName = versionName(packageInfo) ?: buildVersion,
+          versionName = packageInfo.versionName ?: buildVersion,
           appBuildVersion = buildVersion,
           deviceManufacturer = Build.MANUFACTURER,
         )
     )
   }
-
-  private fun versionName(packageInfo: PackageInfo): String? =
-    try {
-      packageInfo.versionName
-    } catch (_: NullPointerException) {
-      // https://github.com/firebase/firebase-android-sdk/issues/5195#issuecomment-1651834306
-      // packageInfo.versionName has type String! but returns null when unset.
-      null
-    }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/LocalOverrideSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/LocalOverrideSettings.kt
@@ -18,32 +18,21 @@ package com.google.firebase.sessions.settings
 
 import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 internal class LocalOverrideSettings(context: Context) : SettingsProvider {
+  @Suppress("DEPRECATION") // TODO(mrober): Use ApplicationInfoFlags when target sdk set to 33
   private val metadata =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      context.packageManager
-        .getApplicationInfo(
-          context.packageName,
-          PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong()),
-        )
-        .metaData
-    } else {
-      @Suppress("DEPRECATION") // For older API levels.
-      context.packageManager
-        .getApplicationInfo(
-          context.packageName,
-          PackageManager.GET_META_DATA,
-        )
-        .metaData
-    }
-    // Default to an empty bundle, meaning no cached values.
-    ?: Bundle.EMPTY
+    context.packageManager
+      .getApplicationInfo(
+        context.packageName,
+        PackageManager.GET_META_DATA,
+      )
+      .metaData
+      ?: Bundle.EMPTY // Default to an empty bundle, meaning no cached values.
 
   override val sessionEnabled: Boolean?
     get() =

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/ApplicationInfoTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/ApplicationInfoTest.kt
@@ -21,6 +21,9 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.ktx.initialize
 import com.google.firebase.sessions.testing.FakeFirebaseApp
 import org.junit.After
 import org.junit.Test
@@ -45,6 +48,39 @@ class ApplicationInfoTest {
             packageName = ApplicationProvider.getApplicationContext<Context>().packageName,
             versionName = FakeFirebaseApp.MOCK_APP_VERSION,
             appBuildVersion = FakeFirebaseApp.MOCK_APP_BUILD_VERSION,
+            deviceManufacturer = Build.MANUFACTURER,
+          )
+        )
+      )
+  }
+
+  @Test
+  fun applicationInfo_missiongVersionCode_populatesInfoCorrectly() {
+    // Initialize Firebase with no version code set.
+    val firebaseApp =
+      Firebase.initialize(
+        ApplicationProvider.getApplicationContext(),
+        FirebaseOptions.Builder()
+          .setApplicationId(FakeFirebaseApp.MOCK_APP_ID)
+          .setApiKey(FakeFirebaseApp.MOCK_API_KEY)
+          .setProjectId(FakeFirebaseApp.MOCK_PROJECT_ID)
+          .build()
+      )
+
+    val applicationInfo = SessionEvents.getApplicationInfo(firebaseApp)
+
+    assertThat(applicationInfo)
+      .isEqualTo(
+        ApplicationInfo(
+          appId = FakeFirebaseApp.MOCK_APP_ID,
+          deviceModel = Build.MODEL,
+          sessionSdkVersion = BuildConfig.VERSION_NAME,
+          osVersion = Build.VERSION.RELEASE,
+          logEnvironment = LogEnvironment.LOG_ENVIRONMENT_PROD,
+          AndroidApplicationInfo(
+            packageName = ApplicationProvider.getApplicationContext<Context>().packageName,
+            versionName = "0",
+            appBuildVersion = "0",
             deviceManufacturer = Build.MANUFACTURER,
           )
         )


### PR DESCRIPTION
Fix NPE when no version name is set. This will make it easier for apps to have Android tests while including the Sessions SDK. Also removed references to ApplicationInfoFlags to make it easier to minify apps with older api levels.

When the version name is unset, use the version code.