### PR TITLE
Integrate interop with Crashlytics sdk

### DIFF
--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-measurement-connector:18.0.2'
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
     implementation project(':firebase-sessions')
+    implementation project(':firebase-config-interop')
 
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsRemoteConfigListenerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsRemoteConfigListenerTest.java
@@ -1,0 +1,134 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.firebase.crashlytics.internal.metadata.RolloutAssignment;
+import com.google.firebase.crashlytics.internal.metadata.UserMetadata;
+import com.google.firebase.remoteconfig.interop.rollouts.RolloutsState;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CrashlyticsRemoteConfigListenerTest {
+  private static final String ROLLOUT_ASSIGNMENT_JSON_1 =
+      "{"
+          + "\"rolloutId\":\"rollout_1\","
+          + "\"variantId\":\"control\","
+          + "\"parameterKey\":\"my_feature\","
+          + "\"parameterValue\":\"false\","
+          + "\"templateVersion\":1"
+          + "}";
+
+  private static final String ROLLOUT_ASSIGNMENT_JSON_2 =
+      "{"
+          + "\"rolloutId\":\"rollout_2\","
+          + "\"variantId\":\"enabled\","
+          + "\"parameterKey\":\"my_another_feature\","
+          + "\"parameterValue\":\"false\","
+          + "\"templateVersion\":1"
+          + "}";
+
+  private static List<RolloutAssignment> CRASHLYTICS_ROLLOUT_ASSIGNMENT_SINGLE_ELEMENT_LIST;
+
+  static {
+    CRASHLYTICS_ROLLOUT_ASSIGNMENT_SINGLE_ELEMENT_LIST = new ArrayList<>();
+    CRASHLYTICS_ROLLOUT_ASSIGNMENT_SINGLE_ELEMENT_LIST.add(
+        RolloutAssignment.create("rollout_1", "my_feature", "false", "control", 1));
+  }
+
+  private static List<RolloutAssignment> CRASHLYTICS_ROLLOUT_ASSIGNMENT_MULTIPLE_ELEMENTS_LIST;
+
+  static {
+    CRASHLYTICS_ROLLOUT_ASSIGNMENT_MULTIPLE_ELEMENTS_LIST = new ArrayList<>();
+    CRASHLYTICS_ROLLOUT_ASSIGNMENT_MULTIPLE_ELEMENTS_LIST.add(
+        RolloutAssignment.create("rollout_1", "my_feature", "false", "control", 1));
+    CRASHLYTICS_ROLLOUT_ASSIGNMENT_MULTIPLE_ELEMENTS_LIST.add(
+        RolloutAssignment.create("rollout_2", "my_another_feature", "false", "enabled", 1));
+  }
+
+  @Mock private UserMetadata userMetadata;
+
+  @Captor private ArgumentCaptor<ArrayList<RolloutAssignment>> captor;
+
+  private CrashlyticsRemoteConfigListener listener;
+
+  @Before
+  public void setup() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    listener = new CrashlyticsRemoteConfigListener(userMetadata);
+  }
+
+  @Test
+  public void testListener_onChangeUpdateRCInteropClassToCrashlyticsClass() throws Exception {
+    RolloutsState rolloutsState = createInteropRolloutsStateWithSingleElement();
+    listener.onRolloutsStateChanged(rolloutsState);
+
+    verify(userMetadata).updateRolloutsState(CRASHLYTICS_ROLLOUT_ASSIGNMENT_SINGLE_ELEMENT_LIST);
+  }
+
+  @Test
+  public void testListener_onChangeUpdateRCInteropClassToCrashlyticsClassMultipleTimes()
+      throws Exception {
+    RolloutsState rolloutsState = createInteropRolloutsStateWithSingleElement();
+    listener.onRolloutsStateChanged(rolloutsState);
+
+    RolloutsState newRolloutsState = createInteropRolloutsStateWithMultipleElements();
+    listener.onRolloutsStateChanged(newRolloutsState);
+
+    verify(userMetadata, times(2)).updateRolloutsState(captor.capture());
+    assertThat(captor.getAllValues().get(1).size()).isEqualTo(2);
+  }
+
+  private RolloutsState createInteropRolloutsStateWithSingleElement() throws Exception {
+    com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment assignment =
+        com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment.create(
+            ROLLOUT_ASSIGNMENT_JSON_1);
+    Set<com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment> rolloutAssignmentsSet =
+        new HashSet<>();
+    rolloutAssignmentsSet.add(assignment);
+
+    RolloutsState rolloutsState = RolloutsState.create(rolloutAssignmentsSet);
+    return rolloutsState;
+  }
+
+  private RolloutsState createInteropRolloutsStateWithMultipleElements() throws Exception {
+    com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment assignment1 =
+        com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment.create(
+            ROLLOUT_ASSIGNMENT_JSON_1);
+
+    com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment assignment2 =
+        com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment.create(
+            ROLLOUT_ASSIGNMENT_JSON_2);
+    Set<com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment> rolloutAssignmentsSet =
+        new HashSet<>();
+
+    rolloutAssignmentsSet.add(assignment1);
+    rolloutAssignmentsSet.add(assignment2);
+
+    RolloutsState rolloutsState = RolloutsState.create(rolloutAssignmentsSet);
+    return rolloutsState;
+  }
+}

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/RemoteConfigDeferredProxyTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/RemoteConfigDeferredProxyTest.java
@@ -1,0 +1,55 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal;
+
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import androidx.annotation.NonNull;
+import com.google.firebase.crashlytics.internal.metadata.UserMetadata;
+import com.google.firebase.inject.Deferred;
+import com.google.firebase.remoteconfig.interop.FirebaseRemoteConfigInterop;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class RemoteConfigDeferredProxyTest {
+
+  @Mock private FirebaseRemoteConfigInterop interop;
+
+  @Mock private UserMetadata userMetadata;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testProviderProxyCallsThroughProvidedValue() {
+    RemoteConfigDeferredProxy proxy =
+        new RemoteConfigDeferredProxy(
+            new Deferred<FirebaseRemoteConfigInterop>() {
+              @Override
+              public void whenAvailable(
+                  @NonNull Deferred.DeferredHandler<FirebaseRemoteConfigInterop> handler) {
+                handler.handle(() -> interop);
+              }
+            });
+    proxy.setupListener(userMetadata);
+    verify(interop).registerRolloutsStateSubscriber(eq("firebase"), anyObject());
+  }
+}

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -31,6 +31,7 @@ import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
+import com.google.firebase.crashlytics.internal.RemoteConfigDeferredProxy;
 import com.google.firebase.crashlytics.internal.analytics.UnavailableAnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.breadcrumbs.DisabledBreadcrumbSource;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
