### PR TITLE
Fix for URLConnection.getInputStream() Crashing

### DIFF
--- a/firebase-ml-modeldownloader/CHANGELOG.md
+++ b/firebase-ml-modeldownloader/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [fixed] Fixed `SecurityException` where the `RECEIVER_EXPORTED` or `RECEIVER_NOT_EXPORTED` flag should be 
+  specified when registerReceiver is being used. [#5597](https://github.com/firebase/firebase-android-sdk/pull/5597)
 
 # 24.2.1
 * [changed] Internal infrastructure improvements.

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
@@ -218,7 +218,7 @@ public class ModelFileDownloadService {
       context.registerReceiver(
           broadcastReceiver,
           new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-          context.RECEIVER_NOT_EXPORTED);
+              Context.RECEIVER_EXPORTED);
     } else {
       context.registerReceiver(
           broadcastReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.ml.modeldownloader.internal;
 
+import android.annotation.SuppressLint;
 import android.app.DownloadManager;
 import android.app.DownloadManager.Query;
 import android.app.DownloadManager.Request;
@@ -23,6 +24,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.ParcelFileDescriptor;
@@ -207,12 +209,20 @@ public class ModelFileDownloadService {
     this.receiverMaps.remove(downloadId);
   }
 
+  @SuppressLint("WrongConstant")
   private Task<Void> registerReceiverForDownloadId(long downloadId, String modelName) {
     BroadcastReceiver broadcastReceiver = getReceiverInstance(downloadId, modelName);
     // It is okay to always register here. Since the broadcast receiver is the same via the lookup
     // for the same download id, the same broadcast receiver will be notified only once.
-    context.registerReceiver(
-        broadcastReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      context.registerReceiver(
+          broadcastReceiver,
+          new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+          context.RECEIVER_NOT_EXPORTED);
+    } else {
+      context.registerReceiver(
+          broadcastReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+    }
 
     return getTaskCompletionSourceInstance(downloadId).getTask();
   }

--- a/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
+++ b/firebase-ml-modeldownloader/src/main/java/com/google/firebase/ml/modeldownloader/internal/ModelFileDownloadService.java
@@ -218,7 +218,7 @@ public class ModelFileDownloadService {
       context.registerReceiver(
           broadcastReceiver,
           new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-              Context.RECEIVER_EXPORTED);
+          Context.RECEIVER_EXPORTED);
     } else {
       context.registerReceiver(
           broadcastReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));

--- a/firebase-perf/src/main/java/com/google/firebase/perf/network/FirebasePerfUrlConnection.java
+++ b/firebase-perf/src/main/java/com/google/firebase/perf/network/FirebasePerfUrlConnection.java
@@ -58,6 +58,9 @@ public class FirebasePerfUrlConnection {
    */
   static InputStream openStream(URLWrapper wrapper, TransportManager transportManager, Timer timer)
       throws IOException {
+    if (!TransportManager.getInstance().isInitialized()) {
+      return wrapper.openConnection().getInputStream();
+    }
     timer.reset();
     long startTime = timer.getMicros();
     NetworkRequestMetricBuilder builder = NetworkRequestMetricBuilder.builder(transportManager);


### PR DESCRIPTION
Proposed fix for #5584:

### Issue
Crash happens if a URL connection is opened e.g. `url.openStream()` when `FirebasePerformance` has not been initialized.

### Investigation
1. `openStream` in `FirebasePerfUrlConnection` intercepts all urls that opens connections. 
2. `openStream` requires `TransportManager` to be initialized
3. `TransportManager` is only initialized after `FirebasePerformance` has been initialized

### Solution
If `TransportManager` is not initialized, we should simply return the URL openStream and not intercept the connection.