### PR TITLE
Avoid changing api surface

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionDatastore.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionDatastore.kt
@@ -65,7 +65,9 @@ internal class SessionDatastore(private val context: Context) {
       preferences[FirebaseSessionDataKeys.SESSION_ID],
       preferences[FirebaseSessionDataKeys.TIMESTAMP_MICROSECONDS]
     )
-}
 
-private val Context.dataStore: DataStore<Preferences> by
-  preferencesDataStore(name = "firebase_session_settings")
+  private companion object {
+    private val Context.dataStore: DataStore<Preferences> by
+      preferencesDataStore(name = "firebase_session_settings")
+  }
+}


### PR DESCRIPTION
Avoid changing the api surface. Having `val`s at the file level causes Kotlin to generate a public class with the filenameKt which adds a public class to the public api surface: "The public api surface has changed for the subproject firebase-sessions: error: Added class com.google.firebase.sessions.SessionDatastoreKt [AddedClass]". So we have to put them in a class or companion object.