@@ -137,7 +138,8 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
           new UnavailableAnalyticsEventLogger(),
           fileStore,
           crashHandlerExecutor,
-          mock(CrashlyticsAppQualitySessionsSubscriber.class));
+          mock(CrashlyticsAppQualitySessionsSubscriber.class),
+          mock(RemoteConfigDeferredProxy.class));
     }
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -33,6 +33,7 @@ import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
+import com.google.firebase.crashlytics.internal.RemoteConfigDeferredProxy;
 import com.google.firebase.crashlytics.internal.analytics.UnavailableAnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.breadcrumbs.BreadcrumbHandler;
 import com.google.firebase.crashlytics.internal.breadcrumbs.BreadcrumbSource;
@@ -427,7 +428,8 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
               new UnavailableAnalyticsEventLogger(),
               new FileStore(context),
               new SameThreadExecutorService(),
-              mock(CrashlyticsAppQualitySessionsSubscriber.class));
+              mock(CrashlyticsAppQualitySessionsSubscriber.class),
+              mock(RemoteConfigDeferredProxy.class));
       return crashlyticsCore;
     }
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/CrashlyticsRegistrar.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/CrashlyticsRegistrar.java
@@ -24,6 +24,7 @@ import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.inject.Deferred;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
+import com.google.firebase.remoteconfig.interop.FirebaseRemoteConfigInterop;
 import com.google.firebase.sessions.FirebaseSessions;
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies;
 import com.google.firebase.sessions.api.SessionSubscriber;
@@ -49,6 +50,7 @@ public class CrashlyticsRegistrar implements ComponentRegistrar {
             .add(Dependency.required(FirebaseSessions.class))
             .add(Dependency.deferred(CrashlyticsNativeComponent.class))
             .add(Dependency.deferred(AnalyticsConnector.class))
+            .add(Dependency.deferred(FirebaseRemoteConfigInterop.class))
             .factory(this::buildCrashlytics)
             .eagerInDefaultApp()
             .build(),
@@ -68,7 +70,15 @@ public class CrashlyticsRegistrar implements ComponentRegistrar {
 
     FirebaseSessions firebaseSessions = container.get(FirebaseSessions.class);
 
+    Deferred<FirebaseRemoteConfigInterop> remoteConfigInterop =
+        container.getDeferred(FirebaseRemoteConfigInterop.class);
+
     return FirebaseCrashlytics.init(
-        app, firebaseInstallations, firebaseSessions, nativeComponent, analyticsConnector);
+        app,
+        firebaseInstallations,
+        firebaseSessions,
+        nativeComponent,
+        analyticsConnector,
+        remoteConfigInterop);
   }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -28,6 +28,7 @@ import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.Logger;
