### PR TITLE
Remove list of SDKs from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,7 @@
 # Firebase Android Open Source Development
 
-This repository contains a subset of the Firebase Android SDK source. It
-currently includes the following Firebase libraries, and some of their
-dependencies:
-
-  * `firebase-abt`
-  * `firebase-appdistribution`
-  * `firebase-common`
-  * `firebase-common-ktx`
-  * `firebase-crashlytics`
-  * `firebase-crashlytics-ktx`
-  * `firebase-crashlytics-ndk`
-  * `firebase-database`
-  * `firebase-database-ktx`
-  * `firebase-database-collection`
-  * `firebase-datatransport`
-  * `firebase-firestore`
-  * `firebase-firestore-ktx`
-  * `firebase-functions`
-  * `firebase-functions-ktx`
-  * `firebase-inappmessaging`
-  * `firebase-inappmessaging-ktx`
-  * `firebase-inappmessaging-display`
-  * `firebase-inappmessaging-display-ktx`
-  * `firebase-messaging`
-  * `firebase-messaging-directboot`
-  * `firebase-perf`
-  * `firebase-perf-ktx`
-  * `firebase-remote-config`
-  * `firebase-remote-config-ktx`
-  * `firebase-storage`
-  * `firebase-storage-ktx`
-
+This repository contains the source code for all Android Firebase SDKs except
+Analytics and Auth.
 
 Firebase is an app development platform with tools to help you build, grow and
 monetize your app. More information about Firebase can be found at


### PR DESCRIPTION
Having an additional list of SDKs to update creates unnecessary maintenance load.