### PR TITLE
Update latestReleasedVersion on version bump

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/gradle.properties
+++ b/appcheck/firebase-appcheck-debug-testing/gradle.properties
@@ -1,2 +1,2 @@
 version=17.1.1
-latestReleasedVersion=17.0.1
+latestReleasedVersion=17.1.0

--- a/appcheck/firebase-appcheck-debug/gradle.properties
+++ b/appcheck/firebase-appcheck-debug/gradle.properties
@@ -1,2 +1,2 @@
 version=17.1.1
-latestReleasedVersion=17.0.1
+latestReleasedVersion=17.1.0

--- a/appcheck/firebase-appcheck-interop/gradle.properties
+++ b/appcheck/firebase-appcheck-interop/gradle.properties
@@ -1,2 +1,2 @@
 version=17.1.1
-latestReleasedVersion=17.0.1
+latestReleasedVersion=17.1.0

--- a/appcheck/firebase-appcheck-playintegrity/gradle.properties
+++ b/appcheck/firebase-appcheck-playintegrity/gradle.properties
@@ -1,2 +1,2 @@
 version=17.1.1
-latestReleasedVersion=17.0.1
+latestReleasedVersion=17.1.0

--- a/appcheck/firebase-appcheck/gradle.properties
+++ b/appcheck/firebase-appcheck/gradle.properties
@@ -1,2 +1,2 @@
 version=17.1.1
