### PR TITLE
Remove `SettingsProvider` abstraction.

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/LocalOverrideSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/LocalOverrideSettings.kt
@@ -23,7 +23,7 @@ import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
-internal class LocalOverrideSettings(context: Context) : SettingsProvider {
+internal class LocalOverrideSettings(context: Context) : LocalSettingsProvider {
   @Suppress("DEPRECATION") // TODO(mrober): Use ApplicationInfoFlags when target sdk set to 33
   private val metadata =
     context.packageManager

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/LocalSettingsProvider.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/LocalSettingsProvider.kt
@@ -18,7 +18,7 @@ package com.google.firebase.sessions.settings
 
 import kotlin.time.Duration
 
-internal interface SettingsProvider {
+internal interface LocalSettingsProvider {
   /** Setting to control if session collection is enabled. */
   val sessionEnabled: Boolean?
 

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
@@ -40,7 +40,7 @@ internal class RemoteSettings(
   private val appInfo: ApplicationInfo,
   private val configsFetcher: CrashlyticsSettingsFetcher,
   dataStore: DataStore<Preferences>,
-) : SettingsProvider {
+) : RemoteSettingsProvider {
   private val settingsCache = SettingsCache(dataStore)
   private val fetchInProgress = Mutex()
 

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettingsProvider.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettingsProvider.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions.settings
+
+import kotlin.time.Duration
+
+internal interface RemoteSettingsProvider {
+  /** Setting to control if session collection is enabled. */
+  val sessionEnabled: Boolean?
+
+  /** Setting to represent when to restart a new session after app backgrounding. */
+  val sessionRestartTimeout: Duration?
+
+  /** Setting denoting the percentage of the sessions data that should be collected. */
+  val samplingRate: Double?
+
+  /** Function to initiate refresh of the settings for the provider. */
+  suspend fun updateSettings() = Unit // Default to no op.
+
+  /** Function representing if the settings are stale. */
+  fun isSettingsStale(): Boolean = false // Default to false.
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/SessionsSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/SessionsSettings.kt
@@ -28,8 +28,8 @@ import kotlin.time.Duration.Companion.minutes
 
 /** [SessionsSettings] manages all the configs that are relevant to the sessions library. */
 internal class SessionsSettings(
-  private val localOverrideSettings: SettingsProvider,
-  private val remoteSettings: SettingsProvider,
+  private val localOverrideSettings: LocalSettingsProvider,
+  private val remoteSettings: RemoteSettingsProvider,
 ) {
   constructor(
     context: Context,

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/EventGDTLoggerTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/EventGDTLoggerTest.kt
@@ -23,8 +23,9 @@ import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
 import com.google.firebase.sessions.settings.SessionsSettings
 import com.google.firebase.sessions.testing.FakeFirebaseApp
+import com.google.firebase.sessions.testing.FakeLocalSettingsProvider
 import com.google.firebase.sessions.testing.FakeProvider
-import com.google.firebase.sessions.testing.FakeSettingsProvider
+import com.google.firebase.sessions.testing.FakeRemoteSettingsProvider
 import com.google.firebase.sessions.testing.FakeTransportFactory
 import com.google.firebase.sessions.testing.TestSessionEventData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -46,8 +47,8 @@ class EventGDTLoggerTest {
         fakeFirebaseApp.firebaseApp,
         TestSessionEventData.TEST_SESSION_DETAILS,
         SessionsSettings(
-          localOverrideSettings = FakeSettingsProvider(),
-          remoteSettings = FakeSettingsProvider(),
+          localOverrideSettings = FakeLocalSettingsProvider(),
+          remoteSettings = FakeRemoteSettingsProvider(),
         ),
       )
     val fakeTransportFactory = FakeTransportFactory()

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionCoordinatorTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionCoordinatorTest.kt
@@ -23,7 +23,8 @@ import com.google.firebase.sessions.settings.SessionsSettings
 import com.google.firebase.sessions.testing.FakeEventGDTLogger
 import com.google.firebase.sessions.testing.FakeFirebaseApp
 import com.google.firebase.sessions.testing.FakeFirebaseInstallations
-import com.google.firebase.sessions.testing.FakeSettingsProvider
+import com.google.firebase.sessions.testing.FakeLocalSettingsProvider
+import com.google.firebase.sessions.testing.FakeRemoteSettingsProvider
 import com.google.firebase.sessions.testing.TestSessionEventData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runCurrent
@@ -52,8 +53,8 @@ class SessionCoordinatorTest {
         fakeFirebaseApp.firebaseApp,
         TestSessionEventData.TEST_SESSION_DETAILS,
         SessionsSettings(
-          localOverrideSettings = FakeSettingsProvider(),
-          remoteSettings = FakeSettingsProvider(),
+          localOverrideSettings = FakeLocalSettingsProvider(),
+          remoteSettings = FakeRemoteSettingsProvider(),
         ),
       )
 

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
@@ -24,8 +24,9 @@ import com.google.firebase.sessions.SessionEvents.SESSION_EVENT_ENCODER
 import com.google.firebase.sessions.api.SessionSubscriber
 import com.google.firebase.sessions.settings.SessionsSettings
 import com.google.firebase.sessions.testing.FakeFirebaseApp
+import com.google.firebase.sessions.testing.FakeLocalSettingsProvider
+import com.google.firebase.sessions.testing.FakeRemoteSettingsProvider
 import com.google.firebase.sessions.testing.FakeSessionSubscriber
-import com.google.firebase.sessions.testing.FakeSettingsProvider
 import com.google.firebase.sessions.testing.TestSessionEventData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -50,8 +51,8 @@ class SessionEventEncoderTest {
         fakeFirebaseApp.firebaseApp,
         TestSessionEventData.TEST_SESSION_DETAILS,
         SessionsSettings(
-          localOverrideSettings = FakeSettingsProvider(),
-          remoteSettings = FakeSettingsProvider(),
+          localOverrideSettings = FakeLocalSettingsProvider(),
+          remoteSettings = FakeRemoteSettingsProvider(),
         ),
         subscribers =
           mapOf(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventTest.kt
@@ -22,7 +22,8 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.sessions.settings.LocalOverrideSettings
 import com.google.firebase.sessions.settings.SessionsSettings
 import com.google.firebase.sessions.testing.FakeFirebaseApp
-import com.google.firebase.sessions.testing.FakeSettingsProvider
+import com.google.firebase.sessions.testing.FakeLocalSettingsProvider
+import com.google.firebase.sessions.testing.FakeRemoteSettingsProvider
 import com.google.firebase.sessions.testing.TestSessionEventData.TEST_DATA_COLLECTION_STATUS
 import com.google.firebase.sessions.testing.TestSessionEventData.TEST_SESSION_DATA
 import com.google.firebase.sessions.testing.TestSessionEventData.TEST_SESSION_DETAILS
@@ -45,8 +46,8 @@ class SessionEventTest {
         fakeFirebaseApp.firebaseApp,
         TEST_SESSION_DETAILS,
         SessionsSettings(
-          localOverrideSettings = FakeSettingsProvider(),
-          remoteSettings = FakeSettingsProvider(),
+          localOverrideSettings = FakeLocalSettingsProvider(),
+          remoteSettings = FakeRemoteSettingsProvider(),
         ),
       )
 
@@ -66,7 +67,7 @@ class SessionEventTest {
         TEST_SESSION_DETAILS,
         SessionsSettings(
           localOverrideSettings = LocalOverrideSettings(context),
-          remoteSettings = FakeSettingsProvider(),
+          remoteSettings = FakeRemoteSettingsProvider(),
         ),
       )
 

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionInitiatorTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionInitiatorTest.kt
@@ -20,7 +20,8 @@ import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
 import com.google.firebase.concurrent.TestOnlyExecutors
 import com.google.firebase.sessions.settings.SessionsSettings
-import com.google.firebase.sessions.testing.FakeSettingsProvider
+import com.google.firebase.sessions.testing.FakeLocalSettingsProvider
+import com.google.firebase.sessions.testing.FakeRemoteSettingsProvider
 import com.google.firebase.sessions.testing.FakeTimeProvider
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,8 +51,8 @@ class SessionInitiatorTest {
     val fakeTimeProvider = FakeTimeProvider()
     val settings =
       SessionsSettings(
-        localOverrideSettings = FakeSettingsProvider(),
-        remoteSettings = FakeSettingsProvider(),
+        localOverrideSettings = FakeLocalSettingsProvider(),
+        remoteSettings = FakeRemoteSettingsProvider(),
       )
 
     // Simulate a cold start by simply constructing the SessionInitiator object
@@ -76,8 +77,8 @@ class SessionInitiatorTest {
     val sessionInitiateCounter = SessionInitiateCounter()
     val settings =
       SessionsSettings(
-        localOverrideSettings = FakeSettingsProvider(),
-        remoteSettings = FakeSettingsProvider(),
+        localOverrideSettings = FakeLocalSettingsProvider(),
+        remoteSettings = FakeRemoteSettingsProvider(),
       )
 
     val sessionInitiator =
@@ -111,8 +112,8 @@ class SessionInitiatorTest {
     val sessionInitiateCounter = SessionInitiateCounter()
     val settings =
       SessionsSettings(
-        localOverrideSettings = FakeSettingsProvider(),
-        remoteSettings = FakeSettingsProvider(),
+        localOverrideSettings = FakeLocalSettingsProvider(),
+        remoteSettings = FakeRemoteSettingsProvider(),
       )
 
     val sessionInitiator =
@@ -146,8 +147,8 @@ class SessionInitiatorTest {
     val sessionInitiateCounter = SessionInitiateCounter()
     val settings =
       SessionsSettings(
-        localOverrideSettings = FakeSettingsProvider(),
-        remoteSettings = FakeSettingsProvider(),
+        localOverrideSettings = FakeLocalSettingsProvider(),
+        remoteSettings = FakeRemoteSettingsProvider(),
       )
 
     val sessionInitiator =
@@ -186,8 +187,8 @@ class SessionInitiatorTest {
     val sessionInitiateCounter = SessionInitiateCounter()
     val settings =
       SessionsSettings(
-        localOverrideSettings = FakeSettingsProvider(),
-        remoteSettings = FakeSettingsProvider(),
+        localOverrideSettings = FakeLocalSettingsProvider(),
+        remoteSettings = FakeRemoteSettingsProvider(),
       )
 
     val sessionInitiator =

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/settings/SessionsSettingsTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/settings/SessionsSettingsTest.kt
@@ -25,8 +25,9 @@ import com.google.firebase.concurrent.TestOnlyExecutors
 import com.google.firebase.sessions.SessionEvents
 import com.google.firebase.sessions.testing.FakeFirebaseApp
 import com.google.firebase.sessions.testing.FakeFirebaseInstallations
+import com.google.firebase.sessions.testing.FakeLocalSettingsProvider
 import com.google.firebase.sessions.testing.FakeRemoteConfigFetcher
-import com.google.firebase.sessions.testing.FakeSettingsProvider
+import com.google.firebase.sessions.testing.FakeRemoteSettingsProvider
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -47,8 +48,8 @@ class SessionsSettingsTest {
   fun sessionSettings_fetchDefaults() {
     val sessionsSettings =
       SessionsSettings(
-        localOverrideSettings = FakeSettingsProvider(),
-        remoteSettings = FakeSettingsProvider(),
+        localOverrideSettings = FakeLocalSettingsProvider(),
+        remoteSettings = FakeRemoteSettingsProvider(),
       )
 
     assertThat(sessionsSettings.sessionsEnabled).isTrue()
@@ -68,7 +69,7 @@ class SessionsSettingsTest {
     val sessionsSettings =
       SessionsSettings(
         localOverrideSettings = LocalOverrideSettings(context),
-        remoteSettings = FakeSettingsProvider(),
+        remoteSettings = FakeRemoteSettingsProvider(),
       )
 
     assertThat(sessionsSettings.sessionsEnabled).isFalse()
@@ -87,7 +88,7 @@ class SessionsSettingsTest {
     val sessionsSettings =
       SessionsSettings(
         localOverrideSettings = LocalOverrideSettings(context),
-        remoteSettings = FakeSettingsProvider(),
+        remoteSettings = FakeRemoteSettingsProvider(),
       )
 
     runCurrent()

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeLocalSettingsProvider.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeLocalSettingsProvider.kt
@@ -16,12 +16,12 @@
 
 package com.google.firebase.sessions.testing
 
-import com.google.firebase.sessions.settings.SettingsProvider
+import com.google.firebase.sessions.settings.LocalSettingsProvider
 import kotlin.time.Duration
 
-/** Fake [SettingsProvider] that can set the settings fields. */
-internal class FakeSettingsProvider(
+/** Fake [LocalSettingsProvider] that can set the settings fields. */
+internal class FakeLocalSettingsProvider(
   override val sessionEnabled: Boolean? = null,
   override val sessionRestartTimeout: Duration? = null,
   override val samplingRate: Double? = null,
-) : SettingsProvider
+) : LocalSettingsProvider

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeRemoteSettingsProvider.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeRemoteSettingsProvider.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions.testing
+
+import com.google.firebase.sessions.settings.RemoteSettingsProvider
+import kotlin.time.Duration
+
+/** Fake [RemoteSettingsProvider] that can set the settings fields. */
+internal class FakeRemoteSettingsProvider(
+  override val sessionEnabled: Boolean? = null,
+  override val sessionRestartTimeout: Duration? = null,
+  override val samplingRate: Double? = null,
+) : RemoteSettingsProvider


### PR DESCRIPTION
We don't benefit from this abstraction and as Local and Remote settings diverge it will only serve to get in our way.