### PR TITLE
Finish PostReleasePlugin

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
@@ -276,3 +276,18 @@ fun FirebaseLibraryExtension.resolveExternalAndroidLibraries() =
  */
 val FirebaseLibraryExtension.artifactName: String
   get() = "$mavenName:$version"
+
+/**
+ * Fetches the latest version for this SDK from GMaven.
+ *
+ * Uses [GmavenHelper] to make the request.
+ */
+val FirebaseLibraryExtension.latestVersion: ModuleVersion
+  get() {
+    val latestVersion = GmavenHelper(groupId.get(), artifactId.get()).getLatestReleasedVersion()
+
+    return ModuleVersion.fromStringOrNull(latestVersion)
+      ?: throw RuntimeException(
+        "Invalid format for ModuleVersion for module '$artifactName':\n $latestVersion"
+      )
+  }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/KotlinUtils.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/KotlinUtils.kt
@@ -188,6 +188,29 @@ fun <T : Any?> Iterable<T>.toPairOrFirst(): Pair<T, T?> = first() to last().take
 fun <T> List<T>.separateAt(index: Int) = slice(0 until index) to slice(index..lastIndex)
 
 /**
+ * Maps any instances of the [regex] found in this list to the provided [transform].
+ *
+ * For example:
+ * ```kotlin
+ * listOf("mom", "mommy", "momma", "dad").replaceMatches(Regex(".*mom.*")) {
+ *   it.value.takeUnless { it.contains("y") }?.drop(1)
+ * } // ["om", "mommy", "omma", "dad"]
+ * ```
+ *
+ * @param regex the [Regex] to use to match against values in this list
+ * @param transform a callback to call with [MathResults][MatchResult] when matches are found. If
+ * the [transform] returns null, then the value remains unchanged.
+ */
+fun List<String>.replaceMatches(regex: Regex, transform: (MatchResult) -> String?) = map {
+  val newValue = regex.find(it)?.let(transform)
+  if (newValue != null) {
+    it.replace(regex, newValue)
+  } else {
+    it
+  }
+}
+
+/**
  * Returns the value of the first capture group.
  *
  * Intended to be used in [MatchResult] that are only supposed to capture a single entry.

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/UpdatePinnedDependenciesTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/UpdatePinnedDependenciesTask.kt
@@ -1,0 +1,115 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins
+
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.StopExecutionException
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Changes the project level dependencies in a project's build file to pinned dependencies.
+ *
+ * Computes project level dependencies outside of the project's library group, looks for instances
+ * of them in the `dependencies` block in the build file, and replaces them with pinned versions.
+ * GMaven is used to figure out the latest version to use for a given dependency.
+ *
+ * For example, given the following input:
+ * ```
+ * dependencies {
+ *    implementation(project(":appcheck:firebase-appcheck-interop"))
+ * }
+ * ```
+ *
+ * The output would be:
+ * ```
+ * dependencies {
+ *    implementation("com.google.firebase:firebase-appcheck-interop:17.0.1")
+ * }
+ * ```
+ *
+ * *Assuming that `17.0.1` is the latest version of `firebase-appcheck-interop`*
+ *
+ * @property buildFile A [File] that should be used as the source to update from. Typically the
+ * `build.gradle` or `build.gradle.kts` file for a given project.
+ * @property outputFile A [File] that should be used to write the new text to. Typically the same as
+ * the input file ([buildFile]).
+ * @see PostReleasePlugin
+ */
+abstract class UpdatePinnedDependenciesTask : DefaultTask() {
+  @get:[InputFile]
+  abstract val buildFile: Property<File>
+
+  @get:[OutputFile]
+  abstract val outputFile: Property<File>
+
+  @TaskAction
+  fun build() {
+    val needsChanging = computeLibrariesThatNeedChanging()
+
+    val lines = buildFile.get().readLines()
+    val newLines = updateDependencyLines(lines, needsChanging)
+
+    if (newLines == lines) throw missingProjectLevelDependenciesError(needsChanging)
+
+    outputFile.get().writeText(newLines.joinToString("\n") + "\n")
+  }
+
+  private fun computeLibrariesThatNeedChanging(): List<FirebaseLibraryExtension> {
+    val firebaseLibrary = project.firebaseLibrary
+    val sisterProjects = firebaseLibrary.getLibrariesToRelease()
+    val dependencies = projectLevelDependenciesForLibrary(firebaseLibrary)
+    val needsChanging = dependencies - sisterProjects
+
+    if (needsChanging.isEmpty()) throw StopExecutionException("No libraries to change.")
+
+    return needsChanging
+  }
+
+  private fun projectLevelDependenciesForLibrary(library: FirebaseLibraryExtension) =
+    library.resolveProjectLevelDependencies().filterNot { it.path in DEPENDENCIES_TO_IGNORE }
+
+  private fun updateDependencyLines(
+    lines: List<String>,
+    libraries: List<FirebaseLibraryExtension>
+  ) =
+    lines.replaceMatches(DEPENDENCY_REGEX) {
+      val projectName = it.firstCapturedValue
+      val projectToChange = libraries.find { it.path == projectName }
+      val latestVersion = projectToChange?.latestVersion
+
+      latestVersion?.let { "\"${projectToChange.mavenName}:$latestVersion\"" }
+    }
+
+  // This should never occur, but if it does- it's probably a regex error. Better safe than sorry?
+  private fun missingProjectLevelDependenciesError(
+    expectedLibraries: List<FirebaseLibraryExtension>
+  ) =
+    RuntimeException(
+      "Expected the following project level dependencies, but found none: " +
+        "${expectedLibraries.joinToString("\n") { it.mavenName }}"
+    )
+
+  companion object {
+    /** TODO() */
+    val DEPENDENCY_REGEX =
+      Regex("(?<=\\s{1,20}\\w{1,20}|(?:\\s|\\())project\\((?:'|\")(:\\S+)(?:'|\")\\)")
+
+    val DEPENDENCIES_TO_IGNORE = listOf(":protolite-well-known-types")
+  }
+}

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/FirebaseTestController.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/FirebaseTestController.kt
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.firebase.gradle.plugins
 
 import io.kotest.matchers.nulls.shouldNotBeNull

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/FirebaseTestController.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/FirebaseTestController.kt
@@ -1,0 +1,187 @@
+package com.google.firebase.gradle.plugins
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Util class for providing a common ground for tests that need to dynamically create [projects]
+ * [Project].
+ *
+ * This class effectively acts as the root controller during multi module testing. The general
+ * workflow can be defined as such:
+ * - Wrap your test in a [FirebaseTestController]
+ * - Create your test [projects][Project]
+ * - Link your test projects with the controller via [withProjects]
+ * - Use the [GradleRunner] to run your build at the [rootDirectory]
+ * - Use any of the provided extension methods to inspect the build files and make assertions in
+ * your test
+ *
+ * Some example of the provided extension methods are:
+ * - [Project.buildFile]
+ * - [Project.pom]
+ *
+ * To see a more involved example of this workflow, you can take a look at test classes that
+ * implement this class, eg; [UpdatePinnedDependenciesTests] and [PublishingPluginTests].
+ *
+ * @see project
+ * @see createReleaseWithConfig
+ * @see createReleaseWithProjects
+ * @see withProjects
+ *
+ * @property rootDirectory the root [TemporaryFolder] that all files will be created under.
+ */
+class FirebaseTestController(val rootDirectory: TemporaryFolder) {
+
+  /**
+   * The `build.gradle` file for this project under the [rootDirectory].
+   *
+   * @see project
+   */
+  val Project.buildFile: File
+    get() = project(this).childFile("build.gradle")
+
+  /**
+   * The compiled [Pom] for this [Project], or null if not found.
+   *
+   * Looks for the [Pom] file under the root `m2repository`, using a REGEX pattern to find matches
+   * for this [Project]. The file is then converted into a [Pom] via [Pom.parse].
+   *
+   * @see pom
+   */
+  fun Project.pomOrNull(): Pom? {
+    val regex = Regex(".*/${group.replace('.', '/')}/$name/$expectedVersion.*/.*\\.pom$")
+    val repository = rootDirectory.root.childFile("build/m2repository")
+    val pomFile = repository.walk().find { it.isFile && it.path.matches(regex) }
+
+    return pomFile?.let { Pom.parse(it) }
+  }
+
+  /**
+   * The compiled [Pom] for this [Project].
+   *
+   * A variant of [pomOrNull] that makes an assertion that the [Pom] should not be null.
+   *
+   * @see pomOrNull
+   * @see shouldNotBeNull
+   */
+  val Project.pom: Pom
+    get() = pomOrNull().shouldNotBeNull()
+
+  /**
+   * The sub directory for the given [project] under the parent [rootDirectory].
+   *
+   * *Alternatively known as the project's directory*
+   *
+   * @see include
+   */
+  fun project(project: Project) = rootDirectory.root.childFile(project.name)
+
+  /**
+   * Creates a subdirectory for the given [project] under [rootDirectory].
+   *
+   * Will use [Project.generateBuildFile] to create the relevant [buildFile], and will populate the
+   * [AndroidManifest.xml][ANDROID_MANIFEST] accordingly.
+   *
+   * Usually, you don't want to invoke this method yourself, as it will not include the [project] in
+   * the build process. What you're probably looking for is [withProjects].
+   *
+   * @see project
+   * @see withProjects
+   */
+  fun include(project: Project) {
+    rootDirectory.newFolder("${project.name}/src/main")
+    rootDirectory.newFile("${project.name}/build.gradle").writeText(project.generateBuildFile())
+    rootDirectory
+      .newFile("${project.name}/src/main/AndroidManifest.xml")
+      .writeText(ANDROID_MANIFEST)
+  }
+
+  /**
+   * Creates the build files for the root project, and subsequently the provided [projects].
+   *
+   * All of the provided [projects] will be included in the root `settings.gradle` file, such that
+   * they are invoked during the build process.
+   *
+   * @param projects a variable amount of [Project] to create subdirectories for and include in the
+   * build process.
+   *
+   * @see include
+   */
+  fun withProjects(vararg projects: Project) {
+    rootDirectory.newFile("build.gradle").writeText(ROOT_PROJECT)
+    rootDirectory
+      .newFile("settings.gradle")
+      .writeText(projects.joinToString("\n") { "include '${it.path}'" })
+
+    projects.forEach(this::include)
+  }
+
+  /**
+   * Creates a `release.json` file at the [rootDirectory].
+   *
+   * @param release the [ReleaseConfig] to convert into a `json` file.
+   *
+   * @see createReleaseWithProjects
+   */
+  fun createReleaseWithConfig(release: ReleaseConfig) {
+    release.toFile(rootDirectory.newFile("release.json"))
+  }
+
+  /**
+   * Creates a `release.json` file at the [rootDirectory].
+   *
+   * The release will have a [name][ReleaseConfig.name] of `test`. If you would rather have a
+   * different name, then pass your own [ReleaseConfig] instead via [createReleaseWithConfig].
+   *
+   * @param projects a variable amount of [Project] to include in the release file.
+   *
+   * @see createReleaseWithConfig
+   */
+  fun createReleaseWithProjects(vararg projects: Project) {
+    createReleaseWithConfig(ReleaseConfig("test", projects.map { it.path }))
+  }
+
+  companion object {
+    const val ROOT_PROJECT =
+      """
+        buildscript {
+            repositories {
+                google()
+                jcenter()
+                maven {
+                    url 'https://storage.googleapis.com/android-ci/mvn/'
+                    metadataSources {
+                        artifact()
+                    }
+                }
+            }
+        }
+        plugins {
+            id 'PublishingPlugin'
+        }
+
+        configure(subprojects) {
+            repositories {
+                google()
+                jcenter()
+                maven {
+                    url 'https://storage.googleapis.com/android-ci/mvn/'
+                    metadataSources {
+                          artifact()
+                    }
+                }
+            }
+        }
+      """
+
+    const val ANDROID_MANIFEST =
+      """<?xml version="1.0" encoding="utf-8"?>
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                  package="com.example">
+            <uses-sdk android:minSdkVersion="14"/>
+        </manifest>
+        """
+  }
+}

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/PublishingPluginTests.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/PublishingPluginTests.kt
@@ -14,290 +14,206 @@
 
 package com.google.firebase.gradle.plugins
 
