### PR TITLE
Get parameter value for rollout without side effects.

### DIFF
--- a/firebase-config/CHANGELOG.md
+++ b/firebase-config/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [fixed] Fixed an issue that could cause Remote Config personalizations to be logged early in
+* [fixed] Fixed an issue that could cause [remote_config] personalizations to be logged early in
   specific cases.
 
 

--- a/firebase-config/CHANGELOG.md
+++ b/firebase-config/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-* [fixed] Fixed an issue that could cause unexpected interactions between other Firebase product 
-  integrations and [remote_config].
+* [fixed] Fixed an issue that could cause Remote Config personalizations to be logged early in
+  specific cases.
 
 
 # 21.6.1

--- a/firebase-config/CHANGELOG.md
+++ b/firebase-config/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [fixed] Fixed an issue that could cause unexpected interactions between other Firebase product 
+  integrations and [remote_config].
 
 
 # 21.6.1

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/RemoteConfigComponent.java
@@ -173,7 +173,7 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
     }
 
     RolloutsStateSubscriptionsHandler rolloutsStateSubscriptionsHandler =
-        getRolloutsStateSubscriptionsHandler(activatedCacheClient, getHandler);
+        getRolloutsStateSubscriptionsHandler(activatedCacheClient, defaultsCacheClient);
 
     return get(
         firebaseApp,
@@ -321,10 +321,9 @@ public class RemoteConfigComponent implements FirebaseRemoteConfigInterop {
   }
 
   private RolloutsStateSubscriptionsHandler getRolloutsStateSubscriptionsHandler(
-      ConfigCacheClient activatedConfigsCache,
-      ConfigGetParameterHandler configGetParameterHandler) {
+      ConfigCacheClient activatedConfigsCache, ConfigCacheClient defaultConfigsCache) {
     RolloutsStateFactory rolloutsStateFactory =
-        RolloutsStateFactory.create(configGetParameterHandler);
+        RolloutsStateFactory.create(activatedConfigsCache, defaultConfigsCache);
 
     return new RolloutsStateSubscriptionsHandler(
         activatedConfigsCache, rolloutsStateFactory, executor);

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandler.java
@@ -116,31 +116,6 @@ public class ConfigGetParameterHandler {
   }
 
   /**
-   * Returns the parameter value of the given parameter key as a {@link String} without side effects
-   * present in the 3P-facing {@link ConfigGetParameterHandler#getString}.
-   *
-   * <p>This implementation is intended for internal use. It does not call listeners to report
-   * Personalization activations to Google Analytics nor does it log a warning if the parameter key
-   * does not exist. See {@link ConfigGetParameterHandler#getString} for additional documentation.
-   *
-   * @param key A Firebase Remote Config parameter key.
-   * @hide
-   */
-  public String getStringWithoutSideEffects(String key) {
-    String activatedString = getStringFromCache(activatedConfigsCache, key);
-    if (activatedString != null) {
-      return activatedString;
-    }
-
-    String defaultsString = getStringFromCache(defaultConfigsCache, key);
-    if (defaultsString != null) {
-      return defaultsString;
-    }
-
-    return DEFAULT_VALUE_FOR_STRING;
-  }
-
-  /**
    * Returns the parameter value of the given parameter key as a {@code boolean}.
    *
    * <p>Evaluates the value of the parameter in the following order:

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandler.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandler.java
@@ -116,6 +116,31 @@ public class ConfigGetParameterHandler {
   }
 
   /**
+   * Returns the parameter value of the given parameter key as a {@link String} without side effects
+   * present in the 3P-facing {@link ConfigGetParameterHandler#getString}.
+   *
+   * <p>This implementation is intended for internal use. It does not call listeners to report
+   * Personalization activations to Google Analytics nor does it log a warning if the parameter key
+   * does not exist. See {@link ConfigGetParameterHandler#getString} for additional documentation.
+   *
+   * @param key A Firebase Remote Config parameter key.
+   * @hide
+   */
+  public String getStringWithoutSideEffects(String key) {
+    String activatedString = getStringFromCache(activatedConfigsCache, key);
+    if (activatedString != null) {
+      return activatedString;
+    }
+
+    String defaultsString = getStringFromCache(defaultConfigsCache, key);
+    if (defaultsString != null) {
+      return defaultsString;
+    }
+
+    return DEFAULT_VALUE_FOR_STRING;
+  }
+
+  /**
    * Returns the parameter value of the given parameter key as a {@code boolean}.
    *
    * <p>Evaluates the value of the parameter in the following order:

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/rollouts/RolloutsStateFactory.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/rollouts/RolloutsStateFactory.java
@@ -66,7 +66,7 @@ public class RolloutsStateFactory {
 
         // Fallback to empty string if (for some reason) there's no affected parameter key.
         String parameterKey = affectedParameterKeys.optString(0, "");
-        String parameterValue = getParameterHandler.getString(parameterKey);
+        String parameterValue = getParameterHandler.getStringWithoutSideEffects(parameterKey);
 
         rolloutAssignments.add(
             RolloutAssignment.builder()

--- a/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/rollouts/RolloutsStateFactory.java
+++ b/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/rollouts/RolloutsStateFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.firebase.remoteconfig.internal.rollouts;
 
+import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.DEFAULT_VALUE_FOR_STRING;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.TAG;
 import static com.google.firebase.remoteconfig.internal.ConfigContainer.ROLLOUT_METADATA_AFFECTED_KEYS;
 import static com.google.firebase.remoteconfig.internal.ConfigContainer.ROLLOUT_METADATA_ID;
@@ -23,7 +24,9 @@ import static com.google.firebase.remoteconfig.internal.ConfigContainer.ROLLOUT_
 
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigClientException;
+import com.google.firebase.remoteconfig.internal.ConfigCacheClient;
 import com.google.firebase.remoteconfig.internal.ConfigContainer;
 import com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler;
 import com.google.firebase.remoteconfig.interop.rollouts.RolloutAssignment;
@@ -35,10 +38,13 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class RolloutsStateFactory {
-  ConfigGetParameterHandler getParameterHandler;
+  ConfigCacheClient activatedConfigsCache;
+  ConfigCacheClient defaultConfigsCache;
 
-  RolloutsStateFactory(ConfigGetParameterHandler getParameterHandler) {
-    this.getParameterHandler = getParameterHandler;
+  RolloutsStateFactory(
+      ConfigCacheClient activatedConfigsCache, ConfigCacheClient defaultConfigsCache) {
+    this.activatedConfigsCache = activatedConfigsCache;
+    this.defaultConfigsCache = defaultConfigsCache;
   }
 
   @NonNull
@@ -66,7 +72,7 @@ public class RolloutsStateFactory {
 
         // Fallback to empty string if (for some reason) there's no affected parameter key.
         String parameterKey = affectedParameterKeys.optString(0, "");
-        String parameterValue = getParameterHandler.getStringWithoutSideEffects(parameterKey);
+        String parameterValue = getParameterValue(parameterKey);
 
         rolloutAssignments.add(
             RolloutAssignment.builder()
@@ -85,9 +91,58 @@ public class RolloutsStateFactory {
     return RolloutsState.create(rolloutAssignments);
   }
 
+  /**
+   * Returns the parameter value of the given parameter key as a {@link String}.
+   *
+   * <p>The logic in {@link ConfigGetParameterHandler#getString} is duplicated here without the side
+   * effect of calling listeners (ex. logging Personalizations in Google Analytics).
+   *
+   * @param key A Firebase Remote Config parameter key.
+   */
+  @NonNull
+  private String getParameterValue(@NonNull String key) {
+    String activatedString = getStringFromCache(activatedConfigsCache, key);
+    if (activatedString != null) {
+      return activatedString;
+    }
+
+    String defaultsString = getStringFromCache(defaultConfigsCache, key);
+    if (defaultsString != null) {
+      return defaultsString;
+    }
+
+    return DEFAULT_VALUE_FOR_STRING;
+  }
+
+  /**
+   * Returns the FRC parameter value for the given key in the given cache as a {@link String}, or
+   * {@code null} if the key does not exist in the cache.
+   *
+   * <p>This method is duplicated from {@link ConfigGetParameterHandler}. Future work might move the
+   * ConfigCacheClient helpers into {@link ConfigCacheClient}.
+   *
+   * @param cacheClient the cache client the parameter is stored in.
+   * @param key the FRC parameter key.
+   */
+  @Nullable
+  private static String getStringFromCache(
+      @NonNull ConfigCacheClient cacheClient, @NonNull String key) {
+    ConfigContainer cachedContainer = cacheClient.getBlocking();
+    if (cachedContainer == null) {
+      return null;
+    }
+
+    try {
+      return cachedContainer.getConfigs().getString(key);
+    } catch (JSONException ignored) {
+      return null;
+    }
+  }
+
   @NonNull
   public static RolloutsStateFactory create(
-      @NonNull ConfigGetParameterHandler configGetParameterHandler) {
-    return new RolloutsStateFactory(configGetParameterHandler);
+      @NonNull ConfigCacheClient activatedConfigsCache,
+      @NonNull ConfigCacheClient defaultConfigsCache) {
+    return new RolloutsStateFactory(activatedConfigsCache, defaultConfigsCache);
   }
 }

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandlerTest.java
@@ -23,7 +23,6 @@ import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.DEFAULT_VALU
 import static com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler.FRC_BYTE_ARRAY_ENCODING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -189,20 +188,6 @@ public class ConfigGetParameterHandlerTest {
 
     assertThat(stringValue).isEqualTo(ACTIVATED_STRING_VALUE);
     verify(this.mockListener).accept(eq(STRING_KEY), any(ConfigContainer.class));
-  }
-
-  @Test
-  public void getStringWithoutSideEffects_activatedKeyExists_doesNotCallListeners()
-      throws Exception {
-    loadActivatedCacheWithMap(ImmutableMap.of(STRING_KEY, ACTIVATED_STRING_VALUE));
-    loadCacheWithConfig(mockDefaultsCache, /*container=*/ null);
-
-    getHandler.addListener(this.mockListener);
-
-    String stringValue = getHandler.getStringWithoutSideEffects(STRING_KEY);
-
-    assertThat(stringValue).isEqualTo(ACTIVATED_STRING_VALUE);
-    verify(this.mockListener, times(0)).accept(any(), any());
   }
 
   @Test

--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandlerTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandlerTest.java
@@ -20,17 +20,14 @@ import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.DEFAULT_VALU
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.DEFAULT_VALUE_FOR_DOUBLE;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.DEFAULT_VALUE_FOR_LONG;
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.DEFAULT_VALUE_FOR_STRING;
-import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.TAG;
 import static com.google.firebase.remoteconfig.internal.ConfigGetParameterHandler.FRC_BYTE_ARRAY_ENCODING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-import android.util.Log;
-
+import com.google.android.gms.common.util.BiConsumer;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.common.collect.ImmutableMap;
@@ -41,9 +38,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import com.google.android.gms.common.util.BiConsumer;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -198,7 +192,8 @@ public class ConfigGetParameterHandlerTest {
   }
 
   @Test
-  public void getStringWithoutSideEffects_activatedKeyExists_doesNotCallListeners() throws Exception {
+  public void getStringWithoutSideEffects_activatedKeyExists_doesNotCallListeners()
+      throws Exception {
     loadActivatedCacheWithMap(ImmutableMap.of(STRING_KEY, ACTIVATED_STRING_VALUE));
     loadCacheWithConfig(mockDefaultsCache, /*container=*/ null);
 


### PR DESCRIPTION
The `getString(String parameterKey)` method calls listeners as a side-effect, which isn't the behavior we want when `activate()` is called and Rollouts are published.

This duplicates the `getString` method without the side-effects (as well as a helper method to access the cache). Alternatively we could duplicate this method _within_ `ConfigGetParameterHandler`, but it'd have to be `public` which implies other callers should use it (they shouldn't - there's no other use case besides Rollouts).

Google internal: b/324275156