### PR TITLE
m137 mergeback

### DIFF
--- a/firebase-components/gradle.properties
+++ b/firebase-components/gradle.properties
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=17.1.1
+version=17.1.2
 latestReleasedVersion=17.1.0

--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+
+# 18.4.2
 * [changed] Updated `firebase-crashlytics` dependency to v18.4.2
 
 # 18.4.1
@@ -16,8 +19,8 @@
 # 18.3.5
 * [fixed] Updated `firebase-common` to its latest version (v20.3.0) to fix an
   issue that was causing a nondeterministic crash on startup.
-
 * [changed] Updated `firebase-crashlytics` dependency to v18.3.5.
+
 # 18.3.4
 <aside class="caution">This version of <code>firebase-crashlytics-ndk</code> can
   cause a nondeterministic crash on startup. For more information, see
@@ -78,13 +81,11 @@ using the latest version of the SDK (v18.3.1+ or [bom] v31.0.1+).**
   change, disabling tagged pointers is no longer required, so the following can
   be removed from your manifest's `application` tag:
   `android:allowNativeHeapPointerTagging=false`.
-
 * [changed] Updated `firebase-crashlytics` dependency to v18.2.6.
 
 # 18.2.5
 * [changed] Internal improvements to [crashlytics] file management, to
   ensure consistent creation and removal of intermediate [crashlytics] files.
-
 * [changed] Updated `firebase-crashlytics` dependency to v18.2.5.
 
 # 18.2.4
@@ -92,13 +93,11 @@ using the latest version of the SDK (v18.3.1+ or [bom] v31.0.1+).**
   `com.google.firebase.crashlytics.ndk.FirebaseCrashlyticsNdk` to the Proguard
   configuration for this AAR, to avoid potential reflection errors when
   obfuscating NDK-enabled apps.
-
 * [changed] Updated `firebase-crashlytics` dependency to v18.2.4.
 
 # 18.2.3
 * [changed] Internal changes to support upcoming Unity crash reporting
   improvements.
-
 * [changed] Updated `firebase-crashlytics` dependency to v18.2.3.
 
 # 18.2.1
@@ -108,7 +107,6 @@ using the latest version of the SDK (v18.3.1+ or [bom] v31.0.1+).**
   module to consistently report native crashes for all supported Android
   versions. [crashlytics] will now report native crashes when used as a
   dependency of a feature module.
-
 * [changed] Updated `firebase-crashlytics` dependency to v18.2.1.
 
 # 18.2.0
@@ -124,7 +122,6 @@ using the latest version of the SDK (v18.3.1+ or [bom] v31.0.1+).**
 
 # 18.0.0
 * [changed] Internal changes to support dynamic feature modules.
-
 * [changed] Updated `firebase-crashlytics` dependency to v18.0.0.
 
 # 17.4.1
