### PR TITLE
broke up the release report generation into two tasks

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -48,18 +48,18 @@ import org.gradle.kotlin.dsl.register
  * - [VALIDATE_POM_TASK][registerValidatePomForReleaseTask]
  * - [VALIDATE_PROJECTS_TO_PUBLISH_TASK][registerValidateProjectsToPublishTask]
  * - [BUILD_MAVEN_ZIP_TASK] -> Creates a zip file of the contents of
- *   [PUBLISH_RELEASING_LIBS_TO_BUILD_TASK] [registerPublishReleasingLibrariesToBuildDirTask]
+ * [PUBLISH_RELEASING_LIBS_TO_BUILD_TASK] [registerPublishReleasingLibrariesToBuildDirTask]
  * - [BUILD_KOTLINDOC_ZIP_TASK] -> Creates a zip file of the contents of
- *   [GENERATE_KOTLINDOC_FOR_RELEASE_TASK] [registerGenerateKotlindocForReleaseTask]
+ * [GENERATE_KOTLINDOC_FOR_RELEASE_TASK] [registerGenerateKotlindocForReleaseTask]
  * - [BUILD_RELEASE_NOTES_ZIP_TASK] -> Creates a zip file of the contents of
- *   [PREPARE_RELEASE_NOTES_FOR_DROP][registerPrepareReleaseNotesForDropTask]
+ * [PREPARE_RELEASE_NOTES_FOR_DROP][registerPrepareReleaseNotesForDropTask]
  * - [FIREBASE_PUBLISH_TASK] -> Runs all the tasks above
  *
  * The following are additional tasks provided- that are either for convenience sake, or are used
  * outside of the standard [FIREBASE_PUBLISH_TASK] workflow (possibly at a later time in the release
  * cycle):
  * - [BUILD_BOM_ZIP_TASK] -> Creates a zip file of the contents of [GENERATE_BOM_TASK]
- *   [registerGenerateBomTask]
+ * [registerGenerateBomTask]
  * - [RELEASE_GENEATOR_TASK][registerGenerateReleaseConfigFilesTask]
  * - [PUBLISH_RELEASING_LIBS_TO_LOCAL_TASK][registerPublishReleasingLibrariesToMavenLocalTask]
  * - [SEMVER_CHECK_TASK][registerSemverCheckForReleaseTask]

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -61,6 +61,7 @@ import org.gradle.kotlin.dsl.register
  * - [BUILD_BOM_ZIP_TASK] -> Creates a zip file of the contents of [GENERATE_BOM_TASK]
  * [registerGenerateBomTask]
  * - [RELEASE_GENEATOR_TASK][registerGenerateReleaseConfigFilesTask]
+ * - [RELEASE_REPORT_GENERATOR_TASK][registerGenerateReleaseReportFilesTask]
  * - [PUBLISH_RELEASING_LIBS_TO_LOCAL_TASK][registerPublishReleasingLibrariesToMavenLocalTask]
  * - [SEMVER_CHECK_TASK][registerSemverCheckForReleaseTask]
  * - [PUBLISH_ALL_TO_BUILD_TASK][registerPublishAllToBuildDir]
