### PR TITLE
Migrate macos runners to ubuntu

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   build-artifacts:
-    # TODO(b/271315039) - Revert back to ubuntu when fixed
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/diff-javadoc.yml
+++ b/.github/workflows/diff-javadoc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:

--- a/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
@@ -87,7 +87,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>Any <code>FirebaseApp</code> initialization must occur only in the main process of the app.
  * Use of Firebase in processes other than the main process is not supported and will likely cause
  * problems related to resource contention.
- * Trigger Javadoc Change
  */
 public class FirebaseApp {
 

--- a/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/firebase-common/src/main/java/com/google/firebase/FirebaseApp.java
@@ -87,6 +87,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>Any <code>FirebaseApp</code> initialization must occur only in the main process of the app.
  * Use of Firebase in processes other than the main process is not supported and will likely cause
  * problems related to resource contention.
+ * Trigger Javadoc Change
  */
 public class FirebaseApp {
 


### PR DESCRIPTION
Per [b/321263425](https://b.corp.google.com/issues/321263425),

This switches our `macos` runners to `ubuntu`, which should help up save a considerable sum- not only in instance overhead/usage (as macos runners are 10x as expensive as standard linux runners), but in the engineering time saved by the CI not needing to wait for a macos runner to be available (as they come in a more limited quantity).

Since [GItHub has increased the amount of cores provided to their ubuntu machines](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/), we can effectively work around [b/271315039](https://b.corp.google.com/issues/271315039) (which forced us to use `macos-latest` instead of `ubuntu-latest` for anything involving our javadoc generation).

