### PR TITLE
Only support the default Firebase app

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -32,7 +32,7 @@ internal constructor(
   private val firebaseApp: FirebaseApp,
   internal val backgroundDispatcher: CoroutineDispatcher,
   private val sessionFirelogPublisher: SessionFirelogPublisher,
-  private val sessionGenerator: SessionGenerator,
+  sessionGenerator: SessionGenerator,
   private val sessionSettings: SessionsSettings,
 ) {
 
@@ -141,9 +141,18 @@ internal constructor(
 
     @JvmStatic
     val instance: FirebaseSessions
-      get() = getInstance(Firebase.app)
+      get() = Firebase.app.get(FirebaseSessions::class.java)
 
     @JvmStatic
-    fun getInstance(app: FirebaseApp): FirebaseSessions = app.get(FirebaseSessions::class.java)
+    @Deprecated(
+      "Firebase Sessions only supports the Firebase default app.",
+      ReplaceWith("FirebaseSessions.instance"),
+    )
+    fun getInstance(app: FirebaseApp): FirebaseSessions =
+      if (app == Firebase.app) {
+        app.get(FirebaseSessions::class.java)
+      } else {
+        throw IllegalArgumentException("Firebase Sessions only supports the Firebase default app.")
+      }
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
@@ -18,7 +18,6 @@ package com.google.firebase.sessions
 
 import android.util.Log
 import com.google.firebase.Firebase
-import com.google.firebase.FirebaseApp
 import com.google.firebase.app
 import com.google.firebase.installations.FirebaseInstallationsApi
 import kotlinx.coroutines.tasks.await
@@ -54,10 +53,7 @@ internal class SessionFirelogPublisher(
   internal companion object {
     const val TAG = "SessionFirelogPublisher"
 
-    fun getInstance(app: FirebaseApp): SessionFirelogPublisher =
-      app.get(SessionFirelogPublisher::class.java)
-
     val instance: SessionFirelogPublisher
-      get() = getInstance(Firebase.app)
+      get() = Firebase.app.get(SessionFirelogPublisher::class.java)
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionGenerator.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionGenerator.kt
@@ -17,7 +17,6 @@
 package com.google.firebase.sessions
 
 import com.google.firebase.Firebase
-import com.google.firebase.FirebaseApp
 import com.google.firebase.app
 import java.util.UUID
 
@@ -67,8 +66,6 @@ internal class SessionGenerator(
 
   internal companion object {
     val instance: SessionGenerator
-      get() = getInstance(Firebase.app)
-
-    fun getInstance(app: FirebaseApp): SessionGenerator = app.get(SessionGenerator::class.java)
+      get() = Firebase.app.get(SessionGenerator::class.java)
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/SessionsSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/SessionsSettings.kt
@@ -138,9 +138,7 @@ internal class SessionsSettings(
     private const val SESSION_CONFIGS_NAME = "firebase_session_settings"
 
     val instance: SessionsSettings
-      get() = getInstance(Firebase.app)
-
-    fun getInstance(app: FirebaseApp): SessionsSettings = app.get(SessionsSettings::class.java)
+      get() = Firebase.app.get(SessionsSettings::class.java)
 
     private val Context.dataStore: DataStore<Preferences> by
       preferencesDataStore(name = SESSION_CONFIGS_NAME)


### PR DESCRIPTION
This will make it safe to call `Firebase.app` any time from anywhere in this SDK.