### PR TITLE
Add useReleasedVersions property to sessions e2e test app

### DIFF
--- a/.github/workflows/sessions-e2e.yml
+++ b/.github/workflows/sessions-e2e.yml
@@ -39,4 +39,4 @@ jobs:
         env:
           FTL_RESULTS_BUCKET: fireescape
         run: |
-          ./gradlew :firebase-sessions:test-app:deviceCheck withErrorProne -PtargetBackend="prod"
+          ./gradlew :firebase-sessions:test-app:deviceCheck withErrorProne -PtargetBackend="prod" -PuseReleasedVersions

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -29,13 +29,11 @@ firebaseLibrary {
 }
 
 android {
-  val targetSdkVersion: Int by rootProject
-
   namespace = "com.google.firebase.sessions"
   compileSdk = 33
   defaultConfig {
     minSdk = 16
-    targetSdk = targetSdkVersion
+    targetSdk = 33
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -29,11 +29,13 @@ firebaseLibrary {
 }
 
 android {
+  val targetSdkVersion: Int by rootProject
+
   namespace = "com.google.firebase.sessions"
   compileSdk = 33
   defaultConfig {
     minSdk = 16
-    targetSdk = 33
+    targetSdk = targetSdkVersion
     multiDexEnabled = true
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/firebase-sessions/test-app/src/main/AndroidManifest.xml
+++ b/firebase-sessions/test-app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     android:allowBackup="true"
     android:icon="@drawable/sensor_window"
     android:label="@string/app_name"
+    android:name="androidx.multidex.MultiDexApplication"
     android:supportsRtl="true"
     android:theme="@style/Theme.TestApp">
     <activity

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -28,11 +28,11 @@ plugins {
 
 android {
   namespace = "com.google.firebase.testing.sessions"
-  compileSdk = 34
+  compileSdk = 33
   defaultConfig {
     applicationId = "com.google.firebase.testing.sessions"
     minSdk = 16
-    targetSdk = 34
+    targetSdk = 33
     versionCode = 1
     versionName = "1.0"
     multiDexEnabled = true
@@ -53,9 +53,9 @@ dependencies {
 
   implementation("androidx.appcompat:appcompat:1.6.1")
   implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-  implementation("androidx.core:core-ktx:1.12.0")
   implementation("androidx.multidex:multidex:2.0.1")
   implementation("com.google.android.material:material:1.9.0")
+  implementation(libs.androidx.core)
 
   androidTestImplementation("com.google.firebase:firebase-common-ktx:20.3.3")
   androidTestImplementation(libs.androidx.test.junit)

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -28,11 +28,11 @@ plugins {
 
 android {
   namespace = "com.google.firebase.testing.sessions"
-  compileSdk = 33
+  compileSdk = 34
   defaultConfig {
     applicationId = "com.google.firebase.testing.sessions"
     minSdk = 16
-    targetSdk = 33
+    targetSdk = 34
     versionCode = 1
     versionName = "1.0"
     multiDexEnabled = true
@@ -53,10 +53,11 @@ dependencies {
 
   implementation("androidx.appcompat:appcompat:1.6.1")
   implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-  implementation("androidx.core:core-ktx:1.9.0")
-  implementation("com.google.android.material:material:1.8.0")
+  implementation("androidx.core:core-ktx:1.12.0")
+  implementation("androidx.multidex:multidex:2.0.1")
+  implementation("com.google.android.material:material:1.9.0")
 
-  androidTestImplementation("com.google.firebase:firebase-common-ktx:20.3.2")
+  androidTestImplementation("com.google.firebase:firebase-common-ktx:20.3.3")
   androidTestImplementation(libs.androidx.test.junit)
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.truth)

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -47,10 +47,8 @@ android {
 }
 
 dependencies {
-  // TODO(mrober): Remove when we have configurable deps on Crashlytics and Fireperf.
-  implementation(project(":firebase-crashlytics"))
-  implementation(project(":firebase-perf"))
-  implementation(project(":firebase-sessions"))
+  implementation("com.google.firebase:firebase-crashlytics:18.4.3")
+  implementation("com.google.firebase:firebase-perf:20.4.1")
 
   implementation("androidx.appcompat:appcompat:1.6.1")
   implementation("androidx.constraintlayout:constraintlayout:2.1.4")

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -1,5 +1,6 @@
 @file:Suppress("DEPRECATION") // App projects should still use FirebaseTestLabPlugin.
 
+import com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabExtension
 import com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabPlugin
 
 /*
@@ -24,6 +25,10 @@ plugins {
   id("com.google.gms.google-services")
   id("com.google.firebase.crashlytics")
   id("com.google.firebase.firebase-perf")
+}
+
+configure<FirebaseTestLabExtension> {
+  device("model=Pixel2,version=28,locale=en,orientation=portrait")
 }
 
 android {

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -47,8 +47,18 @@ android {
 }
 
 dependencies {
-  implementation("com.google.firebase:firebase-crashlytics:18.4.3")
-  implementation("com.google.firebase:firebase-perf:20.4.1")
+  if (project.hasProperty("useReleasedVersions")) {
+    val latestReleasedVersion: String by project
+    println("Using sessions released version: $latestReleasedVersion")
+    // TODO(mrober): How to find the released versions of crashlytics and perf?
+    implementation("com.google.firebase:firebase-crashlytics:18.4.3")
+    implementation("com.google.firebase:firebase-perf:20.4.1")
+    implementation("com.google.firebase:firebase-sessions:$latestReleasedVersion")
+  } else {
+    implementation(project(":firebase-crashlytics"))
+    implementation(project(":firebase-perf"))
+    implementation(project(":firebase-sessions"))
+  }
 
   implementation("androidx.appcompat:appcompat:1.6.1")
   implementation("androidx.constraintlayout:constraintlayout:2.1.4")

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -27,10 +27,6 @@ plugins {
   id("com.google.firebase.firebase-perf")
 }
 
-configure<FirebaseTestLabExtension> {
-  device("model=Pixel2,version=28,locale=en,orientation=portrait")
-}
-
 android {
   namespace = "com.google.firebase.testing.sessions"
   compileSdk = 33
@@ -73,3 +69,7 @@ extra["packageName"] = "com.google.firebase.testing.sessions"
 apply(from = "../../gradle/googleServices.gradle")
 
 apply<FirebaseTestLabPlugin>()
+
+configure<FirebaseTestLabExtension> {
+  device("model=Pixel2,version=28,locale=en,orientation=portrait")
+}

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -71,5 +71,5 @@ apply(from = "../../gradle/googleServices.gradle")
 apply<FirebaseTestLabPlugin>()
 
 configure<FirebaseTestLabExtension> {
-  device("model=panther,version=33")
+  device("model=panther,version=33") // Pixel7
 }

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -71,5 +71,5 @@ apply(from = "../../gradle/googleServices.gradle")
 apply<FirebaseTestLabPlugin>()
 
 configure<FirebaseTestLabExtension> {
-  device("model=Pixel2,version=28,locale=en,orientation=portrait")
+  device("model=panther,version=33")
 }


### PR DESCRIPTION
Add `useReleasedVersions` property to the sessions e2e test app. Also updated dep versions, and configured test lab to be more consistent. This is so the e2e test app can run on released versions in the scheduled workflow, but default to using the project level deps during local development.