### PR TITLE
Remove process-details for now.

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvent.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvent.kt
@@ -35,12 +35,6 @@ internal data class SessionEvent(
 
   /** Information about the application that is generating the session events. */
   val applicationInfo: ApplicationInfo,
-
-  /** Information about this process */
-  val currentProcessDetails: ProcessDetails,
-
-  /** Information about all processes running for this app */
-  val appProcessDetails: List<ProcessDetails>,
 )
 
 /** Enum denoting all possible session event types. */

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
@@ -58,8 +58,6 @@ internal object SessionEvents {
           firebaseInstallationId,
         ),
       applicationInfo = getApplicationInfo(firebaseApp),
-      currentProcessDetails = currentProcessDetails,
-      appProcessDetails = appProcessDetails,
     )
 
   fun getApplicationInfo(firebaseApp: FirebaseApp): ApplicationInfo {

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
@@ -97,14 +97,7 @@ class SessionEventEncoderTest {
                 "appBuildVersion":"0",
                 "deviceManufacturer":"${Build.MANUFACTURER}"
               }
-            },
-            "currentProcessDetails":{
-              "processName":"default",
-              "pid":1,
-              "importance":100,
-              "default":true
-            },
-            "appProcessDetails":[]
+            }
           }
         """
           .lines()
@@ -138,8 +131,6 @@ class SessionEventEncoderTest {
               deviceManufacturer = "",
             ),
           ),
-        currentProcessDetails = ProcessDetails("", 0, 0, false),
-        appProcessDetails = listOf(),
       )
 
     val json = SESSION_EVENT_ENCODER.encode(sessionEvent)
@@ -173,14 +164,7 @@ class SessionEventEncoderTest {
                 "appBuildVersion":"",
                 "deviceManufacturer":""
               }
-            },
-            "currentProcessDetails":{
-              "processName":"",
-              "pid":0,
-              "importance":0,
-              "default":false
-              },
-            "appProcessDetails":[]
+            }
           }
         """
           .lines()

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
@@ -89,7 +89,5 @@ internal object TestSessionEventData {
       eventType = EventType.SESSION_START,
       sessionData = TEST_SESSION_DATA,
       applicationInfo = TEST_APPLICATION_INFO,
-      currentProcessDetails = TEST_PROCESS_DETAILS,
-      appProcessDetails = TEST_APP_PROCESS_DETAILS,
     )
 }


### PR DESCRIPTION
We identified a bug where the backend protobuf is not in agreement with the structure of the message being sent. This causes the entire message to be dropped. Making this work will require a bit of refactoring.

Revert this for now to be safe and add it back in a subsequent PR.