### PR TITLE
Declare firebase-common dependency as api in firebase-appcheck

### DIFF
--- a/appcheck/firebase-appcheck/CHANGELOG.md
+++ b/appcheck/firebase-appcheck/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [fixed] Fixed a bug causing internal tests to depend directly on `firebase-common`.
+
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-appcheck-ktx`
   to `com.google.firebase:firebase-appcheck` under the `com.google.firebase.appcheck` package.
   For details, see the
@@ -105,4 +107,3 @@ additional updates:
 # 16.0.0-beta01
 * [feature] Initial beta release of the [app_check] SDK with abuse reduction
   features.
-

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-annotations:16.2.0'
     implementation project(':appcheck:firebase-appcheck-interop')
     implementation project(path: ':appcheck:firebase-appcheck-interop')
-    implementation("com.google.firebase:firebase-common:20.4.1")
+    api("com.google.firebase:firebase-common:20.4.1")
     implementation("com.google.firebase:firebase-common-ktx:20.4.1")
     implementation("com.google.firebase:firebase-components:17.1.4")
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'

--- a/appcheck/firebase-appcheck/test-app/src/main/AndroidManifest.xml
+++ b/appcheck/firebase-appcheck/test-app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
   <application
       android:label="@string/app_name"
       android:theme="@style/AppTheme">
-    <activity android:name=".MainActivity">
+    <activity android:name=".MainActivity" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
 

--- a/appcheck/firebase-appcheck/test-app/test-app.gradle
+++ b/appcheck/firebase-appcheck/test-app/test-app.gradle
@@ -40,8 +40,6 @@ dependencies {
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
 
     // Firebase dependencies
-    implementation project(':firebase-common')
-    implementation project(':firebase-components')
     implementation project(":appcheck:firebase-appcheck")
     implementation project(":appcheck:firebase-appcheck-debug")
     implementation project(":appcheck:firebase-appcheck-interop")


### PR DESCRIPTION
Additionally, we are explicitly marking firebase-appcheck/test-app activity as exported, and removing direct dependencies it has with common and components.