### PR TITLE
Add missing changelog entry to firebase-crashlytics-ndk

### DIFF
--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Updated `firebase-crashlytics` dependency to v18.4.2
 
 # 18.4.1
 * [changed] Updated `firebase-crashlytics` dependency to v18.4.1


### PR DESCRIPTION
Per [b/299509129](https://b.corp.google.com/issues/299509129),

This adds a changelog entry to `firebase-crashlytics-ndk` that should've been added with #5274, as `firebase-crashlytics` is in the same library group.