### PR TITLE
Make SessionGenerator injectable

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -36,6 +36,7 @@ internal constructor(
   blockingDispatcher: CoroutineDispatcher,
   private val sessionFirelogPublisher: SessionFirelogPublisher,
   @Suppress("UNUSED_PARAMETER") sessionMaintainer: SessionMaintainer,
+  private val sessionGenerator: SessionGenerator,
 ) {
   private val applicationInfo = SessionEvents.getApplicationInfo(firebaseApp)
   private val sessionSettings =
@@ -46,7 +47,6 @@ internal constructor(
       firebaseInstallations,
       applicationInfo,
     )
-  private val sessionGenerator = SessionGenerator(WallClock)
 
   // TODO: This needs to be moved into the service to be consistent across multiple processes.
   private val collectEvents: Boolean
@@ -64,7 +64,7 @@ internal constructor(
 
     val sessionInitiator =
       SessionInitiator(
-        WallClock,
+        timeProvider = WallClock,
         backgroundDispatcher,
         sessionInitiateListener,
         sessionSettings,

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -46,8 +46,7 @@ internal constructor(
       firebaseInstallations,
       applicationInfo,
     )
-  private val timeProvider: TimeProvider = Time()
-  private val sessionGenerator = SessionGenerator(timeProvider)
+  private val sessionGenerator = SessionGenerator(WallClock)
 
   // TODO: This needs to be moved into the service to be consistent across multiple processes.
   private val collectEvents: Boolean
@@ -65,7 +64,7 @@ internal constructor(
 
     val sessionInitiator =
       SessionInitiator(
-        timeProvider,
+        WallClock,
         backgroundDispatcher,
         sessionInitiateListener,
         sessionSettings,

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -47,10 +47,13 @@ internal constructor(
       applicationInfo,
     )
   private val timeProvider: TimeProvider = Time()
-  private val sessionGenerator: SessionGenerator
+  private val sessionGenerator = SessionGenerator(timeProvider)
+
+  // TODO: This needs to be moved into the service to be consistent across multiple processes.
+  private val collectEvents: Boolean
 
   init {
-    sessionGenerator = SessionGenerator(collectEvents = shouldCollectEvents(), timeProvider)
+    collectEvents = shouldCollectEvents()
 
     val sessionInitiateListener =
       object : SessionInitiateListener {
@@ -136,7 +139,7 @@ internal constructor(
       return
     }
 
-    if (!sessionGenerator.collectEvents) {
+    if (!collectEvents) {
       Log.d(TAG, "Sessions SDK has dropped this session due to sampling.")
       return
     }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -45,6 +45,7 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
         .add(Dependency.required(blockingDispatcher))
         .add(Dependency.required(sessionMaintainer))
         .add(Dependency.required(sessionFirelogPublisher))
+        .add(Dependency.required(sessionGenerator))
         .factory { container ->
           FirebaseSessions(
             container.get(firebaseApp),
@@ -52,13 +53,18 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
             container.get(backgroundDispatcher),
             container.get(blockingDispatcher),
             container.get(sessionFirelogPublisher),
-            container.get(sessionMaintainer)
+            container.get(sessionMaintainer),
+            container.get(sessionGenerator),
           )
         }
         .build(),
       Component.builder(SessionMaintainer::class.java)
         .name(MAINTAINER_LIBRARY_NAME)
         .factory { SessionMaintainer() }
+        .build(),
+      Component.builder(SessionGenerator::class.java)
+        .name(SESSION_GENERATOR)
+        .factory { SessionGenerator(timeProvider = WallClock) }
         .build(),
       Component.builder(SessionFirelogPublisher::class.java)
         .name(SESSIONS_PUBLISHER)
@@ -78,6 +84,7 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
     private const val SESSIONS_LIBRARY_NAME = "fire-sessions"
     private const val MAINTAINER_LIBRARY_NAME = "fire-session-maintainer"
     private const val SESSIONS_PUBLISHER = "sessions-publisher"
+    private const val SESSION_GENERATOR = "session-generator"
 
     private val sessionMaintainer = unqualified(SessionMaintainer::class.java)
     private val firebaseApp = unqualified(FirebaseApp::class.java)
@@ -88,5 +95,6 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
       qualified(Blocking::class.java, CoroutineDispatcher::class.java)
     private val transportFactory = unqualified(TransportFactory::class.java)
     private val sessionFirelogPublisher = unqualified(SessionFirelogPublisher::class.java)
+    private val sessionGenerator = unqualified(SessionGenerator::class.java)
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionGenerator.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionGenerator.kt
@@ -16,6 +16,9 @@
 
 package com.google.firebase.sessions
 
+import com.google.firebase.Firebase
+import com.google.firebase.FirebaseApp
+import com.google.firebase.app
 import java.util.UUID
 
 /**
@@ -61,4 +64,11 @@ internal class SessionGenerator(
   }
 
   private fun generateSessionId() = uuidGenerator().toString().replace("-", "").lowercase()
+
+  internal companion object {
+    val instance: SessionGenerator
+      get() = getInstance(Firebase.app)
+
+    fun getInstance(app: FirebaseApp): SessionGenerator = app.get(SessionGenerator::class.java)
+  }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionGenerator.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionGenerator.kt
@@ -33,7 +33,6 @@ internal data class SessionDetails(
  * [SessionDetails] up to date with the latest values.
  */
 internal class SessionGenerator(
-  val collectEvents: Boolean,
   private val timeProvider: TimeProvider,
   private val uuidGenerator: () -> UUID = UUID::randomUUID
 ) {

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/TimeProvider.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/TimeProvider.kt
@@ -27,7 +27,7 @@ internal interface TimeProvider {
 }
 
 /** "Wall clock" time provider. */
-internal class Time : TimeProvider {
+internal object WallClock : TimeProvider {
   /**
    * Gets the [Duration] elapsed in "wall clock" time since device boot.
    *
@@ -45,8 +45,6 @@ internal class Time : TimeProvider {
    */
   override fun currentTimeUs(): Long = System.currentTimeMillis() * US_PER_MILLIS
 
-  companion object {
-    /** Microseconds per millisecond. */
-    private const val US_PER_MILLIS = 1000L
-  }
+  /** Microseconds per millisecond. */
+  private const val US_PER_MILLIS = 1000L
 }

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionGeneratorTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionGeneratorTest.kt
@@ -42,7 +42,6 @@ class SessionGeneratorTest {
   fun currentSession_beforeGenerate_throwsUninitialized() {
     val sessionGenerator =
       SessionGenerator(
-        collectEvents = false,
         timeProvider = FakeTimeProvider(),
       )
 
@@ -53,7 +52,6 @@ class SessionGeneratorTest {
   fun hasGenerateSession_beforeGenerate_returnsFalse() {
     val sessionGenerator =
       SessionGenerator(
-        collectEvents = false,
         timeProvider = FakeTimeProvider(),
       )
 
@@ -64,7 +62,6 @@ class SessionGeneratorTest {
   fun hasGenerateSession_afterGenerate_returnsTrue() {
     val sessionGenerator =
       SessionGenerator(
-        collectEvents = false,
         timeProvider = FakeTimeProvider(),
       )
 
@@ -77,7 +74,6 @@ class SessionGeneratorTest {
   fun generateNewSession_generatesValidSessionIds() {
     val sessionGenerator =
       SessionGenerator(
-        collectEvents = true,
         timeProvider = FakeTimeProvider(),
       )
 
@@ -96,7 +92,6 @@ class SessionGeneratorTest {
   fun generateNewSession_generatesValidSessionDetails() {
     val sessionGenerator =
       SessionGenerator(
-        collectEvents = true,
         timeProvider = FakeTimeProvider(),
         uuidGenerator = UUIDs()::next,
       )
@@ -123,7 +118,6 @@ class SessionGeneratorTest {
   fun generateNewSession_incrementsSessionIndex_keepsFirstSessionId() {
     val sessionGenerator =
       SessionGenerator(
-        collectEvents = true,
         timeProvider = FakeTimeProvider(),
         uuidGenerator = UUIDs()::next,
       )

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionInitiatorTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionInitiatorTest.kt
@@ -60,7 +60,7 @@ class SessionInitiatorTest {
       TestOnlyExecutors.background().asCoroutineDispatcher() + coroutineContext,
       sessionInitiateListener = sessionInitiateCounter,
       settings,
-      SessionGenerator(collectEvents = false, fakeTimeProvider),
+      SessionGenerator(fakeTimeProvider),
     )
 
     // Run onInitiateSession suspend function.
@@ -86,7 +86,7 @@ class SessionInitiatorTest {
         TestOnlyExecutors.background().asCoroutineDispatcher() + coroutineContext,
         sessionInitiateListener = sessionInitiateCounter,
         settings,
-        SessionGenerator(collectEvents = false, fakeTimeProvider),
+        SessionGenerator(fakeTimeProvider),
       )
 
     // Run onInitiateSession suspend function.
@@ -121,7 +121,7 @@ class SessionInitiatorTest {
         TestOnlyExecutors.background().asCoroutineDispatcher() + coroutineContext,
         sessionInitiateListener = sessionInitiateCounter,
         settings,
-        SessionGenerator(collectEvents = false, fakeTimeProvider),
+        SessionGenerator(fakeTimeProvider),
       )
 
     // Run onInitiateSession suspend function.
@@ -156,7 +156,7 @@ class SessionInitiatorTest {
         TestOnlyExecutors.background().asCoroutineDispatcher() + coroutineContext,
         sessionInitiateListener = sessionInitiateCounter,
         settings,
-        SessionGenerator(collectEvents = false, fakeTimeProvider),
+        SessionGenerator(fakeTimeProvider),
       )
 
     // Run onInitiateSession suspend function.
@@ -196,7 +196,7 @@ class SessionInitiatorTest {
         TestOnlyExecutors.background().asCoroutineDispatcher() + coroutineContext,
         sessionInitiateListener = sessionInitiateCounter,
         settings,
-        SessionGenerator(collectEvents = false, fakeTimeProvider),
+        SessionGenerator(fakeTimeProvider),
       )
 
     // Run onInitiateSession suspend function.


### PR DESCRIPTION
Make `SessionGenerator` injectable. Also made `WallClock` an object to avoid needing to pass it around. Moved `collectEvents` out of SessionGenerator since it will need to be handled in the service.