### PR TITLE
Proposed fix for issue 5593

### DIFF
--- a/firebase-ml-modeldownloader/CHANGELOG.md
+++ b/firebase-ml-modeldownloader/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [fixed] Fixed `SecurityException` where the `RECEIVER_EXPORTED` or `RECEIVER_NOT_EXPORTED` flag should be 
+  specified when registerReceiver is being used. [#5597](https://github.com/firebase/firebase-android-sdk/pull/5597)
 
 # 24.2.1
 * [changed] Internal infrastructure improvements.

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
@@ -218,7 +218,7 @@ public class ModelFileDownloadService {
       context.registerReceiver(
           broadcastReceiver,
           new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-          context.RECEIVER_NOT_EXPORTED);
+              Context.RECEIVER_EXPORTED);
     } else {
       context.registerReceiver(
           broadcastReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.ml.modeldownloader.internal;
 
+import android.annotation.SuppressLint;
 import android.app.DownloadManager;
 import android.app.DownloadManager.Query;
 import android.app.DownloadManager.Request;
@@ -23,6 +24,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.ParcelFileDescriptor;
@@ -207,12 +209,20 @@ public class ModelFileDownloadService {
     this.receiverMaps.remove(downloadId);
   }
 
+  @SuppressLint("WrongConstant")
   private Task<Void> registerReceiverForDownloadId(long downloadId, String modelName) {
     BroadcastReceiver broadcastReceiver = getReceiverInstance(downloadId, modelName);
     // It is okay to always register here. Since the broadcast receiver is the same via the lookup
     // for the same download id, the same broadcast receiver will be notified only once.
-    context.registerReceiver(
-        broadcastReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      context.registerReceiver(
+          broadcastReceiver,
+          new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+          context.RECEIVER_NOT_EXPORTED);
+    } else {
+      context.registerReceiver(
+          broadcastReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+    }
 
     return getTaskCompletionSourceInstance(downloadId).getTask();
   }

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
@@ -218,7 +218,7 @@ public class ModelFileDownloadService {
       context.registerReceiver(
           broadcastReceiver,
           new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-              Context.RECEIVER_EXPORTED);
+          Context.RECEIVER_EXPORTED);
     } else {
       context.registerReceiver(
           broadcastReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));


### PR DESCRIPTION
Possible fix for #5593

Android 14 requires `RECEIVER_EXPORTED` or `RECEIVER_NOT_EXPORTED` flag when using `registerReceiver` command:

Currently, `com.google.firebase:firebase-ml-modeldownloader:24.2.1` uses the `registerReceiver` without this flag:
https://github.com/firebase/firebase-android-sdk/blob/ac19e5d561d6a7a24a6004746d95f4e08024fdc4/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java#L214-L215

Proposed fix:
```java
context.registerReceiver(
          broadcastReceiver,
          new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
          context.RECEIVER_NOT_EXPORTED);
```


An alternative solution is using ContextCompat but requires version 1.9.0 of `androidx.core:core`. I noticed in the [Android documentation](https://developer.android.com/guide/components/broadcasts#java) is using `ContextCompat` for calling `registerReceiver`, or for the flag `RECEIVER_EXPORTED` & `RECEIVER_NOT_EXPORTED`:
```java
ContextCompat.registerReceiver(
          context,
          broadcastReceiver,
          new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
          ContextCompat.RECEIVER_NOT_EXPORTED);
```

However, `ContextCompat.RECEIVER_NOT_EXPORTED` and the `RECEIVER_NOT_EXPORTED` from `context` have the same value, so I don't think this is necessary to use ContextCompat.

FYI, added `@SuppressLint("WrongConstant")` annotation due to the method throwing an error: https://stackoverflow.com/a/74433641

 
