### PR TITLE
Set eagerInDefaultApp for Firebase Sessions

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -52,6 +52,7 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
             container[backgroundDispatcher],
           )
         }
+        .eagerInDefaultApp()
         .build(),
       Component.builder(SessionGenerator::class.java)
         .name("session-generator")


### PR DESCRIPTION
We need this since we changed how Crashlytics and Perf will depend on Sessions. Before they got an instance of FirebaseSessions but now they don't.