### PR TITLE
Adds simple logic to only broadcast sessions for cold starts and for …

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionDataService.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionDataService.kt
@@ -37,10 +37,11 @@ import java.util.UUID
 
 /** Service for providing access to session data */
 internal class SessionDataService : Service() {
-  /** Target we publish for clients to send messages to IncomingHandler. */
-  private lateinit var messenger: Messenger
 
-  val boundClients = mutableListOf<Messenger>()
+  private val boundClients = mutableListOf<Messenger>()
+  private var curSessionId: String? = null
+  private var isAppInForeground: Boolean = false
+  private var lastMsgTimeMs: Long = 0
 
   /** Handler of incoming messages from clients. */
   internal inner class IncomingHandler(
@@ -48,54 +49,69 @@ internal class SessionDataService : Service() {
     private val appContext: Context = context.applicationContext,
   ) : Handler(Looper.getMainLooper()) { // TODO(rothbutter) probably want to use our own executor
 
-    private var curSessionId: String? = null
-
     override fun handleMessage(msg: Message) {
+      if (lastMsgTimeMs > msg.getWhen()) {
+        Log.i(TAG, "SERVICE: Received old message $msg. Ignoring")
+        return
+      }
       when (msg.what) {
-        FOREGROUNDED -> handleForegrounding()
-        BACKGROUNDED -> handleBackgrounding()
+        FOREGROUNDED -> handleForegrounding(msg)
+        BACKGROUNDED -> handleBackgrounding(msg)
         else -> super.handleMessage(msg)
       }
+      lastMsgTimeMs = msg.getWhen()
+    }
+  }
+
+  fun handleForegrounding(msg: Message) {
+    Log.i(TAG, "SERVICE: Activity foregrounding at ${msg.getWhen()}")
+
+    if (curSessionId == null) {
+      Log.i(TAG, "SERVICE: Cold start detected.")
+      newSession()
+    } else if (!isAppInForeground && msg.getWhen() - lastMsgTimeMs > MAX_BACKGROUND_MS) {
+      Log.i(TAG, "SERVICE: Session too long in background. Creating new session.")
+      newSession()
     }
 
-    fun handleForegrounding() {
-      Log.i(TAG, "SERVICE: Activity foregrounding - updating ${boundClients.size} clients")
-      broadcastSession(UUID.randomUUID().toString())
-    }
+    isAppInForeground = true
+  }
 
-    fun handleBackgrounding() {
-      Log.i(TAG, "SERVICE: Activity backgrounding")
-    }
+  fun newSession() {
+    curSessionId = UUID.randomUUID().toString()
+    Log.i(TAG, "SERVICE: Broadcasting session $curSessionId to ${boundClients.size} clients")
+    boundClients.forEach { sendSession(it) }
+  }
 
-    fun broadcastSession(sessionId: String) {
-      Log.i(TAG, "SERVICE: Broadcasting new session $sessionId")
-      boundClients.forEach { sendNewSession(it, sessionId) }
-    }
+  fun handleBackgrounding(msg: Message) {
+    Log.i(TAG, "SERVICE: Activity backgrounding at ${msg.getWhen()}")
+    isAppInForeground = false
+  }
 
-    fun sendNewSession(client: Messenger, sessionId: String) {
-      try {
-        client.send(
-          Message.obtain(null, SESSION_UPDATED, 0, 0).also {
-            it.setData(Bundle().also { it.putString(SESSION_UPDATE_EXTRA, sessionId) })
-          }
-        )
-      } catch (e: Exception) {
-        if (e is DeadObjectException) {
-          Log.i(TAG, "SERVICE: Removing dead client from list: $client")
-          boundClients.remove(client)
-        } else {
-          Log.e(TAG, "SERVICE: Unable to push new session to $client.", e)
+  fun sendSession(client: Messenger) {
+    try {
+      client.send(
+        Message.obtain(null, SESSION_UPDATED, 0, 0).also {
+          it.setData(Bundle().also { it.putString(SESSION_UPDATE_EXTRA, curSessionId) })
         }
+      )
+    } catch (e: Exception) {
+      if (e is DeadObjectException) {
+        Log.i(TAG, "SERVICE: Removing dead client from list: $client")
+        boundClients.remove(client)
+      } else {
+        Log.e(TAG, "SERVICE: Unable to push new session to $client.", e)
       }
     }
   }
 
   override fun onBind(intent: Intent): IBinder? {
     Log.i(TAG, "SERVICE: Service bound")
-    messenger = Messenger(IncomingHandler(this))
+    val messenger = Messenger(IncomingHandler(this))
     val callbackMessenger = getCallback(intent)
     if (callbackMessenger != null) {
       boundClients.add(callbackMessenger)
+      sendSession(callbackMessenger)
       Log.i(TAG, "SERVICE: Stored callback to $callbackMessenger. Size: ${boundClients.size}")
     }
     return messenger.binder
@@ -113,6 +129,9 @@ internal class SessionDataService : Service() {
     const val CLIENT_CALLBACK_MESSENGER = "ClientCallbackMessenger"
     const val SESSION_UPDATE_EXTRA = "SessionUpdateExtra"
 
+    // TODO(bryanatkinson): Swap this out for the value coming from settings
+    const val MAX_BACKGROUND_MS = 30000
+
     const val FOREGROUNDED = 1
     const val BACKGROUNDED = 2
     const val SESSION_UPDATED = 3
@@ -121,7 +140,7 @@ internal class SessionDataService : Service() {
     private var testServiceBound: Boolean = false
     private val queuedMessages = LinkedList<Message>()
 
-    internal class ClientUpdateHandler(appContext: Context) : Handler(Looper.getMainLooper()) {
+    internal class ClientUpdateHandler() : Handler(Looper.getMainLooper()) {
       override fun handleMessage(msg: Message) {
         when (msg.what) {
           SESSION_UPDATED ->
@@ -161,7 +180,7 @@ internal class SessionDataService : Service() {
         Log.i(TAG, "CLIENT: Binding service to application.")
         // This is necessary for the onBind() to be called by each process
         intent.setAction(android.os.Process.myPid().toString())
-        intent.putExtra(CLIENT_CALLBACK_MESSENGER, Messenger(ClientUpdateHandler(appContext)))
+        intent.putExtra(CLIENT_CALLBACK_MESSENGER, Messenger(ClientUpdateHandler()))
         appContext.bindService(
           intent,
           testServiceConnection,


### PR DESCRIPTION
…when the app has been backgrounded for too long. Also ignores messages that came in out of order.

Still need to hook this into the persistence layer and FirebaseSessions for actually generating sessions.