### PR TITLE
Update FiresiteTransform

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
@@ -45,7 +45,6 @@ import org.json.JSONObject
  * @property sources a list of source roots
  * @property suppressedFiles a list of files to exclude from documentation
  * @property packageListFiles a list of files that define external package-lists for links
- * @property generateJavadocs should we generate the Javadoc variant, or just Kotlin?
  * @property clientName the name of the module
  * @property outputDirectory where to store the generated files
  */
@@ -68,8 +67,6 @@ abstract class GenerateDocumentationTaskExtension : DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val packageListFiles: ListProperty<File>
-
-  @get:Input abstract val generateJavadocs: Property<Boolean>
 
   @get:Input abstract val clientName: Property<String>
 
@@ -152,7 +149,7 @@ constructor(private val workerExecutor: WorkerExecutor) : GenerateDocumentationT
                 JSONObject(
                     mapOf(
                       "docRootPath" to "/docs/reference/",
-                      "javaDocsPath" to "android".takeIf { generateJavadocs.get() },
+                      "javaDocsPath" to "android",
                       "kotlinDocsPath" to "kotlin",
                       "projectPath" to "client/${clientName.get()}",
                       "includedHeadTagsPathJava" to

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaPlugin.kt
@@ -19,7 +19,6 @@ import com.android.build.gradle.LibraryExtension
 import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
@@ -233,37 +232,19 @@ abstract class DackkaPlugin : Plugin<Project> {
 
     dackkaJarFile.set(dackkaFile)
     clientName.set(project.firebaseLibrary.artifactId)
-    generateJavadocs.set(!project.isKTXLibary)
   }
 
-  // TODO(b/270593375): Refactor when fixed
   private fun registerFiresiteTransformTask(
     project: Project,
     dackkaOutputDirectory: Provider<File>,
     targetDirectory: Provider<File>
-  ): TaskProvider<Task> {
-    val transformJavadoc =
-      project.tasks.register<FiresiteTransformTask>("firesiteTransformJavadoc") {
-        onlyIf { !project.isKTXLibary }
-        dependsOnAndMustRunAfter("generateDackkaDocumentation")
+  ) =
+    project.tasks.register<FiresiteTransformTask>("firesiteTransform") {
+      dependsOnAndMustRunAfter("generateDackkaDocumentation")
 
-        removeGoogleGroupId.set(true)
-        dackkaFiles.set(dackkaOutputDirectory.childFile("docs/reference/android"))
-        outputDirectory.set(targetDirectory.childFile("android"))
-      }
-
-    val transformKotlindoc =
-      project.tasks.register<FiresiteTransformTask>("firesiteTransformKotlindoc") {
-        dependsOnAndMustRunAfter("generateDackkaDocumentation")
-
-        dackkaFiles.set(dackkaOutputDirectory.childFile("docs/reference/kotlin"))
-        outputDirectory.set(targetDirectory.childFile("kotlin"))
-      }
-
-    return project.tasks.register("firesiteTransform") {
-      dependsOn(transformJavadoc, transformKotlindoc)
+      dackkaFiles.set(dackkaOutputDirectory.childFile("docs/reference"))
+      outputDirectory.set(targetDirectory)
     }
-  }
 
   private fun registerCopyDocsToCommonDirectoryTask(
     project: Project,

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -18,9 +18,7 @@ import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -35,9 +33,9 @@ import org.gradle.api.tasks.TaskAction
  * More specifically, it:
  * - Deletes unnecessary files
  * - Removes Class and Index headers from _toc.yaml files
+ * - Adds the deprecated status to ktx sections in _toc.yaml files
  * - Fixes broken hyperlinks in `@see` blocks
  * - Removes the prefix path from book_path
- * - Removes the google groupId for Javadocs
  *
  * **Please note:** This task is idempotent- meaning it can safely be ran multiple times on the same
  * set of files.
@@ -47,8 +45,6 @@ abstract class FiresiteTransformTask : DefaultTask() {
   @get:InputDirectory
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val dackkaFiles: Property<File>
-
-  @get:Input @get:Optional abstract val removeGoogleGroupId: Property<Boolean>
 
   @get:OutputDirectory abstract val outputDirectory: Property<File>
 
@@ -79,33 +75,9 @@ abstract class FiresiteTransformTask : DefaultTask() {
   }
 
   private fun File.fixYamlFile() {
-    val fixedContent =
-      readText().removeClassHeader().removeIndexHeader().let {
-        if (removeGoogleGroupId.getOrElse(false)) it.removeGoogleGroupId() else it
-      }
+    val fixedContent = readText().removeClassHeader().removeIndexHeader().addDeprecatedStatus()
     writeText(fixedContent)
   }
-
-  /**
-   * Removes the leading `com.google` group id from strings in the file
-   *
-   * We have internal SDKs that generate their docs outside the scope of this plugin. The Javadoc
-   * variant of those SDks is typically generated with metalava- which does *not* provide the
-   * groupId. This makes the output look weird, as not all SDKs line up. So this method exists to
-   * correct Javadoc nav files, so that they align with internally generated docs.
-   *
-   * Example input:
-   * ```
-   * "com.google.firebase.appcheck"
-   * ```
-   *
-   * Example output:
-   * ```
-   * "firebase.appcheck"
-   * ```
-   */
-  // TODO(b/270593375): Remove when dackka exposes configuration for this
-  private fun String.removeGoogleGroupId() = remove(Regex("(?<=\")com.google.(?=firebase.)"))
 
   /**
    * Fixes broken hyperlinks in the rendered HTML
@@ -142,11 +114,43 @@ abstract class FiresiteTransformTask : DefaultTask() {
         .trimIndent()
     }
 
+  /**
+   * Adds the deprecated status to ktx libs.
+   *
+   * Our ktx libs are marked as deprecated in the sidebar, and as such- require that we add a
+   * `status: deprecated` to their section in the relevant `_toc.yaml` file.
+   *
+   * Example input:
+   * ```
+   * - title: "firebase.database.ktx"
+   *   path: "/docs/reference/android/com/google/firebase/database/ktx/package-summary.html"
+   * ```
+   *
+   * Example output:
+   * ```
+   * - title: "firebase.database.ktx"
+   *   stauts: deprecated
+   *   path: "/docs/reference/android/com/google/firebase/database/ktx/package-summary.html"
+   * ```
+   */
+  // TODO(b/310964911): Remove when we drop ktx modules
+  private fun String.addDeprecatedStatus(): String =
+    replace(Regex("- title: \"(.+ktx)\"")) {
+      val packageName = it.firstCapturedValue
+
+      """
+      - title: "${packageName}"
+        status: deprecated
+    """
+        .trimIndent()
+    }
+
   // We don't actually upload class or index files,
   // so these headers will throw not found errors if not removed.
   // TODO(b/243674302): Remove when dackka exposes configuration for this
   private fun String.removeClassHeader() =
     remove(Regex("- title: \"Class Index\"\n {2}path: \".+\"\n\n"))
+
   private fun String.removeIndexHeader() =
     remove(Regex("- title: \"Package Index\"\n {2}path: \".+\"\n\n"))
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FiresiteTransformTask.kt
@@ -129,7 +129,7 @@ abstract class FiresiteTransformTask : DefaultTask() {
    * Example output:
    * ```
    * - title: "firebase.database.ktx"
-   *   stauts: deprecated
+   *   status: deprecated
    *   path: "/docs/reference/android/com/google/firebase/database/ktx/package-summary.html"
    * ```
    */


### PR DESCRIPTION
Per [b/310955409](https://b.corp.google.com/issues/310955409),

This adds a transform to our `FiresiteTransform` task to add a deprecated status to the toc sections of our `ktx` libs, as we are marking those as deprecated in the sidebar. Previously- this way being done manually during releases in the ref docs CL.

Additionally, this PR fixes the following:

- [b/310966215](https://b.corp.google.com/issues/310966215): Remove google group id transformations from FiresiteTransform
- [b/310967446](https://b.corp.google.com/issues/310967446): Combine FiresiteTransform tasks

_This PR also updates the relevant documentation to reflect the changes made_