### PR TITLE
Pin firebase-common dependency in components

### DIFF
--- a/firebase-common/CHANGELOG.md
+++ b/firebase-common/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Unreleased
-* [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-common-ktx` 
-to `com.google.firebase:firebase-common` under the `com.google.firebase` package. 
+* [fixed] Correctly declare dependency on firebase-components, issue #5732
+
+
+# 20.4.0
+* [changed] Added Kotlin extensions (KTX) APIs from `com.google.firebase:firebase-common-ktx`
+to `com.google.firebase:firebase-common` under the `com.google.firebase` package.
 For details, see the
 [FAQ about this initiative](https://firebase.google.com/docs/android/kotlin-migration)
 
 ## Kotlin
 * [deprecated] All the APIs from `com.google.firebase:firebase-common-ktx` have been added to
-`com.google.firebase:firebase-common` under the `com.google.firebase package`, and all the 
+`com.google.firebase:firebase-common` under the `com.google.firebase package`, and all the
 Kotlin extensions (KTX) APIs in `com.google.firebase:firebase-common-ktx` are now deprecated.
-As early as April 2024, we'll no longer release KTX modules. For details, see the 
+As early as April 2024, we'll no longer release KTX modules. For details, see the
 FAQ about this initiative.
 [FAQ about this initiative](https://firebase.google.com/docs/android/kotlin-migration)
 

--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -54,7 +54,7 @@ android {
 dependencies {
     api(libs.kotlin.coroutines.tasks)
 
-    implementation("com.google.firebase:firebase-components:17.1.5"))
+    implementation("com.google.firebase:firebase-components:17.1.5")
     implementation("com.google.firebase:firebase-annotations:16.2.0")
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.futures)

--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -54,7 +54,7 @@ android {
 dependencies {
     api(libs.kotlin.coroutines.tasks)
 
-    implementation(project(":firebase-components"))
+    implementation("com.google.firebase:firebase-components:17.1.5"))
     implementation("com.google.firebase:firebase-annotations:16.2.0")
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.futures)


### PR DESCRIPTION
There's no need for common to have a project level dependency on components, as they are both released separately.

This should fix issue #5732 