### PR TITLE
Fix Changelog Error

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
+* [feature] Add option to allow SDK create cache indexes automatically to improve query execution locally. [`db.getPersistentCacheIndexManager().enableIndexAutoCreation()`](//github.com/firebase/firebase-android-sdk/pull/4987)
 
 # 24.7.1
 * [fixed] Implement equals method on Filter class. [#5210](//github.com/firebase/firebase-android-sdk/issues/5210)
-* [feature] Add option to allow SDK create cache indexes automatically to improve query execution locally. [`db.getPersistentCacheIndexManager().enableIndexAutoCreation()`](//github.com/firebase/firebase-android-sdk/pull/4987)
 
 # 24.7.0
 * [feature] Expose MultiDb support in API. [#4015](//github.com/firebase/firebase-android-sdk/issues/4015)


### PR DESCRIPTION
During auto rebase, the change log entry of auto creation cache index was put inside the previous release cycle by mistake. 