### PR TITLE
Enable setting OkHttpClient for FirebaseFunctions

### DIFF
--- a/firebase-functions/src/androidTest/java/com/google/firebase/functions/FirebaseFunctionsTest.kt
+++ b/firebase-functions/src/androidTest/java/com/google/firebase/functions/FirebaseFunctionsTest.kt
@@ -19,6 +19,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.google.firebase.functions.FirebaseFunctions.Companion.getInstance
 import junit.framework.TestCase.assertEquals
+import okhttp3.OkHttpClient
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -89,6 +90,17 @@ class FirebaseFunctionsTest {
     functions1.useEmulator("10.0.2.2", 5001)
     val functions2 = getInstance(app)
     assertEquals(functions1.getURL("foo").toString(), functions2.getURL("foo").toString())
+  }
+
+  @Test
+  fun testSetOkHttpClient() {
+    val client = OkHttpClient.Builder().build()
+    val app = getApp("testSetOkHttpClient")
+    val functions = getInstance(app)
+
+    functions.setOkHttpClient(client)
+
+    assertEquals(client, functions.getOkHttpClient())
   }
 
   private fun getApp(name: String): FirebaseApp {

--- a/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.kt
+++ b/firebase-functions/src/main/java/com/google/firebase/functions/FirebaseFunctions.kt
@@ -58,7 +58,7 @@ internal constructor(
   @UiThread uiExecutor: Executor
 ) {
   // The network client to use for HTTPS requests.
-  private val client: OkHttpClient = OkHttpClient()
+  private var client: OkHttpClient = OkHttpClient()
 
   // A serializer to encode/decode parameters and return values.
   private val serializer: Serializer = Serializer()
@@ -310,6 +310,12 @@ internal constructor(
     )
     return tcs.task
   }
+
+  public fun setOkHttpClient(client: OkHttpClient) {
+    this.client = client
+  }
+
+  public fun getOkHttpClient(): OkHttpClient = this.client
 
   public companion object {
     /** A task that will be resolved once ProviderInstaller has installed what it needs to. */


### PR DESCRIPTION
This PR fixes #5404. I deliberately did not add the `OkHttpClient` instance to the `getInstance` factory methods because this would mean four additional variants of `getInstance`. I believe setting the HTTP client instance is a rare use case, so this is solved through an additional setter.