### PR TITLE
Update release commands in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,29 +225,20 @@ strategy](https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.Resolutio
 
 ### Commands
 
-The simplest way to publish a project and all its associated dependencies is to
-just publish all projects. The following command builds SNAPSHOT dependencies of
-all projects. All pom level dependencies within the published artifacts will
-also point to SNAPSHOT versions that are co-published.
-
-```bash
-./gradlew publishAllToLocal
-```
-
-Developers may take a dependency on these locally published versions by adding
-the `mavenLocal()` repository to your [repositories
-block](https://docs.gradle.org/current/userguide/declaring_repositories.html) in
-your app module's build.gradle.
-
 For more advanced use cases where developers wish to make changes to a project,
 but have transitive dependencies point to publicly released versions, individual
 projects may be published as follows.
 
 ```bash
 # e.g. to publish Firestore and Functions
-./gradlew -PprojectsToPublish=":firebase-firestore,:firebase-functions" \
-    publishProjectsToMavenLocal
+./gradlew -PprojectsToPublish="firebase-firestore,firebase-functions" \
+    publishReleasingLibrariesToMavenLocal
 ```
+
+Developers may take a dependency on these locally published versions by adding
+the `mavenLocal()` repository to your [repositories
+block](https://docs.gradle.org/current/userguide/declaring_repositories.html) in
+your app module's build.gradle.
 
 ### Code Formatting
 

--- a/buildSrc/README.md
+++ b/buildSrc/README.md
@@ -1,5 +1,8 @@
 ## Build Source
 
+> [!NOTE]
+> Eventually, this will be merged with our [contributor documentation](https://firebase.github.io/firebase-android-sdk/).
+
 This file will be more organized as time progresses. Because a lot of our
 plugins and systems require a moderate amount of cognitive overhead to understand,
 I thought it best to provide documentation for such systems. You can find the

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -191,9 +191,9 @@ abstract class PublishingPlugin : Plugin<Project> {
     allFirebaseLibraries: List<FirebaseLibraryExtension>
   ): ReleaseMetadata? {
     val projectsToPublish = project.provideProperty<String>("projectsToPublish").orNull
-    val releaseName = project.provideProperty<String>("releaseName").orNull
+    val releaseName = project.provideProperty<String>("releaseName").orNull ?: "NO_NAME"
 
-    if (projectsToPublish == null || releaseName == null) return null
+    if (projectsToPublish == null) return null
 
     val projectNames = projectsToPublish.split(",")
     val librariesToRelease =

--- a/firebase-firestore/README.md
+++ b/firebase-firestore/README.md
@@ -99,14 +99,9 @@ from within Android Studio.
 
 ## Build Local Jar of Firestore SDK
 
-Run:
 ```bash
-./gradlew publishAllToLocal
+./gradlew -PprojectsToPublish="firebase-firestore" publishReleasingLibrariesToMavenLocal
 ```
-
-This will publish firebase SDK at SNAPSHOT versions. All pom level dependencies
-within the published artifacts will also point to SNAPSHOT versions that are
-co-published. The results will be built into your local maven repo.
 
 Developers may then take a dependency on these locally published versions by adding
 the `mavenLocal()` repository to your [repositories

--- a/firebase-perf/README.md
+++ b/firebase-perf/README.md
@@ -84,28 +84,38 @@ firebase-android-sdk$ ./gradlew :firebase-perf:deviceCheck
 
 ### Creating a Release Candidate
 
+Change the version field in `gradle.properties` to reflect the RC status:
+
+```properties
+version=20.4.1-SNAPSHOT
 ```
-firebase-android-sdk$ ./gradlew -PpublishMode=SNAPSHOT -PprojectsToPublish="firebase-perf" firebasePublish
+
+And then generate the library with required libraries:
+
+```bash
+# firebase-perf requires firebase-sessions
+./gradlew -PprojectsToPublish="firebase-perf,firebase-sessions" firebasePublish
+```
+
+This will generate various files in the root build directory that align with
+the release candidates.
+
+Alternatively, you can just build the repository in isolation:
+```bash
+# firebase-perf requires firebase-sessions
+./gradlew -PprojectsToPublish="firebase-perf,firebase-sessions" buildMavenZip
 ```
 
 ### Publish project locally
 
-The simplest way to publish a project and all its associated dependencies is to just publish all 
-projects. The following command builds **SNAPSHOT** dependencies of all projects. All pom level 
-dependencies within the published artifacts will also point to SNAPSHOT versions that are 
-co-published.
+You can publish the project directly to your [local maven](https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_local) 
+repository like so:
 
+```bash
+# firebase-perf requires firebase-sessions
+./gradlew -PprojectsToPublish="firebase-perf,firebase-sessions" \
+    publishReleasingLibrariesToMavenLocal
 ```
-firebase-android-sdk$ ./gradlew publishAllToLocal
-```
-
-Alternative, publish `firebase-perf` only:
-
-```
-firebase-android-sdk$ ./gradlew -PprojectsToPublish=":firebase-perf"  publishProjectsToMavenLocal
-```
-
-The location of published project `~/.m2/repository/com/google/firebase/`.
 
 ### Read SDK from mavenLocal()
 


### PR DESCRIPTION
Per [b/294577585](https://b.corp.google.com/issues/294577585),

This updates any references to our previous release commands to now represent the new process; including the removal of the barebones `publishAll`.

Additionally, this fixes the following:

- [b/294577524](https://b.corp.google.com/issues/294577524) -> Add a default name for releases when using commands
- [b/294578506](https://b.corp.google.com/issues/294578506) -> Add a link to our contributor documentation in our buildSrc README