### PR TITLE
Update CHANGELOG entries according to CL review for m137

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [feature] Include Firebase sessions with NDK crashes and ANRs.
+* [feature] Expanded Firebase sessions library integration to work with NDK crashes and ANRs.
 * [changed] Improved reliability when reporting memory usage.
 
 # 18.4.1

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [feature] Expanded Firebase sessions library integration to work with NDK crashes and ANRs.
+* [feature] Expanded `firebase-sessions` library integration to work with NDK crashes and ANRs.
 * [changed] Improved reliability when reporting memory usage.
 
 # 18.4.1

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
-* [feature] Add the option to allow the SDK to create cache indexes automatically to
-  improve query execution locally. 
+* [feature] Added the option to allow the SDK to create cache indexes automatically to
+  improve query execution locally. See
   [`db.getPersistentCacheIndexManager().enableIndexAutoCreation()`](/docs/reference/android/com/google/firebase/firestore/PersistentCacheIndexManager#enableIndexAutoCreation())
-  ([GitHub [#4987](//github.com/firebase/firebase-android-sdk/pull/4987){: .external})
+  ([GitHub [#4987](//github.com/firebase/firebase-android-sdk/pull/4987){: .external}).
 
 # 24.7.1
 * [fixed] Implement equals method on Filter class. [#5210](//github.com/firebase/firebase-android-sdk/issues/5210)

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 * [feature] Add the option to allow the SDK to create cache indexes automatically to
-  improve query execution locally. [`db.getPersistentCacheIndexManager().enableIndexAutoCreation()`](//github.com/firebase/firebase-android-sdk/pull/4987)
+  improve query execution locally. 
+  [`db.getPersistentCacheIndexManager().enableIndexAutoCreation()`](/docs/reference/android/com/google/firebase/firestore/PersistentCacheIndexManager#enableIndexAutoCreation())
+  ([GitHub [#4987](//github.com/firebase/firebase-android-sdk/pull/4987){: .external})
 
 # 24.7.1
 * [fixed] Implement equals method on Filter class. [#5210](//github.com/firebase/firebase-android-sdk/issues/5210)

--- a/firebase-inappmessaging-display/CHANGELOG.md
+++ b/firebase-inappmessaging-display/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [changed] Firelog to clearcut migration.
+* [changed] Updated internal logging backend.
 
 # 20.3.3
 * [unchanged] Updated internal Dagger dependency.

--- a/firebase-inappmessaging/CHANGELOG.md
+++ b/firebase-inappmessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [changed] Firelog to clearcut migration.
+* [changed] Updated internal logging backend.
 
 # 20.3.3
 * [unchanged] Updated internal Dagger dependency.


### PR DESCRIPTION
Per [b/300474851](https://b.corp.google.com/issues/300474851),

This updates the `CHANGELOG.md` files that were changed during the release note review for M137; as such to stay in alignment with our goal of keeping the `CHANGELOG.md` files at master in sync with the release notes.

NO_RELEASE_CHANGE