### PR TITLE
Handle bridge methods while mapping

### DIFF
--- a/firebase-database/CHANGELOG.md
+++ b/firebase-database/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [fixed] Fixed the `@Exclude` annotation doesn't been propagated to Kotlin's corresponding bridge methods. [#5626](//github.com/firebase/firebase-android-sdk/pull/5626)
 
 # 20.3.0
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-database-ktx`

--- a/firebase-database/src/main/java/com/google/firebase/database/core/utilities/encoding/CustomClassMapper.java
+++ b/firebase-database/src/main/java/com/google/firebase/database/core/utilities/encoding/CustomClassMapper.java
@@ -523,7 +523,7 @@ public class CustomClassMapper {
                     propertyNamesOfExcludedSetters.add(propertyName);
                   }
                 } else if (!isSetterOverride(method, existingSetter)
-                        && !(correspondingBridgeMethod != null
+                    && !(correspondingBridgeMethod != null
                         && isSetterOverride(method, correspondingBridgeMethod))) {
                   // We require that setters with conflicting property names are
                   // overrides from a base class
@@ -561,7 +561,7 @@ public class CustomClassMapper {
 
       // When subclass setter is annotated with `@Exclude`, the corresponding superclass setter
       // also need to be filtered out.
-      for (String propertyName: propertyNamesOfExcludedSetters) {
+      for (String propertyName : propertyNamesOfExcludedSetters) {
         setters.remove(propertyName);
       }
 

--- a/firebase-database/src/test/java/com/google/firebase/database/KotlinEntities.kt
+++ b/firebase-database/src/test/java/com/google/firebase/database/KotlinEntities.kt
@@ -20,7 +20,7 @@ interface GenericInterface<T> {
   var value: T?
 }
 
-class GenericExcludedSetterBeanKt : GenericInterface<String> {
+class GenericExcludedSetterBeanKotlin : GenericInterface<String> {
 
   @set:Exclude
   override var value: String? = null

--- a/firebase-database/src/test/java/com/google/firebase/database/KotlinEntities.kt
+++ b/firebase-database/src/test/java/com/google/firebase/database/KotlinEntities.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.database
+
+interface GenericInterface<T> {
+  var value: T?
+}
+
+class GenericExcludedSetterBeanKt : GenericInterface<String> {
+
+  @set:Exclude
+  override var value: String? = null
+    set(value) {
+      field = "wrong_setter"
+    }
+}

--- a/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.database.core.utilities.encoding.CustomClassMapper;
@@ -846,6 +848,22 @@ public class MapperTest {
     @Override
     public void setValue(String value) {
       this.value = "subsetter:" + value;
+    }
+  }
+
+  private static class GenericExcludedSetterBean implements GenericInterface<String> {
+    private String value = null;
+
+    @Nullable
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    @Exclude
+    @Override
+    public void setValue(@Nullable String value) {
+      this.value = "wrong setter";
     }
   }
 

--- a/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
@@ -2000,10 +2000,8 @@ public class MapperTest {
     serialize(bean);
   }
 
-  // This should work, but generics and subclassing are tricky to get right. For now we will just
-  // throw and we can add support for generics & subclassing if it becomes a high demand feature
-  @Test(expected = DatabaseException.class)
-  public void settersCanOverrideGenericSettersParsingNot() {
+  @Test
+  public void settersCanOverrideGenericSettersParsing() {
     NonConflictingGenericSetterSubBean bean =
         deserialize("{'value': 'value'}", NonConflictingGenericSetterSubBean.class);
     assertEquals("subsetter:value", bean.value);

--- a/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.fail;
 
 import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.database.core.utilities.encoding.CustomClassMapper;
@@ -2028,7 +2027,7 @@ public class MapperTest {
   @Test
   public void excludedOverriddenGenericSetterSetsValueNotJava() {
     GenericExcludedSetterBean bean =
-            deserialize("{'value': 'foo'}", GenericExcludedSetterBean.class);
+        deserialize("{'value': 'foo'}", GenericExcludedSetterBean.class);
     assertEquals("foo", bean.value);
   }
 
@@ -2037,7 +2036,7 @@ public class MapperTest {
   @Test
   public void excludedOverriddenGenericSetterSetsValueNotKotlin() {
     GenericExcludedSetterBeanKotlin bean =
-            deserialize("{'value': 'foo'}", GenericExcludedSetterBeanKotlin.class);
+        deserialize("{'value': 'foo'}", GenericExcludedSetterBeanKotlin.class);
     assertEquals("foo", bean.getValue());
   }
 }

--- a/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
@@ -2026,7 +2026,7 @@ public class MapperTest {
   }
 
   @Test
-  public void excludedOverridenGenericSetterSetsValueNot() {
+  public void excludedOverriddenGenericSetterSetsValueNotJava() {
     GenericExcludedSetterBean bean =
             deserialize("{'value': 'foo'}", GenericExcludedSetterBean.class);
     assertEquals("foo", bean.value);
@@ -2035,9 +2035,9 @@ public class MapperTest {
   // Unlike Java, in Kotlin, annotations do not get propagated to bridge methods.
   // That's why there are 2 separate tests for Java and Kotlin
   @Test
-  public void excludedOverridenGenericSetterSetsValueNotKotlin() {
-    GenericExcludedSetterBeanKt bean =
-            deserialize("{'value': 'foo'}", GenericExcludedSetterBeanKt.class);
+  public void excludedOverriddenGenericSetterSetsValueNotKotlin() {
+    GenericExcludedSetterBeanKotlin bean =
+            deserialize("{'value': 'foo'}", GenericExcludedSetterBeanKotlin.class);
     assertEquals("foo", bean.getValue());
   }
 }

--- a/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
+++ b/firebase-database/src/test/java/com/google/firebase/database/MapperTest.java
@@ -2024,4 +2024,20 @@ public class MapperTest {
         deserialize("{'value': 'value'}", NonConflictingGenericSetterSubBean.class);
     assertEquals("subsetter:value", bean.value);
   }
+
+  @Test
+  public void excludedOverridenGenericSetterSetsValueNot() {
+    GenericExcludedSetterBean bean =
+            deserialize("{'value': 'foo'}", GenericExcludedSetterBean.class);
+    assertEquals("foo", bean.value);
+  }
+
+  // Unlike Java, in Kotlin, annotations do not get propagated to bridge methods.
+  // That's why there are 2 separate tests for Java and Kotlin
+  @Test
+  public void excludedOverridenGenericSetterSetsValueNotKotlin() {
+    GenericExcludedSetterBeanKt bean =
+            deserialize("{'value': 'foo'}", GenericExcludedSetterBeanKt.class);
+    assertEquals("foo", bean.getValue());
+  }
 }

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * [changed] Internal test improvements.
+* [fixed] Fixed the `@Exclude` annotation doesn't been propagated to Kotlin's corresponding bridge methods. [#5626](//github.com/firebase/firebase-android-sdk/pull/5626)
 
 # 24.10.1
 * [fixed] Fixed an issue caused by calling mutation on immutable map object. [#5573](//github.com/firebase/firebase-android-sdk/pull/5573)
@@ -880,3 +881,4 @@ updates.
   or
   [`FieldValue.serverTimestamp()`](/docs/reference/android/com/google/firebase/firestore/FieldValue.html#serverTimestamp())
   values.
+

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
@@ -567,6 +567,7 @@ public class CustomClassMapper {
 
   // Helper class to convert from maps to custom objects (Beans), and vice versa.
   private static class BeanMapper<T> {
+    private static final String BRIDGE_METHOD_KEY_SUFFIX = "$$bridge";
     private final Class<T> clazz;
     private final Constructor<T> constructor;
     // Whether to throw exception if there are properties we don't know how to set to
@@ -661,13 +662,18 @@ public class CustomClassMapper {
                         + currentClass.getName()
                         + " with invalid case-sensitive name: "
                         + method.getName());
+              } else if (method.isBridge()) {
+                // We ignore bridge setters when creating a bean, but include them in the map
+                // for the purpose of the `isSetterOverride()` check
+                setters.put(propertyName + BRIDGE_METHOD_KEY_SUFFIX, method);
               } else {
                 Method existingSetter = setters.get(propertyName);
+                Method correspondingBridge = setters.get(propertyName + BRIDGE_METHOD_KEY_SUFFIX);
                 if (existingSetter == null) {
                   method.setAccessible(true);
                   setters.put(propertyName, method);
                   applySetterAnnotations(method);
-                } else if (!isSetterOverride(method, existingSetter)) {
+                } else if (!isSetterOverride(method, existingSetter) && !(correspondingBridge != null && isSetterOverride(method, correspondingBridge))) {
                   // We require that setters with conflicting property names are
                   // overrides from a base class
                   if (currentClass == clazz) {
@@ -1003,6 +1009,10 @@ public class CustomClassMapper {
       if (method.getParameterTypes().length != 0) {
         return false;
       }
+      // Bridge methods
+      if (method.isBridge()) {
+        return false;
+      }
       // Excluded methods
       if (method.isAnnotationPresent(Exclude.class)) {
         return false;
@@ -1030,6 +1040,11 @@ public class CustomClassMapper {
       if (method.getParameterTypes().length != 1) {
         return false;
       }
+      // removed the following check (although it's present in `shouldIncludeGetter()`) because bridge methods
+      // are useful in distinguishing logic between conflicting and non-conflicting generic setters
+//      if (method.isBridge()) {
+//        return false;
+//      }
       // Excluded methods
       if (method.isAnnotationPresent(Exclude.class)) {
         return false;

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
@@ -568,7 +568,6 @@ public class CustomClassMapper {
 
   // Helper class to convert from maps to custom objects (Beans), and vice versa.
   private static class BeanMapper<T> {
-    private static final String BRIDGE_METHOD_KEY_SUFFIX = "$$bridge";
     private final Class<T> clazz;
     private final Constructor<T> constructor;
     // Whether to throw exception if there are properties we don't know how to set to
@@ -650,7 +649,8 @@ public class CustomClassMapper {
       // getMethods/getFields only returns public methods/fields we need to traverse the
       // class hierarchy to find the appropriate setter or field.
       Class<? super T> currentClass = clazz;
-      Set<String> propNamesOfExcludedSetters = new HashSet<>();
+      Map<String, Method> bridgeMethods = new HashMap<>();
+      Set<String> propertyNamesOfExcludedSetters = new HashSet<>();
       do {
         // Add any setters
         for (Method method : currentClass.getDeclaredMethods()) {
@@ -667,18 +667,20 @@ public class CustomClassMapper {
               } else if (method.isBridge()) {
                 // We ignore bridge setters when creating a bean, but include them in the map
                 // for the purpose of the `isSetterOverride()` check
-                setters.put(propertyName + BRIDGE_METHOD_KEY_SUFFIX, method);
+                bridgeMethods.put(propertyName, method);
               } else {
                 Method existingSetter = setters.get(propertyName);
-                Method correspondingBridge = setters.get(propertyName + BRIDGE_METHOD_KEY_SUFFIX);
+                Method correspondingBridgeMethod = bridgeMethods.get(propertyName);
                 if (existingSetter == null) {
                   setters.put(propertyName, method);
-                  if (!method.isAnnotationPresent(Exclude.class))
+                  if (!method.isAnnotationPresent(Exclude.class)) {
                     method.setAccessible(true);
-                  else
-                    propNamesOfExcludedSetters.add(propertyName);
-                  applySetterAnnotations(method);
-                } else if (!isSetterOverride(method, existingSetter) && !(correspondingBridge != null && isSetterOverride(method, correspondingBridge))) {
+                  } else {
+                    propertyNamesOfExcludedSetters.add(propertyName);
+                  }
+                } else if (!isSetterOverride(method, existingSetter)
+                    && !(correspondingBridgeMethod != null
+                        && isSetterOverride(method, correspondingBridgeMethod))) {
                   // We require that setters with conflicting property names are
                   // overrides from a base class
                   if (currentClass == clazz) {
@@ -723,7 +725,9 @@ public class CustomClassMapper {
         currentClass = currentClass.getSuperclass();
       } while (currentClass != null && !currentClass.equals(Object.class));
 
-      for (String propertyName: propNamesOfExcludedSetters) {
+      // When subclass setter is annotated with `@Exclude`, the corresponding superclass setter
+      // also need to be filtered out.
+      for (String propertyName : propertyNamesOfExcludedSetters) {
         setters.remove(propertyName);
       }
 
@@ -1049,16 +1053,7 @@ public class CustomClassMapper {
       if (method.getParameterTypes().length != 1) {
         return false;
       }
-      // removed the following check (although it's present in `shouldIncludeGetter()`) because bridge methods
-      // are useful in distinguishing logic between conflicting and non-conflicting generic setters
-//      if (method.isBridge()) {
-//        return false;
-//      }
-      // removed the following check (although it's present in `shouldIncludeGetter()`) because
-      // @Exclude-annotated methods are useful for `isSetterOverride()`
-//      if (method.isAnnotationPresent(Exclude.class)) {
-//        return false;
-//      }
+
       return true;
     }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/KotlinEntities.kt
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/KotlinEntities.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.firestore.util
+
+import com.google.firebase.firestore.Exclude
+
+interface GenericInterface<T> {
+  var value: T?
+}
+
+class GenericExcludedSetterBeanKt : GenericInterface<String> {
+
+  @set:Exclude
+  override var value: String? = null
+    set(value) {
+      field = "wrong_setter"
+    }
+}

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/KotlinEntities.kt
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/KotlinEntities.kt
@@ -22,7 +22,7 @@ interface GenericInterface<T> {
   var value: T?
 }
 
-class GenericExcludedSetterBeanKt : GenericInterface<String> {
+class GenericExcludedSetterBeanKotlin : GenericInterface<String> {
 
   @set:Exclude
   override var value: String? = null

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
@@ -2218,18 +2218,11 @@ public class MapperTest {
         () -> serialize(bean));
   }
 
-  // This should work, but generics and subclassing are tricky to get right. For now we will just
-  // throw and we can add support for generics & subclassing if it becomes a high demand feature
   @Test
-  public void settersCanOverrideGenericSettersParsingNot() {
-    assertExceptionContains(
-        "Class com.google.firebase.firestore.util.MapperTest$NonConflictingGenericSetterSubBean "
-            + "has multiple setter overloads",
-        () -> {
-          NonConflictingGenericSetterSubBean bean =
-              deserialize("{'value': 'value'}", NonConflictingGenericSetterSubBean.class);
-          assertEquals("subsetter:value", bean.value);
-        });
+  public void settersCanOverrideGenericSettersParsing() {
+    NonConflictingGenericSetterSubBean bean =
+        deserialize("{'value': 'value'}", NonConflictingGenericSetterSubBean.class);
+    assertEquals("subsetter:value", bean.value);
   }
 
   @Test

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
@@ -2244,6 +2244,22 @@ public class MapperTest {
   }
 
   @Test
+  public void excludedOverridenGenericSetterSetsValueNot() {
+    GenericExcludedSetterBean bean =
+            deserialize("{'value': 'foo'}", GenericExcludedSetterBean.class);
+    assertEquals("foo", bean.value);
+  }
+
+  // Unlike Java, in Kotlin, annotations do not get propagated to bridge methods.
+  // That's why there are 2 separate tests for Java and Kotlin
+  @Test
+  public void excludedOverridenGenericSetterSetsValueNotKotlin() {
+    GenericExcludedSetterBeanKt bean =
+            deserialize("{'value': 'foo'}", GenericExcludedSetterBeanKt.class);
+    assertEquals("foo", bean.getValue());
+  }
+
+  @Test
   public void serializingRecursiveBeanThrows() {
     ObjectBean bean = new ObjectBean();
     bean.value = bean;

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import androidx.annotation.Nullable;
+
 import com.google.firebase.firestore.DocumentId;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.Exclude;
@@ -904,6 +906,22 @@ public class MapperTest {
     @Override
     public void setValue(String value) {
       this.value = "subsetter:" + value;
+    }
+  }
+
+  private static class GenericExcludedSetterBean implements GenericInterface<String> {
+    private String value = null;
+
+    @Nullable
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    @Exclude
+    @Override
+    public void setValue(@Nullable String value) {
+      this.value = "wrong setter";
     }
   }
 

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import androidx.annotation.Nullable;
-
 import com.google.firebase.firestore.DocumentId;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.Exclude;
@@ -2244,18 +2243,18 @@ public class MapperTest {
   }
 
   @Test
-  public void excludedOverridenGenericSetterSetsValueNot() {
+  public void excludedOverriddenGenericSetterSetsValueNotJava() {
     GenericExcludedSetterBean bean =
-            deserialize("{'value': 'foo'}", GenericExcludedSetterBean.class);
+        deserialize("{'value': 'foo'}", GenericExcludedSetterBean.class);
     assertEquals("foo", bean.value);
   }
 
   // Unlike Java, in Kotlin, annotations do not get propagated to bridge methods.
   // That's why there are 2 separate tests for Java and Kotlin
   @Test
-  public void excludedOverridenGenericSetterSetsValueNotKotlin() {
-    GenericExcludedSetterBeanKt bean =
-            deserialize("{'value': 'foo'}", GenericExcludedSetterBeanKt.class);
+  public void excludedOverriddenGenericSetterSetsValueNotKotlin() {
+    GenericExcludedSetterBeanKotlin bean =
+        deserialize("{'value': 'foo'}", GenericExcludedSetterBeanKotlin.class);
     assertEquals("foo", bean.getValue());
   }
 


### PR DESCRIPTION
This PR was inspired by [this question](https://stackoverflow.com/questions/77739613/kotlin-multiple-setters-getters-generics/). The `@Exclude` annotation has not been propagated to Kotlin's corresponding bridge methods. Additionally, there is no straightforward way to eliminate their 'get-' and 'set-' prefixes, as `@JvmName` is not propagated to them either.

It seemed possible to solve this issue by redesigning the models. However, including bridge methods in the exceptions list – alongside other checks nearby – anyway seems to be a viable solution.