### PR TITLE
Add FINISHED_AFTER_HANDLED metadata to FirebaseInstanceIdReceiver.

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* [changed] Added metadata to FirebaseInstanceIdReceiver to signal that it
+  finishes background broadcasts after the message has been handled.
+
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-messaging-ktx`
   to `com.google.firebase:firebase-messaging` under the `com.google.firebase.messaging` package.
   For details, see the

--- a/firebase-messaging/src/main/AndroidManifest.xml
+++ b/firebase-messaging/src/main/AndroidManifest.xml
@@ -28,6 +28,9 @@
             <intent-filter>
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
             </intent-filter>
+            <meta-data
+                android:name="com.google.android.gms.cloudmessaging.FINISHED_AFTER_HANDLED"
+                android:value="true" />
         </receiver>
 
         <!-- FirebaseMessagingService performs security checks at runtime,


### PR DESCRIPTION
* Added metadata to FirebaseInstanceIdReceiver to signal that it finishes background broadcasts after the message has been handled.