### PR TITLE
Adds support for skipping tests that actually crash or ANR the test a…

### DIFF
--- a/firebase-sessions/test-app/src/androidTest/kotlin/com/google/firebase/testing/sessions/FirebaseSessionsIntegrationTest.kt
+++ b/firebase-sessions/test-app/src/androidTest/kotlin/com/google/firebase/testing/sessions/FirebaseSessionsIntegrationTest.kt
@@ -94,9 +94,10 @@ class FirebaseSessionsIntegrationTest {
 
   @Test
   fun newSessionFollowingCrash() {
+    if (!BuildConfig.SHOULD_CRASH_APP) return
+
     launchApp()
     val origSession = getCurrentSessionId()
-
     getButton("CRASH!").click()
     dismissPossibleErrorDialog()
 
@@ -121,6 +122,7 @@ class FirebaseSessionsIntegrationTest {
 
   @Test
   fun anrMainActivity() {
+    if (!BuildConfig.SHOULD_CRASH_APP) return
     launchApp()
     val origSession = getCurrentSessionId()
 
@@ -136,6 +138,7 @@ class FirebaseSessionsIntegrationTest {
 
   @Test
   fun crashSecondaryProcess() {
+    if (!BuildConfig.SHOULD_CRASH_APP) return
     launchApp()
     navigateToSecondActivity()
     val origSession = getCurrentSessionId()

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -51,7 +51,7 @@ android {
       buildConfigField(
         "boolean",
         "SHOULD_CRASH_APP",
-        if (project.hasProperty("useReleasedVersions")) "true" else "false"
+        project.hasProperty("useReleasedVersions").toString()
       )
     }
     debug {
@@ -59,7 +59,7 @@ android {
       buildConfigField(
         "boolean",
         "SHOULD_CRASH_APP",
-        if (project.hasProperty("useReleasedVersions")) "true" else "false"
+        project.hasProperty("useReleasedVersions").toString()
       )
     }
   }

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -45,6 +45,24 @@ android {
   }
   kotlinOptions { jvmTarget = "1.8" }
   buildFeatures { viewBinding = true }
+  buildTypes {
+    release {
+      // We only want to actually crash the app for the scheduled runs, not the integration tests
+      buildConfigField(
+        "boolean",
+        "SHOULD_CRASH_APP",
+        if (project.hasProperty("useReleasedVersions")) "true" else "false"
+      )
+    }
+    debug {
+      // We only want to actually crash the app for the scheduled runs, not the integration tests
+      buildConfigField(
+        "boolean",
+        "SHOULD_CRASH_APP",
+        if (project.hasProperty("useReleasedVersions")) "true" else "false"
+      )
+    }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
…pp during integration testing. These will still run with the scheduled 4h job.