### PR TITLE
Hooks up the SessionLifecycleService to the FirelogPublisher, and has…

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -114,19 +114,6 @@ internal constructor(
       Log.d(TAG, "Sessions SDK has dropped this session due to sampling.")
       return
     }
-
-    try {
-      val sessionEvent =
-        SessionEvents.startSession(firebaseApp, sessionDetails, sessionSettings, subscribers)
-      sessionFirelogPublisher.attemptLoggingSessionEvent(sessionEvent)
-    } catch (ex: IllegalStateException) {
-      // This can happen if the app suddenly deletes the instance of FirebaseApp.
-      Log.w(
-        TAG,
-        "FirebaseApp is not initialized. Sessions library will not collect session data.",
-        ex
-      )
-    }
   }
 
   /** Calculate whether we should sample events using [sessionSettings] data. */

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -61,12 +61,18 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
         .build(),
       Component.builder(SessionFirelogPublisher::class.java)
         .name("session-publisher")
+        .add(Dependency.required(firebaseApp))
         .add(Dependency.required(firebaseInstallationsApi))
+        .add(Dependency.required(sessionsSettings))
         .add(Dependency.requiredProvider(transportFactory))
+        .add(Dependency.required(backgroundDispatcher))
         .factory { container ->
           SessionFirelogPublisher(
+            container.get(firebaseApp),
             container.get(firebaseInstallationsApi),
+            container.get(sessionsSettings),
             EventGDTLogger(container.getProvider(transportFactory)),
+            container.get(backgroundDispatcher),
           )
         }
         .build(),

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
@@ -37,7 +37,7 @@ internal object SessionEvents {
    *
    * Some mutable fields, e.g. firebaseInstallationId, get populated later.
    */
-  fun startSession(
+  fun buildSession(
     firebaseApp: FirebaseApp,
     sessionDetails: SessionDetails,
     sessionsSettings: SessionsSettings,

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
@@ -21,6 +21,11 @@ import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
 import com.google.firebase.app
 import com.google.firebase.installations.FirebaseInstallationsApi
+import com.google.firebase.sessions.api.FirebaseSessionsDependencies
+import com.google.firebase.sessions.settings.SessionsSettings
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -29,27 +34,52 @@ import kotlinx.coroutines.tasks.await
  * @hide
  */
 internal class SessionFirelogPublisher(
+  private val firebaseApp: FirebaseApp,
   private val firebaseInstallations: FirebaseInstallationsApi,
+  private val sessionSettings: SessionsSettings,
   private val eventGDTLogger: EventGDTLoggerInterface,
+  private val backgroundDispatcher: CoroutineDispatcher,
 ) {
-  suspend fun attemptLoggingSessionEvent(sessionEvent: SessionEvent) {
-    sessionEvent.sessionData.firebaseInstallationId =
-      try {
-        firebaseInstallations.id.await()
-      } catch (ex: Exception) {
-        Log.e(TAG, "Error getting Firebase Installation ID: ${ex}. Using an empty ID")
-        // Use an empty fid if there is any failure.
-        ""
-      }
 
+  /**
+   * Logs the session represented by the given [SessionDetails] to Firelog on a background thread.
+   *
+   * This will pull all the necessary information about the device in order to create a full
+   * [SessionEvent], and then upload that through the Firelog interface.
+   */
+  fun logSession(sessionDetails: SessionDetails) {
+    CoroutineScope(backgroundDispatcher).launch {
+      val sessionEvent =
+        SessionEvents.buildSession(
+          firebaseApp,
+          sessionDetails,
+          sessionSettings,
+          FirebaseSessionsDependencies.getRegisteredSubscribers(),
+        )
+      sessionEvent.sessionData.firebaseInstallationId = getFid()
+      attemptLoggingSessionEvent(sessionEvent)
+    }
+  }
+
+  /** Attempts to write the given [SessionEvent] to firelog. Failures are logged and ignored. */
+  private suspend fun attemptLoggingSessionEvent(sessionEvent: SessionEvent) {
     try {
       eventGDTLogger.log(sessionEvent)
-
       Log.i(TAG, "Successfully logged Session Start event: ${sessionEvent.sessionData.sessionId}")
     } catch (ex: RuntimeException) {
       Log.e(TAG, "Error logging Session Start event to DataTransport: ", ex)
     }
   }
+
+  /** Gets the Firebase Installation ID for the current app installation. */
+  private suspend fun getFid() =
+    try {
+      firebaseInstallations.id.await()
+    } catch (ex: Exception) {
+      Log.e(TAG, "Error getting Firebase Installation ID: ${ex}. Using an empty ID")
+      // Use an empty fid if there is any failure.
+      ""
+    }
 
   internal companion object {
     const val TAG = "SessionFirelogPublisher"

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
@@ -23,7 +23,7 @@ import com.google.firebase.app
 import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.sessions.api.FirebaseSessionsDependencies
 import com.google.firebase.sessions.settings.SessionsSettings
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
@@ -38,7 +38,7 @@ internal class SessionFirelogPublisher(
   private val firebaseInstallations: FirebaseInstallationsApi,
   private val sessionSettings: SessionsSettings,
   private val eventGDTLogger: EventGDTLoggerInterface,
-  private val backgroundDispatcher: CoroutineDispatcher,
+  private val backgroundDispatcher: CoroutineContext,
 ) {
 
   /**

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/EventGDTLoggerTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/EventGDTLoggerTest.kt
@@ -42,7 +42,7 @@ class EventGDTLoggerTest {
   fun event_logsToGoogleDataTransport() = runTest {
     val fakeFirebaseApp = FakeFirebaseApp()
     val sessionEvent =
-      SessionEvents.startSession(
+      SessionEvents.buildSession(
         fakeFirebaseApp.firebaseApp,
         TestSessionEventData.TEST_SESSION_DETAILS,
         SessionsSettings(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
@@ -46,7 +46,7 @@ class SessionEventEncoderTest {
   fun sessionEvent_encodesToJson() = runTest {
     val fakeFirebaseApp = FakeFirebaseApp()
     val sessionEvent =
-      SessionEvents.startSession(
+      SessionEvents.buildSession(
         fakeFirebaseApp.firebaseApp,
         TestSessionEventData.TEST_SESSION_DETAILS,
         SessionsSettings(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventTest.kt
@@ -41,7 +41,7 @@ class SessionEventTest {
   fun sessionStart_populatesSessionDetailsCorrectly() = runTest {
     val fakeFirebaseApp = FakeFirebaseApp()
     val sessionEvent =
-      SessionEvents.startSession(
+      SessionEvents.buildSession(
         fakeFirebaseApp.firebaseApp,
         TEST_SESSION_DETAILS,
         SessionsSettings(
@@ -61,7 +61,7 @@ class SessionEventTest {
     val context = firebaseApp.applicationContext
 
     val sessionEvent =
-      SessionEvents.startSession(
+      SessionEvents.buildSession(
         firebaseApp,
         TEST_SESSION_DETAILS,
         SessionsSettings(

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionFirelogPublisherTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionFirelogPublisherTest.kt
@@ -53,7 +53,7 @@ class SessionFirelogPublisherTest {
         firebaseInstallations,
         sessionsSettings,
         eventGDTLogger = fakeEventGDTLogger,
-        TestOnlyExecutors.background().asCoroutineDispatcher(),
+        TestOnlyExecutors.background().asCoroutineDispatcher() + coroutineContext,
       )
 
     // Construct an event with no fid set.
@@ -61,6 +61,7 @@ class SessionFirelogPublisherTest {
 
     runCurrent()
 
+    System.out.println("FakeEventGDTLogger: $fakeEventGDTLogger")
     assertThat(fakeEventGDTLogger.loggedEvent!!.sessionData.firebaseInstallationId)
       .isEqualTo("FaKeFiD")
   }

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionFirelogPublisherTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionFirelogPublisherTest.kt
@@ -19,6 +19,7 @@ package com.google.firebase.sessions
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.google.firebase.FirebaseApp
+import com.google.firebase.concurrent.TestOnlyExecutors
 import com.google.firebase.sessions.settings.SessionsSettings
 import com.google.firebase.sessions.testing.FakeEventGDTLogger
 import com.google.firebase.sessions.testing.FakeFirebaseApp
@@ -26,6 +27,7 @@ import com.google.firebase.sessions.testing.FakeFirebaseInstallations
 import com.google.firebase.sessions.testing.FakeSettingsProvider
 import com.google.firebase.sessions.testing.TestSessionEventData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -36,32 +38,29 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class SessionFirelogPublisherTest {
   @Test
-  fun attemptLoggingSessionEvent_populatesFid() = runTest {
+  fun logSession_populatesFid() = runTest {
+    val fakeFirebaseApp = FakeFirebaseApp()
     val fakeEventGDTLogger = FakeEventGDTLogger()
     val firebaseInstallations = FakeFirebaseInstallations("FaKeFiD")
-    val sessionCoordinator =
+    val sessionsSettings =
+      SessionsSettings(
+        localOverrideSettings = FakeSettingsProvider(),
+        remoteSettings = FakeSettingsProvider(),
+      )
+    val publisher =
       SessionFirelogPublisher(
+        fakeFirebaseApp.firebaseApp,
         firebaseInstallations,
+        sessionsSettings,
         eventGDTLogger = fakeEventGDTLogger,
+        TestOnlyExecutors.background().asCoroutineDispatcher(),
       )
 
     // Construct an event with no fid set.
-    val fakeFirebaseApp = FakeFirebaseApp()
-    val sessionEvent =
-      SessionEvents.startSession(
-        fakeFirebaseApp.firebaseApp,
-        TestSessionEventData.TEST_SESSION_DETAILS,
-        SessionsSettings(
-          localOverrideSettings = FakeSettingsProvider(),
-          remoteSettings = FakeSettingsProvider(),
-        ),
-      )
-
-    sessionCoordinator.attemptLoggingSessionEvent(sessionEvent)
+    publisher.logSession(TestSessionEventData.TEST_SESSION_DETAILS)
 
     runCurrent()
 
-    assertThat(sessionEvent.sessionData.firebaseInstallationId).isEqualTo("FaKeFiD")
     assertThat(fakeEventGDTLogger.loggedEvent!!.sessionData.firebaseInstallationId)
       .isEqualTo("FaKeFiD")
   }


### PR DESCRIPTION
… the FirelogPublisher handle the full SessionEvent creation since that's only relevant to Firelog.