### PR TITLE
Firestore: Improve test name of "missing index" error message tests

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
@@ -887,7 +887,7 @@ public class AggregationTest {
   }
 
   @Test
-  public void testAggregateFailWithGoodMessageIfMissingIndex() {
+  public void testAggregateErrorMessageShouldContainConsoleLinkIfMissingIndex() {
     assumeFalse(
         "Skip this test when running against the Firestore emulator because the "
             + "Firestore emulator does not use indexes and never fails with a 'missing index'"

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
@@ -262,7 +262,7 @@ public class CountTest {
   }
 
   @Test
-  public void testCountFailWithGoodMessageIfMissingIndex() {
+  public void testCountErrorMessageShouldContainConsoleLinkIfMissingIndex() {
     assumeFalse(
         "Skip this test when running against the Firestore emulator because the Firestore emulator "
             + "does not use indexes and never fails with a 'missing index' error",


### PR DESCRIPTION
Rename some tests from "FailWithGoodMessage" to "ErrorMessageShouldContainConsoleLink" to be more descriptive, as suggested in another code review: https://github.com/firebase/firebase-ios-sdk/pull/12189. No functionality is changed by this PR, merely the test's names.

A similar change was made to the js sdk in https://github.com/firebase/firebase-js-sdk/pull/7875.