### PR TITLE
Firestore: add TODO comments about removing special 'missing index' test logic for multidb

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
@@ -903,14 +903,15 @@ public class AggregationTest {
     Throwable throwable = assertThrows(Throwable.class, () -> waitFor(task));
 
     Throwable cause = throwable.getCause();
+    Truth.assertThat(cause).hasMessageThat().ignoringCase().contains("index");
+    // TODO(b/316359394) Remove this check for the default databases once cl/582465034 is rolled
+    // out to production.
     if (collection
         .firestore
         .getDatabaseId()
         .getDatabaseId()
         .equals(DatabaseId.DEFAULT_DATABASE_ID)) {
       Truth.assertThat(cause).hasMessageThat().contains("https://console.firebase.google.com");
-    } else {
-      Truth.assertThat(cause).hasMessageThat().contains("Missing index configuration");
     }
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
@@ -277,14 +277,14 @@ public class CountTest {
 
     Throwable cause = throwable.getCause();
     assertThat(cause).hasMessageThat().ignoringCase().contains("index");
+    // TODO(b/316359394) Remove this check for the default databases once cl/582465034 is rolled
+    // out to production.
     if (collection
         .firestore
         .getDatabaseId()
         .getDatabaseId()
         .equals(DatabaseId.DEFAULT_DATABASE_ID)) {
       assertThat(cause).hasMessageThat().contains("https://console.firebase.google.com");
-    } else {
-      assertThat(cause).hasMessageThat().contains("Missing index configuration");
     }
   }
 }


### PR DESCRIPTION
Add a comment to Firestore's integration tests about removing special logic when testing for the "missing index" error message. Formerly, the "missing index" error message was different for the default database and a non-default database; however, their logic has been unified, and will be rolled out to production soon. Once rolled out, these tests should be updated to remove the special logic for non-default dbs.

Also, remove the "else" branch that verified a different error message when a non-default db was used because when that change rolls out that "else" block will start to fail, seemingly without reason. This also brings the test into parity with the js sdk.

A similar change was made to the js sdk in https://github.com/firebase/firebase-js-sdk/pull/7874.

Googlers see b/316359394 for details.