+import com.google.firebase.crashlytics.internal.RemoteConfigDeferredProxy;
 import com.google.firebase.crashlytics.internal.common.AppData;
 import com.google.firebase.crashlytics.internal.common.BuildIdInfo;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
@@ -41,6 +42,7 @@ import com.google.firebase.crashlytics.internal.persistence.FileStore;
 import com.google.firebase.crashlytics.internal.settings.SettingsController;
 import com.google.firebase.inject.Deferred;
 import com.google.firebase.installations.FirebaseInstallationsApi;
+import com.google.firebase.remoteconfig.interop.FirebaseRemoteConfigInterop;
 import com.google.firebase.sessions.FirebaseSessions;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -66,7 +68,8 @@ public class FirebaseCrashlytics {
       @NonNull FirebaseInstallationsApi firebaseInstallationsApi,
       @NonNull FirebaseSessions firebaseSessions,
       @NonNull Deferred<CrashlyticsNativeComponent> nativeComponent,
-      @NonNull Deferred<AnalyticsConnector> analyticsConnector) {
+      @NonNull Deferred<AnalyticsConnector> analyticsConnector,
+      @NonNull Deferred<FirebaseRemoteConfigInterop> remoteConfigInteropDeferred) {
 
     Context context = app.getApplicationContext();
     final String appIdentifier = context.getPackageName();
@@ -95,6 +98,9 @@ public class FirebaseCrashlytics {
         new CrashlyticsAppQualitySessionsSubscriber(arbiter);
     firebaseSessions.register(sessionsSubscriber);
 
+    RemoteConfigDeferredProxy remoteConfigDeferredProxy =
+        new RemoteConfigDeferredProxy(remoteConfigInteropDeferred);
+
     final CrashlyticsCore core =
         new CrashlyticsCore(
             app,
@@ -105,7 +111,8 @@ public class FirebaseCrashlytics {
             analyticsDeferredProxy.getAnalyticsEventLogger(),
             fileStore,
             crashHandlerExecutor,
-            sessionsSubscriber);
+            sessionsSubscriber,
+            remoteConfigDeferredProxy);
 
     final String googleAppId = app.getOptions().getApplicationId();
     final String mappingFileId = CommonUtils.getMappingFileId(context);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsRemoteConfigListener.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsRemoteConfigListener.java
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal;
+
+import androidx.annotation.NonNull;
+import com.google.firebase.crashlytics.internal.metadata.RolloutAssignment;
+import com.google.firebase.crashlytics.internal.metadata.UserMetadata;
+import com.google.firebase.remoteconfig.interop.rollouts.RolloutsState;
+import com.google.firebase.remoteconfig.interop.rollouts.RolloutsStateSubscriber;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class CrashlyticsRemoteConfigListener implements RolloutsStateSubscriber {
+  private final UserMetadata userMetadata;
+
+  CrashlyticsRemoteConfigListener(UserMetadata userMetadata) {
+    this.userMetadata = userMetadata;
+  }
+
+  @Override
+  public void onRolloutsStateChanged(@NonNull RolloutsState rolloutsState) {
+    Set<com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment> rolloutAssignmentList =
+        rolloutsState.getRolloutAssignments();
+
+    List<com.google.firebase.crashlytics.internal.metadata.RolloutAssignment>
+        crashlyticsRolloutAssignmentList = new ArrayList();
+    for (com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment assignment :
+        rolloutAssignmentList) {
+      RolloutAssignment crashlyticsRolloutAssignment =
+          RolloutAssignment.create(
+              assignment.getRolloutId(),
+              assignment.getParameterKey(),
+              assignment.getParameterValue(),
+              assignment.getVariantId(),
+              assignment.getTemplateVersion());
+      crashlyticsRolloutAssignmentList.add(crashlyticsRolloutAssignment);
+    }
+    userMetadata.updateRolloutsState(crashlyticsRolloutAssignmentList);
+    Logger.getLogger().d("Updated Crashlytics Rollout State");
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/RemoteConfigDeferredProxy.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/RemoteConfigDeferredProxy.java
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.firebase.crashlytics.internal;
+
+import com.google.firebase.crashlytics.internal.metadata.UserMetadata;
+import com.google.firebase.inject.Deferred;
+import com.google.firebase.remoteconfig.interop.FirebaseRemoteConfigInterop;
+
+public class RemoteConfigDeferredProxy {
+  private final Deferred<FirebaseRemoteConfigInterop> remoteConfigInteropDeferred;
+
+  public RemoteConfigDeferredProxy(
+      Deferred<FirebaseRemoteConfigInterop> remoteConfigInteropDeferred) {
+    this.remoteConfigInteropDeferred = remoteConfigInteropDeferred;
+  }
+
+  public void setupListener(UserMetadata metadata) {
+    if (metadata == null) {
+      Logger.getLogger().w("Didn't successfully register with UserMetadata for rollouts listener");
+      return;
+    }
+    CrashlyticsRemoteConfigListener listener = new CrashlyticsRemoteConfigListener(metadata);
+    remoteConfigInteropDeferred.whenAvailable(
+        remoteConfigInteropProvider -> {
+          FirebaseRemoteConfigInterop interop = remoteConfigInteropProvider.get();
+          interop.registerRolloutsStateSubscriber("firebase", listener);
+          Logger.getLogger().d("Registering RemoteConfig Rollouts subscriber");
+        });
+  }
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -26,6 +26,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.crashlytics.BuildConfig;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.Logger;
+import com.google.firebase.crashlytics.internal.RemoteConfigDeferredProxy;
 import com.google.firebase.crashlytics.internal.analytics.AnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.breadcrumbs.BreadcrumbSource;
 import com.google.firebase.crashlytics.internal.metadata.LogFileManager;
@@ -94,6 +95,8 @@ public class CrashlyticsCore {
 
   private final CrashlyticsNativeComponent nativeComponent;
 
+  private final RemoteConfigDeferredProxy remoteConfigDeferredProxy;
+
   // region Constructors
 
   public CrashlyticsCore(
@@ -105,7 +108,8 @@ public class CrashlyticsCore {
       AnalyticsEventLogger analyticsEventLogger,
       FileStore fileStore,
       ExecutorService crashHandlerExecutor,
-      CrashlyticsAppQualitySessionsSubscriber sessionsSubscriber) {
+      CrashlyticsAppQualitySessionsSubscriber sessionsSubscriber,
+      RemoteConfigDeferredProxy remoteConfigDeferredProxy) {
     this.app = app;
     this.dataCollectionArbiter = dataCollectionArbiter;
     this.context = app.getApplicationContext();
@@ -117,6 +121,7 @@ public class CrashlyticsCore {
     this.fileStore = fileStore;
     this.backgroundWorker = new CrashlyticsBackgroundWorker(crashHandlerExecutor);
     this.sessionsSubscriber = sessionsSubscriber;
+    this.remoteConfigDeferredProxy = remoteConfigDeferredProxy;
 
     startTime = System.currentTimeMillis();
     onDemandCounter = new OnDemandCounter();
@@ -150,6 +155,8 @@ public class CrashlyticsCore {
       final StackTraceTrimmingStrategy stackTraceTrimmingStrategy =
           new MiddleOutFallbackStrategy(
               MAX_STACK_SIZE, new RemoveRepeatsStrategy(NUM_STACK_REPETITIONS_ALLOWED));
+
+      remoteConfigDeferredProxy.setupListener(userMetadata);
 
       final SessionReportingCoordinator sessionReportingCoordinator =
           SessionReportingCoordinator.create(

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/RolloutAssignment.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/RolloutAssignment.java
@@ -40,7 +40,7 @@ public abstract class RolloutAssignment {
 
   public abstract long getTemplateVersion();
 
-  static RolloutAssignment create(
+  public static RolloutAssignment create(
       String rolloutId,
       String parameterKey,
       String parameterValue,
@@ -64,10 +64,8 @@ public abstract class RolloutAssignment {
     String variantId = dataObj.getString("variantId");
     long templateVersion = dataObj.getLong("templateVersion");
 
-    String validatedParameterValue = validate(parameterValue);
-
-    return new AutoValue_RolloutAssignment(
-        rolloutId, parameterKey, validatedParameterValue, variantId, templateVersion);
+    return RolloutAssignment.create(
+        rolloutId, parameterKey, parameterValue, variantId, templateVersion);
   }
 
   public CrashlyticsReport.Session.Event.RolloutAssignment toReportProto() {


### PR DESCRIPTION
Integrate RC interop with Crashlytics SDK:
1. Adding Crashlytics subscriber for RC interop
2. Adding Deferred Proxy  for RC interop
3. Unit tests