### PR TITLE
m137_1 mergeback

### DIFF
--- a/firebase-components/CHANGELOG.md
+++ b/firebase-components/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
-* [changed] Internal changes to ensure only one interface is provided for 
-   kotlinx.coroutines.CoroutineDispatcher interfaces when both firebase-common and
-   firebase-common-ktx provide them.
 
 
-
+# 17.1.2
+* [changed] Internal changes to ensure only one interface is provided for
+  kotlinx.coroutines.CoroutineDispatcher interfaces when both firebase-common and
+  firebase-common-ktx provide them.

--- a/firebase-components/gradle.properties
+++ b/firebase-components/gradle.properties
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=17.1.2
+version=17.1.3
 latestReleasedVersion=17.1.0

--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+
+# 18.4.3
 * [changed] Updated `firebase-crashlytics` dependency to v18.4.3
 
 # 18.4.2

--- a/firebase-crashlytics-ndk/gradle.properties
+++ b/firebase-crashlytics-ndk/gradle.properties
@@ -1,2 +1,2 @@
-version=18.4.3
+version=18.4.4
 latestReleasedVersion=18.4.1

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
-* [fixed] Disabled `GradleMetadataPublishing` to fix breakage of the Kotlin extensions library. #5337 
+
+
+# 18.4.3
+* [fixed] Disabled `GradleMetadataPublishing` to fix breakage of the Kotlin extensions library. [#5337]
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-crashlytics` library. The Kotlin extensions library has no additional
+updates.
 
 # 18.4.2
 * [feature] Expanded `firebase-sessions` library integration to work with NDK crashes and ANRs.

--- a/firebase-crashlytics/gradle.properties
+++ b/firebase-crashlytics/gradle.properties
@@ -1,2 +1,2 @@
-version=18.4.3
+version=18.4.4
 latestReleasedVersion=18.4.1

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
-* [fixed] Disabled `GradleMetadataPublishing` to fix breakage of the Kotlin extensions library. #5337 
+
+
+# 24.8.1
+* [fixed] Disabled `GradleMetadataPublishing` to fix breakage of the Kotlin extensions library. [#5337]
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-firestore` library. The Kotlin extensions library has no additional
+updates.
 
 # 24.8.0
 * [feature] Added the option to allow the SDK to create cache indexes automatically to

--- a/firebase-firestore/gradle.properties
+++ b/firebase-firestore/gradle.properties
@@ -1,2 +1,2 @@
-version=24.8.1
+version=24.8.2
 latestReleasedVersion=24.7.1

--- a/firebase-inappmessaging-display/CHANGELOG.md
+++ b/firebase-inappmessaging-display/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
-* [fixed] Disabled `GradleMetadataPublishing` to fix breakage of the Kotlin extensions library. #5337 
+
+
+# 20.3.5
+* [fixed] Disabled `GradleMetadataPublishing` to fix breakage of the Kotlin extensions library. [#5337]
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-inappmessaging-display` library. The Kotlin extensions library has no additional
+updates.
 
 # 20.3.4
 * [changed] Updated internal logging backend.

--- a/firebase-inappmessaging-display/gradle.properties
+++ b/firebase-inappmessaging-display/gradle.properties
@@ -1,2 +1,2 @@
-version=20.3.5
+version=20.3.6
 latestReleasedVersion=20.3.3

--- a/firebase-inappmessaging/CHANGELOG.md
+++ b/firebase-inappmessaging/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
-* [fixed] Disabled `GradleMetadataPublishing` to fix breakage of the Kotlin extensions library. #5337 
+
+
+# 20.3.5
+* [fixed] Disabled `GradleMetadataPublishing` to fix breakage of the Kotlin extensions library. [#5337]
+
+
+## Kotlin
+The Kotlin extensions library transitively includes the updated
+`firebase-inappmessaging` library. The Kotlin extensions library has no additional
+updates.
 
 # 20.3.4
 * [changed] Updated internal logging backend.

--- a/firebase-inappmessaging/gradle.properties
+++ b/firebase-inappmessaging/gradle.properties
@@ -1,2 +1,2 @@
-version=20.3.5
+version=20.3.6
 latestReleasedVersion=20.3.3


### PR DESCRIPTION
Per [b/300682723](https://b.corp.google.com/issues/300682723),

This does all the post release clean up tasks for m137_1 (the hotfix that just went out).

NO_RELEASE_CHANGE