### PR TITLE
Use the latest release bom in the sessions test app

### DIFF
--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/FirstFragment.kt
@@ -91,16 +91,6 @@ class FirstFragment : Fragment() {
     }
   }
 
-  override fun onResume() {
-    super.onResume()
-    TestApplication.sessionSubscriber.registerView(binding.sessionIdFragmentText)
-  }
-
-  override fun onPause() {
-    super.onPause()
-    TestApplication.sessionSubscriber.unregisterView(binding.sessionIdFragmentText)
-  }
-
   override fun onDestroyView() {
     super.onDestroyView()
     _binding = null

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/SecondActivity.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/SecondActivity.kt
@@ -22,7 +22,6 @@ import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.os.Build
 import android.os.Bundle
 import android.widget.Button
-import android.widget.TextView
 
 /** Second activity from the MainActivity that runs on a different process. */
 class SecondActivity : BaseActivity() {
@@ -45,19 +44,5 @@ class SecondActivity : BaseActivity() {
           .killBackgroundProcesses("com.google.firebase.testing.sessions")
       }
     }
-  }
-
-  override fun onResume() {
-    super.onResume()
-    TestApplication.sessionSubscriber.registerView(
-      findViewById<TextView>(R.id.session_id_second_text)
-    )
-  }
-
-  override fun onPause() {
-    super.onPause()
-    TestApplication.sessionSubscriber.unregisterView(
-      findViewById<TextView>(R.id.session_id_second_text)
-    )
   }
 }

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/TestApplication.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/TestApplication.kt
@@ -18,56 +18,13 @@ package com.google.firebase.testing.sessions
 
 import android.app.Application
 import android.content.IntentFilter
-import android.os.Handler
-import android.os.Looper
-import android.widget.TextView
-import com.google.firebase.sessions.api.FirebaseSessionsDependencies
-import com.google.firebase.sessions.api.SessionSubscriber
 
 class TestApplication : Application() {
-
-  val broadcastReceiver = CrashBroadcastReceiver()
+  private val broadcastReceiver = CrashBroadcastReceiver()
 
   override fun onCreate() {
     super.onCreate()
     registerReceiver(broadcastReceiver, IntentFilter(CrashBroadcastReceiver.CRASH_ACTION))
     registerReceiver(broadcastReceiver, IntentFilter(CrashBroadcastReceiver.TOAST_ACTION))
-  }
-
-  class FakeSessionSubscriber : SessionSubscriber {
-    override val isDataCollectionEnabled = true
-    override val sessionSubscriberName = SessionSubscriber.Name.MATT_SAYS_HI
-    val viewsToUpdate = mutableListOf<TextView>()
-    val uiHandler = Handler(Looper.getMainLooper())
-
-    var sessionDetails: SessionSubscriber.SessionDetails? = null
-      private set
-
-    override fun onSessionChanged(sessionDetails: SessionSubscriber.SessionDetails) {
-      this.sessionDetails = sessionDetails
-      viewsToUpdate.forEach { updateView(it, sessionDetails?.sessionId) }
-    }
-
-    fun registerView(textView: TextView) {
-      viewsToUpdate.add(textView)
-      updateView(textView, sessionDetails?.sessionId)
-    }
-
-    fun unregisterView(textView: TextView) {
-      viewsToUpdate.remove(textView)
-    }
-
-    private fun updateView(textView: TextView, sessionId: String?) {
-      uiHandler.post { textView.setText(sessionId ?: "No Session Id") }
-    }
-  }
-
-  companion object {
-    val sessionSubscriber = FakeSessionSubscriber()
-
-    init {
-      FirebaseSessionsDependencies.addDependency(SessionSubscriber.Name.MATT_SAYS_HI)
-      FirebaseSessionsDependencies.register(sessionSubscriber)
-    }
   }
 }

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -1,8 +1,3 @@
-@file:Suppress("DEPRECATION") // App projects should still use FirebaseTestLabPlugin.
-
-import com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabExtension
-import com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabPlugin
-
 /*
  * Copyright 2023 Google LLC
  *
@@ -18,6 +13,11 @@ import com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabPlugin
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+@file:Suppress("DEPRECATION") // App projects should still use FirebaseTestLabPlugin.
+
+import com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabExtension
+import com.google.firebase.gradle.plugins.ci.device.FirebaseTestLabPlugin
 
 plugins {
   id("com.android.application")
@@ -49,12 +49,10 @@ android {
 
 dependencies {
   if (project.hasProperty("useReleasedVersions")) {
-    val latestReleasedVersion: String by project
-    println("Using sessions released version: $latestReleasedVersion")
-    // TODO(mrober): How to find the released versions of crashlytics and perf?
-    implementation("com.google.firebase:firebase-crashlytics:18.4.3")
-    implementation("com.google.firebase:firebase-perf:20.4.1")
-    implementation("com.google.firebase:firebase-sessions:$latestReleasedVersion")
+    implementation(platform("com.google.firebase:firebase-bom:latest.release"))
+    implementation("com.google.firebase:firebase-crashlytics")
+    implementation("com.google.firebase:firebase-perf")
+    implementation("com.google.firebase:firebase-sessions")
   } else {
     implementation(project(":firebase-crashlytics")) {
       exclude(group = "com.google.firebase", module = "firebase-sessions")


### PR DESCRIPTION
Use the latest release bom in the sessions test app instead of trying to figure out released versions.

Also removed direct references to Sessions subscribers from the test app because it will make the e2e test workflow fail after this feature merges to main line but before the release. After the release, we can put that back in.