### PR TITLE
Automatically add NO_RELEASE_CHANGE to mergeback

### DIFF
--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -31,5 +31,8 @@ jobs:
             **/*.gradle
             **/*.gradle.kts
           title: '${{ inputs.name}} mergeback'
-          body: 'Auto-generated PR for cleaning up release ${{ inputs.name}}'
+          body: |
+            Auto-generated PR for cleaning up release ${{ inputs.name}}
+            
+            NO_RELEASE_CHANGE
           commit-message: 'Post release cleanup for ${{ inputs.name }}'


### PR DESCRIPTION
Per [b/302184829](https://b.corp.google.com/issues/302184829),

This configures the newly added [post release cleanup workflow](https://github.com/firebase/firebase-android-sdk/blob/master/.github/workflows/post_release_cleanup.yml) to add `NO_RELEASE_CHANGE` to the PR's body by default.