### PR TITLE
Fix package prefix removal in doc generation

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
@@ -153,6 +153,7 @@ constructor(private val workerExecutor: WorkerExecutor) : GenerateDocumentationT
                       "docRootPath" to "/docs/reference/",
                       "javaDocsPath" to "android",
                       "kotlinDocsPath" to "kotlin",
+                      "packagePrefixToRemoveInToc" to "com.google",
                       "projectPath" to "client/${clientName.get()}",
                       "includedHeadTagsPathJava" to
                         "docs/reference/android/_reference-head-tags.html",


### PR DESCRIPTION
Per [b/321049856](https://b.corp.google.com/issues/321049856),

This fixes an issue where the docs were being generated with the `com.google` package prefix in the toc files. This behavior was originally fixed by `FiresiteTransform`, but was removed with #5550 in favor of the "newly" added dackka configuration option. Although, it seems the actual configuration managed to be skipped over in the original PR, so this properly enabled it.

[b/321753481](https://b.corp.google.com/issues/321753481) has also been created to track investigating why this initially wasn't caught by our CI job.