### PR TITLE
Fix semver check

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.kt
@@ -91,6 +91,7 @@ class FirebaseLibraryPlugin : BaseFirebaseLibraryPlugin() {
 
   private fun getSemverTaskAar(project: Project, firebaseLibrary: FirebaseLibraryExtension) {
     project.mkdir("semver")
+    project.mkdir("semver/previous-version")
     project.tasks.register<GmavenCopier>("copyPreviousArtifacts") {
       dependsOn("bundleReleaseAar")
       project.file("semver/previous.aar").delete()
@@ -111,7 +112,10 @@ class FirebaseLibraryPlugin : BaseFirebaseLibraryPlugin() {
 
     project.tasks.register<Copy>("extractPreviousClasses") {
       dependsOn("copyPreviousArtifacts")
-      if (File("${project.projectDir.absolutePath}/semver/previous.aar").exists()) {
+      if (
+        GmavenHelper(firebaseLibrary.groupId.get(), firebaseLibrary.artifactId.get())
+          .isPresentInGmaven()
+      ) {
         from(project.zipTree("semver/previous.aar"))
         into(project.file("semver/previous-version"))
       }
@@ -121,6 +125,8 @@ class FirebaseLibraryPlugin : BaseFirebaseLibraryPlugin() {
 
     val previousJarFile = project.file("semver/previous-version/classes.jar").absolutePath
     project.tasks.register<ApiDiffer>("semverCheck") {
+      dependsOn("extractCurrentClasses")
+      dependsOn("extractPreviousClasses")
       currentJar.value(currentJarFile)
       previousJar.value(previousJarFile)
       version.value(firebaseLibrary.version)
@@ -128,8 +134,6 @@ class FirebaseLibraryPlugin : BaseFirebaseLibraryPlugin() {
         GmavenHelper(firebaseLibrary.groupId.get(), firebaseLibrary.artifactId.get())
           .getLatestReleasedVersion()
       )
-      dependsOn("extractCurrentClasses")
-      dependsOn("extractPreviousClasses")
     }
   }
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryPlugin.kt
@@ -111,7 +111,7 @@ class FirebaseLibraryPlugin : BaseFirebaseLibraryPlugin() {
 
     project.tasks.register<Copy>("extractPreviousClasses") {
       dependsOn("copyPreviousArtifacts")
-      if (project.file("semver/previous.aar").exists()) {
+      if (File("${project.projectDir.absolutePath}/semver/previous.aar").exists()) {
         from(project.zipTree("semver/previous.aar"))
         into(project.file("semver/previous-version"))
       }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GmavenHelper.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/GmavenHelper.kt
@@ -15,6 +15,7 @@
 package com.google.firebase.gradle.plugins
 
 import java.io.FileNotFoundException
+import java.net.HttpURLConnection
 import java.net.URL
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
@@ -28,6 +29,16 @@ class GmavenHelper(val groupId: String, val artifactId: String) {
     val pomFileName = "${artifactId}-${version}.pom"
     val groupIdAsPath = groupId.replace(".", "/")
     return "${GMAVEN_ROOT}/${groupIdAsPath}/${artifactId}/${version}/${pomFileName}"
+  }
+
+  fun isPresentInGmaven(): Boolean {
+    val groupIdAsPath = groupId.replace(".", "/")
+    val u = URL("${GMAVEN_ROOT}/${groupIdAsPath}/${artifactId}/maven-metadata.xml")
+    val huc: HttpURLConnection = u.openConnection() as HttpURLConnection
+    huc.setRequestMethod("GET") // OR  huc.setRequestMethod ("HEAD");
+    huc.connect()
+    val code: Int = huc.getResponseCode()
+    return code == HttpURLConnection.HTTP_OK
   }
 
   fun getArtifactForVersion(version: String, isJar: Boolean): String {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -450,7 +450,6 @@ abstract class PublishingPlugin : Plugin<Project> {
     project.tasks.register(SEMVER_CHECK_TASK) {
       for (releasingProject in releasingProjects) {
         val semverCheckTask = releasingProject.tasks.named("semverCheck")
-
         dependsOn(semverCheckTask)
       }
     }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/semver/GmavenCopier.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/semver/GmavenCopier.kt
@@ -36,16 +36,14 @@ abstract class GmavenCopier : DefaultTask() {
   @TaskAction
   fun run() {
     val mavenHelper = GmavenHelper(groupId.get(), artifactId.get())
+    if (!mavenHelper.isPresentInGmaven()) {
+      return
+    }
     val gMavenPath =
       mavenHelper.getArtifactForVersion(
         mavenHelper.getLatestReleasedVersion(),
         !aarAndroidFile.get()
       )
-    try {
-      URL(gMavenPath).openStream().use { Files.copy(it, Paths.get(filePath.get())) }
-    } catch (_: java.io.FileNotFoundException) {
-      // Gmaven Artifact doesn't exist.
-      return
-    }
+    URL(gMavenPath).openStream().use { Files.copy(it, Paths.get(filePath.get())) }
   }
 }


### PR DESCRIPTION
During the m134 release we were releasing firebase-sessions for the first time and due to which the semver test was broken. Hence the if conditions were added. These if conditions were not being evaluated correctly since it dependend on a malleable state of things. So now it's moved to checking in Gmaven itself if the project exists instead of depending on a malleable state which keeps being updated by the gradle tasks.