### PR TITLE
Sessions test app run on min api level 16

### DIFF
--- a/firebase-sessions/test-app/multidex-config.pro
+++ b/firebase-sessions/test-app/multidex-config.pro
@@ -1,0 +1,1 @@
+-keep class com.google.firebase.** { *; }

--- a/firebase-sessions/test-app/src/androidTest/AndroidManifest.xml
+++ b/firebase-sessions/test-app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2023 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:versionCode="1"
+  android:versionName="1.0.0">
+
+  <application>
+
+  </application>
+
+  <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
+
+</manifest>

--- a/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/TestApplication.kt
+++ b/firebase-sessions/test-app/src/main/kotlin/com/google/firebase/testing/sessions/TestApplication.kt
@@ -16,10 +16,10 @@
 
 package com.google.firebase.testing.sessions
 
-import android.app.Application
 import android.content.IntentFilter
+import androidx.multidex.MultiDexApplication
 
-class TestApplication : Application() {
+class TestApplication : MultiDexApplication() {
   private val broadcastReceiver = CrashBroadcastReceiver()
 
   override fun onCreate() {

--- a/firebase-sessions/test-app/src/main/res/values/strings.xml
+++ b/firebase-sessions/test-app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
   -->
 
 <resources>
-  <string name="app_name">1 WidgetTestApp</string>
+  <string name="app_name">Firebase Sessions Test App</string>
   <string name="action_settings">Settings</string>
   <string name="first_fragment_label">First Fragment</string>
   <string name="crash_test_widget_description">Test Widget for Crashing</string>

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -32,11 +32,12 @@ android {
   compileSdk = 33
   defaultConfig {
     applicationId = "com.google.firebase.testing.sessions"
-    minSdk = 18
+    minSdk = 16
     targetSdk = 33
     versionCode = 1
     versionName = "1.0"
     multiDexEnabled = true
+    multiDexKeepProguard = file("multidex-config.pro")
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
   compileOptions {


### PR DESCRIPTION
Enable multidex in the sessions test app to support min api level 16, which is the min level Crashlytics supports