@@ -82,6 +83,7 @@ abstract class PublishingPlugin : Plugin<Project> {
       val releasingProjects = releasingFirebaseLibraries.map { it.project }
 
       val generateBom = registerGenerateBomTask(project)
+      val validatePomForRelease = registerValidatePomForReleaseTask(project, releasingProjects)
       val checkHeadDependencies =
         registerCheckHeadDependenciesTask(project, releasingFirebaseLibraries)
       val validateProjectsToPublish =
@@ -104,7 +106,6 @@ abstract class PublishingPlugin : Plugin<Project> {
         )
       val releaseReportTask = registerGenerateReleaseReportFilesTask(project)
 
-      registerValidatePomForReleaseTask(project, releasingProjects)
       registerGenerateReleaseConfigFilesTask(project, libraryGroups, releaseReportTask)
       registerPublishReleasingLibrariesToMavenLocalTask(project, releasingProjects)
       registerSemverCheckForReleaseTask(project, releasingProjects)

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -48,18 +48,18 @@ import org.gradle.kotlin.dsl.register
  * - [VALIDATE_POM_TASK][registerValidatePomForReleaseTask]
  * - [VALIDATE_PROJECTS_TO_PUBLISH_TASK][registerValidateProjectsToPublishTask]
  * - [BUILD_MAVEN_ZIP_TASK] -> Creates a zip file of the contents of
- * [PUBLISH_RELEASING_LIBS_TO_BUILD_TASK] [registerPublishReleasingLibrariesToBuildDirTask]
+ *   [PUBLISH_RELEASING_LIBS_TO_BUILD_TASK] [registerPublishReleasingLibrariesToBuildDirTask]
  * - [BUILD_KOTLINDOC_ZIP_TASK] -> Creates a zip file of the contents of
- * [GENERATE_KOTLINDOC_FOR_RELEASE_TASK] [registerGenerateKotlindocForReleaseTask]
+ *   [GENERATE_KOTLINDOC_FOR_RELEASE_TASK] [registerGenerateKotlindocForReleaseTask]
  * - [BUILD_RELEASE_NOTES_ZIP_TASK] -> Creates a zip file of the contents of
- * [PREPARE_RELEASE_NOTES_FOR_DROP][registerPrepareReleaseNotesForDropTask]
+ *   [PREPARE_RELEASE_NOTES_FOR_DROP][registerPrepareReleaseNotesForDropTask]
  * - [FIREBASE_PUBLISH_TASK] -> Runs all the tasks above
  *
  * The following are additional tasks provided- that are either for convenience sake, or are used
  * outside of the standard [FIREBASE_PUBLISH_TASK] workflow (possibly at a later time in the release
  * cycle):
  * - [BUILD_BOM_ZIP_TASK] -> Creates a zip file of the contents of [GENERATE_BOM_TASK]
- * [registerGenerateBomTask]
+ *   [registerGenerateBomTask]
  * - [RELEASE_GENEATOR_TASK][registerGenerateReleaseConfigFilesTask]
  * - [PUBLISH_RELEASING_LIBS_TO_LOCAL_TASK][registerPublishReleasingLibrariesToMavenLocalTask]
  * - [SEMVER_CHECK_TASK][registerSemverCheckForReleaseTask]
@@ -82,7 +82,6 @@ abstract class PublishingPlugin : Plugin<Project> {
       val releasingProjects = releasingFirebaseLibraries.map { it.project }
 
       val generateBom = registerGenerateBomTask(project)
-      val validatePomForRelease = registerValidatePomForReleaseTask(project, releasingProjects)
       val checkHeadDependencies =
         registerCheckHeadDependenciesTask(project, releasingFirebaseLibraries)
       val validateProjectsToPublish =
@@ -103,10 +102,10 @@ abstract class PublishingPlugin : Plugin<Project> {
           releasingProjects,
           releaseMetadata?.name.orEmpty(),
         )
-
       val releaseReportTask = registerGenerateReleaseReportFilesTask(project)
-      val releaseConfigTask =
-        registerGenerateReleaseConfigFilesTask(project, libraryGroups, releaseReportTask)
+
+      registerValidatePomForReleaseTask(project, releasingProjects)
+      registerGenerateReleaseConfigFilesTask(project, libraryGroups, releaseReportTask)
       registerPublishReleasingLibrariesToMavenLocalTask(project, releasingProjects)
       registerSemverCheckForReleaseTask(project, releasingProjects)
       registerPublishAllToBuildDir(project, allFirebaseLibraries)

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/PublishingPlugin.kt
@@ -31,6 +31,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.named
@@ -90,7 +91,7 @@ abstract class PublishingPlugin : Plugin<Project> {
         registerValidateLibraryGroupsToPublishTask(
           project,
           releasingFirebaseLibraries,
-          libraryGroups
+          libraryGroups,
         )
       val publishReleasingLibrariesToBuildDir =
         registerPublishReleasingLibrariesToBuildDirTask(project, releasingProjects)
@@ -100,10 +101,12 @@ abstract class PublishingPlugin : Plugin<Project> {
         registerPrepareReleaseNotesForDropTask(
           project,
           releasingProjects,
-          releaseMetadata?.name.orEmpty()
+          releaseMetadata?.name.orEmpty(),
         )
 
-      registerGenerateReleaseConfigFilesTask(project, libraryGroups)
+      val releaseReportTask = registerGenerateReleaseReportFilesTask(project)
+      val releaseConfigTask =
+        registerGenerateReleaseConfigFilesTask(project, libraryGroups, releaseReportTask)
       registerPublishReleasingLibrariesToMavenLocalTask(project, releasingProjects)
       registerSemverCheckForReleaseTask(project, releasingProjects)
       registerPublishAllToBuildDir(project, allFirebaseLibraries)
@@ -145,13 +148,13 @@ abstract class PublishingPlugin : Plugin<Project> {
           // validatePomForRelease, TODO(b/279466888) - Make GmavenHelper testable
           buildMavenZip,
           buildKotlindocZip,
-          buildReleaseNotesZip
+          buildReleaseNotesZip,
         )
 
         doLast {
           logger.lifecycle(
             "Publishing the following libraries:\n{}",
-            releasingProjects.map { it.path }.joinToString("\n")
+            releasingProjects.map { it.path }.joinToString("\n"),
           )
         }
       }
@@ -160,7 +163,7 @@ abstract class PublishingPlugin : Plugin<Project> {
 
   private fun registerLibraryGroupsTask(
     project: Project,
-    libraryGroups: Map<String, List<FirebaseLibraryExtension>>
+    libraryGroups: Map<String, List<FirebaseLibraryExtension>>,
   ) {
     project.tasks.register(LIBRARY_GROUPS_TASK) {
       for (libraryGroup in libraryGroups) {
@@ -206,7 +209,7 @@ abstract class PublishingPlugin : Plugin<Project> {
   private fun computeReleaseMetadata(
     project: Project,
     allFirebaseLibraries: List<FirebaseLibraryExtension>,
-    libraryGroups: Map<String, List<FirebaseLibraryExtension>>
+    libraryGroups: Map<String, List<FirebaseLibraryExtension>>,
   ): ReleaseMetadata? =
     releaseMetadataFromProperties(project, allFirebaseLibraries, libraryGroups)
       ?: releaseMetadataFromReleaseConfig(project, allFirebaseLibraries, libraryGroups)
@@ -214,7 +217,7 @@ abstract class PublishingPlugin : Plugin<Project> {
   private fun releaseMetadataFromProperties(
     project: Project,
     allFirebaseLibraries: List<FirebaseLibraryExtension>,
-    libraryGroups: Map<String, List<FirebaseLibraryExtension>>
+    libraryGroups: Map<String, List<FirebaseLibraryExtension>>,
   ): ReleaseMetadata? {
     val projectsToPublish = project.provideProperty<String>("projectsToPublish").orNull
     val releaseName = project.provideProperty<String>("releaseName").orNull ?: "NO_NAME"
@@ -236,7 +239,7 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private tailrec fun getDeepTransitiveReleases(
     inputProjects: List<FirebaseLibraryExtension>,
-    libraryGroups: Map<String, List<FirebaseLibraryExtension>>
+    libraryGroups: Map<String, List<FirebaseLibraryExtension>>,
   ): List<FirebaseLibraryExtension> {
     val libraryGroupsToRelease =
       inputProjects
@@ -254,7 +257,7 @@ abstract class PublishingPlugin : Plugin<Project> {
   private fun releaseMetadataFromReleaseConfig(
     project: Project,
     allFirebaseLibraries: List<FirebaseLibraryExtension>,
-    libraryGroups: Map<String, List<FirebaseLibraryExtension>>
+    libraryGroups: Map<String, List<FirebaseLibraryExtension>>,
   ): ReleaseMetadata? {
     val releaseConfigFile =
       project.layout.projectDirectory.file(RELEASE_CONFIG_FILE).asFile.takeIf { it.exists() }
@@ -299,7 +302,7 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private fun registerValidatePomForReleaseTask(
     project: Project,
-    releasingProjects: List<Project>
+    releasingProjects: List<Project>,
   ) =
     project.tasks.register(VALIDATE_POM_TASK) {
       for (releasingProject in releasingProjects) {
@@ -318,7 +321,7 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private fun registerCheckHeadDependenciesTask(
     project: Project,
-    releasingLibraries: List<FirebaseLibraryExtension>
+    releasingLibraries: List<FirebaseLibraryExtension>,
   ) =
     project.tasks.register<CheckHeadDependencies>(CHECK_HEAD_DEPS_TASK) {
       projectsToPublish.set(releasingLibraries)
@@ -335,7 +338,7 @@ abstract class PublishingPlugin : Plugin<Project> {
   // TODO(b/280320915): Remove doLast when Gradle + IDEA fix task configuration avoidance bug
   private fun registerValidateProjectsToPublishTask(
     project: Project,
-    releasinglibraries: List<FirebaseLibraryExtension>
+    releasinglibraries: List<FirebaseLibraryExtension>,
   ) =
     project.tasks.register(VALIDATE_PROJECTS_TO_PUBLISH_TASK) {
       doLast {
@@ -359,7 +362,7 @@ abstract class PublishingPlugin : Plugin<Project> {
   private fun registerValidateLibraryGroupsToPublishTask(
     project: Project,
     librariesToRelease: List<FirebaseLibraryExtension>,
-    libraryGroups: Map<String, List<FirebaseLibraryExtension>>
+    libraryGroups: Map<String, List<FirebaseLibraryExtension>>,
   ) =
     project.tasks.register(VALIDATE_LIBRARY_GROUPS_TO_PUBLISH_TASK) {
       doLast {
@@ -388,7 +391,7 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private fun registerPublishReleasingLibrariesToBuildDirTask(
     project: Project,
-    releasingProjects: List<Project>
+    releasingProjects: List<Project>,
   ) =
     project.tasks.register(PUBLISH_RELEASING_LIBS_TO_BUILD_TASK) {
       for (releasingProject in releasingProjects) {
@@ -411,7 +414,7 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private fun registerGenerateKotlindocForReleaseTask(
     project: Project,
-    releasingLibraries: List<FirebaseLibraryExtension>
+    releasingLibraries: List<FirebaseLibraryExtension>,
   ) =
     project.tasks.register(GENERATE_KOTLINDOC_FOR_RELEASE_TASK) {
       for (releasingLibrary in releasingLibraries) {
@@ -435,7 +438,7 @@ abstract class PublishingPlugin : Plugin<Project> {
   private fun registerPrepareReleaseNotesForDropTask(
     project: Project,
     releasingProjects: List<Project>,
-    releaseName: String
+    releaseName: String,
   ) =
     project.tasks.register<Copy>(PREPARE_RELEASE_NOTES_FOR_DROP) {
       for (releasingProject in releasingProjects) {
@@ -461,7 +464,8 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private fun registerGenerateReleaseConfigFilesTask(
     project: Project,
-    libraryGroups: Map<String, List<FirebaseLibraryExtension>>
+    libraryGroups: Map<String, List<FirebaseLibraryExtension>>,
+    releaseReportTask: TaskProvider<ReleaseReportGenerator>,
   ) =
     project.tasks.register<ReleaseGenerator>(RELEASE_GENEATOR_TASK) {
       currentRelease.convention(project.provideProperty("currentRelease"))
@@ -470,11 +474,27 @@ abstract class PublishingPlugin : Plugin<Project> {
       commitsToIgnoreFile.convention(project.layout.projectDirectory.file("ignoreCommits.txt"))
 
       releaseConfigFile.convention(project.layout.projectDirectory.file(RELEASE_CONFIG_FILE))
-      releaseReportMdFile.convention(project.layout.projectDirectory.file(RELEASE_REPORT_MD_FILE))
       releaseReportJsonFile.convention(
         project.layout.projectDirectory.file(RELEASE_REPORT_JSON_FILE)
       )
       this.libraryGroups = libraryGroups
+      finalizedBy(releaseReportTask)
+    }
+
+  /**
+   * Registers the [RELEASE_REPORT_GENERATOR_TASK] task.
+   *
+   * Creates a markdown file that keeps track of what libraries are releasing. To learn more about
+   * the file's format see [ReleaseConfig].
+   *
+   * @see [ReleaseReportGenerator]
+   */
+  private fun registerGenerateReleaseReportFilesTask(project: Project) =
+    project.tasks.register<ReleaseReportGenerator>(RELEASE_REPORT_GENERATOR_TASK) {
+      releaseReportMdFile.convention(project.layout.projectDirectory.file(RELEASE_REPORT_MD_FILE))
+      releaseReportJsonFile.convention(
+        project.layout.projectDirectory.file(RELEASE_REPORT_JSON_FILE)
+      )
     }
 
   /**
@@ -488,7 +508,7 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private fun registerPublishReleasingLibrariesToMavenLocalTask(
     project: Project,
-    releasingProjects: List<Project>
+    releasingProjects: List<Project>,
   ) =
     project.tasks.register(PUBLISH_RELEASING_LIBS_TO_LOCAL_TASK) {
       for (releasingProject in releasingProjects) {
@@ -508,7 +528,7 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private fun registerSemverCheckForReleaseTask(
     project: Project,
-    releasingProjects: List<Project>
+    releasingProjects: List<Project>,
   ) =
     project.tasks.register(SEMVER_CHECK_TASK) {
       for (releasingProject in releasingProjects) {
@@ -528,7 +548,7 @@ abstract class PublishingPlugin : Plugin<Project> {
    */
   private fun registerPublishAllToBuildDir(
     project: Project,
-    allFirebaseLibraries: List<FirebaseLibraryExtension>
+    allFirebaseLibraries: List<FirebaseLibraryExtension>,
   ) =
     project.tasks.register(PUBLISH_ALL_TO_BUILD_TASK) {
       for (firebaseLibrary in allFirebaseLibraries) {
@@ -557,6 +577,7 @@ abstract class PublishingPlugin : Plugin<Project> {
     const val VALIDATE_LIBRARY_GROUPS_TO_PUBLISH_TASK = "validateLibraryGroupsToPublish"
     const val SEMVER_CHECK_TASK = "semverCheckForRelease"
     const val RELEASE_GENEATOR_TASK = "generateReleaseConfig"
+    const val RELEASE_REPORT_GENERATOR_TASK = "generateReleaseReport"
     const val VALIDATE_POM_TASK = "validatePomForRelease"
     const val LIBRARY_GROUPS_TASK = "libraryGroups"
     const val PUBLISH_RELEASING_LIBS_TO_BUILD_TASK = "publishReleasingLibrariesToBuildDir"
@@ -584,5 +605,5 @@ abstract class PublishingPlugin : Plugin<Project> {
  */
 data class ReleaseMetadata(
   val releasingLibraries: List<FirebaseLibraryExtension>,
-  val name: String
+  val name: String,
 )

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ReleaseGenerator.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ReleaseGenerator.kt
@@ -43,7 +43,7 @@ import org.gradle.api.tasks.TaskAction
  *
  * @property changesByLibraryName contains libs which have opted into the release, and their changes
  * @property changedLibrariesWithNoChangelog contains libs not opted into the release, despite
- * having changes
+ *   having changes
  */
 @Serializable
 data class ReleaseReport(
@@ -61,14 +61,13 @@ data class ReleaseReport(
   override fun toString() =
     """
       |# Release Report
-      |${
-        changesByLibraryName.entries.joinToString("\n") {
-            """
+      |${changesByLibraryName.entries.joinToString("\n") 
+      """
       |## ${it.key}
       
       |${it.value.joinToString("\n") { it.toString() }}
       """.trimMargin()
-        }
+      }
     }
       |
       |## SDKs with changes, but no changelogs
@@ -185,8 +184,7 @@ abstract class ReleaseGenerator : DefaultTask() {
       .setListMode(ListBranchCommand.ListMode.REMOTE)
       .call()
       .firstOrNull { it.name == "refs/remotes/origin/releases/$branchName" }
-      ?.objectId
-      ?: throw RuntimeException("Could not find branch named $branchName")
+      ?.objectId ?: throw RuntimeException("Could not find branch named $branchName")
 
   private fun getChangedLibraries(
     repo: Git,
@@ -270,7 +268,6 @@ abstract class ReleaseReportGenerator : DefaultTask() {
   @TaskAction
   @Throws(Exception::class)
   fun generateReleaseReport() {
-    val rootDir = project.rootDir
 
     val releaseReport =
       ReleaseReport.fromFile(
@@ -281,5 +278,4 @@ abstract class ReleaseReportGenerator : DefaultTask() {
   }
 }
 
-fun RegularFileProperty.asFileIfExistsOrNull(): File? =
-  if (isPresent && asFile.get().exists()) asFile.get() else null
+fun RegularFileProperty.asFileIfExistsOrNull(): File? = orNull?.asFile?.takeIf { it.exists() }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ReleaseGenerator.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ReleaseGenerator.kt
@@ -43,7 +43,7 @@ import org.gradle.api.tasks.TaskAction
  *
  * @property changesByLibraryName contains libs which have opted into the release, and their changes
  * @property changedLibrariesWithNoChangelog contains libs not opted into the release, despite
- *   having changes
+ * having changes
  */
 @Serializable
 data class ReleaseReport(
@@ -61,7 +61,7 @@ data class ReleaseReport(
   override fun toString() =
     """
       |# Release Report
-      |${changesByLibraryName.entries.joinToString("\n") 
+      |${changesByLibraryName.entries.joinToString("\n") {
       """
       |## ${it.key}
       
@@ -184,7 +184,8 @@ abstract class ReleaseGenerator : DefaultTask() {
       .setListMode(ListBranchCommand.ListMode.REMOTE)
       .call()
       .firstOrNull { it.name == "refs/remotes/origin/releases/$branchName" }
-      ?.objectId ?: throw RuntimeException("Could not find branch named $branchName")
+      ?.objectId
+      ?: throw RuntimeException("Could not find branch named $branchName")
 
   private fun getChangedLibraries(
     repo: Git,


### PR DESCRIPTION
markdown should always generate, but can be generated seperately