### PR TITLE
Firestore: AggregationTest.java: fix variable name (no functionality changed)

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
@@ -896,9 +896,10 @@ public class AggregationTest {
 
     CollectionReference collection = testCollectionWithDocs(Collections.emptyMap());
     Query compositeIndexQuery = collection.whereEqualTo("field1", 42).whereLessThan("field2", 99);
-    AggregateQuery compositeIndexCountQuery =
+    AggregateQuery compositeIndexAggregateQuery =
         compositeIndexQuery.aggregate(AggregateField.count(), sum("pages"), average("pages"));
-    Task<AggregateQuerySnapshot> task = compositeIndexCountQuery.get(AggregateSource.SERVER);
+    Task<AggregateQuerySnapshot> task =
+        compositeIndexAggregateCountQuery.get(AggregateSource.SERVER);
 
     Throwable throwable = assertThrows(Throwable.class, () -> waitFor(task));
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
@@ -898,8 +898,7 @@ public class AggregationTest {
     Query compositeIndexQuery = collection.whereEqualTo("field1", 42).whereLessThan("field2", 99);
     AggregateQuery compositeIndexAggregateQuery =
         compositeIndexQuery.aggregate(AggregateField.count(), sum("pages"), average("pages"));
-    Task<AggregateQuerySnapshot> task =
-        compositeIndexAggregateCountQuery.get(AggregateSource.SERVER);
+    Task<AggregateQuerySnapshot> task = compositeIndexAggregateQuery.get(AggregateSource.SERVER);
 
     Throwable throwable = assertThrows(Throwable.class, () -> waitFor(task));
 


### PR DESCRIPTION
Fix variable name: compositeIndexCountQuery -> compositeIndexAggregateQuery (was a copy/paste oversight).