### PR TITLE
Add RC Interop to RC SDK with a stubbed implementation.

### DIFF
--- a/firebase-config/firebase-config.gradle
+++ b/firebase-config/firebase-config.gradle
@@ -51,6 +51,8 @@ android {
 }
 
 dependencies {
+    // TODO: Switch to a versioned dependency once released.
+    implementation project(':firebase-config-interop')
     implementation 'com.google.firebase:firebase-annotations:16.2.0'
     implementation 'com.google.firebase:firebase-common:20.3.1'
     implementation 'com.google.firebase:firebase-abt:21.1.1'

--- a/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/TestConstructorUtil.kt
+++ b/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/TestConstructorUtil.kt
@@ -23,6 +23,7 @@ import com.google.firebase.remoteconfig.internal.ConfigFetchHandler
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
 import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler
+import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler
 import java.util.concurrent.Executor
 
 // This method is a workaround for testing. It enable us to create a FirebaseRemoteConfig object
@@ -39,7 +40,8 @@ fun createRemoteConfig(
   fetchHandler: ConfigFetchHandler,
   getHandler: ConfigGetParameterHandler,
   frcMetadata: ConfigMetadataClient,
-  realtimeHandler: ConfigRealtimeHandler
+  realtimeHandler: ConfigRealtimeHandler,
+  rolloutsStateSubscriptionsHandler: RolloutsStateSubscriptionsHandler
 ): FirebaseRemoteConfig {
   return FirebaseRemoteConfig(
     context,
@@ -53,6 +55,7 @@ fun createRemoteConfig(
     fetchHandler,
     getHandler,
     frcMetadata,
-    realtimeHandler
+    realtimeHandler,
+    rolloutsStateSubscriptionsHandler
   )
 }

--- a/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
+++ b/firebase-config/ktx/src/test/kotlin/com/google/firebase/remoteconfig/ktx/RemoteConfigTests.kt
@@ -32,6 +32,7 @@ import com.google.firebase.remoteconfig.internal.ConfigFetchHandler
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler
 import com.google.firebase.remoteconfig.internal.ConfigMetadataClient
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler
+import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -140,7 +141,8 @@ class ConfigTests : BaseTestCase() {
         fetchHandler = mock(ConfigFetchHandler::class.java),
         getHandler = mockGetHandler,
         frcMetadata = mock(ConfigMetadataClient::class.java),
-        realtimeHandler = mock(ConfigRealtimeHandler::class.java)
+        realtimeHandler = mock(ConfigRealtimeHandler::class.java),
+        rolloutsStateSubscriptionsHandler = mock(RolloutsStateSubscriptionsHandler::class.java)
       )
 
     `when`(mockGetHandler.getValue("KEY")).thenReturn(StringRemoteConfigValue("non default value"))

--- a/firebase-config/src/androidTest/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigIntegrationTest.java
+++ b/firebase-config/src/androidTest/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigIntegrationTest.java
@@ -37,6 +37,7 @@ import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
 import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
+import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,6 +62,7 @@ public class FirebaseRemoteConfigIntegrationTest {
   @Mock private ConfigGetParameterHandler mockGetHandler;
   @Mock private ConfigMetadataClient metadataClient;
   @Mock private ConfigRealtimeHandler mockConfigRealtimeHandler;
+  @Mock private RolloutsStateSubscriptionsHandler mockRolloutsStateSubscriptionHandler;
 
   @Mock private ConfigCacheClient mockFireperfFetchedCache;
   @Mock private ConfigCacheClient mockFireperfActivatedCache;
@@ -111,7 +113,8 @@ public class FirebaseRemoteConfigIntegrationTest {
             mockFetchHandler,
             mockGetHandler,
             metadataClient,
-            mockConfigRealtimeHandler);
+            mockConfigRealtimeHandler,
+            mockRolloutsStateSubscriptionHandler);
   }
 
   @Test

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -36,6 +36,7 @@ import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
 import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
 import com.google.firebase.remoteconfig.internal.DefaultsXmlParser;
+import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -152,6 +153,7 @@ public class FirebaseRemoteConfig {
   private final ConfigMetadataClient frcMetadata;
   private final FirebaseInstallationsApi firebaseInstallations;
   private final ConfigRealtimeHandler configRealtimeHandler;
+  private final RolloutsStateSubscriptionsHandler rolloutsStateSubscriptionsHandler;
 
   /**
    * Firebase Remote Config constructor.
@@ -170,7 +172,8 @@ public class FirebaseRemoteConfig {
       ConfigFetchHandler fetchHandler,
       ConfigGetParameterHandler getHandler,
       ConfigMetadataClient frcMetadata,
-      ConfigRealtimeHandler configRealtimeHandler) {
+      ConfigRealtimeHandler configRealtimeHandler,
+      RolloutsStateSubscriptionsHandler rolloutsStateSubscriptionsHandler) {
     this.context = context;
     this.firebaseApp = firebaseApp;
     this.firebaseInstallations = firebaseInstallations;
@@ -183,6 +186,7 @@ public class FirebaseRemoteConfig {
     this.getHandler = getHandler;
     this.frcMetadata = frcMetadata;
     this.configRealtimeHandler = configRealtimeHandler;
+    this.rolloutsStateSubscriptionsHandler = rolloutsStateSubscriptionsHandler;
   }
 
   /**
@@ -702,6 +706,10 @@ public class FirebaseRemoteConfig {
       experimentInfoMaps.add(experimentInfo);
     }
     return experimentInfoMaps;
+  }
+
+  RolloutsStateSubscriptionsHandler getRolloutsStateSubscriptionHandler() {
+    return rolloutsStateSubscriptionsHandler;
   }
 
   /** Returns true if the fetched configs are fresher than the activated configs. */

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -708,7 +708,7 @@ public class FirebaseRemoteConfig {
     return experimentInfoMaps;
   }
 
-  RolloutsStateSubscriptionsHandler getRolloutsStateSubscriptionHandler() {
+  RolloutsStateSubscriptionsHandler getRolloutsStateSubscriptionsHandler() {
     return rolloutsStateSubscriptionsHandler;
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -40,8 +40,6 @@ import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
 import com.google.firebase.remoteconfig.internal.ConfigStorageClient;
 import com.google.firebase.remoteconfig.internal.Personalization;
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
-import com.google.firebase.remoteconfig.interop.FirebaseRemoteConfigInterop;
-import com.google.firebase.remoteconfig.interop.rollouts.RolloutsStateSubscriber;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -39,6 +39,9 @@ import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
 import com.google.firebase.remoteconfig.internal.ConfigStorageClient;
 import com.google.firebase.remoteconfig.internal.Personalization;
+import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
+import com.google.firebase.remoteconfig.interop.FirebaseRemoteConfigInterop;
+import com.google.firebase.remoteconfig.interop.rollouts.RolloutsStateSubscriber;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -167,6 +170,9 @@ public class RemoteConfigComponent {
     if (personalization != null) {
       getHandler.addListener(personalization::logArmActive);
     }
+
+    RolloutsStateSubscriptionsHandler rolloutsStateSubscriptionsHandler =
+        getRolloutsStateSubscriptionsHandler();
 
     return get(
         firebaseApp,
@@ -307,6 +313,10 @@ public class RemoteConfigComponent {
       return new Personalization(analyticsConnector);
     }
     return null;
+  }
+
+  private RolloutsStateSubscriptionsHandler getRolloutsStateSubscriptionsHandler() {
+    return new RolloutsStateSubscriptionsHandler();
   }
 
   /**

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -361,7 +361,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
   public void registerRolloutsStateSubscriber(
       @NonNull String namespace, @NonNull RolloutsStateSubscriber subscriber) {
     get(namespace)
-        .getRolloutsStateSubscriptionHandler()
+        .getRolloutsStateSubscriptionsHandler()
         .registerRolloutsStateSubscriber(subscriber);
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigRegistrar.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigRegistrar.java
@@ -27,6 +27,7 @@ import com.google.firebase.components.Dependency;
 import com.google.firebase.components.Qualified;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
+import com.google.firebase.remoteconfig.interop.FirebaseRemoteConfigInterop;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -47,7 +48,7 @@ public class RemoteConfigRegistrar implements ComponentRegistrar {
     Qualified<ScheduledExecutorService> blockingExecutor =
         Qualified.qualified(Blocking.class, ScheduledExecutorService.class);
     return Arrays.asList(
-        Component.builder(RemoteConfigComponent.class)
+        Component.builder(RemoteConfigComponent.class, FirebaseRemoteConfigInterop.class)
             .name(LIBRARY_NAME)
             .add(Dependency.required(Context.class))
             .add(Dependency.required(blockingExecutor))

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -67,12 +67,12 @@ public class ConfigContainer {
    * <p>The {@code configsJson} must not be modified.
    */
   private ConfigContainer(
-      JSONObject configsJson,
-      Date fetchTime,
-      JSONArray abtExperiments,
-      JSONObject personalizationMetadata,
-      long templateVersionNumber)
-      throws JSONException {
+          JSONObject configsJson,
+          Date fetchTime,
+          JSONArray abtExperiments,
+          JSONObject personalizationMetadata,
+          long templateVersionNumber)
+          throws JSONException {
     JSONObject containerJson = new JSONObject();
     containerJson.put(CONFIGS_KEY, configsJson);
     containerJson.put(FETCH_TIME_KEY, fetchTime.getTime());
@@ -97,18 +97,18 @@ public class ConfigContainer {
   static ConfigContainer copyOf(JSONObject containerJson) throws JSONException {
     // Personalization metadata may not have been written yet.
     JSONObject personalizationMetadataJSON =
-        containerJson.optJSONObject(PERSONALIZATION_METADATA_KEY);
+            containerJson.optJSONObject(PERSONALIZATION_METADATA_KEY);
     if (personalizationMetadataJSON == null) {
       personalizationMetadataJSON = new JSONObject();
     }
 
     return new ConfigContainer(
-        containerJson.getJSONObject(CONFIGS_KEY),
-        new Date(containerJson.getLong(FETCH_TIME_KEY)),
-        containerJson.getJSONArray(ABT_EXPERIMENTS_KEY),
-        personalizationMetadataJSON,
-        // Default to 0 if template_version_number_key has not been cached yet.
-        containerJson.optLong(TEMPLATE_VERSION_NUMBER_KEY));
+            containerJson.getJSONObject(CONFIGS_KEY),
+            new Date(containerJson.getLong(FETCH_TIME_KEY)),
+            containerJson.getJSONArray(ABT_EXPERIMENTS_KEY),
+            personalizationMetadataJSON,
+            // Default to 0 if template_version_number_key has not been cached yet.
+            containerJson.optLong(TEMPLATE_VERSION_NUMBER_KEY));
   }
 
   /**
@@ -196,7 +196,7 @@ public class ConfigContainer {
 
       // If only one of the configs has PersonalizationMetadata for the key
       if (this.getPersonalizationMetadata().has(key) && !other.getPersonalizationMetadata().has(key)
-          || !this.getPersonalizationMetadata().has(key)
+              || !this.getPersonalizationMetadata().has(key)
               && other.getPersonalizationMetadata().has(key)) {
         changed.add(key);
         continue;
@@ -204,8 +204,8 @@ public class ConfigContainer {
 
       // If the both configs have PersonalizationMetadata for the key, but the metadata has changed
       if (this.getPersonalizationMetadata().has(key)
-          && other.getPersonalizationMetadata().has(key)
-          && !this.getPersonalizationMetadata()
+              && other.getPersonalizationMetadata().has(key)
+              && !this.getPersonalizationMetadata()
               .getJSONObject(key)
               .toString()
               .equals(other.getPersonalizationMetadata().getJSONObject(key).toString())) {
@@ -309,11 +309,11 @@ public class ConfigContainer {
     /** If a fetch time is not provided, the defaults container fetch time is used. */
     public ConfigContainer build() throws JSONException {
       return new ConfigContainer(
-          builderConfigsJson,
-          builderFetchTime,
-          builderAbtExperiments,
-          builderPersonalizationMetadata,
-          builderTemplateVersionNumber);
+              builderConfigsJson,
+              builderFetchTime,
+              builderAbtExperiments,
+              builderPersonalizationMetadata,
+              builderTemplateVersionNumber);
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -67,12 +67,12 @@ public class ConfigContainer {
    * <p>The {@code configsJson} must not be modified.
    */
   private ConfigContainer(
-          JSONObject configsJson,
-          Date fetchTime,
-          JSONArray abtExperiments,
-          JSONObject personalizationMetadata,
-          long templateVersionNumber)
-          throws JSONException {
+      JSONObject configsJson,
+      Date fetchTime,
+      JSONArray abtExperiments,
+      JSONObject personalizationMetadata,
+      long templateVersionNumber)
+      throws JSONException {
     JSONObject containerJson = new JSONObject();
     containerJson.put(CONFIGS_KEY, configsJson);
     containerJson.put(FETCH_TIME_KEY, fetchTime.getTime());
@@ -97,18 +97,18 @@ public class ConfigContainer {
   static ConfigContainer copyOf(JSONObject containerJson) throws JSONException {
     // Personalization metadata may not have been written yet.
     JSONObject personalizationMetadataJSON =
-            containerJson.optJSONObject(PERSONALIZATION_METADATA_KEY);
+        containerJson.optJSONObject(PERSONALIZATION_METADATA_KEY);
     if (personalizationMetadataJSON == null) {
       personalizationMetadataJSON = new JSONObject();
     }
 
     return new ConfigContainer(
-            containerJson.getJSONObject(CONFIGS_KEY),
-            new Date(containerJson.getLong(FETCH_TIME_KEY)),
-            containerJson.getJSONArray(ABT_EXPERIMENTS_KEY),
-            personalizationMetadataJSON,
-            // Default to 0 if template_version_number_key has not been cached yet.
-            containerJson.optLong(TEMPLATE_VERSION_NUMBER_KEY));
+        containerJson.getJSONObject(CONFIGS_KEY),
+        new Date(containerJson.getLong(FETCH_TIME_KEY)),
+        containerJson.getJSONArray(ABT_EXPERIMENTS_KEY),
+        personalizationMetadataJSON,
+        // Default to 0 if template_version_number_key has not been cached yet.
+        containerJson.optLong(TEMPLATE_VERSION_NUMBER_KEY));
   }
 
   /**
@@ -196,7 +196,7 @@ public class ConfigContainer {
 
       // If only one of the configs has PersonalizationMetadata for the key
       if (this.getPersonalizationMetadata().has(key) && !other.getPersonalizationMetadata().has(key)
-              || !this.getPersonalizationMetadata().has(key)
+          || !this.getPersonalizationMetadata().has(key)
               && other.getPersonalizationMetadata().has(key)) {
         changed.add(key);
         continue;
@@ -204,8 +204,8 @@ public class ConfigContainer {
 
       // If the both configs have PersonalizationMetadata for the key, but the metadata has changed
       if (this.getPersonalizationMetadata().has(key)
-              && other.getPersonalizationMetadata().has(key)
-              && !this.getPersonalizationMetadata()
+          && other.getPersonalizationMetadata().has(key)
+          && !this.getPersonalizationMetadata()
               .getJSONObject(key)
               .toString()
               .equals(other.getPersonalizationMetadata().getJSONObject(key).toString())) {
@@ -309,11 +309,11 @@ public class ConfigContainer {
     /** If a fetch time is not provided, the defaults container fetch time is used. */
     public ConfigContainer build() throws JSONException {
       return new ConfigContainer(
-              builderConfigsJson,
-              builderFetchTime,
-              builderAbtExperiments,
-              builderPersonalizationMetadata,
-              builderTemplateVersionNumber);
+          builderConfigsJson,
+          builderFetchTime,
+          builderAbtExperiments,
+          builderPersonalizationMetadata,
+          builderTemplateVersionNumber);
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClient.java
@@ -282,6 +282,7 @@ public class ConfigMetadataClient {
   // Realtime exponential backoff logic.
   // -----------------------------------------------------------------
 
+  @VisibleForTesting
   public RealtimeBackoffMetadata getRealtimeBackoffMetadata() {
     synchronized (realtimeBackoffMetadataLock) {
       return new RealtimeBackoffMetadata(
@@ -318,6 +319,7 @@ public class ConfigMetadataClient {
     private int numFailedStreams;
     private Date backoffEndTime;
 
+    @VisibleForTesting
     public RealtimeBackoffMetadata(int numFailedStreams, Date backoffEndTime) {
       this.numFailedStreams = numFailedStreams;
       this.backoffEndTime = backoffEndTime;

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigMetadataClient.java
@@ -282,7 +282,7 @@ public class ConfigMetadataClient {
   // Realtime exponential backoff logic.
   // -----------------------------------------------------------------
 
-  RealtimeBackoffMetadata getRealtimeBackoffMetadata() {
+  public RealtimeBackoffMetadata getRealtimeBackoffMetadata() {
     synchronized (realtimeBackoffMetadataLock) {
       return new RealtimeBackoffMetadata(
           frcMetadata.getInt(NUM_FAILED_REALTIME_STREAMS_KEY, NO_FAILED_REALTIME_STREAMS),
@@ -313,11 +313,12 @@ public class ConfigMetadataClient {
    * <p>The purpose of this class is to avoid race conditions when retrieving backoff metadata
    * values separately.
    */
-  static class RealtimeBackoffMetadata {
+  @VisibleForTesting
+  public static class RealtimeBackoffMetadata {
     private int numFailedStreams;
     private Date backoffEndTime;
 
-    RealtimeBackoffMetadata(int numFailedStreams, Date backoffEndTime) {
+    public RealtimeBackoffMetadata(int numFailedStreams, Date backoffEndTime) {
       this.numFailedStreams = numFailedStreams;
       this.backoffEndTime = backoffEndTime;
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/rollouts/RolloutsStateSubscriptionsHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/rollouts/RolloutsStateSubscriptionsHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig.internal.rollouts;
+
+import androidx.annotation.NonNull;
+import com.google.firebase.remoteconfig.internal.ConfigContainer;
+import com.google.firebase.remoteconfig.interop.rollouts.RolloutsStateSubscriber;
+
+public class RolloutsStateSubscriptionsHandler {
+
+  public RolloutsStateSubscriptionsHandler() {}
+
+  public void registerRolloutsStateSubscriber(@NonNull RolloutsStateSubscriber subscriber) {
+    // TODO: Implement registration.
+  }
+
+  public void publishActiveRolloutsState(@NonNull ConfigContainer configContainer) {
+    // TODO: Implement publishing.
+  }
+}

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -78,7 +78,6 @@ import com.google.firebase.remoteconfig.internal.ConfigRealtimeHttpClient;
 import com.google.firebase.remoteconfig.internal.FakeHttpURLConnection;
 import com.google.firebase.remoteconfig.internal.Personalization;
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -110,9 +109,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-/**
- * Unit tests for the Firebase Remote Config API.
- */
+/** Unit tests for the Firebase Remote Config API. */
 @RunWith(RobolectricTestRunner.class)
 @Config(
     manifest = Config.NONE,
@@ -245,7 +242,7 @@ public final class FirebaseRemoteConfigTest {
             mockGetHandler,
             metadataClient,
             mockConfigRealtimeHandler,
-                mockRolloutsStateSubscriptionsHandler);
+            mockRolloutsStateSubscriptionsHandler);
 
     // Set up an FRC instance for the Fireperf namespace that uses mocked clients.
     fireperfFrc =
@@ -263,7 +260,7 @@ public final class FirebaseRemoteConfigTest {
                 mockFireperfFetchHandler,
                 mockFireperfGetHandler,
                 RemoteConfigComponent.getMetadataClient(context, APP_ID, FIREPERF_NAMESPACE),
-                    mockRolloutsStateSubscriptionsHandler);
+                mockRolloutsStateSubscriptionsHandler);
 
     personalizationFrc =
         FirebaseApp.getInstance()
@@ -279,9 +276,8 @@ public final class FirebaseRemoteConfigTest {
                 mockDefaultsCache,
                 mockFetchHandler,
                 parameterHandler,
-                RemoteConfigComponent.getMetadataClient(
-                    context, APP_ID, PERSONALIZATION_NAMESPACE),
-                    mockRolloutsStateSubscriptionsHandler);
+                RemoteConfigComponent.getMetadataClient(context, APP_ID, PERSONALIZATION_NAMESPACE),
+                mockRolloutsStateSubscriptionsHandler);
 
     firstFetchedContainer =
         ConfigContainer.newBuilder()

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -77,6 +77,8 @@ import com.google.firebase.remoteconfig.internal.ConfigRealtimeHandler;
 import com.google.firebase.remoteconfig.internal.ConfigRealtimeHttpClient;
 import com.google.firebase.remoteconfig.internal.FakeHttpURLConnection;
 import com.google.firebase.remoteconfig.internal.Personalization;
+import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -110,8 +112,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * Unit tests for the Firebase Remote Config API.
- *
- * @author Miraziz Yusupov
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(
@@ -184,6 +184,8 @@ public final class FirebaseRemoteConfigTest {
   @Mock private FirebaseInstallationsApi mockFirebaseInstallations;
   @Mock private Provider<AnalyticsConnector> mockAnalyticsConnectorProvider;
 
+  @Mock private RolloutsStateSubscriptionsHandler mockRolloutsStateSubscriptionsHandler;
+
   private FirebaseRemoteConfig frc;
   private FirebaseRemoteConfig fireperfFrc;
   private FirebaseRemoteConfig personalizationFrc;
@@ -242,7 +244,8 @@ public final class FirebaseRemoteConfigTest {
             mockFetchHandler,
             mockGetHandler,
             metadataClient,
-            mockConfigRealtimeHandler);
+            mockConfigRealtimeHandler,
+                mockRolloutsStateSubscriptionsHandler);
 
     // Set up an FRC instance for the Fireperf namespace that uses mocked clients.
     fireperfFrc =
@@ -259,7 +262,8 @@ public final class FirebaseRemoteConfigTest {
                 mockFireperfDefaultsCache,
                 mockFireperfFetchHandler,
                 mockFireperfGetHandler,
-                RemoteConfigComponent.getMetadataClient(context, APP_ID, FIREPERF_NAMESPACE));
+                RemoteConfigComponent.getMetadataClient(context, APP_ID, FIREPERF_NAMESPACE),
+                    mockRolloutsStateSubscriptionsHandler);
 
     personalizationFrc =
         FirebaseApp.getInstance()
@@ -276,7 +280,8 @@ public final class FirebaseRemoteConfigTest {
                 mockFetchHandler,
                 parameterHandler,
                 RemoteConfigComponent.getMetadataClient(
-                    context, APP_ID, PERSONALIZATION_NAMESPACE));
+                    context, APP_ID, PERSONALIZATION_NAMESPACE),
+                    mockRolloutsStateSubscriptionsHandler);
 
     firstFetchedContainer =
         ConfigContainer.newBuilder()

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -190,7 +190,7 @@ public class RemoteConfigComponentTest {
 
     frcComponent.registerRolloutsStateSubscriber(DEFAULT_NAMESPACE, mockRolloutsStateSubscriber);
 
-    verify(instance.getRolloutsStateSubscriptionHandler())
+    verify(instance.getRolloutsStateSubscriptionsHandler())
         .registerRolloutsStateSubscriber(mockRolloutsStateSubscriber);
   }
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
+import android.nfc.tech.NfcA;
+
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Tasks;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -40,6 +42,10 @@ import com.google.firebase.remoteconfig.internal.ConfigFetchHandler;
 import com.google.firebase.remoteconfig.internal.ConfigFetchHttpClient;
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
 import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
+import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
+import com.google.firebase.remoteconfig.interop.rollouts.RolloutsStateSubscriber;
+
+import java.util.Date;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -54,8 +60,6 @@ import org.robolectric.annotation.LooperMode;
 
 /**
  * Unit tests for the Firebase Remote Config Component.
- *
- * @author Miraziz Yusupov
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -75,6 +79,9 @@ public class RemoteConfigComponentTest {
   @Mock private ConfigFetchHandler mockFetchHandler;
   @Mock private ConfigGetParameterHandler mockGetParameterHandler;
   @Mock private ConfigMetadataClient mockMetadataClient;
+  @Mock private RolloutsStateSubscriptionsHandler mockRolloutsStateSubscriptionsHandler;
+
+  @Mock private RolloutsStateSubscriber mockRolloutsStateSubscriber;
 
   private Context context;
   private ExecutorService directExecutor;
@@ -177,6 +184,19 @@ public class RemoteConfigComponentTest {
     assertThat(actualReadTimeout).isEqualTo(customConnectionTimeoutInSeconds);
   }
 
+  @Test
+  public void registerRolloutsStateSubscriber_firebaseNamespace_callsSubscriptionHandler() {
+    // Mock metadata client response since Realtime handler can't be mocked here.
+    when(mockMetadataClient.getRealtimeBackoffMetadata()).thenReturn(new ConfigMetadataClient.RealtimeBackoffMetadata(0, new Date()));
+
+    RemoteConfigComponent frcComponent = getNewFrcComponent();
+    FirebaseRemoteConfig instance = getFrcInstanceFromComponent(frcComponent, DEFAULT_NAMESPACE);
+
+    frcComponent.registerRolloutsStateSubscriber(DEFAULT_NAMESPACE, mockRolloutsStateSubscriber);
+
+    verify(instance.getRolloutsStateSubscriptionHandler()).registerRolloutsStateSubscriber(mockRolloutsStateSubscriber);
+  }
+
   private RemoteConfigComponent getNewFrcComponent() {
     return new RemoteConfigComponent(
         context,
@@ -212,7 +232,8 @@ public class RemoteConfigComponentTest {
         mockDefaultsCache,
         mockFetchHandler,
         mockGetParameterHandler,
-        metadataClient);
+        metadataClient,
+        mockRolloutsStateSubscriptionsHandler);
   }
 
   private FirebaseRemoteConfig getFrcInstanceFromComponent(
@@ -228,7 +249,8 @@ public class RemoteConfigComponentTest {
         mockDefaultsCache,
         mockFetchHandler,
         mockGetParameterHandler,
-        mockMetadataClient);
+        mockMetadataClient,
+        mockRolloutsStateSubscriptionsHandler);
   }
 
   private void loadConfigsWithExperimentsForActivate() throws Exception {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -26,8 +26,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
-import android.nfc.tech.NfcA;
-
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.tasks.Tasks;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -44,7 +42,6 @@ import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
 import com.google.firebase.remoteconfig.internal.ConfigMetadataClient;
 import com.google.firebase.remoteconfig.internal.rollouts.RolloutsStateSubscriptionsHandler;
 import com.google.firebase.remoteconfig.interop.rollouts.RolloutsStateSubscriber;
-
 import java.util.Date;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -58,9 +55,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
 
-/**
- * Unit tests for the Firebase Remote Config Component.
- */
+/** Unit tests for the Firebase Remote Config Component. */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class RemoteConfigComponentTest {
@@ -187,14 +182,16 @@ public class RemoteConfigComponentTest {
   @Test
   public void registerRolloutsStateSubscriber_firebaseNamespace_callsSubscriptionHandler() {
     // Mock metadata client response since Realtime handler can't be mocked here.
-    when(mockMetadataClient.getRealtimeBackoffMetadata()).thenReturn(new ConfigMetadataClient.RealtimeBackoffMetadata(0, new Date()));
+    when(mockMetadataClient.getRealtimeBackoffMetadata())
+        .thenReturn(new ConfigMetadataClient.RealtimeBackoffMetadata(0, new Date()));
 
     RemoteConfigComponent frcComponent = getNewFrcComponent();
     FirebaseRemoteConfig instance = getFrcInstanceFromComponent(frcComponent, DEFAULT_NAMESPACE);
 
     frcComponent.registerRolloutsStateSubscriber(DEFAULT_NAMESPACE, mockRolloutsStateSubscriber);
 
-    verify(instance.getRolloutsStateSubscriptionHandler()).registerRolloutsStateSubscriber(mockRolloutsStateSubscriber);
+    verify(instance.getRolloutsStateSubscriptionHandler())
+        .registerRolloutsStateSubscriber(mockRolloutsStateSubscriber);
   }
 
   private RemoteConfigComponent getNewFrcComponent() {

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/rollouts/RolloutsStateSubscriptionsHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/rollouts/RolloutsStateSubscriptionsHandlerTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig.internal.rollouts;
+
+// TODO: Add tests.
+public class RolloutsStateSubscriptionsHandlerTest {}


### PR DESCRIPTION
PR 1 of 3 implementing the pub/sub pattern in RC.

PRs: 
1. **This PR: Add dependency with stubbed implementation.**
2. [Implement publish and subscribe.](https://github.com/firebase/firebase-android-sdk/pull/5280)
3. [Implement getActiveRolloutsState.](https://github.com/firebase/firebase-android-sdk/pull/5281)