### PR TITLE
Create package-info.java for rollouts package.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/rollouts/package-info.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/rollouts/package-info.java
@@ -1,0 +1,16 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @hide */
+package com.google.firebase.remoteconfig.internal.rollouts;


### PR DESCRIPTION
Hides internal sub-package from doc generation.

Follow up from internal cl/581411075