@@ -153,7 +150,6 @@ using this version of the [crashlytics] NDK SDK and above.
 # 17.2.1
 * [fixed] Fixed signal handler to properly release storage on app exit.
   ([Github Issue #1749](https://github.com/firebase/firebase-android-sdk/issues/1749))
-
 * [changed] Updated `firebase-crashlytics` dependency to v17.2.1.
 
 # 17.1.1
@@ -168,7 +164,6 @@ using this version of the [crashlytics] NDK SDK and above.
 # 17.0.0
 * [changed] The [firebase_crashlytics] SDK for NDK is now generally
   available.
-
 * [changed] Updated `firebase-crashlytics` dependency to v17.0.0.
 
 # 17.0.0-beta04
@@ -177,11 +172,8 @@ using this version of the [crashlytics] NDK SDK and above.
 # 17.0.0-beta03
 * [fixed] Updated package name in `AndroidManifest.xml` to reflect new
   [firebase_crashlytics] NDK package name.
-
 * [changed] Improved debug logging.
-
 * [changed] Released new `crashlytics.h` with updated C++ APIs.
-
 * [changed] Added ProGuard rules files to avoid obfuscating public APIs called
   from C++.
 
@@ -216,3 +208,4 @@ change. The following release notes describe changes in the new SDK.
  uploading symbol files to [crashlytics] servers. See the
  [[crashlytics] Gradle plugin documentation](/docs/crashlytics/ndk-reports-new-sdk)
  for more information.
+

--- a/firebase-crashlytics-ndk/gradle.properties
+++ b/firebase-crashlytics-ndk/gradle.properties
@@ -1,2 +1,2 @@
-version=18.4.2
+version=18.4.3
 latestReleasedVersion=18.4.1

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Unreleased
+
+
+# 18.4.2
 * [feature] Expanded `firebase-sessions` library integration to work with NDK crashes and ANRs.
 * [changed] Improved reliability when reporting memory usage.
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-crashlytics` library. The Kotlin extensions library has no additional
+updates.
 
 # 18.4.1
 * [changed] Updated `firebase-sessions` dependency to v1.0.2
@@ -8,6 +17,7 @@
 # 18.4.0
 * [feature] Integrated with Firebase sessions library to enable upcoming features related to
   session-based crash metrics.
+
 
 ## Kotlin
 The Kotlin extensions library transitively includes the updated
@@ -482,3 +492,4 @@ The following release notes describe changes in the new SDK.
  from your `AndroidManifest.xml` file.
  * [removed] The `fabric.properties` and `crashlytics.properties` files are no
  longer supported. Remove them from your app.
+

--- a/firebase-crashlytics/gradle.properties
+++ b/firebase-crashlytics/gradle.properties
@@ -1,2 +1,2 @@
-version=18.4.2
+version=18.4.3
 latestReleasedVersion=18.4.1

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Unreleased
+
+
+# 24.8.0
 * [feature] Added the option to allow the SDK to create cache indexes automatically to
   improve query execution locally. See
   [`db.getPersistentCacheIndexManager().enableIndexAutoCreation()`](/docs/reference/android/com/google/firebase/firestore/PersistentCacheIndexManager#enableIndexAutoCreation())
   ([GitHub [#4987](//github.com/firebase/firebase-android-sdk/pull/4987){: .external}).
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-firestore` library. The Kotlin extensions library has no additional
+updates.
 
 # 24.7.1
 * [fixed] Implement equals method on Filter class. [#5210](//github.com/firebase/firebase-android-sdk/issues/5210)
@@ -822,3 +831,4 @@ updates.
   or
   [`FieldValue.serverTimestamp()`](/docs/reference/android/com/google/firebase/firestore/FieldValue.html#serverTimestamp())
   values.
+

--- a/firebase-firestore/gradle.properties
+++ b/firebase-firestore/gradle.properties
@@ -1,2 +1,2 @@
-version=24.8.0
+version=24.8.1
 latestReleasedVersion=24.7.1

--- a/firebase-inappmessaging-display/CHANGELOG.md
+++ b/firebase-inappmessaging-display/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
+
+
+# 20.3.4
 * [changed] Updated internal logging backend.
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-inappmessaging-display` library. The Kotlin extensions library has no additional
+updates.
 
 # 20.3.3
 * [unchanged] Updated internal Dagger dependency.
@@ -29,9 +38,7 @@ updates.
 # 20.3.0
 * [changed] Migrated [inappmessaging] Display to use standard Firebase
   executors.
-
 * [changed] Moved Task continuations off the main thread.
-
 * [feature] Added a new API for
   [removing a dismiss listener](/docs/reference/android/com/google/firebase/inappmessaging/FirebaseInAppMessaging#removeDismissListener(com.google.firebase.inappmessaging.FirebaseInAppMessagingDismissListener)).
   (GitHub
@@ -154,7 +161,6 @@ additional updates.
 # 19.1.1
 * [fixed] Improved link handling on devices without any browser installed
   or without Chrome installed.
-
 * [feature] Added the ability to register a dismiss listener that reacts to
   message dismissal.
 
@@ -171,7 +177,6 @@ additional updates.
   No developer action is necessary.
 
 
-
 ## Kotlin
 The Kotlin extensions library transitively includes the updated
 `firebase-inappmessaging-display` library. The Kotlin extensions library has no
@@ -181,12 +186,10 @@ additional updates.
 * [fixed] Improved handling of activity transitions.
   (GitHub [Issue #1410](//github.com/firebase/firebase-android-sdk/issues/1410)
   and [Issue #1092](//github.com/firebase/firebase-android-sdk/issues/1092))
-
 * [changed] Migrated to use the [firebase_installations] service _directly_
   instead of using an indirect dependency via the Firebase Instance ID SDK.
 
   {% include "docs/reference/android/client/_includes/_iid-indirect-dependency-solutions.html" %}
-
 
 
 ## Kotlin
@@ -216,9 +219,7 @@ additional updates.
 
 # 19.0.4
 * [fixed] Fixed issue with messages not being fetched on app first open.
-
 * [fixed] Fixed issue with first foreground trigger not being picked up.
-
 
 
 ## Kotlin
@@ -228,7 +229,6 @@ additional updates.
 
 # 19.0.3
 * [changed] Internal changes to enable future SDK improvements.
-
 
 
 ## Kotlin
@@ -292,3 +292,4 @@ additional updates.
 
 # 17.0.0
 * [feature] The initial public beta release of the Firebase In-App Messaging Display SDK for Android is now available. To learn more, see the [Firebase In-App Messaging documentation](/docs/in-app-messaging).
+

--- a/firebase-inappmessaging-display/gradle.properties
+++ b/firebase-inappmessaging-display/gradle.properties
@@ -1,2 +1,2 @@
-version=20.3.4
+version=20.3.5
 latestReleasedVersion=20.3.3

--- a/firebase-inappmessaging/CHANGELOG.md
+++ b/firebase-inappmessaging/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
+
+
+# 20.3.4
 * [changed] Updated internal logging backend.
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-inappmessaging` library. The Kotlin extensions library has no additional
+updates.
 
 # 20.3.3
 * [unchanged] Updated internal Dagger dependency.
@@ -17,7 +26,6 @@ updates.
 # 20.3.1
 * [fixed] Fixed nullpointer crash
   ([GitHub Issue #4214](//github.com/firebase/firebase-android-sdk/issues/4214))
-
 * [changed] Updated gRPC to 1.52.1, and updated JavaLite, protoc,
   protobuf-java-util to 3.21.11.
 
@@ -29,9 +37,7 @@ updates.
 
 # 20.3.0
 * [changed] Migrated [inappmessaging] to use standard Firebase executors.
-
 * [changed] Moved Task continuations off the main thread.
-
 * [feature] Added a new API for
   [removing a dismiss listener](/docs/reference/android/com/google/firebase/inappmessaging/FirebaseInAppMessaging#removeDismissListener(com.google.firebase.inappmessaging.FirebaseInAppMessagingDismissListener)).
   (GitHub
@@ -154,7 +160,6 @@ additional updates.
 # 19.1.1
 * [fixed] Improved link handling on devices without any browser installed
   or without Chrome installed.
-
 * [feature] Added the ability to register a dismiss listener that reacts to
   message dismissal.
 
@@ -180,12 +185,10 @@ additional updates.
 * [fixed] Improved handling of activity transitions.
   (GitHub [Issue #1410](//github.com/firebase/firebase-android-sdk/issues/1410)
   and [Issue #1092](//github.com/firebase/firebase-android-sdk/issues/1092))
-
 * [changed] Migrated to use the [firebase_installations] service _directly_
   instead of using an indirect dependency via the Firebase Instance ID SDK.
 
   {% include "docs/reference/android/client/_includes/_iid-indirect-dependency-solutions.html" %}
-
 
 
 ## Kotlin
@@ -215,11 +218,8 @@ additional updates.
 
 # 19.0.4
 * [fixed] Fixed issue with messages not being fetched on app first open.
-
 * [fixed] Fixed issue with first foreground trigger not being picked up.
-
 * [changed] Internal migration to use the [firebase_installations] service.
-
 
 
 ## Kotlin
@@ -229,7 +229,6 @@ additional updates.
 
 # 19.0.3
 * [changed] Internal changes to enable future SDK improvements.
-
 
 
 ## Kotlin
@@ -292,3 +291,4 @@ additional updates.
 
 # 17.0.0
 * [feature] The initial public beta release of the Firebase In-App Messaging SDK for Android is now available. To learn more, see the [Firebase In-App Messaging documentation](/docs/in-app-messaging).
+

--- a/firebase-inappmessaging/gradle.properties
+++ b/firebase-inappmessaging/gradle.properties
@@ -1,2 +1,2 @@
-version=20.3.4
+version=20.3.5
 latestReleasedVersion=20.3.3


### PR DESCRIPTION
Per [b/300503321](https://b.corp.google.com/issues/300503321),

This does all the post release clean up tasks for m137 (the release that just went out).

NO_RELEASE_CHANGE