### PR TITLE
Minor bump for firestore

### DIFF
--- a/firebase-firestore/gradle.properties
+++ b/firebase-firestore/gradle.properties
@@ -1,2 +1,2 @@
-version=24.7.2
+version=24.8.0
 latestReleasedVersion=24.7.1


### PR DESCRIPTION
Per [b/299650417](https://b.corp.google.com/issues/299650417),

This bumps `firebase-firestore` by a minor version, as should've been done by the deprecation of a public method in #5256.