### PR TITLE
Add auth token to sessions

### DIFF
--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Unreleased
+
+* [fixed] Force validation or rotation of FIDs.
+
+# 1.2.1
+
 * [changed] Bump internal dependencies.
 * [fixed] Handle corruption in DataStore Preferences more gracefully.
 

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/InstallationId.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/InstallationId.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions
+
+import android.util.Log
+import com.google.firebase.installations.FirebaseInstallationsApi
+import kotlinx.coroutines.tasks.await
+
+/** Provides the Firebase installation id and Firebase authentication token. */
+internal class InstallationId private constructor(val fid: String, val authToken: String) {
+  companion object {
+    private const val TAG = "FirebaseInstallationId"
+
+    suspend fun create(firebaseInstallations: FirebaseInstallationsApi) =
+      try {
+        // Fetch the auth token first, so the fid will be validated.
+        val authToken = firebaseInstallations.getToken(false).await().token
+        val fid = firebaseInstallations.id.await()
+        InstallationId(fid, authToken)
+      } catch (ex: Exception) {
+        Log.e(TAG, "Error getting Firebase installation id or authentication token.", ex)
+        // If there are any failures, the fid is not validated. So return empty values for both.
+        InstallationId(fid = "", authToken = "")
+      }
+  }
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/InstallationId.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/InstallationId.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.tasks.await
 /** Provides the Firebase installation id and Firebase authentication token. */
 internal class InstallationId private constructor(val fid: String, val authToken: String) {
   companion object {
-    private const val TAG = "FirebaseInstallationId"
+    private const val TAG = "InstallationId"
 
     suspend fun create(firebaseInstallations: FirebaseInstallationsApi) =
       try {
@@ -32,7 +32,7 @@ internal class InstallationId private constructor(val fid: String, val authToken
         val fid = firebaseInstallations.id.await()
         InstallationId(fid, authToken)
       } catch (ex: Exception) {
-        Log.e(TAG, "Error getting Firebase installation id or authentication token.", ex)
+        Log.w(TAG, "Error getting Firebase installation id or authentication token.", ex)
         // If there are any failures, the fid is not validated. So return empty values for both.
         InstallationId(fid = "", authToken = "")
       }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/InstallationId.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/InstallationId.kt
@@ -25,16 +25,25 @@ internal class InstallationId private constructor(val fid: String, val authToken
   companion object {
     private const val TAG = "InstallationId"
 
-    suspend fun create(firebaseInstallations: FirebaseInstallationsApi) =
-      try {
-        // Fetch the auth token first, so the fid will be validated.
-        val authToken = firebaseInstallations.getToken(false).await().token
-        val fid = firebaseInstallations.id.await()
-        InstallationId(fid, authToken)
-      } catch (ex: Exception) {
-        Log.w(TAG, "Error getting Firebase installation id or authentication token.", ex)
-        // If there are any failures, the fid is not validated. So return empty values for both.
-        InstallationId(fid = "", authToken = "")
-      }
+    suspend fun create(firebaseInstallations: FirebaseInstallationsApi): InstallationId {
+      // Fetch the auth token first, so the fid will be validated.
+      val authToken =
+        try {
+          firebaseInstallations.getToken(false).await().token
+        } catch (ex: Exception) {
+          Log.w(TAG, "Error getting authentication token.", ex)
+          // If there are any failures, return an empty value.
+          ""
+        }
+      val fid =
+        try {
+          firebaseInstallations.id.await()
+        } catch (ex: Exception) {
+          Log.w(TAG, "Error getting Firebase installation id .", ex)
+          ""
+        }
+
+      return InstallationId(fid, authToken)
+    }
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvent.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvent.kt
@@ -64,10 +64,13 @@ internal data class SessionInfo(
   val eventTimestampUs: Long,
 
   /** Data collection status of the dependent product SDKs. */
-  val dataCollectionStatus: DataCollectionStatus = DataCollectionStatus(),
+  val dataCollectionStatus: DataCollectionStatus,
 
   /** Identifies a unique device+app installation: go/firebase-installations */
-  val firebaseInstallationId: String = "",
+  val firebaseInstallationId: String,
+
+  /** Authentication token for the firebaseInstallationId. */
+  val firebaseAuthenticationToken: String,
 )
 
 /** Contains the data collection state for all dependent SDKs and sampling info */

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionEvents.kt
@@ -39,6 +39,7 @@ internal object SessionEvents {
     sessionsSettings: SessionsSettings,
     subscribers: Map<SessionSubscriber.Name, SessionSubscriber> = emptyMap(),
     firebaseInstallationId: String = "",
+    firebaseAuthenticationToken: String = "",
   ) =
     SessionEvent(
       eventType = EventType.SESSION_START,
@@ -54,6 +55,7 @@ internal object SessionEvents {
             sessionSamplingRate = sessionsSettings.samplingRate,
           ),
           firebaseInstallationId,
+          firebaseAuthenticationToken,
         ),
       applicationInfo = getApplicationInfo(firebaseApp),
     )
@@ -84,7 +86,7 @@ internal object SessionEvents {
           deviceManufacturer = Build.MANUFACTURER,
           ProcessDetailsProvider.getCurrentProcessDetails(firebaseApp.applicationContext),
           ProcessDetailsProvider.getAppProcessDetails(firebaseApp.applicationContext),
-        )
+        ),
     )
   }
 

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
@@ -23,6 +23,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import com.google.firebase.installations.FirebaseInstallationsApi
 import com.google.firebase.sessions.ApplicationInfo
+import com.google.firebase.sessions.InstallationId
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -73,8 +74,8 @@ internal class RemoteSettings(
       }
 
       // Get the installations ID before making a remote config fetch.
-      val installationId = firebaseInstallationsApi.id.await()
-      if (installationId == null) {
+      val installationId = InstallationId.create(firebaseInstallationsApi).fid
+      if (installationId == "") {
         Log.w(TAG, "Error getting Firebase Installation ID. Skipping this Session Event.")
         return
       }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.tasks.await
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -88,7 +87,7 @@ internal class RemoteSettings(
             removeForwardSlashesIn(String.format("%s/%s", Build.MANUFACTURER, Build.MODEL)),
           "X-Crashlytics-OS-Build-Version" to removeForwardSlashesIn(Build.VERSION.INCREMENTAL),
           "X-Crashlytics-OS-Display-Version" to removeForwardSlashesIn(Build.VERSION.RELEASE),
-          "X-Crashlytics-API-Client-Version" to appInfo.sessionSdkVersion
+          "X-Crashlytics-API-Client-Version" to appInfo.sessionSdkVersion,
         )
 
       Log.d(TAG, "Fetching settings from server.")
@@ -139,7 +138,7 @@ internal class RemoteSettings(
         onFailure = { msg ->
           // Network request failed here.
           Log.e(TAG, "Error failing to fetch the remote configs: $msg")
-        }
+        },
       )
     }
   }

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionEventEncoderTest.kt
@@ -81,7 +81,8 @@ class SessionEventEncoderTest {
                 "crashlytics":2,
                 "sessionSamplingRate":1.0
               },
