### PR TITLE
Add diffing for ABT Experiments in real-time RC

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigConstants.java
@@ -95,12 +95,14 @@ public final class RemoteConfigConstants {
    */
   @StringDef({
     ExperimentDescriptionFieldKey.EXPERIMENT_ID,
-    ExperimentDescriptionFieldKey.VARIANT_ID
+    ExperimentDescriptionFieldKey.VARIANT_ID,
+    ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEYS
   })
   @Retention(RetentionPolicy.SOURCE)
   public @interface ExperimentDescriptionFieldKey {
     String EXPERIMENT_ID = "experimentId";
     String VARIANT_ID = "variantId";
+    String AFFECTED_PARAMETER_KEYS = "affectedParameterKeys";
   }
 
   private RemoteConfigConstants() {}

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigContainer.java
@@ -14,6 +14,9 @@
 
 package com.google.firebase.remoteconfig.internal;
 
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEYS;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_ID;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,6 +40,7 @@ public class ConfigContainer {
   static final String PERSONALIZATION_METADATA_KEY = "personalization_metadata_key";
   static final String TEMPLATE_VERSION_NUMBER_KEY = "template_version_number_key";
   static final String ROLLOUT_METADATA_KEY = "rollout_metadata_key";
+  static final String ROLLOUT_ID_PREFIX = "rollout";
   public static final String ROLLOUT_METADATA_AFFECTED_KEYS = "affectedParameterKeys";
   public static final String ROLLOUT_METADATA_ID = "rolloutId";
   public static final String ROLLOUT_METADATA_VARIANT_ID = "variantId";
@@ -189,6 +193,38 @@ public class ConfigContainer {
     return containerJson.toString().equals(that.toString());
   }
 
+  /** Creates a map where the key is the config key and the value if the experiment description. */
+  private Map<String, JSONObject> createExperimentsMap(JSONArray allExperiments)
+      throws JSONException {
+    Map<String, JSONObject> experimentsMap = new HashMap<>();
+    if (allExperiments == null) {
+      return experimentsMap;
+    }
+
+    // Iterate through all experiments to check if it has the `affectedParameterKeys` field.
+    for (int i = 0; i < allExperiments.length(); i++) {
+      JSONObject experiment = allExperiments.getJSONObject(i);
+      if (!experiment.has(AFFECTED_PARAMETER_KEYS)
+          || experiment.getString(EXPERIMENT_ID).startsWith(ROLLOUT_ID_PREFIX)) {
+        continue;
+      }
+
+      // Since a config key can only have one experiment associated with it, map the key to the
+      // experiment.
+      JSONArray affectedKeys = experiment.getJSONArray(AFFECTED_PARAMETER_KEYS);
+      for (int j = 0; j < affectedKeys.length(); j++) {
+        String key = affectedKeys.getString(j);
+        JSONObject experimentsCopy = new JSONObject(experiment.toString());
+        // Removing `affectedParameterKeys` because its values never come in the same order which
+        // would affect the diffing.
+        experimentsCopy.remove(AFFECTED_PARAMETER_KEYS);
+        experimentsMap.put(key, experimentsCopy);
+      }
+    }
+
+    return experimentsMap;
+  }
+
   // Create a map of maps of parameter key to `rolloutId`/`variantId`.
   private Map<String, Map<String, String>> createRolloutParameterKeyMap() throws JSONException {
     // Create a map where the key is the parameter key and the value is a maps of
@@ -230,6 +266,10 @@ public class ConfigContainer {
     // Config key to `rolloutMetadata` map.
     Map<String, Map<String, String>> rolloutMetadataMap = this.createRolloutParameterKeyMap();
     Map<String, Map<String, String>> otherRolloutMetadataMap = other.createRolloutParameterKeyMap();
+
+    // Config key to experiments map.
+    Map<String, JSONObject> experimentsMap = createExperimentsMap(this.getAbtExperiments());
+    Map<String, JSONObject> otherExperimentsMap = createExperimentsMap(other.getAbtExperiments());
 
     Set<String> changed = new HashSet<>();
     Iterator<String> keys = this.getConfigs().keys();
@@ -278,6 +318,20 @@ public class ConfigContainer {
       if (rolloutMetadataMap.containsKey(key)
           && otherRolloutMetadataMap.containsKey(key)
           && !rolloutMetadataMap.get(key).equals(otherRolloutMetadataMap.get(key))) {
+        changed.add(key);
+        continue;
+      }
+
+      // If one and only one of the experiments map contains the key, add it to changed.
+      if (experimentsMap.containsKey(key) != otherExperimentsMap.containsKey(key)) {
+        changed.add(key);
+        continue;
+      }
+
+      // If both experiment maps contains the key, compare the experiments to see if it's different.
+      if (otherExperimentsMap.containsKey(key)
+          && experimentsMap.containsKey(key)
+          && !otherExperimentsMap.get(key).toString().equals(experimentsMap.get(key).toString())) {
         changed.add(key);
         continue;
       }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigContainerTest.java
@@ -15,6 +15,7 @@
 package com.google.firebase.remoteconfig.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.AFFECTED_PARAMETER_KEYS;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.EXPERIMENT_ID;
 import static com.google.firebase.remoteconfig.RemoteConfigConstants.ExperimentDescriptionFieldKey.VARIANT_ID;
 import static com.google.firebase.remoteconfig.internal.Personalization.ARM_INDEX;
@@ -137,22 +138,97 @@ public class ConfigContainerTest {
     assertThat(changedParams).isEmpty();
   }
 
-  @Test
-  public void getChangedParams_changedExperimentsMetadata_returnsNoParamKeys() throws Exception {
+  public void getChangedParams_sameExperimentsMetadata_returnsEmptySet() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
     ConfigContainer config =
         ConfigContainer.newBuilder()
-            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
+            .replaceConfigsWith(ImmutableMap.of("abt_test_key_1", "value_1"))
+            .withAbtExperiments(activeExperiments)
             .build();
 
     ConfigContainer other =
         ConfigContainer.newBuilder()
-            .replaceConfigsWith(ImmutableMap.of("string_param", "value_1"))
-            .withAbtExperiments(generateAbtExperiments(1))
+            .replaceConfigsWith(ImmutableMap.of("abt_test_key_1", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
             .build();
 
     Set<String> changedParams = config.getChangedParams(other);
 
     assertThat(changedParams).isEmpty();
+  }
+
+  @Test
+  public void getChangedParams_changedExperimentsMetadata_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    activeExperiments.getJSONObject(0).put(VARIANT_ID, "32");
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("abt_test_key_1", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("abt_test_key_1", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_deletedExperiment_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = new JSONArray();
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("abt_test_key_1", "value_1"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(ImmutableMap.of("abt_test_key_1", "value_1"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_1");
+  }
+
+  @Test
+  public void getChangedParams_changedExperimentsKeys_returnsUpdatedKey() throws Exception {
+    JSONArray activeExperiments = generateAbtExperiments(1);
+    JSONArray fetchedExperiments = generateAbtExperiments(1);
+
+    fetchedExperiments.getJSONObject(0).getJSONArray(AFFECTED_PARAMETER_KEYS).put("abt_test_key_2");
+
+    ConfigContainer config =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(
+                ImmutableMap.of("abt_test_key_1", "value_1", "abt_test_key_2", "value_2"))
+            .withAbtExperiments(activeExperiments)
+            .build();
+
+    ConfigContainer other =
+        ConfigContainer.newBuilder()
+            .replaceConfigsWith(
+                ImmutableMap.of("abt_test_key_1", "value_1", "abt_test_key_2", "value_2"))
+            .withAbtExperiments(fetchedExperiments)
+            .build();
+
+    Set<String> changedParams = config.getChangedParams(other);
+
+    assertThat(changedParams).containsExactly("abt_test_key_2");
   }
 
   @Test
@@ -452,9 +528,15 @@ public class ConfigContainerTest {
 
   private static JSONArray generateAbtExperiments(int numExperiments) throws JSONException {
     JSONArray experiments = new JSONArray();
+    JSONArray experimentKeys = new JSONArray();
+    experimentKeys.put("abt_test_key_1");
     for (int experimentNum = 1; experimentNum <= numExperiments; experimentNum++) {
       experiments.put(
           new JSONObject().put(EXPERIMENT_ID, "exp" + experimentNum).put(VARIANT_ID, "var1"));
+      new JSONObject()
+          .put(EXPERIMENT_ID, "exp" + experimentNum)
+          .put(VARIANT_ID, "var1")
+          .put(AFFECTED_PARAMETER_KEYS, experimentKeys);
     }
     return experiments;
   }


### PR DESCRIPTION
Adds diffing logic between experiments fetched via real-time and experiments active on the device. The config keys that have been affected by the differences will be added to ConfigUpdate. Testing below:

Created experiments with https://docs.google.com/document/d/1MXxUg1JSBbh3m_Qy4tGPrGs3-Nh8FAwKmg5ZWOKQ3J8/edit

Add experiments to configs using Management API, example: https://rpc.corp.google.com/rpc/builder?rpcId=15352346049097272373

2.1) Add/Remove Experiment to Config Key.
2.2) Replace experiment in Config Key
2.3) Create new param with experiment attached

See changes in SDK