### PR TITLE
Fix perf devapp namespace

### DIFF
--- a/firebase-perf/dev-app/dev-app.gradle
+++ b/firebase-perf/dev-app/dev-app.gradle
@@ -24,7 +24,7 @@ firebaseTestLab {
 android {
     compileSdkVersion 31
 
-    namespace "com.googletest.firebase.perf.testapp.prod"
+    namespace "com.googletest.firebase.perf.testapp"
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8


### PR DESCRIPTION
Namespace should be `com.googletest.firebase.perf.testapp` without the `prod` suffix