### PR TITLE
Moves SessionFirelogPublisher and SessionDatastore behind an interfac…

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -21,7 +21,6 @@ import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
 import com.google.firebase.app
-import com.google.firebase.sessions.api.SessionSubscriber
 import com.google.firebase.sessions.settings.SessionsSettings
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -63,7 +63,7 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
         .add(Dependency.requiredProvider(transportFactory))
         .add(Dependency.required(backgroundDispatcher))
         .factory { container ->
-          SessionFirelogPublisher(
+          SessionFirelogPublisherImpl(
             container.get(firebaseApp),
             container.get(firebaseInstallationsApi),
             container.get(sessionsSettings),
@@ -93,6 +93,17 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
         .add(Dependency.required(backgroundDispatcher))
         .factory { container ->
           Dispatchers(container.get(blockingDispatcher), container.get(backgroundDispatcher))
+        }
+        .build(),
+      Component.builder(SessionDatastore::class.java)
+        .name("sessions-datastore")
+        .add(Dependency.required(firebaseApp))
+        .add(Dependency.required(backgroundDispatcher))
+        .factory { container ->
+          SessionDatastoreImpl(
+            container.get(firebaseApp).getApplicationContext(),
+            container.get(backgroundDispatcher)
+          )
         }
         .build(),
       LibraryVersionComponent.create(LIBRARY_NAME, BuildConfig.VERSION_NAME),

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionFirelogPublisher.kt
@@ -28,14 +28,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
-/**
- * Responsible for uploading session events to Firelog.
- */
+/** Responsible for uploading session events to Firelog. */
 internal interface SessionFirelogPublisher {
 
-  /**
-   * Asynchronously logs the session represented by the given [SessionDetails] to Firelog.
-   */
+  /** Asynchronously logs the session represented by the given [SessionDetails] to Firelog. */
   fun logSession(sessionDetails: SessionDetails): Unit
 
   companion object {

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleClient.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleClient.kt
@@ -23,7 +23,6 @@ import android.content.ServiceConnection
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.IBinder
-import android.os.Looper
 import android.os.Message
 import android.os.Messenger
 import android.os.RemoteException
@@ -60,7 +59,7 @@ internal object SessionLifecycleClient {
   init {
     handlerThread.start()
   }
-  
+
   /**
    * The callback class that will be used to receive updated session events from the
    * [SessionLifecycleService].
@@ -150,16 +149,14 @@ internal object SessionLifecycleClient {
     sendLifecycleEvent(SessionLifecycleService.BACKGROUNDED)
   }
 
-  /**
-   * Perform initialization that requires cleanup
-   */
+  /** Perform initialization that requires cleanup */
   fun started() {
-    if (!handlerThread.isAlive) { handlerThread.start() }
+    if (!handlerThread.isAlive) {
+      handlerThread.start()
+    }
   }
 
-  /**
-   * Cleanup initialization
-   */
+  /** Cleanup initialization */
   fun stopped() {
     handlerThread.quit()
   }

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionFirelogPublisherTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionFirelogPublisherTest.kt
@@ -66,7 +66,7 @@ class SessionFirelogPublisherTest {
         remoteSettings = FakeSettingsProvider(),
       )
     val publisher =
-      SessionFirelogPublisher(
+      SessionFirelogPublisherImpl(
         fakeFirebaseApp.firebaseApp,
         firebaseInstallations,
         sessionsSettings,


### PR DESCRIPTION
…e and managed by the Registrar in order to improve testability in the SessionLifecycleService.