### PR TITLE
FIAM: Fix FirebaseInAppMessagingDisplayErrorListener not being called

### DIFF
--- a/firebase-inappmessaging-display/CHANGELOG.md
+++ b/firebase-inappmessaging-display/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [fixed] Fixed FirebaseInAppMessagingDisplayErrorListener not being called
+  (GitHub [#5644](//github.com/firebase/firebase-android-sdk/issues/5644){: .external})
 
 # 20.4.0
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-inappmessaging-display-ktx`

--- a/firebase-inappmessaging-display/CHANGELOG.md
+++ b/firebase-inappmessaging-display/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [fixed] Fixed FirebaseInAppMessagingDisplayErrorListener not being called
-  (GitHub [#5644](//github.com/firebase/firebase-android-sdk/issues/5644){: .external})
+  (GitHub [#5644](//github.com/firebase/firebase-android-sdk/issues/5644))
 
 # 20.4.0
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-inappmessaging-display-ktx`

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -98,8 +98,6 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   private InAppMessage inAppMessage;
   private FirebaseInAppMessagingDisplayCallbacks callbacks;
 
-  private final GlideErrorListener glideErrorListener;
-
   @VisibleForTesting @Nullable String currentlyBoundActivityName;
 
   @Inject
@@ -112,8 +110,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
       FiamWindowManager windowManager,
       Application application,
       BindingWrapperFactory bindingWrapperFactory,
-      FiamAnimator animator,
-      GlideErrorListener glideErrorListener) {
+      FiamAnimator animator) {
     super();
     this.headlessInAppMessaging = headlessInAppMessaging;
     this.layoutConfigs = layoutConfigs;
@@ -124,7 +121,6 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     this.application = application;
     this.bindingWrapperFactory = bindingWrapperFactory;
     this.animator = animator;
-    this.glideErrorListener = glideErrorListener;
   }
 
   /**
@@ -157,7 +153,6 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
                                             FirebaseInAppMessagingDisplayCallbacks callbacks) {
     this.inAppMessage = inAppMessage;
     this.callbacks = callbacks;
-    glideErrorListener.setInAppMessage(inAppMessage, callbacks);
   }
 
   private void clearInAppMessageAndCallbacks() {
@@ -504,6 +499,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     if (isValidImageData(imageData)) {
       imageLoader
           .load(imageData.getImageUrl())
+          .addErrorListener(new GlideErrorListener(inAppMessage, callbacks))
           .tag(activity.getClass())
           .placeholder(R.drawable.image_placeholder)
           .into(fiam.getImageView(), callback);

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -149,8 +149,8 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     showActiveFiam(activity);
   }
 
-  private void setInAppMessageAndCallbacks(InAppMessage inAppMessage,
-                                            FirebaseInAppMessagingDisplayCallbacks callbacks) {
+  private void setInAppMessageAndCallbacks(
+      InAppMessage inAppMessage, FirebaseInAppMessagingDisplayCallbacks callbacks) {
     this.inAppMessage = inAppMessage;
     this.callbacks = callbacks;
   }

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -98,7 +98,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   private InAppMessage inAppMessage;
   private FirebaseInAppMessagingDisplayCallbacks callbacks;
 
-  private GlideErrorListener glideErrorListener;
+  private final GlideErrorListener glideErrorListener;
 
   @VisibleForTesting @Nullable String currentlyBoundActivityName;
 
@@ -149,10 +149,19 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
       Activity activity,
       InAppMessage inAppMessage,
       FirebaseInAppMessagingDisplayCallbacks callbacks) {
+    setInAppMessageAndCallbacks(inAppMessage, callbacks);
+    showActiveFiam(activity);
+  }
+
+  private void setInAppMessageAndCallbacks(InAppMessage inAppMessage,
+                                            FirebaseInAppMessagingDisplayCallbacks callbacks) {
     this.inAppMessage = inAppMessage;
     this.callbacks = callbacks;
     glideErrorListener.setInAppMessage(inAppMessage, callbacks);
-    showActiveFiam(activity);
+  }
+
+  private void clearInAppMessageAndCallbacks() {
+    setInAppMessageAndCallbacks(null, null);
   }
 
   /**
@@ -210,9 +219,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
               Logging.logd("Active FIAM exists. Skipping trigger");
               return;
             }
-            inAppMessage = iam;
-            callbacks = cb;
-            glideErrorListener.setInAppMessage(inAppMessage, callbacks);
+            setInAppMessageAndCallbacks(iam, cb);
             showActiveFiam(activity);
           });
       // set the current activity to be the one passed in so that we know not to bind again to the
@@ -336,9 +343,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
                 // Ensure that we remove the displayed FIAM, and ensure that on re-load, the message
                 // isn't re-displayed
                 removeDisplayedFiam(activity);
-                inAppMessage = null;
-                callbacks = null;
-                glideErrorListener.setInAppMessage(inAppMessage, callbacks);
+                clearInAppMessageAndCallbacks();
               }
             };
       } else {
@@ -440,9 +445,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
                   .removeGlobalOnLayoutListener(layoutListener);
             }
             cancelTimers(); // Not strictly necessary.
-            inAppMessage = null;
-            callbacks = null;
-            glideErrorListener.setInAppMessage(inAppMessage, callbacks);
+            clearInAppMessageAndCallbacks();
           }
         });
   }
@@ -515,9 +518,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     Logging.logd("Dismissing fiam");
     notifyFiamDismiss();
     removeDisplayedFiam(activity);
-    inAppMessage = null;
-    callbacks = null;
-    glideErrorListener.setInAppMessage(inAppMessage, callbacks);
+    clearInAppMessageAndCallbacks();
   }
 
   private void removeDisplayedFiam(Activity activity) {

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplay.java
@@ -40,6 +40,7 @@ import com.google.firebase.inappmessaging.display.internal.FiamAnimator;
 import com.google.firebase.inappmessaging.display.internal.FiamImageLoader;
 import com.google.firebase.inappmessaging.display.internal.FiamWindowManager;
 import com.google.firebase.inappmessaging.display.internal.FirebaseInAppMessagingDisplayImpl;
+import com.google.firebase.inappmessaging.display.internal.GlideErrorListener;
 import com.google.firebase.inappmessaging.display.internal.InAppMessageLayoutConfig;
 import com.google.firebase.inappmessaging.display.internal.Logging;
 import com.google.firebase.inappmessaging.display.internal.RenewableTimer;
@@ -97,6 +98,8 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
   private InAppMessage inAppMessage;
   private FirebaseInAppMessagingDisplayCallbacks callbacks;
 
+  private GlideErrorListener glideErrorListener;
+
   @VisibleForTesting @Nullable String currentlyBoundActivityName;
 
   @Inject
@@ -109,7 +112,8 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
       FiamWindowManager windowManager,
       Application application,
       BindingWrapperFactory bindingWrapperFactory,
-      FiamAnimator animator) {
+      FiamAnimator animator,
+      GlideErrorListener glideErrorListener) {
     super();
     this.headlessInAppMessaging = headlessInAppMessaging;
     this.layoutConfigs = layoutConfigs;
@@ -120,6 +124,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     this.application = application;
     this.bindingWrapperFactory = bindingWrapperFactory;
     this.animator = animator;
+    this.glideErrorListener = glideErrorListener;
   }
 
   /**
@@ -146,6 +151,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
       FirebaseInAppMessagingDisplayCallbacks callbacks) {
     this.inAppMessage = inAppMessage;
     this.callbacks = callbacks;
+    glideErrorListener.setInAppMessage(inAppMessage, callbacks);
     showActiveFiam(activity);
   }
 
@@ -206,6 +212,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
             }
             inAppMessage = iam;
             callbacks = cb;
+            glideErrorListener.setInAppMessage(inAppMessage, callbacks);
             showActiveFiam(activity);
           });
       // set the current activity to be the one passed in so that we know not to bind again to the
@@ -331,6 +338,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
                 removeDisplayedFiam(activity);
                 inAppMessage = null;
                 callbacks = null;
+                glideErrorListener.setInAppMessage(inAppMessage, callbacks);
               }
             };
       } else {
@@ -434,6 +442,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
             cancelTimers(); // Not strictly necessary.
             inAppMessage = null;
             callbacks = null;
+            glideErrorListener.setInAppMessage(inAppMessage, callbacks);
           }
         });
   }
@@ -508,6 +517,7 @@ public class FirebaseInAppMessagingDisplay extends FirebaseInAppMessagingDisplay
     removeDisplayedFiam(activity);
     inAppMessage = null;
     callbacks = null;
+    glideErrorListener.setInAppMessage(inAppMessage, callbacks);
   }
 
   private void removeDisplayedFiam(Activity activity) {

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/FiamImageLoader.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/FiamImageLoader.java
@@ -97,6 +97,11 @@ public class FiamImageLoader {
       return this;
     }
 
+    public FiamImageRequestCreator addErrorListener(GlideErrorListener glideErrorListener) {
+      requestBuilder.addListener(glideErrorListener);
+      return this;
+    }
+
     public FiamImageRequestCreator tag(Class c) {
       tag = c.getSimpleName();
       checkAndTag();

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/GlideErrorListener.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/GlideErrorListener.java
@@ -14,40 +14,29 @@
 
 package com.google.firebase.inappmessaging.display.internal;
 
-// Picasso 's api forces us to listen to errors only using a global listener set on the picasso
-// singleton. Since we initialize picasso from a static context and the in app message param to the
-// logError method is not available statically, we are forced to introduce a error listener with
-// mutable state so that the error from picasso can be translated to a logError on
-// fiam headless, with the in app message as a parameter
-
+import android.graphics.drawable.Drawable;
 import androidx.annotation.Nullable;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.target.Target;
 import com.google.firebase.inappmessaging.FirebaseInAppMessagingDisplayCallbacks;
-import com.google.firebase.inappmessaging.display.internal.injection.scopes.FirebaseAppScope;
 import com.google.firebase.inappmessaging.model.InAppMessage;
-import javax.inject.Inject;
 
-/** @hide */
-@FirebaseAppScope
-public class GlideErrorListener implements RequestListener<Object> {
-  private InAppMessage inAppMessage;
-  private FirebaseInAppMessagingDisplayCallbacks displayCallbacks;
+public class GlideErrorListener implements RequestListener<Drawable> {
+  private final InAppMessage inAppMessage;
+  private final FirebaseInAppMessagingDisplayCallbacks displayCallbacks;
 
-  @Inject
-  GlideErrorListener() {}
 
-  public void setInAppMessage(
-      InAppMessage inAppMessage, FirebaseInAppMessagingDisplayCallbacks displayCallbacks) {
+  public GlideErrorListener(
+          InAppMessage inAppMessage, FirebaseInAppMessagingDisplayCallbacks displayCallbacks) {
     this.inAppMessage = inAppMessage;
     this.displayCallbacks = displayCallbacks;
   }
 
   @Override
   public boolean onLoadFailed(
-      @Nullable GlideException e, Object model, Target<Object> target, boolean isFirstResource) {
+      @Nullable GlideException e, Object model, Target<Drawable> target, boolean isFirstResource) {
     Logging.logd("Image Downloading  Error : " + e.getMessage() + ":" + e.getCause());
 
     if (inAppMessage != null && displayCallbacks != null) {
@@ -67,9 +56,9 @@ public class GlideErrorListener implements RequestListener<Object> {
 
   @Override
   public boolean onResourceReady(
-      Object resource,
+      Drawable resource,
       Object model,
-      Target<Object> target,
+      Target<Drawable> target,
       DataSource dataSource,
       boolean isFirstResource) {
     Logging.logd("Image Downloading  Success : " + resource);

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/GlideErrorListener.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/GlideErrorListener.java
@@ -27,9 +27,8 @@ public class GlideErrorListener implements RequestListener<Drawable> {
   private final InAppMessage inAppMessage;
   private final FirebaseInAppMessagingDisplayCallbacks displayCallbacks;
 
-
   public GlideErrorListener(
-          InAppMessage inAppMessage, FirebaseInAppMessagingDisplayCallbacks displayCallbacks) {
+      InAppMessage inAppMessage, FirebaseInAppMessagingDisplayCallbacks displayCallbacks) {
     this.inAppMessage = inAppMessage;
     this.displayCallbacks = displayCallbacks;
   }

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/injection/components/AppComponent.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/injection/components/AppComponent.java
@@ -16,7 +16,6 @@ package com.google.firebase.inappmessaging.display.internal.injection.components
 
 import com.google.firebase.inappmessaging.display.FirebaseInAppMessagingDisplay;
 import com.google.firebase.inappmessaging.display.internal.FiamImageLoader;
-import com.google.firebase.inappmessaging.display.internal.GlideErrorListener;
 import com.google.firebase.inappmessaging.display.internal.injection.modules.GlideModule;
 import com.google.firebase.inappmessaging.display.internal.injection.modules.HeadlessInAppMessagingModule;
 import com.google.firebase.inappmessaging.display.internal.injection.scopes.FirebaseAppScope;
@@ -30,8 +29,6 @@ import dagger.Component;
 public interface AppComponent {
   @FirebaseAppScope
   FirebaseInAppMessagingDisplay providesFirebaseInAppMessagingUI();
-
-  GlideErrorListener glideErrorListener();
 
   FiamImageLoader fiamImageLoader();
 }

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/injection/modules/GlideModule.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/injection/modules/GlideModule.java
@@ -26,8 +26,7 @@ import dagger.Provides;
 public class GlideModule {
   @Provides
   @FirebaseAppScope
-  RequestManager providesGlideRequestManager(
-      Application application) {
+  RequestManager providesGlideRequestManager(Application application) {
     return Glide.with(application);
   }
 }

--- a/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/injection/modules/GlideModule.java
+++ b/firebase-inappmessaging-display/src/main/java/com/google/firebase/inappmessaging/display/internal/injection/modules/GlideModule.java
@@ -17,7 +17,6 @@ package com.google.firebase.inappmessaging.display.internal.injection.modules;
 import android.app.Application;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
-import com.google.firebase.inappmessaging.display.internal.GlideErrorListener;
 import com.google.firebase.inappmessaging.display.internal.injection.scopes.FirebaseAppScope;
 import dagger.Module;
 import dagger.Provides;
@@ -28,7 +27,7 @@ public class GlideModule {
   @Provides
   @FirebaseAppScope
   RequestManager providesGlideRequestManager(
-      Application application, GlideErrorListener glideErrorListener) {
-    return Glide.with(application).addDefaultRequestListener(glideErrorListener);
+      Application application) {
+    return Glide.with(application);
   }
 }

--- a/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
+++ b/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
@@ -26,6 +26,7 @@ import static com.google.firebase.inappmessaging.testutil.TestData.WEB_ACTION_UR
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -61,6 +62,7 @@ import com.google.firebase.inappmessaging.display.internal.FiamAnimator;
 import com.google.firebase.inappmessaging.display.internal.FiamImageLoader;
 import com.google.firebase.inappmessaging.display.internal.FiamImageLoader.Callback;
 import com.google.firebase.inappmessaging.display.internal.FiamWindowManager;
+import com.google.firebase.inappmessaging.display.internal.GlideErrorListener;
 import com.google.firebase.inappmessaging.display.internal.InAppMessageLayoutConfig;
 import com.google.firebase.inappmessaging.display.internal.RenewableTimer;
 import com.google.firebase.inappmessaging.display.internal.bindingwrappers.BannerBindingWrapper;
@@ -419,6 +421,8 @@ public class FirebaseInAppMessagingDisplayTest {
 
     verify(fiamImageRequestCreator).tag(TestActivity.class);
     verify(fiamImageRequestCreator).placeholder(R.drawable.image_placeholder);
+    verify(fiamImageRequestCreator)
+        .addErrorListener(refEq(new GlideErrorListener(IMAGE_MESSAGE_MODEL, callbacks)));
     verify(fiamImageRequestCreator).into(any(ImageView.class), any(Callback.class));
   }
 
@@ -428,6 +432,7 @@ public class FirebaseInAppMessagingDisplayTest {
     listener.displayMessage(null, callbacks);
     verify(fiamImageRequestCreator, times(0)).tag(TestActivity.class);
     verify(fiamImageRequestCreator, times(0)).placeholder(R.drawable.image_placeholder);
+    verify(fiamImageRequestCreator, times(0)).addErrorListener(any(GlideErrorListener.class));
     verify(fiamImageRequestCreator, times(0)).into(any(ImageView.class), any(Callback.class));
   }
 

--- a/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
+++ b/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
@@ -220,7 +220,7 @@ public class FirebaseInAppMessagingDisplayTest {
             windowManager,
             ApplicationProvider.getApplicationContext(),
             bindingClient,
-            animator, null);
+            animator);
   }
 
   @Test

--- a/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
+++ b/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/FirebaseInAppMessagingDisplayTest.java
@@ -220,7 +220,7 @@ public class FirebaseInAppMessagingDisplayTest {
             windowManager,
             ApplicationProvider.getApplicationContext(),
             bindingClient,
-            animator);
+            animator, null);
   }
 
   @Test

--- a/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/internal/FiamImageLoaderTest.java
+++ b/firebase-inappmessaging-display/src/test/java/com/google/firebase/inappmessaging/display/internal/FiamImageLoaderTest.java
@@ -65,6 +65,14 @@ public class FiamImageLoaderTest {
   }
 
   @Test
+  public void addErrorListener_setsErrorListenerOnUnderlyingRequestCreator() {
+    FiamImageLoader.FiamImageRequestCreator fiamImageRequestCreator = imageLoader.load(IMAGE_URL);
+    GlideErrorListener errorListener = new GlideErrorListener(null, null);
+    fiamImageRequestCreator.addErrorListener(errorListener);
+    verify(requestBuilder).addListener(errorListener);
+  }
+
+  @Test
   public void tag_tagsUnderlyingRequestCreator() {
     ImageView imageView = mock(ImageView.class);
     FiamImageLoader.Callback callback = mock(FiamImageLoader.Callback.class);

--- a/firebase-inappmessaging/CHANGELOG.md
+++ b/firebase-inappmessaging/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [fixed] Fixed FirebaseInAppMessagingDisplayErrorListener not being called
+  (GitHub [#5644](//github.com/firebase/firebase-android-sdk/issues/5644))
 
 # 20.4.0
 * [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-inappmessaging-ktx`


### PR DESCRIPTION
Changed `GlideErrorListener` to a normal class and pass a new instance of the listener into each load image request instead of being injected as a defaultRequestListener.

Refactored `InAppMessage` and `FirebaseInAppMessagingDisplayCallbacks` assignment code for clarity.

Internal tracking: b/321732964

Issue: #5644 