### PR TITLE
[Test App] Use versioned deps for Installations.

### DIFF
--- a/firebase-config/test-app/test-app.gradle.kts
+++ b/firebase-config/test-app/test-app.gradle.kts
@@ -66,12 +66,12 @@ dependencies {
   // "implementation" dependencies. The alternative would be to make common an "api" dep of remote-config.
   // Released artifacts don't need these dependencies since they don't use `project` to refer
   // to Remote Config.
-  implementation("com.google.firebase:firebase-common:20.3.2")
-  implementation("com.google.firebase:firebase-common-ktx:20.3.2")
-  implementation("com.google.firebase:firebase-components:17.1.0")
+  implementation("com.google.firebase:firebase-common:20.3.3")
+  implementation("com.google.firebase:firebase-common-ktx:20.3.3")
+  implementation("com.google.firebase:firebase-components:17.1.1")
 
-  implementation(project(":firebase-installations-interop"))
-  runtimeOnly(project(":firebase-installations"))
+  implementation("com.google.firebase:firebase-installations-interop:17.1.0")
+  runtimeOnly("com.google.firebase:firebase-installations:17.1.4")
 
   implementation("com.google.android.gms:play-services-basement:18.1.0")
   implementation("com.google.android.gms:play-services-tasks:18.0.1")


### PR DESCRIPTION
Fixes ~Attempting to fix~ instrumentation tests failing with the message:

```
Execution failed for task ':firebase-config:test-app:dexBuilderDebugAndroidTest'.
> Could not resolve all files for configuration ':firebase-config:test-app:debugRuntimeClasspath'.
   > Failed to transform classes.jar (project :firebase-installations) to match attributes {artifactType=android-asm-instrumented-jars, asm-transformed-variant=debug, com.android.build.api.attributes.AgpVersionAttr=7.4.2, com.android.build.api.attributes.BuildTypeAttr=debug, com.android.build.gradle.internal.attributes.VariantAttr=debug, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.
```

`./gradlew :firebase-config:test-app:dexBuilderDebugAndroidTest` passes when run locally before and after (wasn't able to repro the failure locally)

Instrumentation tests now passing on this PR: 
<img width="857" alt="Screenshot 2023-09-14 at 7 23 44 PM" src="https://github.com/firebase/firebase-android-sdk/assets/3270544/1a231a4b-2c56-400a-b790-e596f25b6b9d">


Also bump versions for other Firebase deps.