### PR TITLE
Specify notification's dismiss intent target via action instead of co…

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* [changed] Specified notification's dismiss intent target via action instead of
+  component name.
+
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-messaging-ktx`
   to `com.google.firebase:firebase-messaging` under the `com.google.firebase.messaging` package.
   For details, see the

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/CommonNotificationBuilder.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/CommonNotificationBuilder.java
@@ -20,7 +20,6 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -71,7 +70,7 @@ public final class CommonNotificationBuilder {
   // resource file exists (possibly stripped by Progurad). Note this name is set purposefully
   // different from FM's default resource channel name "Miscellaneous" for debugability.
   private static final String FCM_FALLBACK_NOTIFICATION_CHANNEL_NAME_NO_RESOURCE = "Misc";
-  private static final String ACTION_MESSAGING_EVENT = "com.google.firebase.MESSAGING_EVENT";
+  private static final String ACTION_RECEIVER = "com.google.android.c2dm.intent.RECEIVE";
 
   // Getting illegal resouce id from context will throw NotFoundException.
   // See: https://developer.android.com/reference/android/content/res/Resources#ID_NULL
@@ -559,15 +558,14 @@ public final class CommonNotificationBuilder {
     return createMessagingPendingIntent(callingContext, appContext, dismissIntent);
   }
 
-  /** Create a PendingIntent to start the app's messaging service via FirebaseInstanceIdReceiver */
+  /** Create a PendingIntent for the app's messaging receiver. */
   private static PendingIntent createMessagingPendingIntent(
       Context callingContext, Context appContext, Intent intent) {
     return PendingIntent.getBroadcast(
         callingContext,
         generatePendingIntentRequestCode(),
-        new Intent(ACTION_MESSAGING_EVENT)
-            .setComponent(
-                new ComponentName(appContext, "com.google.firebase.iid.FirebaseInstanceIdReceiver"))
+        new Intent(ACTION_RECEIVER)
+            .setPackage(appContext.getPackageName())
             .putExtra(IntentKeys.WRAPPED_INTENT, intent),
         getPendingIntentFlags(PendingIntent.FLAG_ONE_SHOT));
   }

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/CommonNotificationBuilderRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/CommonNotificationBuilderRoboTest.java
@@ -14,11 +14,9 @@
 package com.google.firebase.messaging;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.firebase.messaging.ServiceStarter.ACTION_MESSAGING_EVENT;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Notification;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
@@ -66,6 +64,7 @@ public class CommonNotificationBuilderRoboTest {
   private static final String NOTIFICATION_PRIORITY_DEFAULT = "0";
   private static final String NOTIFICATION_PRIORITY_NEGATIVE = "-999";
   private static final int DEFAULTS_ALL_OFF = 0;
+  private static final String ACTION_RECEIVER = "com.google.android.c2dm.intent.RECEIVE";
 
   private Context appContext;
   private Context callingContext;
@@ -802,10 +801,8 @@ public class CommonNotificationBuilderRoboTest {
     assertThat(deletePendingIntent.isBroadcastIntent()).isTrue();
     assertThat(deletePendingIntent.getSavedContext()).isEqualTo(callingContext);
     Intent deleteIntent = deletePendingIntent.getSavedIntent();
-    assertThat(deleteIntent.getComponent())
-        .isEqualTo(
-            new ComponentName(appContext, "com.google.firebase.iid.FirebaseInstanceIdReceiver"));
-    assertThat(deleteIntent.getAction()).isEqualTo(ACTION_MESSAGING_EVENT);
+    assertThat(deleteIntent.getPackage()).isEqualTo(appContext.getPackageName());
+    assertThat(deleteIntent.getAction()).isEqualTo(ACTION_RECEIVER);
     Intent dismissIntent = deleteIntent.getParcelableExtra(IntentKeys.WRAPPED_INTENT);
     assertThat(dismissIntent).isNotNull();
     assertThat(dismissIntent.getAction()).isEqualTo(IntentActionKeys.NOTIFICATION_DISMISS);

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingServiceRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingServiceRoboTest.java
@@ -43,7 +43,6 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -90,6 +89,7 @@ public class FirebaseMessagingServiceRoboTest {
 
   // Constants are copied so that tests will break if these change
   private static final String ACTION_NEW_TOKEN = "com.google.firebase.messaging.NEW_TOKEN";
+  private static final String ACTION_RECEIVER = "com.google.android.c2dm.intent.RECEIVE";
 
   private static final String DEFAULT_FROM = "123";
   private static final String DEFAULT_TO = "456";
@@ -585,8 +585,8 @@ public class FirebaseMessagingServiceRoboTest {
     // Ensure the intent is a broadcast to the receiver, then dispatch it
     assertWithMessage("expected broadcast intent").that(shadowOf(pi).isBroadcastIntent()).isTrue();
 
-    assertEquals(
-        intent.getComponent(), new ComponentName(context, FirebaseInstanceIdReceiver.class));
+    assertEquals(intent.getAction(), ACTION_RECEIVER);
+    assertEquals(intent.getPackage(), context.getPackageName());
     sendBroadcastToReceiver(intent);
     ShadowLooper.idleMainLooper();
   }


### PR DESCRIPTION
…mponent name.

* Changed createMessagingPendingIntent() to create an Intent targeting the BroadcastReceiver via action and package instead of specifying the ComponentName directly. This will make it easier to change FirebaseInstanceIdReceiver's class name in the future.