### PR TITLE
Firestore: Remove obsolete special case from tests when verifying "missing index" error message in non-default DB

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assume.assumeFalse;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.gms.tasks.Task;
 import com.google.common.truth.Truth;
-import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Collections;
 import java.util.Map;
@@ -904,15 +903,7 @@ public class AggregationTest {
 
     Throwable cause = throwable.getCause();
     Truth.assertThat(cause).hasMessageThat().ignoringCase().contains("index");
-    // TODO(b/316359394) Remove this check for the default databases once cl/582465034 is rolled
-    // out to production.
-    if (collection
-        .firestore
-        .getDatabaseId()
-        .getDatabaseId()
-        .equals(DatabaseId.DEFAULT_DATABASE_ID)) {
-      Truth.assertThat(cause).hasMessageThat().contains("https://console.firebase.google.com");
-    }
+    Truth.assertThat(cause).hasMessageThat().contains("https://console.firebase.google.com");
   }
 
   @Test

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assume.assumeFalse;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Collections;
 import org.junit.After;
@@ -277,14 +276,6 @@ public class CountTest {
 
     Throwable cause = throwable.getCause();
     assertThat(cause).hasMessageThat().ignoringCase().contains("index");
-    // TODO(b/316359394) Remove this check for the default databases once cl/582465034 is rolled
-    // out to production.
-    if (collection
-        .firestore
-        .getDatabaseId()
-        .getDatabaseId()
-        .equals(DatabaseId.DEFAULT_DATABASE_ID)) {
-      assertThat(cause).hasMessageThat().contains("https://console.firebase.google.com");
-    }
+    assertThat(cause).hasMessageThat().contains("https://console.firebase.google.com");
   }
 }


### PR DESCRIPTION
This PR removes a special case from the integration tests ([#7874](https://github.com/firebase/firebase-android-sdk/pull/5600)) that verifies the "missing index" error message returned from the server. Previously, a non-default database would result in a different, less descriptive error message; however, the backend was updated to use the same, descriptive error message for both default and non-default databases. The tests, therefore, should have to the special case removed to increase the coverage of the tests.

Googlers see b/316359394 for more information.