### PR TITLE
Create post release plugin workflow

### DIFF
--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -1,0 +1,35 @@
+name: Post release cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Release name'
+        required: true
+        type: string
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.3
+        with:
+          fetch-depth: 0
+
+      - name: Run post release cleanup task
+        run: |
+          ./gradlew postReleaseCleanup
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: 'master'
+          branch: 'releases/${{ inputs.name }}.mergeback'
+          add-paths: |
+            **/CHANGELOG.md
+            **/gradle.properties
+            **/*.gradle
+            **/*.gradle.kts
+          title: '${{ inputs.name}} mergeback'
+          body: 'Auto-generated PR for cleaning up release ${{ inputs.name}}'
+          commit-message: 'Post release cleanup for ${{ inputs.name }}'


### PR DESCRIPTION
Per [b/301961341](https://b.corp.google.com/issues/301961341),

This creates a workflow that can be invoked to automatically create a mergeback branch *and* run the `postReleaseCleanup` task for after a release.

The workflow is ran from the release branch, but the PR is created for `master`. I will update the release manual to reflect this as well after it's merged and I've tested it.

The `name` input is purely used for naming the mergeback branch PR and such.