-latestReleasedVersion=17.0.1
+latestReleasedVersion=17.1.0

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PostReleasePlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PostReleasePlugin.kt
@@ -73,6 +73,9 @@ class PostReleasePlugin : Plugin<Project> {
    */
   fun registerMoveUnreleasedChangesTask(project: Project) =
     project.tasks.register<MoveUnreleasedChangesTask>("moveUnreleasedChanges")
+    project.tasks.register<MoveUnreleasedChangesTask>("moveUnreleasedChanges") {
+      onlyIf("CHANGELOG.md file must be present") { project.file("CHANGELOG.md").exists() }
+    }
 
   /**
    * Registers the `updatePinnedDependencies` for the provided [Project]

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PostReleasePlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PostReleasePlugin.kt
@@ -52,6 +52,10 @@ class PostReleasePlugin : Plugin<Project> {
    * is set to the current version of said module. After a release, this `version` should be bumped
    * up to differentiate between code at HEAD, and the latest released version.
    *
+   * Furthermore, this file may optionally contain a `latestReleasedVersion` variable (if the SDK
+   * has released). If this property is present, it should be updated to the related version that
+   * went out during the release.
+   *
    * @see VersionBumpTask
    *
    * @param project the [Project] to register this task to
@@ -72,7 +76,6 @@ class PostReleasePlugin : Plugin<Project> {
    * @param project the [Project] to register this task to
    */
   fun registerMoveUnreleasedChangesTask(project: Project) =
-    project.tasks.register<MoveUnreleasedChangesTask>("moveUnreleasedChanges")
     project.tasks.register<MoveUnreleasedChangesTask>("moveUnreleasedChanges") {
       onlyIf("CHANGELOG.md file must be present") { project.file("CHANGELOG.md").exists() }
     }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VersionBumpTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/VersionBumpTask.kt
@@ -56,7 +56,6 @@ abstract class VersionBumpTask : DefaultTask() {
 
   @TaskAction
   fun build() {
-    project.version
     versionFile.get().rewriteLines {
       when {
         it.startsWith("version=") -> "version=${newVersion.get()}"

--- a/firebase-config/gradle.properties
+++ b/firebase-config/gradle.properties
@@ -15,6 +15,6 @@
 #
 
 version=21.5.1
-latestReleasedVersion=21.4.1
+latestReleasedVersion=21.5.0
 android.enableUnitTestBinaryResources=true
 

--- a/firebase-crashlytics-ndk/gradle.properties
+++ b/firebase-crashlytics-ndk/gradle.properties
@@ -1,2 +1,2 @@
 version=18.5.1
-latestReleasedVersion=18.4.3
+latestReleasedVersion=18.5.0

--- a/firebase-crashlytics/gradle.properties
+++ b/firebase-crashlytics/gradle.properties
@@ -1,2 +1,2 @@
 version=18.5.1
-latestReleasedVersion=18.4.3
+latestReleasedVersion=18.5.0

--- a/firebase-database/gradle.properties
+++ b/firebase-database/gradle.properties
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 version=20.3.1
-latestReleasedVersion=20.2.2
+latestReleasedVersion=20.3.0
 android.enableUnitTestBinaryResources=true

--- a/firebase-dynamic-links/gradle.properties
+++ b/firebase-dynamic-links/gradle.properties
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 version=21.2.1
-latestReleasedVersion=21.1.0
+latestReleasedVersion=21.2.0
 android.enableUnitTestBinaryResources=true

--- a/firebase-firestore/gradle.properties
+++ b/firebase-firestore/gradle.properties
@@ -1,2 +1,2 @@
 version=24.9.1
-latestReleasedVersion=24.8.1
+latestReleasedVersion=24.9.0

--- a/firebase-functions/gradle.properties
+++ b/firebase-functions/gradle.properties
@@ -1,3 +1,3 @@
 version=20.4.1
-latestReleasedVersion=20.3.1
+latestReleasedVersion=20.4.0
 android.enableUnitTestBinaryResources=true

--- a/firebase-inappmessaging-display/gradle.properties
+++ b/firebase-inappmessaging-display/gradle.properties
@@ -1,2 +1,2 @@
 version=20.4.1
-latestReleasedVersion=20.3.5
+latestReleasedVersion=20.4.0

--- a/firebase-inappmessaging/gradle.properties
+++ b/firebase-inappmessaging/gradle.properties
@@ -1,2 +1,2 @@
 version=20.4.1
-latestReleasedVersion=20.3.5
+latestReleasedVersion=20.4.0

--- a/firebase-installations-interop/gradle.properties
+++ b/firebase-installations-interop/gradle.properties
@@ -1,2 +1,2 @@
-version=17.1.2
+version=17.2.0
 latestReleasedVersion=17.1.1

--- a/firebase-installations-interop/gradle.properties
+++ b/firebase-installations-interop/gradle.properties
@@ -1,2 +1,2 @@
 version=17.1.2
-latestReleasedVersion=17.1.0
+latestReleasedVersion=17.1.1

--- a/firebase-installations/gradle.properties
+++ b/firebase-installations/gradle.properties
@@ -1,2 +1,2 @@
 version=17.2.1
-latestReleasedVersion=17.1.4
+latestReleasedVersion=17.2.0

--- a/firebase-messaging-directboot/gradle.properties
+++ b/firebase-messaging-directboot/gradle.properties
@@ -1,3 +1,3 @@
 version=23.3.1
-latestReleasedVersion=23.2.1
+latestReleasedVersion=23.3.0
 android.enableUnitTestBinaryResources=true

--- a/firebase-messaging/gradle.properties
+++ b/firebase-messaging/gradle.properties
@@ -1,3 +1,3 @@
 version=23.3.1
-latestReleasedVersion=23.2.1
+latestReleasedVersion=23.3.0
 android.enableUnitTestBinaryResources=true

--- a/firebase-ml-modeldownloader/gradle.properties
+++ b/firebase-ml-modeldownloader/gradle.properties
@@ -1,2 +1,2 @@
 version=24.2.1
-latestReleasedVersion=24.1.3
+latestReleasedVersion=24.2.0

--- a/firebase-perf/gradle.properties
+++ b/firebase-perf/gradle.properties
@@ -16,6 +16,6 @@
 #
 
 version=20.5.1
-latestReleasedVersion=20.4.1
+latestReleasedVersion=20.5.0
 android.enableUnitTestBinaryResources=true
 

--- a/firebase-sessions/gradle.properties
+++ b/firebase-sessions/gradle.properties
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 version=1.1.1
-latestReleasedVersion=1.0.2
+latestReleasedVersion=1.1.0

--- a/firebase-storage/gradle.properties
+++ b/firebase-storage/gradle.properties
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 version=20.3.1
-latestReleasedVersion=20.2.1
+latestReleasedVersion=20.3.0
 android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
Per [b/306709509](https://b.corp.google.com/issues/306709509),

This fixes an oversight in which we were not updating the `latestReleasedVersion` during our version bumps. 

Additionally, this fixes the following:

- [b/306713770](https://b.corp.google.com/issues/306713770) -> Update the `latestReleasedVersion` for libraries where it's invalid
- [b/300682493](https://b.corp.google.com/issues/300682493) -> Add condition to `moveUnreleasedChanges` task for changelog file existence