### PR TITLE
FIAM: check Activity's `isDestroyed()` as well

### DIFF
--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/FiamWindowManager.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/FiamWindowManager.java
@@ -54,7 +54,7 @@ public class FiamWindowManager {
       return;
     }
 
-    if (activity.isFinishing()) {
+    if (activity.isFinishing() || activity.isDestroyed()) {
       Logging.loge("Activity is finishing or does not have valid window token. Cannot show FIAM.");
       return;
     }


### PR DESCRIPTION
When screen rotation happens, an Activity will be destroyed but not finishing.

- ref: #2402 