### PR TITLE
Fix client-side throttling for Play Integrity flows

### DIFF
--- a/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [unchanged] Updated to keep [app_check] SDK versions aligned.
+* [fixed] Fixed retry manager logic to not reset the backoff period for successful `GeneratePlayIntegrityChallenge` requests.
 
 # 17.0.0
 * [unchanged] Updated to keep [app_check] SDK versions aligned.

--- a/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 * [fixed] Fixed client-side throttling in Play Integrity flows.
 
+* [unchanged] Updated to keep [app_check] SDK versions aligned.
+
 # 17.0.0
 * [unchanged] Updated to keep [app_check] SDK versions aligned.
 

--- a/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
+++ b/appcheck/firebase-appcheck-playintegrity/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [fixed] Fixed retry manager logic to not reset the backoff period for successful `GeneratePlayIntegrityChallenge` requests.
+* [fixed] Fixed client-side throttling in Play Integrity flows.
 
 # 17.0.0
 * [unchanged] Updated to keep [app_check] SDK versions aligned.

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -10,6 +10,7 @@
   now deprecated. As early as April 2024, we'll no longer release KTX modules. For details, see the
   [FAQ about this initiative](https://firebase.google.com/docs/android/kotlin-migration)
 
+* [fixed] Fixed retry manager logic to not reset the backoff period for successful `GeneratePlayIntegrityChallenge` requests.
 
 
 # 17.0.1

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 * [fixed] Fixed a bug causing internal tests to depend directly on `firebase-common`.
 
+* [fixed] Fixed client-side throttling in Play Integrity flows.
+
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-appcheck-ktx`
   to `com.google.firebase:firebase-appcheck` under the `com.google.firebase.appcheck` package.
   For details, see the
@@ -11,9 +13,6 @@
   and all the Kotlin extensions (KTX) APIs in `com.google.firebase:firebase-appcheck-ktx` are
   now deprecated. As early as April 2024, we'll no longer release KTX modules. For details, see the
   [FAQ about this initiative](https://firebase.google.com/docs/android/kotlin-migration)
-
-* [fixed] Fixed client-side throttling in Play Integrity flows.
-
 
 # 17.0.1
 * [changed] Internal updates to allow Firebase SDKs to obtain limited-use tokens.

--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -10,7 +10,7 @@
   now deprecated. As early as April 2024, we'll no longer release KTX modules. For details, see the
   [FAQ about this initiative](https://firebase.google.com/docs/android/kotlin-migration)
 
-* [fixed] Fixed retry manager logic to not reset the backoff period for successful `GeneratePlayIntegrityChallenge` requests.
+* [fixed] Fixed client-side throttling in Play Integrity flows.
 
 
 # 17.0.1

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/NetworkClient.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/NetworkClient.java
@@ -21,6 +21,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.util.Log;
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.gms.common.util.AndroidUtilsLight;
 import com.google.android.gms.common.util.Hex;
@@ -138,11 +139,13 @@ public class NetworkClient {
     }
     URL url =
         new URL(String.format(PLAY_INTEGRITY_CHALLENGE_URL_TEMPLATE, projectId, appId, apiKey));
-    return makeNetworkRequest(url, requestBytes, retryManager);
+    // We don't forward the RetryManager, as we don't want a successful
+    // GeneratePlayIntegrityChallenge call to reset the retry throttling.
+    return makeNetworkRequest(url, requestBytes, /* retryManager= */ null);
   }
 
   private String makeNetworkRequest(
-      @NonNull URL url, @NonNull byte[] requestBytes, @NonNull RetryManager retryManager)
+      @NonNull URL url, @NonNull byte[] requestBytes, @Nullable RetryManager retryManager)
       throws FirebaseException, IOException, JSONException {
     HttpURLConnection urlConnection = createHttpUrlConnection(url);
 
@@ -178,7 +181,9 @@ public class NetworkClient {
       }
       String responseBody = response.toString();
       if (!isResponseSuccess(responseCode)) {
-        retryManager.updateBackoffOnFailure(responseCode);
+        if (retryManager != null) {
+          retryManager.updateBackoffOnFailure(responseCode);
+        }
         // TODO: Create a mapping from HTTP error codes to public App Check error codes.
         HttpErrorResponse httpErrorResponse = HttpErrorResponse.fromJsonString(responseBody);
         throw new FirebaseException(
@@ -187,7 +192,9 @@ public class NetworkClient {
                 + " body: "
                 + httpErrorResponse.getErrorMessage());
       }
-      retryManager.resetBackoffOnSuccess();
+      if (retryManager != null) {
+        retryManager.resetBackoffOnSuccess();
+      }
       return responseBody;
     } finally {
       urlConnection.disconnect();

--- a/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/RetryManager.java
+++ b/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/RetryManager.java
@@ -26,7 +26,6 @@ import java.lang.annotation.RetentionPolicy;
 public class RetryManager {
 
   @VisibleForTesting static final int BAD_REQUEST_ERROR_CODE = 400;
-  @VisibleForTesting static final int FORBIDDEN_ERROR_CODE = 403;
   @VisibleForTesting static final int NOT_FOUND_ERROR_CODE = 404;
   @VisibleForTesting static final long MAX_EXP_BACKOFF_MILLIS = 4 * 60 * 60 * 1000; // 4 hours
   @VisibleForTesting static final long ONE_DAY_MILLIS = 24 * 60 * 60 * 1000; // 24 hours
@@ -91,9 +90,7 @@ public class RetryManager {
 
   @BackoffStrategyType
   private static int getBackoffStrategyByErrorCode(int errorCode) {
-    if (errorCode == BAD_REQUEST_ERROR_CODE
-        || errorCode == FORBIDDEN_ERROR_CODE
-        || errorCode == NOT_FOUND_ERROR_CODE) {
+    if (errorCode == BAD_REQUEST_ERROR_CODE || errorCode == NOT_FOUND_ERROR_CODE) {
       return ONE_DAY;
     }
     return EXPONENTIAL;

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/NetworkClientTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/NetworkClientTest.java
@@ -325,7 +325,7 @@ public class NetworkClientTest {
     verify(mockOutputStream)
         .write(JSON_REQUEST.getBytes(), /* off= */ 0, JSON_REQUEST.getBytes().length);
     verify(mockRetryManager, never()).updateBackoffOnFailure(anyInt());
-    verify(mockRetryManager).resetBackoffOnSuccess();
+    verify(mockRetryManager, never()).resetBackoffOnSuccess();
     verifyRequestHeaders();
   }
 
@@ -350,7 +350,7 @@ public class NetworkClientTest {
     verify(networkClient).createHttpUrlConnection(expectedUrl);
     verify(mockOutputStream)
         .write(JSON_REQUEST.getBytes(), /* off= */ 0, JSON_REQUEST.getBytes().length);
-    verify(mockRetryManager).updateBackoffOnFailure(ERROR_CODE);
+    verify(mockRetryManager, never()).updateBackoffOnFailure(anyInt());
     verify(mockRetryManager, never()).resetBackoffOnSuccess();
     verifyRequestHeaders();
   }

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/NetworkClientTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/NetworkClientTest.java
@@ -350,7 +350,7 @@ public class NetworkClientTest {
     verify(networkClient).createHttpUrlConnection(expectedUrl);
     verify(mockOutputStream)
         .write(JSON_REQUEST.getBytes(), /* off= */ 0, JSON_REQUEST.getBytes().length);
-    verify(mockRetryManager, never()).updateBackoffOnFailure(anyInt());
+    verify(mockRetryManager).updateBackoffOnFailure(ERROR_CODE);
     verify(mockRetryManager, never()).resetBackoffOnSuccess();
     verifyRequestHeaders();
   }

--- a/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/RetryManagerTest.java
+++ b/appcheck/firebase-appcheck/src/test/java/com/google/firebase/appcheck/internal/RetryManagerTest.java
@@ -16,7 +16,6 @@ package com.google.firebase.appcheck.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.appcheck.internal.RetryManager.BAD_REQUEST_ERROR_CODE;
-import static com.google.firebase.appcheck.internal.RetryManager.FORBIDDEN_ERROR_CODE;
 import static com.google.firebase.appcheck.internal.RetryManager.MAX_EXP_BACKOFF_MILLIS;
 import static com.google.firebase.appcheck.internal.RetryManager.NOT_FOUND_ERROR_CODE;
 import static com.google.firebase.appcheck.internal.RetryManager.ONE_DAY_MILLIS;
@@ -61,14 +60,6 @@ public class RetryManagerTest {
   }
 
   @Test
-  public void updateBackoffOnFailure_forbiddenError_oneDayRetryStrategy() {
-    retryManager.updateBackoffOnFailure(FORBIDDEN_ERROR_CODE);
-
-    assertThat(retryManager.getNextRetryTimeMillis())
-        .isEqualTo(CURRENT_TIME_MILLIS + ONE_DAY_MILLIS);
-  }
-
-  @Test
   public void updateBackoffOnFailure_notFoundError_oneDayRetryStrategy() {
     retryManager.updateBackoffOnFailure(NOT_FOUND_ERROR_CODE);
 
@@ -78,9 +69,9 @@ public class RetryManagerTest {
 
   @Test
   public void updateBackoffOnFailure_oneDayRetryStrategy_multipleRetries() {
-    retryManager.updateBackoffOnFailure(FORBIDDEN_ERROR_CODE);
-    retryManager.updateBackoffOnFailure(FORBIDDEN_ERROR_CODE);
-    retryManager.updateBackoffOnFailure(FORBIDDEN_ERROR_CODE);
+    retryManager.updateBackoffOnFailure(BAD_REQUEST_ERROR_CODE);
+    retryManager.updateBackoffOnFailure(BAD_REQUEST_ERROR_CODE);
+    retryManager.updateBackoffOnFailure(BAD_REQUEST_ERROR_CODE);
 
     // The backoff period should not increase for consecutive failed retries with the ONE_DAY
     // strategy.
@@ -133,7 +124,7 @@ public class RetryManagerTest {
 
   @Test
   public void canRetry_beforeNextRetryTime() {
-    retryManager.updateBackoffOnFailure(FORBIDDEN_ERROR_CODE);
+    retryManager.updateBackoffOnFailure(BAD_REQUEST_ERROR_CODE);
 
     // Sanity check.
     assertThat(mockClock.currentTimeMillis()).isEqualTo(CURRENT_TIME_MILLIS);
@@ -145,7 +136,7 @@ public class RetryManagerTest {
 
   @Test
   public void canRetry_afterNextRetryTime() {
-    retryManager.updateBackoffOnFailure(FORBIDDEN_ERROR_CODE);
+    retryManager.updateBackoffOnFailure(BAD_REQUEST_ERROR_CODE);
     long nextRetryMillis = retryManager.getNextRetryTimeMillis();
 
     when(mockClock.currentTimeMillis()).thenReturn(nextRetryMillis + 1);
@@ -154,7 +145,7 @@ public class RetryManagerTest {
 
   @Test
   public void resetBackoffOnSuccess() {
-    retryManager.updateBackoffOnFailure(FORBIDDEN_ERROR_CODE);
+    retryManager.updateBackoffOnFailure(BAD_REQUEST_ERROR_CODE);
     // Sanity check.
     assertThat(retryManager.getNextRetryTimeMillis())
         .isEqualTo(CURRENT_TIME_MILLIS + ONE_DAY_MILLIS);


### PR DESCRIPTION
Changes:
- Successful `GeneratePlayIntegrityChallenge` call should not reset `RetryManager` backoff
- Cache in-flight App Check token fetching tasks
- Update `403` errors to throttle with exponential backoff rather than a flat one-day period (to match [iOS](https://github.com/firebase/firebase-ios-sdk/blob/f3a14c249e001b3c894bb943ecc3973f50e60a49/FirebaseAppCheck/Sources/Core/Backoff/FIRAppCheckBackoffWrapper.m#L264-L268))