### PR TITLE
Fix version typo in firebase-messaging/CHANGELOG.md

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -10,7 +10,7 @@ The Kotlin extensions library transitively includes the updated
 `firebase-messaging` library. The Kotlin extensions library has no additional
 updates.
 
-# 24.0.0
+# 23.4.0
 * [changed] Called messageHandled() after a message has been handled to indicate
   that the message has been handled successfully.
 * [changed] Added an internal identifier to Firelog logging for compliance.


### PR DESCRIPTION
I fixed the typo in the CHANGELOG.md of firebase-messaging module.