-              "firebaseInstallationId":""
+              "firebaseInstallationId":"",
+              "firebaseAuthenticationToken":""
             },
             "applicationInfo":{
               "appId":"1:12345:android:app",
@@ -128,6 +129,9 @@ class SessionEventEncoderTest {
             firstSessionId = "",
             sessionIndex = 0,
             eventTimestampUs = 0,
+            dataCollectionStatus = DataCollectionStatus(),
+            firebaseInstallationId = "",
+            firebaseAuthenticationToken = "",
           ),
         applicationInfo =
           ApplicationInfo(
@@ -164,7 +168,8 @@ class SessionEventEncoderTest {
                 "crashlytics":1,
                 "sessionSamplingRate":1.0
               },
-              "firebaseInstallationId":""
+              "firebaseInstallationId":"",
+              "firebaseAuthenticationToken":""
             },
             "applicationInfo":{
               "appId":"",
@@ -201,7 +206,7 @@ class SessionEventEncoderTest {
           EventType.SESSION_START,
           EventType.EVENT_TYPE_UNKNOWN,
           EventType.SESSION_START,
-          EventType.SESSION_START
+          EventType.SESSION_START,
         )
       )
 

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionFirelogPublisherTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionFirelogPublisherTest.kt
@@ -59,7 +59,7 @@ class SessionFirelogPublisherTest {
   fun logSession_populatesFid() = runTest {
     val fakeFirebaseApp = FakeFirebaseApp()
     val fakeEventGDTLogger = FakeEventGDTLogger()
-    val firebaseInstallations = FakeFirebaseInstallations("FaKeFiD")
+    val firebaseInstallations = FakeFirebaseInstallations("FaKeFiD", "FakeAuthToken")
     val sessionsSettings =
       SessionsSettings(
         localOverrideSettings = FakeSettingsProvider(),
@@ -81,5 +81,7 @@ class SessionFirelogPublisherTest {
 
     assertThat(fakeEventGDTLogger.loggedEvent!!.sessionData.firebaseInstallationId)
       .isEqualTo("FaKeFiD")
+    assertThat(fakeEventGDTLogger.loggedEvent!!.sessionData.firebaseAuthenticationToken)
+      .isEqualTo("FakeAuthToken")
   }
 }

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeFirebaseInstallations.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/FakeFirebaseInstallations.kt
@@ -23,12 +23,23 @@ import com.google.firebase.installations.InstallationTokenResult
 import com.google.firebase.installations.internal.FidListener
 import com.google.firebase.installations.internal.FidListenerHandle
 
-/** Fake [FirebaseInstallationsApi] that implements [getId] and always returns the given [fid]. */
-internal class FakeFirebaseInstallations(private val fid: String = "") : FirebaseInstallationsApi {
+/**
+ * Fake [FirebaseInstallationsApi] that implements always returns the given [fid] and [authToken].
+ */
+internal class FakeFirebaseInstallations(
+  private val fid: String = "",
+  private val authToken: String = "",
+) : FirebaseInstallationsApi {
   override fun getId(): Task<String> = Tasks.forResult(fid)
 
   override fun getToken(forceRefresh: Boolean): Task<InstallationTokenResult> =
-    throw NotImplementedError("getToken not faked.")
+    Tasks.forResult(
+      InstallationTokenResult.builder()
+        .setToken(authToken)
+        .setTokenCreationTimestamp(0)
+        .setTokenExpirationTimestamp(0)
+        .build()
+    )
 
   override fun delete(): Task<Void> = throw NotImplementedError("delete not faked.")
 

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/testing/TestSessionEventData.kt
@@ -57,6 +57,7 @@ internal object TestSessionEventData {
       eventTimestampUs = TEST_SESSION_TIMESTAMP_US,
       dataCollectionStatus = TEST_DATA_COLLECTION_STATUS,
       firebaseInstallationId = "",
+      firebaseAuthenticationToken = "",
     )
 
   val TEST_PROCESS_DETAILS =


### PR DESCRIPTION
This adds the auth token to sessions, which forced the client to validate the fid, as well as allow us to validate it on the backend.

I will make a similar change in Crashlytics in the next PR.