### PR TITLE
Handle corruption in DataStore Preferences gracefully

### DIFF
--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* [fixed] Handle corruption in DataStore Preferences more gracefully.
+
 # 1.2.0
 
 * [feature] Added support for accurate sessions on multi-process apps.
@@ -11,7 +13,7 @@
 # 1.0.1
 
 * [fixed] Fixed NPE when no version name is
-  set ([#5195](//github.com/firebase/firebase-android-sdk/issues/5195)).
+  set ([#5195](https://github.com/firebase/firebase-android-sdk/issues/5195)).
 * [fixed] Populate DataCollectionStatus fields for Crashlytics and Perf.
 
 # 1.0.0

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionDatastore.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionDatastore.kt
@@ -19,6 +19,7 @@ package com.google.firebase.sessions
 import android.content.Context
 import android.util.Log
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
@@ -26,6 +27,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.firebase.Firebase
 import com.google.firebase.app
+import com.google.firebase.sessions.ProcessDetailsProvider.getProcessName
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
@@ -97,7 +99,15 @@ internal class SessionDatastoreImpl(
 
   private companion object {
     private const val TAG = "FirebaseSessionsRepo"
+
     private val Context.dataStore: DataStore<Preferences> by
-      preferencesDataStore(name = SessionDataStoreConfigs.SESSIONS_CONFIG_NAME)
+      preferencesDataStore(
+        name = SessionDataStoreConfigs.SESSIONS_CONFIG_NAME,
+        corruptionHandler =
+          ReplaceFileCorruptionHandler { ex ->
+            Log.w(TAG, "CorruptionException in sessions DataStore in ${getProcessName()}.", ex)
+            emptyPreferences()
+          },
+      )
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/SessionsSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/SessionsSettings.kt
@@ -17,14 +17,18 @@
 package com.google.firebase.sessions.settings
 
 import android.content.Context
+import android.util.Log
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
 import com.google.firebase.app
 import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.sessions.ApplicationInfo
+import com.google.firebase.sessions.ProcessDetailsProvider.getProcessName
 import com.google.firebase.sessions.SessionDataStoreConfigs
 import com.google.firebase.sessions.SessionEvents
 import kotlin.coroutines.CoroutineContext
@@ -136,10 +140,19 @@ internal class SessionsSettings(
   }
 
   internal companion object {
+    private const val TAG = "SessionsSettings"
+
     val instance: SessionsSettings
       get() = Firebase.app[SessionsSettings::class.java]
 
     private val Context.dataStore: DataStore<Preferences> by
-      preferencesDataStore(name = SessionDataStoreConfigs.SETTINGS_CONFIG_NAME)
+      preferencesDataStore(
+        name = SessionDataStoreConfigs.SETTINGS_CONFIG_NAME,
+        corruptionHandler =
+          ReplaceFileCorruptionHandler { ex ->
+            Log.w(TAG, "CorruptionException in settings DataStore in ${getProcessName()}.", ex)
+            emptyPreferences()
+          },
+      )
   }
 }


### PR DESCRIPTION
Handle corruption in DataStore Preferences more gracefully.

Tested manually by piping junk data into the datastore files.

When the Settings data store preferences gets corrupt, it will be replaced by an empty preferences with all null values. This will cause settings to fall through to sdk defaults until the next settings fetch. If the Sessions data store preferences gets corrupt, it will lose the session id until the next session is generated on the next foreground. I could not force a session to upload will a null session id, but I expect it to be rare but possible with a multi-process app.