### PR TITLE
Correct tense in firebase-config changelog.

### DIFF
--- a/firebase-config/CHANGELOG.md
+++ b/firebase-config/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [changed] Add support for other Firebase products to integrate with [remote_config].
+* [changed] Added support for other Firebase products to integrate with [remote_config].
 
 # 21.5.0
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-config-ktx`


### PR DESCRIPTION
Should be past tense. Already fixed internally (cl/582309851).