-import com.google.common.truth.Truth.assertThat
-import java.io.File
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSingleElement
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
-import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.TaskOutcome.FAILED
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 class PublishingPluginTests {
   @Rule @JvmField val testProjectDir = TemporaryFolder()
-
-  private val subprojects = mutableListOf<Project>()
-  private lateinit var rootBuildFile: File
-  private lateinit var rootSettingsFile: File
+  private val controller = FirebaseTestController(testProjectDir)
 
   @Test
   fun `Publishing dependent projects succeeds`() {
-    val project1 = Project(name = "childProject1", version = "1.0")
-    val project2 =
-      Project(
-        name = "childProject2",
-        version = "0.9",
-        projectDependencies = setOf(project1),
-        customizePom = """
+    with(controller) {
+      val project1 = Project(name = "childProject1", version = "1.0")
+      val project2 =
+        Project(
+          name = "childProject2",
+          version = "0.9",
+          projectDependencies = setOf(project1),
+          customizePom = """
   licenses {
     license {
       name = 'Hello'
     }
   }
   """
-      )
-    subprojectsDefined(project1, project2)
-    val result = publish(project1, project2)
-    assertThat(result.task(":firebasePublish")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-    val pomOrNull1 = project1.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    val pomOrNull2 = project2.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    assertThat(pomOrNull1).isNotNull()
-    assertThat(pomOrNull2).isNotNull()
-    val pom1 = pomOrNull1!!
-    val pom2 = pomOrNull2!!
-
-    assertThat(pom1.artifact.version).isEqualTo(project1.version)
-    assertThat(pom2.artifact.version).isEqualTo(project2.version)
-    assertThat(pom1.license)
-      .isEqualTo(
-        License(
-          "The Apache Software License, Version 2.0",
-          "http://www.apache.org/licenses/LICENSE-2.0.txt"
         )
-      )
-    assertThat(pom2.license).isEqualTo(License("Hello", ""))
 
-    assertThat(pom2.dependencies)
-      .isEqualTo(
-        listOf(
-          Artifact(
-            groupId = project1.group,
-            artifactId = project1.name,
-            version = project1.version,
-            type = Type.AAR,
-            scope = "compile"
+      withProjects(project1, project2)
+      publish(project1, project2)
+
+      project1.pom.let {
+        it.artifact.version shouldBe project1.version
+        it.license shouldBe
+          License(
+            "The Apache Software License, Version 2.0",
+            "http://www.apache.org/licenses/LICENSE-2.0.txt"
           )
-        )
-      )
+      }
+      project2.pom.let {
+        it.artifact.version shouldBe project2.version
+        it.license shouldBe License("Hello", "")
+        it.dependencies shouldHaveSingleElement project1.toArtifact()
+      }
+    }
   }
 
   @Test
   fun `Publishing dependent projects one of which is a jar succeeds`() {
-    val project1 = Project(name = "childProject1", version = "1.0", libraryType = LibraryType.JAVA)
-    val project2 =
-      Project(
-        name = "childProject2",
-        version = "0.9",
-        projectDependencies = setOf(project1),
-        customizePom = """
+    with(controller) {
+      val project1 =
+        Project(name = "childProject1", version = "1.0", libraryType = LibraryType.JAVA)
+      val project2 =
+        Project(
+          name = "childProject2",
+          version = "0.9",
+          projectDependencies = setOf(project1),
+          customizePom = """
   licenses {
     license {
       name = 'Hello'
     }
   }
   """
-      )
-    subprojectsDefined(project1, project2)
-    val result = publish(project1, project2)
-    assertThat(result.task(":firebasePublish")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-    val pomOrNull1 = project1.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    val pomOrNull2 = project2.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    assertThat(pomOrNull1).isNotNull()
-    assertThat(pomOrNull2).isNotNull()
-    val pom1 = pomOrNull1!!
-    val pom2 = pomOrNull2!!
-
-    assertThat(pom1.artifact.version).isEqualTo(project1.version)
-    assertThat(pom2.artifact.version).isEqualTo(project2.version)
-    assertThat(pom1.license)
-      .isEqualTo(
-        License(
-          "The Apache Software License, Version 2.0",
-          "http://www.apache.org/licenses/LICENSE-2.0.txt"
         )
-      )
-    assertThat(pom2.license).isEqualTo(License("Hello", ""))
 
-    assertThat(pom2.dependencies)
-      .isEqualTo(
-        listOf(
-          Artifact(
-            groupId = project1.group,
-            artifactId = project1.name,
-            version = project1.version,
-            type = Type.JAR,
-            scope = "compile"
+      withProjects(project1, project2)
+      publish(project1, project2)
+
+      project1.pom.let {
+        it.artifact.version shouldBe project1.version
+        it.license shouldBe
+          License(
+            "The Apache Software License, Version 2.0",
+            "http://www.apache.org/licenses/LICENSE-2.0.txt"
           )
-        )
-      )
+      }
+      project2.pom.let {
+        it.artifact.version shouldBe project2.version
+        it.license shouldBe License("Hello", "")
+        it.dependencies shouldHaveSingleElement project1.toArtifact()
+      }
+    }
   }
 
   @Test
   fun `Publish with unreleased dependency`() {
-    val project1 = Project(name = "childProject1", version = "1.0")
-    val project2 =
-      Project(name = "childProject2", version = "0.9", projectDependencies = setOf(project1))
+    with(controller) {
+      val project1 = Project(name = "childProject1", version = "1.0")
+      val project2 =
+        Project(name = "childProject2", version = "0.9", projectDependencies = setOf(project1))
 
-    subprojectsDefined(project1, project2)
-    val result = publishAndFail(project2)
-    assertThat(result.task(":checkHeadDependencies")?.outcome).isEqualTo(TaskOutcome.FAILED)
+      withProjects(project1, project2)
+      publishAndFail(project2)
+    }
   }
 
   @Test
   fun `Publish with released dependency`() {
-    val project1 = Project(name = "childProject1", version = "1.0", latestReleasedVersion = "0.8")
-    val project2 =
-      Project(name = "childProject2", version = "0.9", projectDependencies = setOf(project1))
-    subprojectsDefined(project1, project2)
+    with(controller) {
+      val project1 = Project(name = "childProject1", version = "1.0", latestReleasedVersion = "0.8")
+      val project2 =
+        Project(name = "childProject2", version = "0.9", projectDependencies = setOf(project1))
 
-    val result = publish(project2, project1)
-    assertThat(result.task(":firebasePublish")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+      withProjects(project1, project2)
+      publish(project2, project1)
 
-    val pomOrNull1 = project1.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    val pomOrNull2 = project2.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    assertThat(pomOrNull1).isNotNull()
-    assertThat(pomOrNull2).isNotNull()
-
-    val pom2 = pomOrNull2!!
-    assertThat(pom2.dependencies)
-      .isEqualTo(
-        listOf(
-          Artifact(
-            groupId = project1.group,
-            artifactId = project1.name,
-            version = project1.version,
-            type = Type.AAR,
-            scope = "compile"
-          )
-        )
-      )
+      project1.pomOrNull().shouldNotBeNull()
+      project2.pom.dependencies shouldHaveSingleElement project1.toArtifact()
+    }
   }
 
   @Test
   fun `Publish project should also publish coreleased projects`() {
-    val project1 = Project(name = "childProject1", version = "1.0.0", libraryGroup = "test123")
-    val project2 =
-      Project(
-        name = "childProject2",
-        projectDependencies = setOf(project1),
-        libraryGroup = "test123",
-        expectedVersion = "1.0.0"
-      )
-    subprojectsDefined(project1, project2)
-
-    val result = publish(project1)
-    assertThat(result.task(":firebasePublish")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-    val pomOrNull1 = project1.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    val pomOrNull2 = project2.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    assertThat(pomOrNull1).isNotNull()
-    assertThat(pomOrNull2).isNotNull()
-
-    val pom1 = pomOrNull1!!
-    val pom2 = pomOrNull2!!
-
-    assertThat(pom1.artifact.version).isEqualTo(project1.version)
-    assertThat(pom2.artifact.version).isEqualTo(project1.version)
-    assertThat(pom2.dependencies)
-      .isEqualTo(
-        listOf(
-          Artifact(
-            groupId = project1.group,
-            artifactId = project1.name,
-            version = project1.version,
-            type = Type.AAR,
-            scope = "compile"
-          )
+    with(controller) {
+      val project1 = Project(name = "childProject1", version = "1.0.0", libraryGroup = "test123")
+      val project2 =
+        Project(
+          name = "childProject2",
+          projectDependencies = setOf(project1),
+          libraryGroup = "test123",
+          expectedVersion = "1.0.0"
         )
-      )
+
+      withProjects(project1, project2)
+      publish(project1)
+
+      project1.pom.artifact.version shouldBe project1.version
+      project2.pom.let {
+        it.artifact.version shouldBe project1.version
+        it.dependencies shouldHaveSingleElement project1.toArtifact()
+      }
+    }
   }
 
   @Test
   fun `Publish project should correctly set dependency types`() {
-    val project1 = Project(name = "childProject1", version = "1.0", latestReleasedVersion = "0.8")
-    val project2 =
-      Project(
-        name = "childProject2",
-        version = "0.9",
-        projectDependencies = setOf(project1),
-        externalDependencies =
-          setOf(
-            Artifact("com.google.dagger", "dagger", "2.22"),
-            Artifact("com.google.dagger", "dagger-android-support", "2.22")
-          )
-      )
-    subprojectsDefined(project1, project2)
+    with(controller) {
+      val dagger = Artifact("com.google.dagger", "dagger", "2.22")
+      val daggerAndroid = Artifact("com.google.dagger", "dagger-android-support", "2.22", Type.AAR)
 
-    val result = publish(project2, project1)
-    assertThat(result.task(":firebasePublish")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-    val pomOrNull2 = project2.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    assertThat(pomOrNull2).isNotNull()
-
-    val pom2 = pomOrNull2!!
-    assertThat(pom2.artifact.version).isEqualTo(project2.version)
-    assertThat(pom2.dependencies)
-      .containsExactly(
-        Artifact(
-          groupId = project1.group,
-          artifactId = project1.name,
-          version = project1.version,
-          type = Type.AAR,
-          scope = "compile"
-        ),
-        Artifact(
-          groupId = "com.google.dagger",
-          artifactId = "dagger",
-          version = "2.22",
-          type = Type.JAR,
-          scope = "compile"
-        ),
-        Artifact(
-          groupId = "com.google.dagger",
-          artifactId = "dagger-android-support",
-          version = "2.22",
-          type = Type.AAR,
-          scope = "compile"
+      val project1 = Project(name = "childProject1", version = "1.0", latestReleasedVersion = "0.8")
+      val project2 =
+        Project(
+          name = "childProject2",
+          version = "0.9",
+          projectDependencies = setOf(project1),
+          externalDependencies = setOf(dagger.copy(scope = ""), daggerAndroid.copy(scope = ""))
         )
-      )
+
+      withProjects(project1, project2)
+      publish(project2, project1)
+
+      project2.pom.let {
+        it.artifact.version shouldBe project2.version
+        it.dependencies shouldContainExactly listOf(project1.toArtifact(), dagger, daggerAndroid)
+      }
+    }
   }
 
   @Test
   fun `Publish project should ignore dependency versions`() {
-    val externalAARLibrary = Artifact("com.google.dagger", "dagger-android-support", "2.21")
+    with(controller) {
+      val externalAARLibrary = Artifact("com.google.dagger", "dagger-android-support", "2.21")
 
-    val project1 =
-      Project(
-        name = "childProject1",
-        version = "1.0",
-        libraryType = LibraryType.ANDROID,
-        externalDependencies = setOf(externalAARLibrary)
-      )
-    val project2 =
-      Project(
-        name = "childProject2",
-        version = "1.0",
-        libraryType = LibraryType.ANDROID,
-        externalDependencies = setOf(externalAARLibrary.copy(version = "2.22"))
-      )
+      val project1 =
+        Project(
+          name = "childProject1",
+          version = "1.0",
+          externalDependencies = setOf(externalAARLibrary)
+        )
+      val project2 =
+        Project(
+          name = "childProject2",
+          version = "1.0",
+          externalDependencies = setOf(externalAARLibrary.copy(version = "2.22"))
+        )
 
-    subprojectsDefined(project1, project2)
-    val result = publish(project1, project2)
-    assertThat(result.task(":firebasePublish")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+      withProjects(project1, project2)
+      publish(project1, project2)
 
-    val pomOrNull2 = project2.getPublishedPom("${testProjectDir.root}/build/m2repository")
-    assertThat(pomOrNull2).isNotNull()
-
-    val pom2 = pomOrNull2!!
-
-    assertThat(pom2.dependencies.first().type).isEqualTo(Type.AAR)
+      project2.pom.dependencies.first().type shouldBe Type.AAR
+    }
   }
 
-  private fun publish(vararg projects: Project): BuildResult = makeGradleRunner(*projects).build()
+  private fun publish(vararg projects: Project): BuildResult =
+    makeGradleRunner(*projects).build().also {
+      it.task(":firebasePublish")?.outcome shouldBe SUCCESS
+    }
 
-  private fun publishAndFail(vararg projects: Project) = makeGradleRunner(*projects).buildAndFail()
+  private fun publishAndFail(vararg projects: Project) =
+    makeGradleRunner(*projects).buildAndFail().also {
+      it.task(":checkHeadDependencies")?.outcome shouldBe FAILED
+    }
 
   private fun makeGradleRunner(vararg projects: Project) =
     GradleRunner.create()
@@ -308,62 +224,4 @@ class PublishingPluginTests {
         "firebasePublish"
       )
       .withPluginClasspath()
-
-  private fun include(project: Project) {
-    testProjectDir.newFolder(project.name, "src", "main")
-    testProjectDir.newFile("${project.name}/build.gradle").writeText(project.generateBuildFile())
-    testProjectDir.newFile("${project.name}/src/main/AndroidManifest.xml").writeText(MANIFEST)
-    subprojects.add(project)
-  }
-
-  private fun subprojectsDefined(vararg projects: Project) {
-    rootBuildFile = testProjectDir.newFile("build.gradle")
-    rootSettingsFile = testProjectDir.newFile("settings.gradle")
-
-    projects.forEach(this::include)
-
-    rootBuildFile.writeText(ROOT_PROJECT)
-    rootSettingsFile.writeText(projects.joinToString("\n") { "include ':${it.name}'" })
-  }
-
-  companion object {
-    private const val ROOT_PROJECT =
-      """
-        buildscript {
-            repositories {
-                google()
-                jcenter()
-                maven {
-                    url 'https://storage.googleapis.com/android-ci/mvn/'
-                    metadataSources {
-                        artifact()
-                    }
-                }
-            }
-        }
-        plugins {
-            id 'PublishingPlugin'
-        }
-
-        configure(subprojects) {
-            repositories {
-                google()
-                jcenter()
-                maven {
-                    url 'https://storage.googleapis.com/android-ci/mvn/'
-                    metadataSources {
-                          artifact()
-                    }
-                }
-            }
-        }
-        """
-    private const val MANIFEST =
-      """<?xml version="1.0" encoding="utf-8"?>
-        <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-                  package="com.example">
-            <uses-sdk android:minSdkVersion="14"/>
-        </manifest>
-        """
-  }
 }

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/UpdatePinnedDependenciesTests.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/UpdatePinnedDependenciesTests.kt
@@ -1,0 +1,104 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.gradle.plugins
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class UpdatePinnedDependenciesTests : FunSpec() {
+
+  @Rule @JvmField val testProjectDirectory = TemporaryFolder()
+  private val controller = FirebaseTestController(testProjectDirectory)
+
+  @Test
+  fun `Replaces project level dependencies with pinned dependencies`() {
+    with(controller) {
+      val fakeFirestore =
+        Project(name = "firebase-firestore", group = "com.google.firebase", version = "1.0.0")
+      val testProject =
+        Project(name = "testProject", version = "1.0.0", projectDependencies = setOf(fakeFirestore))
+
+      withProjects(fakeFirestore, testProject)
+      createReleaseWithProjects(testProject)
+      buildProject()
+
+      testProject.buildFile.readText() shouldNotContain fakeFirestore.toDependency(true)
+    }
+  }
+
+  @Test
+  fun `Does not replace dependencies in same library group`() {
+    with(controller) {
+      val fakeFirestore =
+        Project(
+          name = "firebase-firestore",
+          libraryGroup = "test",
+          group = "com.google.firebase",
+          version = "1.0.0"
+        )
+      val testProject =
+        Project(
+          name = "testProject",
+          libraryGroup = "test",
+          version = "1.0.0",
+          projectDependencies = setOf(fakeFirestore)
+        )
+
+      withProjects(fakeFirestore, testProject)
+      createReleaseWithProjects(testProject)
+      buildProject()
+
+      testProject.buildFile.readText() shouldContain fakeFirestore.toDependency(true)
+    }
+  }
+
+  @Test
+  fun `Does not change already pinned dependencies`() {
+    with(controller) {
+      val fakeFirestore =
+        Project(
+          name = "firebase-firestore",
+          libraryGroup = "test",
+          group = "com.google.firebase",
+          version = "1.0.0"
+        )
+      val testProject =
+        Project(
+          name = "testProject",
+          libraryGroup = "test",
+          version = "1.0.0",
+          externalDependencies = setOf(fakeFirestore.toArtifact())
+        )
+
+      withProjects(fakeFirestore, testProject)
+      createReleaseWithProjects(testProject)
+      buildProject()
+
+      testProject.buildFile.readText() shouldContain fakeFirestore.toDependency(false)
+    }
+  }
+
+  private fun buildProject() =
+    GradleRunner.create()
+      .withProjectDir(testProjectDirectory.root)
+      .withPluginClasspath()
+      .withArguments("updatePinnedDependencies")
+      .build()
+}


### PR DESCRIPTION
Per [b/292140435](https://b.corp.google.com/issues/292140435),

This implements a task to handle conversion of project level dependencies to pinned dependencies post release. Relevant documentation explaining everything is added as well.

The following is also fixed by this PR:

- [b/296419486](https://b.corp.google.com/issues/296419486) - Connect `updatePinnedDependencies` task with `PostReleasePlugin`
- [b/296419551](https://b.corp.google.com/issues/296419551) - Implement a `postReleaseCleanup` task
- [b/296419351](https://b.corp.google.com/issues/296419351) - Add tests for the `updatePinnedDependencies` task
- [b/296420102](https://b.corp.google.com/issues/296420102) - Implement a common test interface for dynamically created projects
- [b/296420881](https://b.corp.google.com/issues/296420881) - Migrate `PublishingPluginTests` to the new testing interface
- [b/296422065](https://b.corp.google.com/issues/296422065) - Migrate `PublishingPluginTests` to kotest assertions