### PR TITLE
Fixes issue where handler thread is started/stopped based on activity…

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleClient.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleClient.kt
@@ -56,10 +56,6 @@ internal object SessionLifecycleClient {
   private var curSessionId: String = ""
   private var handlerThread: HandlerThread = HandlerThread("FirebaseSessionsClient_HandlerThread")
 
-  init {
-    handlerThread.start()
-  }
-
   /**
    * The callback class that will be used to receive updated session events from the
    * [SessionLifecycleService].
@@ -115,6 +111,7 @@ internal object SessionLifecycleClient {
    * relay session updates to this client.
    */
   fun bindToService(appContext: Context) {
+    handlerThread.start()
     Intent(appContext, SessionLifecycleService::class.java).also { intent ->
       Log.d(TAG, "Binding service to application.")
       // This is necessary for the onBind() to be called by each process
@@ -147,18 +144,6 @@ internal object SessionLifecycleClient {
    */
   fun backgrounded() {
     sendLifecycleEvent(SessionLifecycleService.BACKGROUNDED)
-  }
-
-  /** Perform initialization that requires cleanup */
-  fun started() {
-    if (!handlerThread.isAlive) {
-      handlerThread.start()
-    }
-  }
-
-  /** Cleanup initialization */
-  fun stopped() {
-    handlerThread.quit()
   }
 
   /**

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionsActivityLifecycleCallbacks.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionsActivityLifecycleCallbacks.kt
@@ -31,9 +31,9 @@ internal object SessionsActivityLifecycleCallbacks : ActivityLifecycleCallbacks 
 
   override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
 
-  override fun onActivityStarted(activity: Activity) = SessionLifecycleClient.started()
+  override fun onActivityStarted(activity: Activity) = Unit
 
-  override fun onActivityStopped(activity: Activity) = SessionLifecycleClient.stopped()
+  override fun onActivityStopped(activity: Activity) = Unit
 
   override fun onActivityDestroyed(activity: Activity) = Unit
 


### PR DESCRIPTION
… lifecycle events. We can't have the handler thread reacting to lifecycle events because:

* There's no guarantee that an activity is ever started on a process, but we still want session ids pushed there (eg. service-only process)
* There can be more than one activity per process and the first time one of those activities is stopped, the handlertthread will be stopped and so we'll have no thread to process the callback messages.

Updated to start the thread on service binding and never stop it since we don't yet support unbinding.