### PR TITLE
Move sum&avg composite index tests to compositeIndexQueryTest.java

### DIFF
--- a/firebase-firestore/firestore_collection_group_index_config.tf
+++ b/firebase-firestore/firestore_collection_group_index_config.tf
@@ -1,0 +1,14 @@
+locals {
+  collection_group_indexes = {
+    index1 = [
+      {
+        field_path = "testId"
+        order      = "ASCENDING"
+      },
+      {
+        field_path = "a"
+        order      = "ASCENDING"
+      },
+    ]
+  }
+}

--- a/firebase-firestore/firestore_composite_index_config.tf
+++ b/firebase-firestore/firestore_composite_index_config.tf
@@ -100,5 +100,55 @@ locals {
         order      = "DESCENDING"
       },
     ]
+    index9 = [
+      {
+        field_path = "testId"
+        order      = "ASCENDING"
+      },
+      {
+        field_path = "pages"
+        order      = "ASCENDING"
+      },
+      {
+        field_path = "year"
+        order      = "ASCENDING"
+      },
+    ]
+    index10 = [
+      {
+        field_path = "testId"
+        order      = "ASCENDING"
+      },
+      {
+        field_path = "pages"
+        order      = "ASCENDING"
+      },
+      {
+        field_path = "rating"
+        order      = "ASCENDING"
+      },
+      {
+        field_path = "year"
+        order      = "ASCENDING"
+      },
+    ]
+    index11 = [
+      {
+        field_path   = "rating"
+        array_config = "CONTAINS"
+      },
+      {
+        field_path = "testId"
+        order      = "ASCENDING"
+      },
+      {
+        field_path = "pages"
+        order      = "ASCENDING"
+      },
+      {
+        field_path = "rating"
+        order      = "ASCENDING"
+      },
+    ]
   }
 }

--- a/firebase-firestore/main.tf
+++ b/firebase-firestore/main.tf
@@ -4,25 +4,46 @@ provider "google" {
   project = var.project_info.project_id
 }
 
