### PR TITLE
Remove non link brackets from release notes

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
@@ -162,10 +162,12 @@ abstract class MakeReleaseNotesTask : DefaultTask() {
     if (message.isBlank()) throw RuntimeException("A changelog entry message can not be blank.")
 
     val fixedMessage =
-      LINK_REGEX.replace(message) {
-        val id = it.firstCapturedValue
-        "GitHub [#$id](//github.com/firebase/firebase-android-sdk/issues/$id){: .external}"
-      }
+      message
+        .replace(LINK_REGEX) {
+          val id = it.firstCapturedValue
+          "GitHub [#$id](//github.com/firebase/firebase-android-sdk/issues/$id){: .external}"
+        }
+        .replace(NON_LINK_BRACKETS_REGEX) { it.firstCapturedValue }
 
     return "* {{${type.name.toLowerCase()}}} $fixedMessage"
   }

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/MakeReleaseNotesTask.kt
@@ -213,5 +213,29 @@ abstract class MakeReleaseNotesTask : DefaultTask() {
         "(?:GitHub )?(?:\\[|\\()#(\\d+)(?:\\]|\\))(?:\\(.+?\\))?(?:\\{: \\.external\\})?",
         RegexOption.MULTILINE
       )
+
+    /**
+     * Regex for non link brackets in change messages.
+     *
+     * The regex can be described as such:
+     * - Look for non newline characters surrounded by brackets
+     * - The brackets should not be followed by a `(`
+     *
+     * For example:
+     * ```markdown
+     * We fixed [release_config] and added some
+     * other cool stuff: [#5678](//github.com/firebase-firebase-android-sdk/issues/number)
+     * ```
+     *
+     * Will match the following:
+     * ```kotlin
+     * [
+     *   "[release_config]"
+     * ]
+     * ```
+     *
+     * @see [Change.toReleaseNote]
+     */
+    private val NON_LINK_BRACKETS_REGEX = Regex("\\[(.+?)](?!\\()", RegexOption.MULTILINE)
   }
 }


### PR DESCRIPTION
Per [b/326629027](https://b.corp.google.com/issues/326629027),

This adds a transformation in our release notes to separate brackets from their content if they're not wrapping a link. This is to avoid propagating the content to the release notes, as it shouldn't be there. In the future, we may want to add some warning for instances found (as they may have been intended to be links).