### PR TITLE
Allow package prefix in docs

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/DackkaGenerationTask.kt
@@ -153,7 +153,6 @@ constructor(private val workerExecutor: WorkerExecutor) : GenerateDocumentationT
                       "docRootPath" to "/docs/reference/",
                       "javaDocsPath" to "android",
                       "kotlinDocsPath" to "kotlin",
-                      "packagePrefixToRemoveInToc" to "com.google",
                       "projectPath" to "client/${clientName.get()}",
                       "includedHeadTagsPathJava" to
                         "docs/reference/android/_reference-head-tags.html",


### PR DESCRIPTION
Per [b/326624050](https://b.corp.google.com/issues/326624050),

This deletes the configuration that was removing the package prefix from our toc files. 

We previously needed to remove the `com.google` package prefix from our docs; since of the SDKs were still using the old doc engine. Now that everyone has migrated, this is no longer needed. We should remove this transformation from our doc generation to align with internal systems.

