### PR TITLE
Add process details to Crashlytics events

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -15,6 +15,8 @@
 * [fixed] Fixed Flutter and Unity on-demand fatal `setUserIdentifier` behaviour. Github
   [#10759](https://github.com/firebase/flutterfire/issues/10759)
 
+* [changed] Include more details about app processes in reports.
+
 ## Kotlin
 The Kotlin extensions library transitively includes the updated
 `firebase-crashlytics` library. The Kotlin extensions library has no additional
@@ -520,4 +522,3 @@ The following release notes describe changes in the new SDK.
  from your `AndroidManifest.xml` file.
  * [removed] The `fabric.properties` and `crashlytics.properties` files are no
  longer supported. Remove them from your app.
-

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* [changed] Include more details about app processes in reports.
 
 # 18.5.0
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-crashlytics-ktx`
@@ -14,8 +15,6 @@
 
 * [fixed] Fixed Flutter and Unity on-demand fatal `setUserIdentifier` behaviour. Github
   [#10759](https://github.com/firebase/flutterfire/issues/10759)
-
-* [changed] Include more details about app processes in reports.
 
 ## Kotlin
 The Kotlin extensions library transitively includes the updated

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import android.app.ActivityManager.RunningAppProcessInfo;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
@@ -139,18 +139,6 @@ public class CommonUtilsTest extends CrashlyticsTestCase {
     Log.d(Logger.TAG, "testGetTotalRam: " + bytes);
   }
 
-  public void testGetAppProcessInfo() {
-    final Context context = getContext();
-    RunningAppProcessInfo info = CommonUtils.getAppProcessInfo(context.getPackageName(), context);
-    assertNotNull(info);
-    // It is not possible to test the state of info.importance because the value is not
-    // always the same under test as it is when the sdk is running in an app. In API 21, the
-    // importance under test started returning VISIBLE instead of FOREGROUND.
-
-    info = CommonUtils.getAppProcessInfo("nonexistant.package.name", context);
-    assertNull(info);
-  }
-
   public void testIsRooted() {
     // No good way to test the alternate case,
     // just want to ensure we can complete the call without an exception here.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/ProcessDetailsProvider.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/ProcessDetailsProvider.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.firebase.crashlytics.internal.common
+package com.google.firebase.crashlytics.internal
 
 import android.app.ActivityManager
 import android.content.Context

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -132,28 +132,6 @@ public class CommonUtils {
     }
   }
 
-  /**
-   * Returns the RunningAppProcessInfo object for the given package, or null if it cannot be found.
-   */
-  public static ActivityManager.RunningAppProcessInfo getAppProcessInfo(
-      String packageName, Context context) {
-    final ActivityManager actman =
-        (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
-    final List<ActivityManager.RunningAppProcessInfo> processes = actman.getRunningAppProcesses();
-    ActivityManager.RunningAppProcessInfo procInfo = null;
-    // According to docs, the result of getRunningAppProcesses can be null instead of empty.
-    // Yay.
-    if (processes != null) {
-      for (ActivityManager.RunningAppProcessInfo info : processes) {
-        if (info.processName.equals(packageName)) {
-          procInfo = info;
-          break;
-        }
-      }
-    }
-    return procInfo;
-  }
-
   public static String streamToString(InputStream is) {
     // Previous code was running into this: http://code.google.com/p/android/issues/detail?id=14562
     // on Android 2.3.3. The below code below does not exhibit that problem.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
@@ -25,6 +25,7 @@ import android.os.Environment;
 import android.os.StatFs;
 import android.text.TextUtils;
 import com.google.firebase.crashlytics.BuildConfig;
+import com.google.firebase.crashlytics.internal.ProcessDetailsProvider;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Architecture;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsReportDataCapture.java
@@ -30,6 +30,7 @@ import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Architec
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.BinaryImage;
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.ProcessDetails;
 import com.google.firebase.crashlytics.internal.model.ImmutableList;
 import com.google.firebase.crashlytics.internal.settings.SettingsProvider;
 import com.google.firebase.crashlytics.internal.stacktrace.StackTraceTrimmingStrategy;
@@ -71,6 +72,7 @@ public class CrashlyticsReportDataCapture {
   private final AppData appData;
   private final StackTraceTrimmingStrategy stackTraceTrimmingStrategy;
   private final SettingsProvider settingsProvider;
+  private final ProcessDetailsProvider processDetailsProvider = ProcessDetailsProvider.INSTANCE;
 
   public CrashlyticsReportDataCapture(
       Context context,
@@ -239,17 +241,18 @@ public class CrashlyticsReportDataCapture {
       int maxChainedExceptions,
       boolean includeAllThreads) {
     Boolean isBackground = null;
-    final RunningAppProcessInfo runningAppProcessInfo =
-        CommonUtils.getAppProcessInfo(appData.packageName, context);
-    if (runningAppProcessInfo != null) {
+    ProcessDetails currentProcessDetails = processDetailsProvider.getCurrentProcessDetails(context);
+    if (currentProcessDetails.getImportance() > 0) {
       // Several different types of "background" states, easiest to check for not foreground.
       isBackground =
-          runningAppProcessInfo.importance
+          currentProcessDetails.getImportance()
               != ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
     }
 
     return Event.Application.builder()
         .setBackground(isBackground)
+        .setCurrentProcessDetails(currentProcessDetails)
+        .setAppProcessDetails(processDetailsProvider.getAppProcessDetails(context))
         .setUiOrientation(orientation)
         .setExecution(
             populateExecutionData(
@@ -268,6 +271,7 @@ public class CrashlyticsReportDataCapture {
 
     return Event.Application.builder()
         .setBackground(isBackground)
+        .setCurrentProcessDetails(processDetailsFromApplicationExitInfo(applicationExitInfo))
         .setUiOrientation(orientation)
         .setExecution(populateExecutionData(applicationExitInfo))
         .build();
@@ -474,5 +478,14 @@ public class CrashlyticsReportDataCapture {
   /** Returns the given value, or zero is the value is negative. */
   private static long ensureNonNegative(long value) {
     return value > 0 ? value : 0;
+  }
+
+  /** Builds a ProcessDetails object from the details in applicationExitInfo. */
+  private ProcessDetails processDetailsFromApplicationExitInfo(
+      CrashlyticsReport.ApplicationExitInfo applicationExitInfo) {
+    return processDetailsProvider.buildProcessDetails(
+        applicationExitInfo.getProcessName(),
+        applicationExitInfo.getPid(),
+        applicationExitInfo.getImportance());
   }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/ProcessDetailsProvider.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/ProcessDetailsProvider.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.crashlytics.internal.common
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import android.os.Process
+import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.ProcessDetails
+import com.google.firebase.crashlytics.internal.model.ImmutableList
+
+/**
+ * Provider of ProcessDetails.
+ *
+ * @hide
+ */
+internal object ProcessDetailsProvider {
+  /** Gets the details of all running app processes. */
+  fun getAppProcessDetails(context: Context): ImmutableList<ProcessDetails> {
+    val defaultProcessName = context.applicationInfo.processName
+    val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    val runningAppProcesses = activityManager?.runningAppProcesses ?: listOf()
+
+    return ImmutableList.from(
+      runningAppProcesses.filterNotNull().map { runningAppProcessInfo ->
+        ProcessDetails.builder()
+          .setName(runningAppProcessInfo.processName)
+          .setPid(runningAppProcessInfo.pid)
+          .setImportance(runningAppProcessInfo.importance)
+          .setIsDefaultProcess(runningAppProcessInfo.processName == defaultProcessName)
+          .build()
+      }
+    )
+  }
+
+  /**
+   * Gets the current process details.
+   *
+   * If the current process details are not found for whatever reason, returns process details with
+   * just the current process name and pid set.
+   */
+  fun getProcessDetails(context: Context): ProcessDetails {
+    val pid = Process.myPid()
+    return getAppProcessDetails(context).find { processDetails -> processDetails.pid == pid }
+      ?: buildProcess(getProcessName(), pid)
+  }
+
+  /** Gets the current process name. If the API is not available, returns an empty string. */
+  private fun getProcessName(): String =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      Process.myProcessName()
+    } else {
+      ""
+    }
+
+  /** Builds a ProcessDetails object from just a process name and pid. */
+  private fun buildProcess(processName: String, pid: Int) =
+    ProcessDetails.builder()
+      .setName(processName)
+      .setPid(pid)
+      .setImportance(0)
+      .setIsDefaultProcess(false)
+      .build()
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/ProcessDetailsProvider.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/ProcessDetailsProvider.kt
@@ -38,10 +38,10 @@ internal object ProcessDetailsProvider {
     return ImmutableList.from(
       runningAppProcesses.filterNotNull().map { runningAppProcessInfo ->
         ProcessDetails.builder()
-          .setName(runningAppProcessInfo.processName)
+          .setProcessName(runningAppProcessInfo.processName)
           .setPid(runningAppProcessInfo.pid)
           .setImportance(runningAppProcessInfo.importance)
-          .setIsDefaultProcess(runningAppProcessInfo.processName == defaultProcessName)
+          .setDefaultProcess(runningAppProcessInfo.processName == defaultProcessName)
           .build()
       }
     )
@@ -53,11 +53,26 @@ internal object ProcessDetailsProvider {
    * If the current process details are not found for whatever reason, returns process details with
    * just the current process name and pid set.
    */
-  fun getProcessDetails(context: Context): ProcessDetails {
+  fun getCurrentProcessDetails(context: Context): ProcessDetails {
     val pid = Process.myPid()
     return getAppProcessDetails(context).find { processDetails -> processDetails.pid == pid }
-      ?: buildProcess(getProcessName(), pid)
+      ?: buildProcessDetails(getProcessName(), pid)
   }
+
+  /** Builds a ProcessDetails object. */
+  @JvmOverloads
+  fun buildProcessDetails(
+    processName: String,
+    pid: Int = 0,
+    importance: Int = 0,
+    isDefaultProcess: Boolean = false
+  ) =
+    ProcessDetails.builder()
+      .setProcessName(processName)
+      .setPid(pid)
+      .setImportance(importance)
+      .setDefaultProcess(isDefaultProcess)
+      .build()
 
   /** Gets the current process name. If the API is not available, returns an empty string. */
   private fun getProcessName(): String =
@@ -66,13 +81,4 @@ internal object ProcessDetailsProvider {
     } else {
       ""
     }
-
-  /** Builds a ProcessDetails object from just a process name and pid. */
-  private fun buildProcess(processName: String, pid: Int) =
-    ProcessDetails.builder()
-      .setName(processName)
-      .setPid(pid)
-      .setImportance(0)
-      .setIsDefaultProcess(false)
-      .build()
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -18,7 +18,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
-import com.google.firebase.crashlytics.internal.model.AutoValue_CrashlyticsReport_Session_Event_Application_ProcessDetails.Builder;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.Thread.Frame;
 import com.google.firebase.encoders.annotations.Encodable;
@@ -688,10 +687,10 @@ public abstract class CrashlyticsReport {
         public abstract Boolean getBackground();
 
         @Nullable
-        public abstract ProcessDetails processDetails();
+        public abstract ProcessDetails getCurrentProcessDetails();
 
         @Nullable
-        public abstract ImmutableList<ProcessDetails> appProcessDetails();
+        public abstract ImmutableList<ProcessDetails> getAppProcessDetails();
 
         public abstract int getUiOrientation();
 
@@ -965,13 +964,13 @@ public abstract class CrashlyticsReport {
         @AutoValue
         public abstract static class ProcessDetails {
           @NonNull
-          public abstract String getName();
+          public abstract String getProcessName();
 
           public abstract int getPid();
 
           public abstract int getImportance();
 
-          public abstract boolean getIsDefaultProcess();
+          public abstract boolean isDefaultProcess();
 
           @NonNull
           public static Builder builder() {
@@ -983,7 +982,7 @@ public abstract class CrashlyticsReport {
           @AutoValue.Builder
           public abstract static class Builder {
             @NonNull
-            public abstract Builder setName(@NonNull String name);
+            public abstract Builder setProcessName(@NonNull String processName);
 
             @NonNull
             public abstract Builder setPid(int pid);
@@ -992,7 +991,7 @@ public abstract class CrashlyticsReport {
             public abstract Builder setImportance(int importance);
 
             @NonNull
-            public abstract Builder setIsDefaultProcess(boolean isDefaultProcess);
+            public abstract Builder setDefaultProcess(boolean isDefaultProcess);
 
             @NonNull
             public abstract ProcessDetails build();
@@ -1015,6 +1014,13 @@ public abstract class CrashlyticsReport {
 
           @NonNull
           public abstract Builder setBackground(@Nullable Boolean value);
+
+          @NonNull
+          public abstract Builder setCurrentProcessDetails(@NonNull ProcessDetails processDetails);
+
+          @NonNull
+          public abstract Builder setAppProcessDetails(
+              @NonNull ImmutableList<ProcessDetails> appProcessDetails);
 
           @NonNull
           public abstract Builder setUiOrientation(int value);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -18,6 +18,7 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
+import com.google.firebase.crashlytics.internal.model.AutoValue_CrashlyticsReport_Session_Event_Application_ProcessDetails.Builder;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport.Session.Event.Application.Execution.Thread.Frame;
 import com.google.firebase.encoders.annotations.Encodable;
@@ -686,6 +687,12 @@ public abstract class CrashlyticsReport {
         @Nullable
         public abstract Boolean getBackground();
 
+        @Nullable
+        public abstract ProcessDetails processDetails();
+
+        @Nullable
+        public abstract ImmutableList<ProcessDetails> appProcessDetails();
+
         public abstract int getUiOrientation();
 
         @NonNull
@@ -952,6 +959,43 @@ public abstract class CrashlyticsReport {
 
             @NonNull
             public abstract Execution build();
+          }
+        }
+
+        @AutoValue
+        public abstract static class ProcessDetails {
+          @NonNull
+          public abstract String getName();
+
+          public abstract int getPid();
+
+          public abstract int getImportance();
+
+          public abstract boolean getIsDefaultProcess();
+
+          @NonNull
+          public static Builder builder() {
+            return new AutoValue_CrashlyticsReport_Session_Event_Application_ProcessDetails
+                .Builder();
+          }
+
+          /** Builder for {@link ProcessDetails}. */
+          @AutoValue.Builder
+          public abstract static class Builder {
+            @NonNull
+            public abstract Builder setName(@NonNull String name);
+
+            @NonNull
+            public abstract Builder setPid(int pid);
+
+            @NonNull
+            public abstract Builder setImportance(int importance);
+
+            @NonNull
+            public abstract Builder setIsDefaultProcess(boolean isDefaultProcess);
+
+            @NonNull
+            public abstract ProcessDetails build();
           }
         }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/CrashlyticsReport.java
@@ -1016,11 +1016,11 @@ public abstract class CrashlyticsReport {
           public abstract Builder setBackground(@Nullable Boolean value);
 
           @NonNull
-          public abstract Builder setCurrentProcessDetails(@NonNull ProcessDetails processDetails);
+          public abstract Builder setCurrentProcessDetails(@Nullable ProcessDetails processDetails);
 
           @NonNull
           public abstract Builder setAppProcessDetails(
-              @NonNull ImmutableList<ProcessDetails> appProcessDetails);
+              @Nullable ImmutableList<ProcessDetails> appProcessDetails);
 
           @NonNull
           public abstract Builder setUiOrientation(int value);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
@@ -483,12 +483,50 @@ public class CrashlyticsReportJsonTransform {
           builder.setInternalKeys(
               parseArray(jsonReader, CrashlyticsReportJsonTransform::parseCustomAttribute));
           break;
+        case "currentProcessDetails":
+          builder.setCurrentProcessDetails(parseProcessDetails(jsonReader));
+          break;
+        case "appProcessDetails":
+          builder.setAppProcessDetails(
+              parseArray(jsonReader, CrashlyticsReportJsonTransform::parseProcessDetails));
+          break;
         default:
           jsonReader.skipValue();
           break;
       }
     }
     jsonReader.endObject();
+    return builder.build();
+  }
+
+  @NonNull
+  private static Event.Application.ProcessDetails parseProcessDetails(@NonNull JsonReader jsonReader)
+      throws IOException {
+    Event.Application.ProcessDetails.Builder builder = Event.Application.ProcessDetails.builder();
+
+    jsonReader.beginObject();
+    while (jsonReader.hasNext()) {
+      String name = jsonReader.nextName();
+      switch (name) {
+        case "processName":
+          builder.setProcessName(jsonReader.nextString());
+          break;
+        case "pid":
+          builder.setPid(jsonReader.nextInt());
+          break;
+        case "importance":
+          builder.setImportance(jsonReader.nextInt());
+          break;
+        case "defaultProcess":
+          builder.setDefaultProcess(jsonReader.nextBoolean());
+          break;
+        default:
+          jsonReader.skipValue();
+          break;
+      }
+    }
+    jsonReader.endObject();
+
     return builder.build();
   }
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/model/serialization/CrashlyticsReportJsonTransform.java
@@ -500,8 +500,8 @@ public class CrashlyticsReportJsonTransform {
   }
 
   @NonNull
-  private static Event.Application.ProcessDetails parseProcessDetails(@NonNull JsonReader jsonReader)
-      throws IOException {
+  private static Event.Application.ProcessDetails parseProcessDetails(
+      @NonNull JsonReader jsonReader) throws IOException {
     Event.Application.ProcessDetails.Builder builder = Event.Application.ProcessDetails.builder();
 
     jsonReader.beginObject();


### PR DESCRIPTION
Add process details to Crashlytics java and anr events. NDK events will be handled later after we upgrade crashpad. Also fixed a bug in detecting background processes.

The proto change was made in internal cl/574516195