### PR TITLE
Disconnect from RC real-time server when app is backgrounded.

### DIFF
--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -102,7 +102,7 @@ public class ConfigAutoFetch {
   // Check connection and establish InputStream
   // TODO: Refactor connection management so it's handled by ConfigRealtimeHttpClient.
   @VisibleForTesting
-  public void listenForNotifications() throws IOException {
+  public void listenForNotifications() {
     if (httpURLConnection == null) {
       return;
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigAutoFetch.java
@@ -54,6 +54,7 @@ public class ConfigAutoFetch {
   private final ConfigUpdateListener retryCallback;
   private final ScheduledExecutorService scheduledExecutorService;
   private final Random random;
+  private Boolean isInBackground;
 
   public ConfigAutoFetch(
       HttpURLConnection httpURLConnection,
@@ -99,8 +100,9 @@ public class ConfigAutoFetch {
   }
 
   // Check connection and establish InputStream
+  // TODO: Refactor connection management so it's handled by ConfigRealtimeHttpClient.
   @VisibleForTesting
-  public void listenForNotifications() {
+  public void listenForNotifications() throws IOException {
     if (httpURLConnection == null) {
       return;
     }
@@ -110,11 +112,21 @@ public class ConfigAutoFetch {
       handleNotifications(inputStream);
       inputStream.close();
     } catch (IOException ex) {
-      // Stream was interrupted due to a transient issue and the system will retry the connection.
-      Log.d(TAG, "Stream was cancelled due to an exception. Retrying the connection...", ex);
+      // If the real-time connection is at an unexpected lifecycle state when the app is
+      // backgrounded, it's expected closing the InputStream will throw an exception.
+      // Moving network management to a single place should remove the need for this check.
+      // See above todo.
+      if (!isInBackground) {
+        // Otherwise, the real-time server connection was closed due to a transient issue.
+        Log.d(TAG, "Real-time connection was closed due to an exception.", ex);
+      }
     } finally {
       httpURLConnection.disconnect();
     }
+  }
+
+  public void setInBackground(Boolean inBackground) {
+    isInBackground = inBackground;
   }
 
   // Auto-fetch new config and execute callbacks on each new message

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -94,6 +94,10 @@ public class ConfigRealtimeHandler {
     configRealtimeHttpClient.setRealtimeBackgroundState(isInBackground);
     if (!isInBackground) {
       beginRealtime();
+    } else {
+
+      // If we're in the background, close the client's real-time server connection.
+      configRealtimeHttpClient.closeRealtimeHttpStream();
     }
   }
 

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHandler.java
@@ -95,7 +95,6 @@ public class ConfigRealtimeHandler {
     if (!isInBackground) {
       beginRealtime();
     } else {
-
       // If we're in the background, close the client's real-time server connection.
       configRealtimeHttpClient.closeRealtimeHttpStream();
     }

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -293,6 +293,11 @@ public class ConfigRealtimeHttpClient {
         && !isInBackground;
   }
 
+  /**
+   * The check and set http connection method are combined so that when canMakeHttpStreamConnection
+   * returns true, the same thread can mark isHttpConnectionIsRunning as true to prevent a race
+   * condition with another thread.
+   */
   private synchronized boolean checkAndSetHttpConnectionFlagIfNotRunning() {
     boolean canMakeConnection = canMakeHttpStreamConnection();
     if (canMakeConnection) {
@@ -381,10 +386,6 @@ public class ConfigRealtimeHttpClient {
   }
 
   private synchronized void makeRealtimeHttpConnection(long retryMilliseconds) {
-    if (!canMakeHttpStreamConnection()) {
-      return;
-    }
-
     if (httpRetriesRemaining > 0) {
       httpRetriesRemaining--;
       scheduledExecutorService.schedule(

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigRealtimeHttpClient.java
@@ -293,6 +293,15 @@ public class ConfigRealtimeHttpClient {
         && !isInBackground;
   }
 
+  private synchronized boolean checkAndSetHttpConnectionFlagIfNotRunning() {
+    boolean canMakeConnection = canMakeHttpStreamConnection();
+    if (canMakeConnection) {
+      setIsHttpConnectionRunning(true);
+    }
+
+    return canMakeConnection;
+  }
+
   private String getRealtimeURL(String namespace) {
     return String.format(
         REALTIME_REGEX_URL,
@@ -478,7 +487,7 @@ public class ConfigRealtimeHttpClient {
    */
   @SuppressLint({"VisibleForTests", "DefaultLocale"})
   public void beginRealtimeHttpStream() {
-    if (!canMakeHttpStreamConnection()) {
+    if (!checkAndSetHttpConnectionFlagIfNotRunning()) {
       return;
     }
 

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1286,6 +1286,8 @@ public final class FirebaseRemoteConfigTest {
     verify(mockHttpURLConnection).disconnect();
   }
 
+
+
   @Test
   public void realtime_fetchesWithoutChangedParams_doesNotCallOnUpdate() throws Exception {
     when(mockHttpURLConnection.getInputStream())
@@ -1521,6 +1523,25 @@ public final class FirebaseRemoteConfigTest {
     configAutoFetch.listenForNotifications();
 
     verify(mockHttpURLConnection).disconnect();
+  }
+
+  @Test
+  public void realtime_stream_listen_backgrounded_disconnects() throws Exception {
+    when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
+    when(mockHttpURLConnection.getInputStream())
+            .thenReturn(
+                    new ByteArrayInputStream(
+                            "{ \"featureDisabled\": false,  \"latestTemplateVersionNumber\": 2 } }"
+                                    .getBytes(StandardCharsets.UTF_8)));
+    when(mockFetchHandler.getTemplateVersionNumber()).thenReturn(1L);
+    when(mockFetchHandler.fetchNowWithTypeAndAttemptNumber(
+            ConfigFetchHandler.FetchType.REALTIME, 1))
+            .thenReturn(Tasks.forResult(realtimeFetchedContainerResponse));
+
+    configAutoFetch.listenForNotifications();
+    frc.setConfigUpdateBackgroundState(true);
+
+    verify(mockHttpURLConnection, times(1)).disconnect();
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1286,8 +1286,6 @@ public final class FirebaseRemoteConfigTest {
     verify(mockHttpURLConnection).disconnect();
   }
 
-
-
   @Test
   public void realtime_fetchesWithoutChangedParams_doesNotCallOnUpdate() throws Exception {
     when(mockHttpURLConnection.getInputStream())
@@ -1529,14 +1527,14 @@ public final class FirebaseRemoteConfigTest {
   public void realtime_stream_listen_backgrounded_disconnects() throws Exception {
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
     when(mockHttpURLConnection.getInputStream())
-            .thenReturn(
-                    new ByteArrayInputStream(
-                            "{ \"featureDisabled\": false,  \"latestTemplateVersionNumber\": 2 } }"
-                                    .getBytes(StandardCharsets.UTF_8)));
+        .thenReturn(
+            new ByteArrayInputStream(
+                "{ \"featureDisabled\": false,  \"latestTemplateVersionNumber\": 2 } }"
+                    .getBytes(StandardCharsets.UTF_8)));
     when(mockFetchHandler.getTemplateVersionNumber()).thenReturn(1L);
     when(mockFetchHandler.fetchNowWithTypeAndAttemptNumber(
             ConfigFetchHandler.FetchType.REALTIME, 1))
-            .thenReturn(Tasks.forResult(realtimeFetchedContainerResponse));
+        .thenReturn(Tasks.forResult(realtimeFetchedContainerResponse));
 
     configAutoFetch.listenForNotifications();
     frc.setConfigUpdateBackgroundState(true);

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -1305,9 +1305,7 @@ public final class FirebaseRemoteConfigTest {
     doReturn(Tasks.forResult(mockHttpURLConnection))
         .when(configRealtimeHttpClientSpy)
         .createRealtimeConnection();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(301);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
@@ -1326,9 +1324,7 @@ public final class FirebaseRemoteConfigTest {
         .createRealtimeConnection();
     doReturn(mockConfigAutoFetch).when(configRealtimeHttpClientSpy).startAutoFetch(any());
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
@@ -1345,9 +1341,7 @@ public final class FirebaseRemoteConfigTest {
         .when(configRealtimeHttpClientSpy)
         .createRealtimeConnection();
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
@@ -1364,9 +1358,7 @@ public final class FirebaseRemoteConfigTest {
         .when(configRealtimeHttpClientSpy)
         .createRealtimeConnection();
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
     int failedStreams = configRealtimeHttpClientSpy.getNumberOfFailedStreams();
 
@@ -1383,9 +1375,7 @@ public final class FirebaseRemoteConfigTest {
         .when(configRealtimeHttpClientSpy)
         .createRealtimeConnection();
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
     Date backoffDate = configRealtimeHttpClientSpy.getBackoffEndTime();
 
@@ -1404,9 +1394,7 @@ public final class FirebaseRemoteConfigTest {
         .createRealtimeConnection();
     doReturn(mockConfigAutoFetch).when(configRealtimeHttpClientSpy).startAutoFetch(any());
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
     int failedStreams = configRealtimeHttpClientSpy.getNumberOfFailedStreams();
 
@@ -1425,9 +1413,7 @@ public final class FirebaseRemoteConfigTest {
         .createRealtimeConnection();
     doReturn(mockConfigAutoFetch).when(configRealtimeHttpClientSpy).startAutoFetch(any());
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
     Date backoffDate = configRealtimeHttpClientSpy.getBackoffEndTime();
 
@@ -1443,9 +1429,7 @@ public final class FirebaseRemoteConfigTest {
     doReturn(Tasks.forResult(mockHttpURLConnection))
         .when(configRealtimeHttpClientSpy)
         .createRealtimeConnection();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
     when(mockHttpURLConnection.getErrorStream())
         .thenReturn(
             new ByteArrayInputStream(FORBIDDEN_ERROR_MESSAGE.getBytes(StandardCharsets.UTF_8)));
@@ -1466,9 +1450,7 @@ public final class FirebaseRemoteConfigTest {
         .when(configRealtimeHttpClientSpy)
         .createRealtimeConnection();
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
-    doNothing()
-        .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream();
+    doNothing().when(configRealtimeHttpClientSpy).closeRealtimeHttpStream();
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     flushScheduledTasks();

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -349,6 +349,7 @@ public final class FirebaseRemoteConfigTest {
             listeners,
             mockRetryListener,
             scheduledExecutorService);
+    configAutoFetch.setInBackground(false);
     realtimeMetadataClient =
         new ConfigMetadataClient(context.getSharedPreferences("test_file", Context.MODE_PRIVATE));
     configRealtimeHttpClient =
@@ -1306,7 +1307,7 @@ public final class FirebaseRemoteConfigTest {
         .createRealtimeConnection();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(301);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
@@ -1327,7 +1328,7 @@ public final class FirebaseRemoteConfigTest {
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
@@ -1346,7 +1347,7 @@ public final class FirebaseRemoteConfigTest {
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
@@ -1365,7 +1366,7 @@ public final class FirebaseRemoteConfigTest {
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
     int failedStreams = configRealtimeHttpClientSpy.getNumberOfFailedStreams();
 
@@ -1384,7 +1385,7 @@ public final class FirebaseRemoteConfigTest {
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(502);
     Date backoffDate = configRealtimeHttpClientSpy.getBackoffEndTime();
 
@@ -1405,7 +1406,7 @@ public final class FirebaseRemoteConfigTest {
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
     int failedStreams = configRealtimeHttpClientSpy.getNumberOfFailedStreams();
 
@@ -1426,7 +1427,7 @@ public final class FirebaseRemoteConfigTest {
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
     when(mockHttpURLConnection.getResponseCode()).thenReturn(200);
     Date backoffDate = configRealtimeHttpClientSpy.getBackoffEndTime();
 
@@ -1444,7 +1445,7 @@ public final class FirebaseRemoteConfigTest {
         .createRealtimeConnection();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
     when(mockHttpURLConnection.getErrorStream())
         .thenReturn(
             new ByteArrayInputStream(FORBIDDEN_ERROR_MESSAGE.getBytes(StandardCharsets.UTF_8)));
@@ -1467,7 +1468,7 @@ public final class FirebaseRemoteConfigTest {
     doNothing().when(configRealtimeHttpClientSpy).retryHttpConnectionWhenBackoffEnds();
     doNothing()
         .when(configRealtimeHttpClientSpy)
-        .closeRealtimeHttpStream(any(HttpURLConnection.class));
+        .closeRealtimeHttpStream();
 
     configRealtimeHttpClientSpy.beginRealtimeHttpStream();
     flushScheduledTasks();
@@ -1534,6 +1535,7 @@ public final class FirebaseRemoteConfigTest {
     when(mockFetchHandler.fetchNowWithTypeAndAttemptNumber(
             ConfigFetchHandler.FetchType.REALTIME, 1))
         .thenReturn(Tasks.forResult(realtimeFetchedContainerResponse));
+
     configAutoFetch.listenForNotifications();
 
     verify(mockHttpURLConnection).disconnect();


### PR DESCRIPTION
Store the Realtime client's `HttpUrlConnection` reference on the class instance so it can used by another client instance method (`closeRealtimeHttpStream`) to disconnect when the app is backgrounded.

The rest of the changes are follow on work to handle network errors thrown when `HttpUrlConnection#disconnect` is called. Since HttpUrlConnection enforces a [strict lifecycle](https://android.googlesource.com/platform/external/okhttp/+/602d5e4/okhttp/src/main/java/com/squareup/okhttp/internal/http/HttpConnection.java#43) and this code (1) interacts with the connection in several methods/classes and (2) holds open the connection for a long time, it's likely randomly disconnecting when backgrounded will occur at an inopportune lifecycle state.

This change inserts a few conditionals to ensure we only call once-only network methods once, and error handling to catch expected errors when we disconnect intentionally.

Generally, the code could be refactored to consolidate network handling into one class, which would simplify the state that needs to be passed around and places errors must be handled.