### PR TITLE
Feature Rollouts RC Fetch Integration

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
@@ -76,7 +76,8 @@ public final class RemoteConfigConstants {
     ResponseFieldKey.EXPERIMENT_DESCRIPTIONS,
     ResponseFieldKey.PERSONALIZATION_METADATA,
     ResponseFieldKey.STATE,
-    ResponseFieldKey.TEMPLATE_VERSION_NUMBER
+    ResponseFieldKey.TEMPLATE_VERSION_NUMBER,
+    ResponseFieldKey.ROLLOUT_METADATA
   })
   @Retention(RetentionPolicy.SOURCE)
   public @interface ResponseFieldKey {
@@ -85,6 +86,7 @@ public final class RemoteConfigConstants {
     String PERSONALIZATION_METADATA = "personalizationMetadata";
     String STATE = "state";
     String TEMPLATE_VERSION_NUMBER = "templateVersion";
+    String ROLLOUT_METADATA = "rolloutMetadata";
   }
 
   /**

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -327,7 +327,14 @@ public class ConfigContainer {
     }
 
     public Builder withRolloutMetadata(JSONArray rolloutMetadata) {
-      this.builderRolloutMetadata = rolloutMetadata;
+      try {
+        this.builderRolloutMetadata = new JSONArray(rolloutMetadata.toString());
+      } catch (JSONException e) {
+        // We serialize and deserialize the JSONArray to guarantee that it cannot be mutated after
+        // being set in the builder.
+        // A JSONException should never occur because the JSON that is being deserialized is
+        // guaranteed to be valid.
+      }
       return this;
     }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -35,6 +35,7 @@ public class ConfigContainer {
   static final String ABT_EXPERIMENTS_KEY = "abt_experiments_key";
   static final String PERSONALIZATION_METADATA_KEY = "personalization_metadata_key";
   static final String TEMPLATE_VERSION_NUMBER_KEY = "template_version_number_key";
+  static final String ROLLOUT_METADATA_KEY = "rollout_metadata_key";
 
   private static final Date DEFAULTS_FETCH_TIME = new Date(0L);
 
@@ -61,6 +62,8 @@ public class ConfigContainer {
 
   private long templateVersionNumber;
 
+  private JSONArray rolloutMetadata;
+
   /**
    * Creates a new container with the specified configs and fetch time.
    *
@@ -71,7 +74,8 @@ public class ConfigContainer {
       Date fetchTime,
       JSONArray abtExperiments,
       JSONObject personalizationMetadata,
-      long templateVersionNumber)
+      long templateVersionNumber,
+      JSONArray rolloutMetadata)
       throws JSONException {
     JSONObject containerJson = new JSONObject();
     containerJson.put(CONFIGS_KEY, configsJson);
@@ -79,12 +83,14 @@ public class ConfigContainer {
     containerJson.put(ABT_EXPERIMENTS_KEY, abtExperiments);
     containerJson.put(PERSONALIZATION_METADATA_KEY, personalizationMetadata);
     containerJson.put(TEMPLATE_VERSION_NUMBER_KEY, templateVersionNumber);
+    containerJson.put(ROLLOUT_METADATA_KEY, rolloutMetadata);
 
     this.configsJson = configsJson;
     this.fetchTime = fetchTime;
     this.abtExperiments = abtExperiments;
     this.personalizationMetadata = personalizationMetadata;
     this.templateVersionNumber = templateVersionNumber;
+    this.rolloutMetadata = rolloutMetadata;
 
     this.containerJson = containerJson;
   }
@@ -102,13 +108,19 @@ public class ConfigContainer {
       personalizationMetadataJSON = new JSONObject();
     }
 
+    JSONArray rolloutMetadataJSON = containerJson.optJSONArray(ROLLOUT_METADATA_KEY);
+    if (rolloutMetadataJSON == null) {
+      rolloutMetadataJSON = new JSONArray();
+    }
+
     return new ConfigContainer(
         containerJson.getJSONObject(CONFIGS_KEY),
         new Date(containerJson.getLong(FETCH_TIME_KEY)),
         containerJson.getJSONArray(ABT_EXPERIMENTS_KEY),
         personalizationMetadataJSON,
         // Default to 0 if template_version_number_key has not been cached yet.
-        containerJson.optLong(TEMPLATE_VERSION_NUMBER_KEY));
+        containerJson.optLong(TEMPLATE_VERSION_NUMBER_KEY),
+        rolloutMetadataJSON);
   }
 
   /**
@@ -148,6 +160,10 @@ public class ConfigContainer {
 
   public long getTemplateVersionNumber() {
     return templateVersionNumber;
+  }
+
+  public JSONArray getRolloutMetadata() {
+    return rolloutMetadata;
   }
 
   @Override
@@ -239,12 +255,15 @@ public class ConfigContainer {
     private JSONObject builderPersonalizationMetadata;
     private long builderTemplateVersionNumber;
 
+    private JSONArray builderRolloutMetadata;
+
     private Builder() {
       builderConfigsJson = new JSONObject();
       builderFetchTime = DEFAULTS_FETCH_TIME;
       builderAbtExperiments = new JSONArray();
       builderPersonalizationMetadata = new JSONObject();
       builderTemplateVersionNumber = 0L;
+      builderRolloutMetadata = new JSONArray();
     }
 
     public Builder(ConfigContainer otherContainer) {
@@ -253,6 +272,7 @@ public class ConfigContainer {
       this.builderAbtExperiments = otherContainer.getAbtExperiments();
       this.builderPersonalizationMetadata = otherContainer.getPersonalizationMetadata();
       this.builderTemplateVersionNumber = otherContainer.getTemplateVersionNumber();
+      this.builderRolloutMetadata = otherContainer.getRolloutMetadata();
     }
 
     public Builder replaceConfigsWith(Map<String, String> configsMap) {
@@ -306,6 +326,11 @@ public class ConfigContainer {
       return this;
     }
 
+    public Builder withRolloutMetadata(JSONArray rolloutMetadata) {
+      this.builderRolloutMetadata = rolloutMetadata;
+      return this;
+    }
+
     /** If a fetch time is not provided, the defaults container fetch time is used. */
     public ConfigContainer build() throws JSONException {
       return new ConfigContainer(
@@ -313,7 +338,8 @@ public class ConfigContainer {
           builderFetchTime,
           builderAbtExperiments,
           builderPersonalizationMetadata,
-          builderTemplateVersionNumber);
+          builderTemplateVersionNumber,
+          builderRolloutMetadata);
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -254,7 +254,6 @@ public class ConfigContainer {
     private JSONArray builderAbtExperiments;
     private JSONObject builderPersonalizationMetadata;
     private long builderTemplateVersionNumber;
-
     private JSONArray builderRolloutMetadata;
 
     private Builder() {

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -108,6 +108,7 @@ public class ConfigContainer {
       personalizationMetadataJSON = new JSONObject();
     }
 
+    // Default to empty JSONArray if Rollout metadata does not exist.
     JSONArray rolloutMetadataJSON = containerJson.optJSONArray(ROLLOUT_METADATA_KEY);
     if (rolloutMetadataJSON == null) {
       rolloutMetadataJSON = new JSONArray();

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -454,7 +454,7 @@ public class ConfigFetchHttpClient {
         // Do nothing if rolloutMetadata does not exist.
       }
       if (rolloutMetadata != null) {
-        containerBuilder.withRolloutMetadata(rolloutMetadata);
+        containerBuilder = containerBuilder.withRolloutMetadata(rolloutMetadata);
       }
 
       return containerBuilder.build();

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClient.java
@@ -32,6 +32,7 @@ import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFiel
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.ENTRIES;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.EXPERIMENT_DESCRIPTIONS;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.PERSONALIZATION_METADATA;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.ROLLOUT_METADATA;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.STATE;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.TEMPLATE_VERSION_NUMBER;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -444,6 +445,16 @@ public class ConfigFetchHttpClient {
 
       if (templateVersionNumber != null) {
         containerBuilder.withTemplateVersionNumber(Long.parseLong(templateVersionNumber));
+      }
+
+      JSONArray rolloutMetadata = null;
+      try {
+        rolloutMetadata = fetchResponse.getJSONArray(ROLLOUT_METADATA);
+      } catch (JSONException e) {
+        // Do nothing if rolloutMetadata does not exist.
+      }
+      if (rolloutMetadata != null) {
+        containerBuilder.withRolloutMetadata(rolloutMetadata);
       }
 
       return containerBuilder.build();

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1157,6 +1157,65 @@ public final class FirebaseRemoteConfigTest {
   }
 
   @Test
+  public void activate_configWithRolloutMetadata_storedInActivatedCacheSuccessfully()
+      throws Exception {
+    JSONArray affectedParameterKeys = new JSONArray();
+    affectedParameterKeys.put("key_1");
+    affectedParameterKeys.put("key_2");
+
+    JSONArray rolloutsMetadata = new JSONArray();
+    rolloutsMetadata.put(
+        new JSONObject()
+            .put("rolloutId", "1")
+            .put("variantId", "A")
+            .put("affectedParameterKeys", affectedParameterKeys));
+
+    ConfigContainer fetchedConfigContainer =
+        ConfigContainer.newBuilder(firstFetchedContainer)
+            .withRolloutMetadata(rolloutsMetadata)
+            .build();
+
+    loadCacheWithConfig(mockFetchedCache, fetchedConfigContainer);
+    loadCacheWithConfig(mockActivatedCache, null);
+    cachePutReturnsConfig(mockActivatedCache, fetchedConfigContainer);
+
+    frc.activate();
+
+    verify(mockActivatedCache).put(fetchedConfigContainer);
+    verify(mockFetchedCache).clear();
+  }
+
+  @Test
+  public void fetchAndActivate_configWithRolloutMetadata_storedInActivatedCacheSuccessfully()
+      throws Exception {
+    JSONArray affectedParameterKeys = new JSONArray();
+    affectedParameterKeys.put("key_1");
+    affectedParameterKeys.put("key_2");
+
+    JSONArray rolloutsMetadata = new JSONArray();
+    rolloutsMetadata.put(
+        new JSONObject()
+            .put("rolloutId", "1")
+            .put("variantId", "A")
+            .put("affectedParameterKeys", affectedParameterKeys));
+
+    ConfigContainer fetchedConfigContainer =
+        ConfigContainer.newBuilder(firstFetchedContainer)
+            .withRolloutMetadata(rolloutsMetadata)
+            .build();
+
+    loadFetchHandlerWithResponse(fetchedConfigContainer);
+    loadCacheWithConfig(mockFetchedCache, fetchedConfigContainer);
+    loadCacheWithConfig(mockActivatedCache, null);
+    cachePutReturnsConfig(mockActivatedCache, fetchedConfigContainer);
+
+    frc.fetchAndActivate();
+
+    verify(mockActivatedCache).put(fetchedConfigContainer);
+    verify(mockFetchedCache).clear();
+  }
+
+  @Test
   public void realtime_frc_full_test() {
     ConfigUpdateListener eventListener = generateEmptyRealtimeListener();
     when(mockConfigRealtimeHandler.addRealtimeConfigUpdateListener(eventListener))
@@ -1609,6 +1668,12 @@ public final class FirebaseRemoteConfigTest {
 
   private void loadFetchHandlerWithResponse() {
     when(mockFetchHandler.fetch()).thenReturn(Tasks.forResult(firstFetchedContainerResponse));
+  }
+
+  private void loadFetchHandlerWithResponse(ConfigContainer configContainer) {
+    FetchResponse fetchResponse =
+        FetchResponse.forBackendUpdatesFetched(firstFetchedContainer, ETAG);
+    when(mockFetchHandler.fetch()).thenReturn(Tasks.forResult(fetchResponse));
   }
 
   private void load2pFetchHandlerWithResponse() {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -270,6 +270,72 @@ public class ConfigContainerTest {
     assertThat(configWithoutTemplateVersion.getTemplateVersionNumber()).isEqualTo(0L);
   }
 
+  @Test
+  public void copyOfConfigContainer_withoutRolloutsMetadata_defaultsToEmptyArray()
+      throws Exception {
+    JSONArray affectedParameterKeys = new JSONArray();
+    affectedParameterKeys.put("key_1");
+    affectedParameterKeys.put("key_2");
+
+    JSONArray rolloutsMetadata = new JSONArray();
+    rolloutsMetadata.put(
+        new JSONObject()
+            .put("rolloutId", "1")
+            .put("variantId", "A")
+            .put("affectedParameterKeys", affectedParameterKeys));
+    ConfigContainer configContainer =
+        ConfigContainer.newBuilder().withRolloutMetadata(rolloutsMetadata).build();
+    JSONObject configContainerJson = new JSONObject(configContainer.toString());
+    configContainerJson.remove(ConfigContainer.ROLLOUT_METADATA_KEY);
+
+    ConfigContainer otherConfigContainer = ConfigContainer.copyOf(configContainerJson);
+
+    assertThat(otherConfigContainer.getRolloutMetadata()).isNotNull();
+    assertThat(otherConfigContainer.getRolloutMetadata().length()).isEqualTo(0);
+  }
+
+  @Test
+  public void copyOfConfigContainer_withRolloutsMetadata_returnsSameRolloutsMetadata()
+      throws Exception {
+    JSONArray affectedParameterKeys = new JSONArray();
+    affectedParameterKeys.put("key_1");
+    affectedParameterKeys.put("key_2");
+
+    JSONArray rolloutsMetadata = new JSONArray();
+    rolloutsMetadata.put(
+        new JSONObject()
+            .put("rolloutId", "1")
+            .put("variantId", "A")
+            .put("affectedParameterKeys", affectedParameterKeys));
+    ConfigContainer configContainer =
+        ConfigContainer.newBuilder().withRolloutMetadata(rolloutsMetadata).build();
+    ConfigContainer otherConfigContainer =
+        ConfigContainer.copyOf(new JSONObject(configContainer.toString()));
+
+    assertThat(otherConfigContainer.getRolloutMetadata().toString())
+        .isEqualTo(rolloutsMetadata.toString());
+  }
+
+  @Test
+  public void configContainer_withRolloutsMetadata_returnsCorrectRolloutsMetadata()
+      throws Exception {
+    JSONArray affectedParameterKeys = new JSONArray();
+    affectedParameterKeys.put("key_1");
+    affectedParameterKeys.put("key_2");
+
+    JSONArray rolloutsMetadata = new JSONArray();
+    rolloutsMetadata.put(
+        new JSONObject()
+            .put("rolloutId", "1")
+            .put("variantId", "A")
+            .put("affectedParameterKeys", affectedParameterKeys));
+    ConfigContainer configContainer =
+        ConfigContainer.newBuilder().withRolloutMetadata(rolloutsMetadata).build();
+
+    assertThat(configContainer.getRolloutMetadata().toString())
+        .isEqualTo(rolloutsMetadata.toString());
+  }
+
   private static JSONArray generateAbtExperiments(int numExperiments) throws JSONException {
     JSONArray experiments = new JSONArray();
     for (int experimentNum = 1; experimentNum <= numExperiments; experimentNum++) {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigFetchHttpClientTest.java
@@ -34,6 +34,7 @@ import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFiel
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.RequestFieldKey.TIME_ZONE;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.ENTRIES;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.EXPERIMENT_DESCRIPTIONS;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.ROLLOUT_METADATA;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ResponseFieldKey.STATE;
 import static com.google.firebase.remoteconfig.testutil.Assert.assertFalse;
 import static com.google.firebase.remoteconfig.testutil.Assert.assertThrows;
@@ -126,7 +127,17 @@ public class ConfigFetchHttpClientTest {
                             .put("trigger_event", "event_trigger_1")
                             .put("experiment_start_time", "2017-10-30T21:46:40Z")
                             .put("trigger_timeout", "15552000s")
-                            .put("time_to_live", "7776000s")));
+                            .put("time_to_live", "7776000s")))
+            .put(
+                ROLLOUT_METADATA,
+                new JSONArray()
+                    .put(
+                        new JSONObject()
+                            .put("rolloutId", "1")
+                            .put("variantId", "A")
+                            .put(
+                                "affectedParameterKeys",
+                                new JSONArray().put("key_1").put("key_2"))));
     noChangeResponseBody = new JSONObject().put(STATE, "NO_CHANGE");
 
     fakeHttpURLConnection =
@@ -156,6 +167,8 @@ public class ConfigFetchHttpClientTest {
         .isEqualTo(hasChangeResponseBody.getJSONObject(ENTRIES).toString());
     assertThat(response.getFetchedConfigs().getAbtExperiments().toString())
         .isEqualTo(hasChangeResponseBody.getJSONArray(EXPERIMENT_DESCRIPTIONS).toString());
+    assertThat(response.getFetchedConfigs().getRolloutMetadata().toString())
+        .isEqualTo(hasChangeResponseBody.getJSONArray(ROLLOUT_METADATA).toString());
     assertThat(response.getFetchedConfigs().getFetchTime())
         .isEqualTo(new Date(mockClock.currentTimeMillis()));
   }


### PR DESCRIPTION
- Parse rollout_metadata out of fetch response in `extractConfigs` method
- Add field in ConfigContainer for rollout_metadata to be saved
- Add unit tests for fetching/activating configs with rollout_metadata