-resource "google_firestore_index" "default-db-index" {
+resource "google_firestore_index" "default_db_index" {
   collection = "composite-index-test-collection"
 
   for_each = local.indexes
   dynamic "fields" {
     for_each = distinct(flatten([for k, v in local.indexes : [
       for i in each.value : {
-        field_path = i.field_path
-        order      = i.order
+        field_path   = i.field_path
+        order        = can(i.order) ? i.order : null
+        array_config = can(i.array_config) ? i.array_config : null
     }]]))
     content {
-      field_path = lookup(fields.value, "field_path", null)
-      order      = lookup(fields.value, "order", null)
+      field_path   = fields.value.field_path
+      order        = fields.value.order
+      array_config = fields.value.array_config
     }
   }
-
 }
 
-resource "google_firestore_index" "named-db-index" {
+resource "google_firestore_index" "default_db_collection_group_index" {
+  collection  = "composite-index-test-collection"
+  query_scope = "COLLECTION_GROUP"
+
+  for_each = local.collection_group_indexes
+  dynamic "fields" {
+    for_each = distinct(flatten([for k, v in local.indexes : [
+      for i in each.value : {
+        field_path   = i.field_path
+        order        = can(i.order) ? i.order : null
+        array_config = can(i.array_config) ? i.array_config : null
+    }]]))
+    content {
+      field_path   = fields.value.field_path
+      order        = fields.value.order
+      array_config = fields.value.array_config
+    }
+  }
+}
+
+resource "google_firestore_index" "named_db_index" {
   collection = "composite-index-test-collection"
   database   = "test-db"
 
@@ -30,12 +51,35 @@ resource "google_firestore_index" "named-db-index" {
   dynamic "fields" {
     for_each = distinct(flatten([for k, v in local.indexes : [
       for i in each.value : {
-        field_path = i.field_path
-        order      = i.order
+        field_path   = i.field_path
+        order        = can(i.order) ? i.order : null
+        array_config = can(i.array_config) ? i.array_config : null
     }]]))
     content {
-      field_path = lookup(fields.value, "field_path", null)
-      order      = lookup(fields.value, "order", null)
+      field_path   = fields.value.field_path
+      order        = fields.value.order
+      array_config = fields.value.array_config
+    }
+  }
+}
+
+resource "google_firestore_index" "named_db_collection_group_index" {
+  collection  = "composite-index-test-collection"
+  database    = "test-db"
+  query_scope = "COLLECTION_GROUP"
+
+  for_each = local.collection_group_indexes
+  dynamic "fields" {
+    for_each = distinct(flatten([for k, v in local.indexes : [
+      for i in each.value : {
+        field_path   = i.field_path
+        order        = can(i.order) ? i.order : null
+        array_config = can(i.array_config) ? i.array_config : null
+    }]]))
+    content {
+      field_path   = fields.value.field_path
+      order        = fields.value.order
+      array_config = fields.value.array_config
     }
   }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
@@ -45,6 +45,10 @@ import org.junit.runner.RunWith;
  * To get started, please refer to the instructions provided in the README file. This will guide
  * you through setting up your local testing environment and updating the Terraform configuration
  * with any new composite indexes required for your testing scenarios.
+ * 
+ * Note: Whenever feasible, make use of the current document fields (such as 'a,' 'b,' 'author,'
+ * 'title') to avoid introducing new composite indexes and surpassing the limit. Refer to the
+ * guidelines at https://firebase.google.com/docs/firestore/quotas#indexes for further information.
  */
 @RunWith(AndroidJUnit4.class)
 public class CompositeIndexQueryTest {

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
  * To get started, please refer to the instructions provided in the README file. This will guide
  * you through setting up your local testing environment and updating the Terraform configuration
  * with any new composite indexes required for your testing scenarios.
- * 
+ *
  * Note: Whenever feasible, make use of the current document fields (such as 'a,' 'b,' 'author,'
  * 'title') to avoid introducing new composite indexes and surpassing the limit. Refer to the
  * guidelines at https://firebase.google.com/docs/firestore/quotas#indexes for further information.

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
@@ -13,10 +13,18 @@
 // limitations under the License.
 package com.google.firebase.firestore;
 
+import static com.google.firebase.firestore.AggregateField.average;
+import static com.google.firebase.firestore.AggregateField.sum;
 import static com.google.firebase.firestore.Filter.equalTo;
 import static com.google.firebase.firestore.Filter.greaterThan;
 import static com.google.firebase.firestore.Filter.or;
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testFirestore;
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.waitFor;
 import static com.google.firebase.firestore.testutil.TestUtil.map;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.firestore.testutil.CompositeIndexTestHelper;
@@ -45,6 +53,13 @@ public class CompositeIndexQueryTest {
   public void tearDown() {
     IntegrationTestUtil.tearDown();
   }
+
+  private static Map<String, Map<String, Object>> testDocs =
+      map(
+          "a",
+          map("author", "authorA", "title", "titleA", "pages", 100, "year", 1980, "rating", 5.0),
+          "b",
+          map("author", "authorB", "title", "titleB", "pages", 50, "year", 2020, "rating", 4.0));
 
   @Test
   public void testOrQueriesWithCompositeIndexes() {
@@ -78,5 +93,148 @@ public class CompositeIndexQueryTest {
     // Test with limits (explicit order by DESC): (a==2) || (b == 1) ORDER BY a LIMIT_TO_LAST 1
     query = collection.where(or(equalTo("a", 2), equalTo("b", 1))).limitToLast(1).orderBy("a");
     testHelper.assertOnlineAndOfflineResultsMatch(testHelper.query(query), "doc2");
+  }
+
+  @Test
+  public void testCanRunAggregateCollectionGroupQuery() {
+    CompositeIndexTestHelper testHelper = new CompositeIndexTestHelper();
+    String collectionGroup = testHelper.withTestCollection().getId();
+
+    FirebaseFirestore db = testFirestore();
+
+    String[] docPaths =
+        new String[] {
+          "abc/123/${collectionGroup}/cg-doc1",
+          "abc/123/${collectionGroup}/cg-doc2",
+          "${collectionGroup}/cg-doc3",
+          "${collectionGroup}/cg-doc4",
+          "def/456/${collectionGroup}/cg-doc5",
+          "${collectionGroup}/virtual-doc/nested-coll/not-cg-doc",
+          "x${collectionGroup}/not-cg-doc",
+          "${collectionGroup}x/not-cg-doc",
+          "abc/123/${collectionGroup}x/not-cg-doc",
+          "abc/123/x${collectionGroup}/not-cg-doc",
+          "abc/${collectionGroup}"
+        };
+    WriteBatch batch = db.batch();
+    for (String path : docPaths) {
+      batch.set(
+          db.document(path.replace("${collectionGroup}", collectionGroup)),
+          testHelper.addTestSpecificFieldsToDoc(map("a", 2)));
+    }
+    waitFor(batch.commit());
+
+    AggregateQuerySnapshot snapshot =
+        waitFor(
+            testHelper
+                .query(db.collectionGroup(collectionGroup))
+                .aggregate(AggregateField.count(), sum("a"), average("a"))
+                .get(AggregateSource.SERVER));
+    assertEquals(
+        5L, // "cg-doc1", "cg-doc2", "cg-doc3", "cg-doc4", "cg-doc5",
+        snapshot.get(AggregateField.count()));
+    assertEquals(10L, snapshot.get(sum("a")));
+    assertEquals((Double) 2.0, snapshot.get(average("a")));
+  }
+
+  @Test
+  public void testCanPerformMaxAggregations() {
+    CompositeIndexTestHelper testHelper = new CompositeIndexTestHelper();
+    CollectionReference collection = testHelper.withTestDocs(testDocs);
+
+    AggregateField f1 = sum("pages");
+    AggregateField f2 = average("pages");
+    AggregateField f3 = AggregateField.count();
+    AggregateField f4 = sum("year");
+    AggregateField f5 = average("rating");
+
+    AggregateQuerySnapshot snapshot =
+        waitFor(
+            testHelper.query(collection).aggregate(f1, f2, f3, f4, f5).get(AggregateSource.SERVER));
+
+    assertEquals(snapshot.get(f1), 150L);
+    assertEquals(snapshot.get(f2), 75.0);
+    assertEquals(snapshot.get(f3), 2L);
+    assertEquals(snapshot.get(f4), 4000L);
+    assertEquals(snapshot.get(f5), 4.5);
+  }
+
+  @Test
+  public void testCanGetCorrectTypeForSum() {
+    CompositeIndexTestHelper testHelper = new CompositeIndexTestHelper();
+    CollectionReference collection = testHelper.withTestDocs(testDocs);
+
+    AggregateQuerySnapshot snapshot =
+        waitFor(
+            testHelper
+                .query(collection)
+                .aggregate(sum("pages"), sum("year"), sum("rating"))
+                .get(AggregateSource.SERVER));
+
+    Object sumPages = snapshot.get(sum("pages"));
+    Object sumYear = snapshot.get(sum("year"));
+    Object sumRating = snapshot.get(sum("rating"));
+    assertTrue(sumPages instanceof Long);
+    assertTrue(sumYear instanceof Long);
+    assertTrue(sumRating instanceof Double);
+  }
+
+  @Test
+  public void testPerformsAggregationWhenUsingArrayContainsAnyOperator() {
+    CompositeIndexTestHelper testHelper = new CompositeIndexTestHelper();
+
+    Map<String, Map<String, Object>> testDocs =
+        map(
+            "a",
+            map(
+                "author",
+                "authorA",
+                "title",
+                "titleA",
+                "pages",
+                100,
+                "year",
+                1980,
+                "rating",
+                asList(5, 1000)),
+            "b",
+            map(
+                "author", "authorB", "title", "titleB", "pages", 50, "year", 2020, "rating",
+                asList(4)),
+            "c",
+            map(
+                "author",
+                "authorC",
+                "title",
+                "titleC",
+                "pages",
+                100,
+                "year",
+                1980,
+                "rating",
+                asList(2222, 3)),
+            "d",
+            map(
+                "author", "authorD", "title", "titleD", "pages", 50, "year", 2020, "rating",
+                asList(0)));
+    CollectionReference collection = testHelper.withTestDocs(testDocs);
+
+    AggregateQuerySnapshot snapshot =
+        waitFor(
+            testHelper
+                .query(collection.whereArrayContainsAny("rating", asList(5, 3)))
+                .aggregate(
+                    sum("rating"),
+                    average("rating"),
+                    sum("pages"),
+                    average("pages"),
+                    AggregateField.count())
+                .get(AggregateSource.SERVER));
+
+    assertEquals(snapshot.get(sum("rating")), 0L);
+    assertNull(snapshot.get(average("rating")));
+    assertEquals(snapshot.get(sum("pages")), 200L);
+    assertEquals(snapshot.get(average("pages")), (Double) 100.0);
+    assertEquals(snapshot.get(AggregateField.count()), 2L);
   }
 }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/CompositeIndexTestHelper.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/CompositeIndexTestHelper.java
@@ -58,10 +58,15 @@ public class CompositeIndexTestHelper {
     this.testId = "test-id-" + autoId();
   }
 
+  @NonNull
+  public CollectionReference withTestCollection() {
+    return testFirestore().collection(COMPOSITE_INDEX_TEST_COLLECTION);
+  }
+
   // Runs a test with specified documents in the COMPOSITE_INDEX_TEST_COLLECTION.
   @NonNull
   public CollectionReference withTestDocs(@NonNull Map<String, Map<String, Object>> docs) {
-    CollectionReference writer = testFirestore().collection(COMPOSITE_INDEX_TEST_COLLECTION);
+    CollectionReference writer = withTestCollection();
     writeAllDocs(writer, prepareTestDocuments(docs));
     CollectionReference reader = testFirestore().collection(writer.getPath());
     return reader;
@@ -81,7 +86,7 @@ public class CompositeIndexTestHelper {
   }
 
   // Adds test-specific fields to a document, including the testId and expiration date.
-  private Map<String, Object> addTestSpecificFieldsToDoc(Map<String, Object> doc) {
+  public Map<String, Object> addTestSpecificFieldsToDoc(Map<String, Object> doc) {
     Map<String, Object> updatedDoc = new HashMap<>(doc);
     updatedDoc.put(TEST_ID_FIELD, testId);
     updatedDoc.put(


### PR DESCRIPTION
- [x] update terraform to accept collection group index and array membership query
- [x] add new composite indexes required for testing
- [x] move sum&avg composite index tests to compositeIndexQueryTest.java(some of the field names are changed to be the same with web SDK, so that indexes in terraform are consistent)