### PR TITLE
Separate logic to upload sessions and notify subscribers

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -18,67 +18,34 @@ package com.google.firebase.sessions
 
 import android.app.Application
 import android.util.Log
-import com.google.android.datatransport.TransportFactory
 import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
 import com.google.firebase.app
-import com.google.firebase.inject.Provider
-import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies
 import com.google.firebase.sessions.api.SessionSubscriber
-import com.google.firebase.sessions.settings.SessionsSettings
-import kotlinx.coroutines.CoroutineDispatcher
 
-/** The [FirebaseSessions] API provides methods to register a [SessionSubscriber]. */
-class FirebaseSessions
-internal constructor(
-  private val firebaseApp: FirebaseApp,
-  firebaseInstallations: FirebaseInstallationsApi,
-  backgroundDispatcher: CoroutineDispatcher,
-  blockingDispatcher: CoroutineDispatcher,
-  transportFactoryProvider: Provider<TransportFactory>,
-  @Suppress("UNUSED_PARAMETER") sessionMaintainer: SessionMaintainer,
-) {
-  private val applicationInfo = SessionEvents.getApplicationInfo(firebaseApp)
-  private val sessionSettings =
-    SessionsSettings(
-      firebaseApp.applicationContext,
-      blockingDispatcher,
-      backgroundDispatcher,
-      firebaseInstallations,
-      applicationInfo,
-    )
-  private val timeProvider: TimeProvider = Time()
-  private val sessionGenerator: SessionGenerator
-  private val eventGDTLogger = EventGDTLogger(transportFactoryProvider)
-  private val sessionCoordinator = SessionCoordinator(firebaseInstallations, eventGDTLogger)
-
+/** The [FirebaseSessions] API provides the function to register a [SessionSubscriber]. */
+class FirebaseSessions internal constructor(private val sessionMaintainer: SessionMaintainer) {
   init {
-    sessionGenerator = SessionGenerator(collectEvents = shouldCollectEvents(), timeProvider)
-
-    val sessionInitiateListener =
-      object : SessionInitiateListener {
-        // Avoid making a public function in FirebaseSessions for onInitiateSession.
-        override suspend fun onInitiateSession(sessionDetails: SessionDetails) {
-          initiateSessionStart(sessionDetails)
-        }
-      }
-
     val sessionInitiator =
       SessionInitiator(
-        timeProvider,
-        backgroundDispatcher,
-        sessionInitiateListener,
-        sessionSettings,
-        sessionGenerator,
+        timeProvider = WallClock,
+        sessionMaintainer.backgroundDispatcher,
+        sessionInitiateListener = { sessionDetails ->
+          // TODO: Let the service decide when to call which one.
+          notifySubscribers(sessionDetails)
+          sessionMaintainer.initiateSessionStart(sessionDetails)
+        },
+        sessionMaintainer.sessionSettings,
+        sessionMaintainer.sessionGenerator,
       )
 
-    val appContext = firebaseApp.applicationContext.applicationContext
+    val appContext = sessionMaintainer.firebaseApp.applicationContext.applicationContext
     if (appContext is Application) {
       SessionDataService.bind(appContext)
       appContext.registerActivityLifecycleCallbacks(sessionInitiator.activityLifecycleCallbacks)
 
-      firebaseApp.addLifecycleEventListener { _, _ ->
+      sessionMaintainer.firebaseApp.addLifecycleEventListener { _, _ ->
         Log.w(TAG, "FirebaseApp instance deleted. Sessions library will not collect session data.")
         appContext.unregisterActivityLifecycleCallbacks(sessionInitiator.activityLifecycleCallbacks)
       }
@@ -102,69 +69,20 @@ internal constructor(
 
     // Immediately call the callback if Sessions generated a session before the
     // subscriber subscribed, otherwise subscribers might miss the first session.
-    if (sessionGenerator.hasGenerateSession) {
+    if (sessionMaintainer.sessionGenerator.hasGenerateSession) {
       subscriber.onSessionChanged(
-        SessionSubscriber.SessionDetails(sessionGenerator.currentSession.sessionId)
+        SessionSubscriber.SessionDetails(
+          sessionMaintainer.sessionGenerator.currentSession.sessionId
+        )
       )
     }
   }
 
-  private suspend fun initiateSessionStart(sessionDetails: SessionDetails) {
-    val subscribers = FirebaseSessionsDependencies.getRegisteredSubscribers()
-
-    if (subscribers.isEmpty()) {
-      Log.d(
-        TAG,
-        "Sessions SDK did not have any dependent SDKs register as dependencies. Events will not be sent."
-      )
-      return
-    }
-
-    subscribers.values.forEach { subscriber ->
-      // Notify subscribers, regardless of sampling and data collection state.
+  /** Notify subscribers, regardless of sampling and data collection state. */
+  private suspend fun notifySubscribers(sessionDetails: SessionDetails) =
+    FirebaseSessionsDependencies.getRegisteredSubscribers().values.forEach { subscriber ->
       subscriber.onSessionChanged(SessionSubscriber.SessionDetails(sessionDetails.sessionId))
     }
-
-    if (subscribers.values.none { it.isDataCollectionEnabled }) {
-      Log.d(TAG, "Data Collection is disabled for all subscribers. Skipping this Session Event")
-      return
-    }
-
-    Log.d(TAG, "Data Collection is enabled for at least one Subscriber")
-
-    // This will cause remote settings to be fetched if the cache is expired.
-    sessionSettings.updateSettings()
-
-    if (!sessionSettings.sessionsEnabled) {
-      Log.d(TAG, "Sessions SDK disabled. Events will not be sent.")
-      return
-    }
-
-    if (!sessionGenerator.collectEvents) {
-      Log.d(TAG, "Sessions SDK has dropped this session due to sampling.")
-      return
-    }
-
-    try {
-      val sessionEvent =
-        SessionEvents.startSession(firebaseApp, sessionDetails, sessionSettings, subscribers)
-      sessionCoordinator.attemptLoggingSessionEvent(sessionEvent)
-    } catch (ex: IllegalStateException) {
-      // This can happen if the app suddenly deletes the instance of FirebaseApp.
-      Log.w(
-        TAG,
-        "FirebaseApp is not initialized. Sessions library will not collect session data.",
-        ex
-      )
-    }
-  }
-
-  /** Calculate whether we should sample events using [sessionSettings] data. */
-  private fun shouldCollectEvents(): Boolean {
-    // Sampling rate of 1 means the SDK will send every event.
-    val randomValue = Math.random()
-    return randomValue <= sessionSettings.samplingRate
-  }
 
   companion object {
     private const val TAG = "FirebaseSessions"

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -37,28 +37,27 @@ import kotlinx.coroutines.CoroutineDispatcher
 internal class FirebaseSessionsRegistrar : ComponentRegistrar {
   override fun getComponents() =
     listOf(
-      Component.builder(FirebaseSessions::class.java)
-        .name(SESSIONS_LIBRARY_NAME)
+      Component.builder(SessionMaintainer::class.java)
+        .name(MAINTAINER_LIBRARY_NAME)
         .add(Dependency.required(firebaseApp))
         .add(Dependency.required(firebaseInstallationsApi))
         .add(Dependency.required(backgroundDispatcher))
         .add(Dependency.required(blockingDispatcher))
         .add(Dependency.requiredProvider(transportFactory))
-        .add(Dependency.required(sessionMaintainer))
         .factory { container ->
-          FirebaseSessions(
+          SessionMaintainer(
             container.get(firebaseApp),
             container.get(firebaseInstallationsApi),
             container.get(backgroundDispatcher),
             container.get(blockingDispatcher),
-            container.getProvider(transportFactory),
-            container.get(sessionMaintainer)
+            container.getProvider(transportFactory)
           )
         }
         .build(),
-      Component.builder(SessionMaintainer::class.java)
-        .name(MAINTAINER_LIBRARY_NAME)
-        .factory { SessionMaintainer() }
+      Component.builder(FirebaseSessions::class.java)
+        .name(SESSIONS_LIBRARY_NAME)
+        .add(Dependency.required(sessionMaintainer))
+        .factory { container -> FirebaseSessions(container.get(sessionMaintainer)) }
         .build(),
       LibraryVersionComponent.create(SESSIONS_LIBRARY_NAME, BuildConfig.VERSION_NAME),
     )

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionCoordinator.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionCoordinator.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.tasks.await
  *
  * @hide
  */
+// TODO(mrober): Merge this with SessionMaintainer.
 internal class SessionCoordinator(
   private val firebaseInstallations: FirebaseInstallationsApi,
   private val eventGDTLogger: EventGDTLoggerInterface,

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionInitiateListener.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionInitiateListener.kt
@@ -17,7 +17,7 @@
 package com.google.firebase.sessions
 
 /** Interface for listening to the initiation of a new session. */
-internal interface SessionInitiateListener {
+internal fun interface SessionInitiateListener {
   /** To be called whenever a new session is initiated. */
   suspend fun onInitiateSession(sessionDetails: SessionDetails)
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionMaintainer.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionMaintainer.kt
@@ -16,14 +16,111 @@
 
 package com.google.firebase.sessions
 
+import android.util.Log
+import com.google.android.datatransport.TransportFactory
 import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
 import com.google.firebase.app
+import com.google.firebase.inject.Provider
+import com.google.firebase.installations.FirebaseInstallationsApi
+import com.google.firebase.sessions.api.FirebaseSessionsDependencies
+import com.google.firebase.sessions.settings.SessionsSettings
+import kotlinx.coroutines.CoroutineDispatcher
 
-/** Maintainer for Sessions. */
-internal class SessionMaintainer {
+/**
+ * [SessionMaintainer] is responsible for coordinating the systems in this SDK involved with sending
+ * a [SessionEvent].
+ */
+internal class SessionMaintainer(
+  val firebaseApp: FirebaseApp,
+  firebaseInstallations: FirebaseInstallationsApi,
+  val backgroundDispatcher: CoroutineDispatcher,
+  blockingDispatcher: CoroutineDispatcher,
+  transportFactoryProvider: Provider<TransportFactory>,
+) {
+  // TODO: Settings needs to be moved to the Service so there is one instance in multi-process apps.
+  val sessionSettings =
+    SessionsSettings(
+      firebaseApp.applicationContext,
+      blockingDispatcher,
+      backgroundDispatcher,
+      firebaseInstallations,
+      SessionEvents.getApplicationInfo(firebaseApp),
+    )
+  val sessionGenerator: SessionGenerator
+
+  // TODO(mrober): Merge SessionCoordinator into here.
+  private val eventGDTLogger = EventGDTLogger(transportFactoryProvider)
+  private val sessionCoordinator = SessionCoordinator(firebaseInstallations, eventGDTLogger)
+
+  init {
+    sessionGenerator =
+      SessionGenerator(
+        collectEvents = shouldCollectEvents(),
+        timeProvider = WallClock,
+      )
+  }
+
+  suspend fun initiateSessionStart(sessionDetails: SessionDetails) {
+    val subscribers = FirebaseSessionsDependencies.getRegisteredSubscribers()
+
+    if (subscribers.isEmpty()) {
+      Log.d(
+        TAG,
+        "Sessions SDK did not have any dependent SDKs register as dependencies. Events will not be sent."
+      )
+      return
+    }
+
+    if (subscribers.values.none { it.isDataCollectionEnabled }) {
+      Log.d(TAG, "Data Collection is disabled for all subscribers. Skipping this Session Event")
+      return
+    }
+
+    Log.d(TAG, "Data Collection is enabled for at least one Subscriber")
+
+    // This will cause remote settings to be fetched if the cache is expired.
+    sessionSettings.updateSettings()
+
+    if (!sessionSettings.sessionsEnabled) {
+      Log.d(TAG, "Sessions SDK disabled. Events will not be sent.")
+      return
+    }
+
+    if (!sessionGenerator.collectEvents) {
+      Log.d(TAG, "Sessions SDK has dropped this session due to sampling.")
+      return
+    }
+
+    try {
+      val sessionEvent =
+        SessionEvents.startSession(
+          firebaseApp,
+          sessionDetails,
+          sessionSettings,
+          subscribers,
+        )
+      sessionCoordinator.attemptLoggingSessionEvent(sessionEvent)
+    } catch (ex: IllegalStateException) {
+      // This can happen if the app suddenly deletes the instance of FirebaseApp.
+      Log.w(
+        TAG,
+        "FirebaseApp is not initialized. Sessions library will not collect session data.",
+        ex,
+      )
+    }
+  }
+
+  /** Calculate whether we should sample events using settings data. */
+  private fun shouldCollectEvents(): Boolean {
+    // Sampling rate of 1 means the SDK will send every event.
+    val randomValue = Math.random()
+    return randomValue <= sessionSettings.samplingRate
+  }
 
   internal companion object {
+    private const val TAG = "SessionMaintainer"
+
     @JvmStatic
     val instance: SessionMaintainer
       get() = getInstance(Firebase.app)

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/Time.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/Time.kt
@@ -27,7 +27,7 @@ internal interface TimeProvider {
 }
 
 /** "Wall clock" time provider. */
-internal class Time : TimeProvider {
+internal object WallClock : TimeProvider {
   /**
    * Gets the [Duration] elapsed in "wall clock" time since device boot.
    *
@@ -45,8 +45,6 @@ internal class Time : TimeProvider {
    */
   override fun currentTimeUs(): Long = System.currentTimeMillis() * US_PER_MILLIS
 
-  companion object {
-    /** Microseconds per millisecond. */
-    private const val US_PER_MILLIS = 1000L
-  }
+  /** Microseconds per millisecond. */
+  private const val US_PER_MILLIS = 1000L
 }


### PR DESCRIPTION
Separate the logic to upload sessions and notify subscribers. Moved a lot of logic into the `SessionMaintainer` but plan to merge that with the `SessionCoordinator`. Added TODOs for things that need to be moved into `SessionDataService`. Also made the `WallClock` an object not a class so it's easier to work with in multiple places without re-creating it or passing it around.