### PR TITLE
Add a 40 second sleep at the end of each Fireperf e2e test to ensure that events are sent before the app exits.

### DIFF
--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
@@ -58,6 +58,7 @@ public class FirebasePerformanceFragmentScreenTracesTest {
 
     // End Activity screen trace by relaunching the activity to ensure the screen trace is sent.
     scenario.launch(FirebasePerfFragmentsActivity.class);
+    Thread.sleep(15 * 1000);
   }
 
   private void scrollRecyclerViewToEnd(int itemCount, int viewId) {

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceFragmentScreenTracesTest.java
@@ -58,7 +58,7 @@ public class FirebasePerformanceFragmentScreenTracesTest {
 
     // End Activity screen trace by relaunching the activity to ensure the screen trace is sent.
     scenario.launch(FirebasePerfFragmentsActivity.class);
-    Thread.sleep(15 * 1000);
+    Thread.sleep(30 * 1000);
   }
 
   private void scrollRecyclerViewToEnd(int itemCount, int viewId) {

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java
@@ -51,6 +51,6 @@ public class FirebasePerformanceScreenTracesTest {
     }
     // End Activity screen trace by switching to another Activity
     scenario.launch(FirebasePerfScreenTracesActivity.class);
-    Thread.sleep(15 * 1000);
+    Thread.sleep(30 * 1000);
   }
 }

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceScreenTracesTest.java
@@ -51,5 +51,6 @@ public class FirebasePerformanceScreenTracesTest {
     }
     // End Activity screen trace by switching to another Activity
     scenario.launch(FirebasePerfScreenTracesActivity.class);
+    Thread.sleep(15 * 1000);
   }
 }

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
@@ -60,6 +60,6 @@ public class FirebasePerformanceTest {
     for (Future<?> future : futureList) {
       future.get();
     }
-    Thread.sleep(15 * 1000);
+    Thread.sleep(30 * 1000);
   }
 }

--- a/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
+++ b/firebase-perf/e2e-app/src/androidTest/java/com/google/firebase/testing/fireperf/FirebasePerformanceTest.java
@@ -60,5 +60,6 @@ public class FirebasePerformanceTest {
     for (Future<?> future : futureList) {
       future.get();
     }
+    Thread.sleep(15 * 1000);
   }
 }


### PR DESCRIPTION
This should fix the flaky TAP tests that expect traces to be sent.