### PR TITLE
Add support for new batching

### DIFF
--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
@@ -336,8 +336,9 @@ final class CctTransportBackend implements TransportBackend {
     connection.setRequestProperty(CONTENT_TYPE_HEADER_KEY, JSON_CONTENT_TYPE);
     connection.setRequestProperty(ACCEPT_ENCODING_HEADER_KEY, GZIP_CONTENT_ENCODING);
 
-    if(request.pseudonymousId != null) {
-      connection.setRequestProperty(COOKIE_HEADER_KEY, String.format("NID=%s", request.pseudonymousId));
+    if (request.pseudonymousId != null) {
+      connection.setRequestProperty(
+          COOKIE_HEADER_KEY, String.format("NID=%s", request.pseudonymousId));
     }
 
     if (request.apiKey != null) {
@@ -392,13 +393,13 @@ final class CctTransportBackend implements TransportBackend {
   private @Nullable String findPseudonymousId(BackendRequest request) {
     Iterator<EventInternal> events = request.getEvents().iterator();
 
-    if(!events.hasNext()) return null;
+    if (!events.hasNext()) return null;
 
     String pseudonymousId = events.next().getPseudonymousId();
 
-    for(EventInternal event : request.getEvents()) {
+    for (EventInternal event : request.getEvents()) {
       String currentId = event.getPseudonymousId();
-      if(!Objects.equals(pseudonymousId, currentId)) {
+      if (!Objects.equals(pseudonymousId, currentId)) {
         Logging.w(LOG_TAG, "Invalid pseudonymous id event found: %s", currentId);
         return null;
       }
@@ -487,7 +488,11 @@ final class CctTransportBackend implements TransportBackend {
     @Nullable final String pseudonymousId;
     @Nullable final String apiKey;
 
-    HttpRequest(URL url, BatchedLogRequest requestBody, @Nullable String apiKey, @Nullable String pseudonymousId) {
+    HttpRequest(
+        URL url,
+        BatchedLogRequest requestBody,
+        @Nullable String apiKey,
+        @Nullable String pseudonymousId) {
       this.url = url;
       this.requestBody = requestBody;
       this.apiKey = apiKey;

--- a/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
+++ b/transport/transport-backend-cct/src/main/java/com/google/android/datatransport/cct/CctTransportBackend.java
@@ -63,9 +63,11 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -82,6 +84,7 @@ final class CctTransportBackend implements TransportBackend {
   private static final String GZIP_CONTENT_ENCODING = "gzip";
   private static final String CONTENT_TYPE_HEADER_KEY = "Content-Type";
   static final String API_KEY_HEADER_KEY = "X-Goog-Api-Key";
+  private static final String COOKIE_HEADER_KEY = "Cookie";
   private static final String JSON_CONTENT_TYPE = "application/json";
 
   @VisibleForTesting static final String KEY_NETWORK_TYPE = "net-type";
@@ -320,7 +323,6 @@ final class CctTransportBackend implements TransportBackend {
   }
 
   private HttpResponse doSend(HttpRequest request) throws IOException {
-
     Logging.i(LOG_TAG, "Making request to: %s", request.url);
     HttpURLConnection connection = (HttpURLConnection) request.url.openConnection();
     connection.setConnectTimeout(CONNECTION_TIME_OUT);
@@ -333,6 +335,10 @@ final class CctTransportBackend implements TransportBackend {
     connection.setRequestProperty(CONTENT_ENCODING_HEADER_KEY, GZIP_CONTENT_ENCODING);
     connection.setRequestProperty(CONTENT_TYPE_HEADER_KEY, JSON_CONTENT_TYPE);
     connection.setRequestProperty(ACCEPT_ENCODING_HEADER_KEY, GZIP_CONTENT_ENCODING);
+
+    if(request.pseudoId != null) {
+      connection.setRequestProperty(COOKIE_HEADER_KEY, String.format("NID=%s", request.pseudoId));
+    }
 
     if (request.apiKey != null) {
       connection.setRequestProperty(API_KEY_HEADER_KEY, request.apiKey);
@@ -383,6 +389,23 @@ final class CctTransportBackend implements TransportBackend {
     return input;
   }
 
+  private String findPseudoId(BackendRequest request) {
+    Iterator<EventInternal> events = request.getEvents().iterator();
+
+    if(!events.hasNext()) return null;
+
+    String pseudoId = events.next().getPseudonymousId();
+
+    for(EventInternal event : request.getEvents()) {
+      String currentId = event.getPseudonymousId();
+      if(!Objects.equals(pseudoId, currentId)) {
+        Logging.w(LOG_TAG, "Invalid pseudo id event found: %s", currentId);
+      }
+    }
+
+    return pseudoId;
+  }
+
   @Override
   public BackendResponse send(BackendRequest request) {
     BatchedLogRequest requestBody = getRequestBody(request);
@@ -405,11 +428,13 @@ final class CctTransportBackend implements TransportBackend {
       }
     }
 
+    String pseudoId = findPseudoId(request);
+
     try {
       HttpResponse response =
           retry(
               5,
-              new HttpRequest(actualEndPoint, requestBody, apiKey),
+              new HttpRequest(actualEndPoint, requestBody, apiKey, pseudoId),
               this::doSend,
               (req, resp) -> {
                 if (resp.redirectUrl != null) {
@@ -458,16 +483,18 @@ final class CctTransportBackend implements TransportBackend {
   static final class HttpRequest {
     final URL url;
     final BatchedLogRequest requestBody;
+    @Nullable final String pseudoId;
     @Nullable final String apiKey;
 
-    HttpRequest(URL url, BatchedLogRequest requestBody, @Nullable String apiKey) {
+    HttpRequest(URL url, BatchedLogRequest requestBody, @Nullable String apiKey, @Nullable String pseudoId) {
       this.url = url;
       this.requestBody = requestBody;
       this.apiKey = apiKey;
+      this.pseudoId = pseudoId;
     }
 
     HttpRequest withUrl(URL newUrl) {
-      return new HttpRequest(newUrl, requestBody, apiKey);
+      return new HttpRequest(newUrl, requestBody, apiKey, pseudoId);
     }
   }
 }

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
@@ -749,20 +749,20 @@ public class CctTransportBackendTest {
   public void schedule_shouldAddCookieOnPseudonymousIds() {
     String pseudonymousId = "testing_world";
     BackendRequest request =
-            BackendRequest.builder()
-                    .setEvents(
-                            Collections.singletonList(
-                                    BACKEND.decorate(
-                                            EventInternal.builder()
-                                                    .setEventMillis(INITIAL_WALL_TIME)
-                                                    .setUptimeMillis(INITIAL_UPTIME)
-                                                    .setTransportName("4")
-                                                    .setEncodedPayload(
-                                                            new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
-                                                    .setPseudonymousId(pseudonymousId)
-                                                    .build())))
-                    .setExtras(new CCTDestination(TEST_ENDPOINT, null).getExtras())
-                    .build();
+        BackendRequest.builder()
+            .setEvents(
+                Collections.singletonList(
+                    BACKEND.decorate(
+                        EventInternal.builder()
+                            .setEventMillis(INITIAL_WALL_TIME)
+                            .setUptimeMillis(INITIAL_UPTIME)
+                            .setTransportName("4")
+                            .setEncodedPayload(
+                                new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
+                            .setPseudonymousId(pseudonymousId)
+                            .build())))
+            .setExtras(new CCTDestination(TEST_ENDPOINT, null).getExtras())
+            .build();
 
     stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
     wallClock.tick();
@@ -770,8 +770,8 @@ public class CctTransportBackendTest {
 
     BACKEND.send(request);
     verify(
-            postRequestedFor(urlEqualTo("/api"))
-                    .withHeader("Cookie", equalTo(String.format("NID=%s", pseudonymousId))));
+        postRequestedFor(urlEqualTo("/api"))
+            .withHeader("Cookie", equalTo(String.format("NID=%s", pseudonymousId))));
   }
 
   @Test
@@ -779,39 +779,37 @@ public class CctTransportBackendTest {
     String pseudonymousId = "testing_world";
     String otherPseudonymousId = "world_testing";
     BackendRequest request =
-            BackendRequest.builder()
-                    .setEvents(
-                            Arrays.asList(
-                                    BACKEND.decorate(
-                                            EventInternal.builder()
-                                                    .setEventMillis(INITIAL_WALL_TIME)
-                                                    .setUptimeMillis(INITIAL_UPTIME)
-                                                    .setTransportName("4")
-                                                    .setPseudonymousId(pseudonymousId)
-                                                    .setEncodedPayload(
-                                                            new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
-                                                    .build()),
-                                    BACKEND.decorate(
-                                            EventInternal.builder()
-                                                    .setEventMillis(INITIAL_WALL_TIME)
-                                                    .setUptimeMillis(INITIAL_UPTIME)
-                                                    .setTransportName("4")
-                                                    .setPseudonymousId(otherPseudonymousId)
-                                                    .setEncodedPayload(
-                                                            new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
-                                                    .setCode(CODE)
-                                                    .build())))
-                    .setExtras(new CCTDestination(TEST_ENDPOINT, null).getExtras())
-                    .build();
+        BackendRequest.builder()
+            .setEvents(
+                Arrays.asList(
+                    BACKEND.decorate(
+                        EventInternal.builder()
+                            .setEventMillis(INITIAL_WALL_TIME)
+                            .setUptimeMillis(INITIAL_UPTIME)
+                            .setTransportName("4")
+                            .setPseudonymousId(pseudonymousId)
+                            .setEncodedPayload(
+                                new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
+                            .build()),
+                    BACKEND.decorate(
+                        EventInternal.builder()
+                            .setEventMillis(INITIAL_WALL_TIME)
+                            .setUptimeMillis(INITIAL_UPTIME)
+                            .setTransportName("4")
+                            .setPseudonymousId(otherPseudonymousId)
+                            .setEncodedPayload(
+                                new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
+                            .setCode(CODE)
+                            .build())))
+            .setExtras(new CCTDestination(TEST_ENDPOINT, null).getExtras())
+            .build();
 
     stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
     wallClock.tick();
     uptimeClock.tick();
 
     BACKEND.send(request);
-    verify(
-            postRequestedFor(urlEqualTo("/api"))
-                    .withoutHeader("Cookie"));
+    verify(postRequestedFor(urlEqualTo("/api")).withoutHeader("Cookie"));
   }
 
   // When there is no active network, the ConnectivityManager returns null when

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.zip.GZIPOutputStream;
 import org.junit.Rule;
@@ -741,6 +742,75 @@ public class CctTransportBackendTest {
             .withRequestBody(matchingJsonPath("$[?(@.logRequest[1].logEvent.size() == 1)]")));
 
     assertEquals(BackendResponse.ok(3), response);
+  }
+
+  @Test
+  public void schedule_shouldAddCookieOnPseudonymousIds() {
+    String pseudonymousId = "testing_world";
+    BackendRequest request =
+            BackendRequest.builder()
+                    .setEvents(
+                            Collections.singletonList(
+                                    BACKEND.decorate(
+                                            EventInternal.builder()
+                                                    .setEventMillis(INITIAL_WALL_TIME)
+                                                    .setUptimeMillis(INITIAL_UPTIME)
+                                                    .setTransportName("4")
+                                                    .setEncodedPayload(
+                                                            new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
+                                                    .setPseudonymousId(pseudonymousId)
+                                                    .build())))
+                    .setExtras(new CCTDestination(TEST_ENDPOINT, null).getExtras())
+                    .build();
+
+    stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
+    wallClock.tick();
+    uptimeClock.tick();
+
+    BACKEND.send(request);
+    verify(
+            postRequestedFor(urlEqualTo("/api"))
+                    .withHeader("Cookie", equalTo(String.format("NID=%s", pseudonymousId))));
+  }
+
+  @Test
+  public void schedule_shouldDropCookieOnMixedPseudonymousIds() {
+    String pseudonymousId = "testing_world";
+    String otherPseudonymousId = "world_testing";
+    BackendRequest request =
+            BackendRequest.builder()
+                    .setEvents(
+                            Arrays.asList(
+                                    BACKEND.decorate(
+                                            EventInternal.builder()
+                                                    .setEventMillis(INITIAL_WALL_TIME)
+                                                    .setUptimeMillis(INITIAL_UPTIME)
+                                                    .setTransportName("4")
+                                                    .setPseudonymousId(pseudonymousId)
+                                                    .setEncodedPayload(
+                                                            new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
+                                                    .build()),
+                                    BACKEND.decorate(
+                                            EventInternal.builder()
+                                                    .setEventMillis(INITIAL_WALL_TIME)
+                                                    .setUptimeMillis(INITIAL_UPTIME)
+                                                    .setTransportName("4")
+                                                    .setPseudonymousId(otherPseudonymousId)
+                                                    .setEncodedPayload(
+                                                            new EncodedPayload(PROTOBUF_ENCODING, PAYLOAD.toByteArray()))
+                                                    .setCode(CODE)
+                                                    .build())))
+                    .setExtras(new CCTDestination(TEST_ENDPOINT, null).getExtras())
+                    .build();
+
+    stubFor(post(urlEqualTo("/api")).willReturn(aResponse().withStatus(200)));
+    wallClock.tick();
+    uptimeClock.tick();
+
+    BACKEND.send(request);
+    verify(
+            postRequestedFor(urlEqualTo("/api"))
+                    .withoutHeader("Cookie"));
   }
 
   // When there is no active network, the ConnectivityManager returns null when

--- a/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
+++ b/transport/transport-backend-cct/src/test/java/com/google/android/datatransport/cct/CctTransportBackendTest.java
@@ -223,7 +223,8 @@ public class CctTransportBackendTest {
                 matchingJsonPath(
                     String.format(
                         "$[?(@.logRequest[0].logEvent[1].sourceExtensionJsonProto3 == \"%s\")]",
-                        JSON_PAYLOAD_ESCAPED))));
+                        JSON_PAYLOAD_ESCAPED)))
+            .withoutHeader("Cookie"));
 
     assertEquals(BackendResponse.ok(3), response);
   }

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/UploaderIntegrationTest.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/UploaderIntegrationTest.java
@@ -29,6 +29,7 @@ import androidx.test.InstrumentationRegistry;
 import androidx.test.runner.AndroidJUnit4;
 import com.google.android.datatransport.Encoding;
 import com.google.android.datatransport.Event;
+import com.google.android.datatransport.EventContext;
 import com.google.android.datatransport.Priority;
 import com.google.android.datatransport.Transport;
 import com.google.android.datatransport.TransportFactory;
@@ -91,6 +92,19 @@ public class UploaderIntegrationTest {
 
   private String generateBackendName() {
     return UUID.randomUUID().toString().replace("-", "");
+  }
+
+  private EventInternal makeEventWithPseudonymousId(String id) {
+    return EventInternal.builder()
+            .setTransportName(testTransport)
+            .setEventMillis(1)
+            .setUptimeMillis(2)
+            .setEncodedPayload(
+                    new EncodedPayload(Encoding.of("proto"), "Hello".getBytes(Charset.defaultCharset())))
+            .addMetadata("key1", "value1")
+            .addMetadata("key2", "value2")
+            .setPseudonymousId(id)
+            .build();
   }
 
   @Test
@@ -414,5 +428,76 @@ public class UploaderIntegrationTest {
     verify(spyScheduler, times(0)).schedule(any(), eq(2));
 
     assertThat(store.loadClientMetrics().getLogSourceMetricsList()).hasSize(1);
+  }
+
+  @Test
+  public void uploader_shouldBatchSamePseudonymousIds() {
+    TransportRuntime runtime = TransportRuntime.getInstance();
+    SQLiteEventStore store = component.getEventStore();
+
+    String mockBackendName = generateBackendName();
+
+    String targetId = "myId";
+    String alternativeId = "otherId";
+
+    EventInternal oldestEvent = makeEventWithPseudonymousId(targetId);
+    EventInternal siblingEvent = makeEventWithPseudonymousId(targetId);
+    EventInternal otherEvent = makeEventWithPseudonymousId(alternativeId);
+
+    EventContext event = EventContext.builder().setPseudonymousId(alternativeId).build();
+
+    when(mockRegistry.get(mockBackendName)).thenReturn(mockBackend);
+
+    Transport<String> transport =
+            runtime
+                    .newFactory(new TestDestination(mockBackendName, null))
+                    .getTransport(testTransport, String.class, Encoding.of("proto"), String::getBytes);
+
+    TransportContext TRANSPORT_CONTEXT =
+            TransportContext.builder().setBackendName(mockBackendName).build();
+
+    store.persist(TRANSPORT_CONTEXT, oldestEvent);
+    store.persist(TRANSPORT_CONTEXT, otherEvent);
+    store.persist(TRANSPORT_CONTEXT, siblingEvent);
+
+    transport.send(Event.ofData("", event));
+    verify(mockBackend, times(1))
+            .send(eq(BackendRequest.create(Arrays.asList(oldestEvent, siblingEvent))));
+  }
+
+  @Test
+  public void upload_shouldBatchOldestEventType() {
+    TransportRuntime runtime = TransportRuntime.getInstance();
+    SQLiteEventStore store = component.getEventStore();
+
+    String mockBackendName = generateBackendName();
+
+    String randomId = "myId";
+
+
+    EventInternal targetEvent = makeEventWithPseudonymousId(null);
+    EventInternal otherEvent = makeEventWithPseudonymousId(randomId);
+    EventInternal siblingEvent = makeEventWithPseudonymousId(randomId);
+
+
+    EventContext event = EventContext.builder().setPseudonymousId(randomId).build();
+
+    when(mockRegistry.get(mockBackendName)).thenReturn(mockBackend);
+
+    Transport<String> transport =
+            runtime
+                    .newFactory(new TestDestination(mockBackendName, null))
+                    .getTransport(testTransport, String.class, Encoding.of("proto"), String::getBytes);
+
+    TransportContext TRANSPORT_CONTEXT =
+            TransportContext.builder().setBackendName(mockBackendName).build();
+
+    store.persist(TRANSPORT_CONTEXT, targetEvent);
+    store.persist(TRANSPORT_CONTEXT, otherEvent);
+    store.persist(TRANSPORT_CONTEXT, siblingEvent);
+
+    transport.send(Event.ofData("", event));
+    verify(mockBackend, times(1))
+            .send(eq(BackendRequest.create(Collections.singletonList(targetEvent))));
   }
 }

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/UploaderIntegrationTest.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/UploaderIntegrationTest.java
@@ -277,7 +277,7 @@ public class UploaderIntegrationTest {
                 new EncodedPayload(
                     PROTOBUF_ENCODING, "TelemetryData".getBytes(Charset.defaultCharset())))
             .build();
-    EventInternal metricsEvent = component.getUploader().createMetricsEvent(mockBackend);
+    EventInternal metricsEvent = component.getUploader().createMetricsEvent(mockBackend, null);
     transport.send(Event.ofTelemetry("TelemetryData"));
     verify(mockBackend, times(1))
         .send(
@@ -320,7 +320,7 @@ public class UploaderIntegrationTest {
                 new EncodedPayload(
                     PROTOBUF_ENCODING, "TelemetryData".getBytes(Charset.defaultCharset())))
             .build();
-    EventInternal metricsEvent = component.getUploader().createMetricsEvent(mockBackend);
+    EventInternal metricsEvent = component.getUploader().createMetricsEvent(mockBackend, null);
     transport.send(Event.ofTelemetry("TelemetryData"));
     verify(mockBackend, times(1))
         .send(
@@ -363,7 +363,7 @@ public class UploaderIntegrationTest {
                 new EncodedPayload(
                     PROTOBUF_ENCODING, "TelemetryData".getBytes(Charset.defaultCharset())))
             .build();
-    EventInternal metricsEvent = component.getUploader().createMetricsEvent(mockBackend);
+    EventInternal metricsEvent = component.getUploader().createMetricsEvent(mockBackend, null);
     transport.send(Event.ofTelemetry("TelemetryData"));
     verify(mockBackend, times(1))
         .send(

--- a/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/UploaderIntegrationTest.java
+++ b/transport/transport-runtime/src/androidTest/java/com/google/android/datatransport/runtime/UploaderIntegrationTest.java
@@ -96,15 +96,15 @@ public class UploaderIntegrationTest {
 
   private EventInternal makeEventWithPseudonymousId(String id) {
     return EventInternal.builder()
-            .setTransportName(testTransport)
-            .setEventMillis(1)
-            .setUptimeMillis(2)
-            .setEncodedPayload(
-                    new EncodedPayload(Encoding.of("proto"), "Hello".getBytes(Charset.defaultCharset())))
-            .addMetadata("key1", "value1")
-            .addMetadata("key2", "value2")
-            .setPseudonymousId(id)
-            .build();
+        .setTransportName(testTransport)
+        .setEventMillis(1)
+        .setUptimeMillis(2)
+        .setEncodedPayload(
+            new EncodedPayload(Encoding.of("proto"), "Hello".getBytes(Charset.defaultCharset())))
+        .addMetadata("key1", "value1")
+        .addMetadata("key2", "value2")
+        .setPseudonymousId(id)
+        .build();
   }
 
   @Test
@@ -449,12 +449,12 @@ public class UploaderIntegrationTest {
     when(mockRegistry.get(mockBackendName)).thenReturn(mockBackend);
 
     Transport<String> transport =
-            runtime
-                    .newFactory(new TestDestination(mockBackendName, null))
-                    .getTransport(testTransport, String.class, Encoding.of("proto"), String::getBytes);
+        runtime
+            .newFactory(new TestDestination(mockBackendName, null))
+            .getTransport(testTransport, String.class, Encoding.of("proto"), String::getBytes);
 
     TransportContext TRANSPORT_CONTEXT =
-            TransportContext.builder().setBackendName(mockBackendName).build();
+        TransportContext.builder().setBackendName(mockBackendName).build();
 
     store.persist(TRANSPORT_CONTEXT, oldestEvent);
     store.persist(TRANSPORT_CONTEXT, otherEvent);
@@ -462,7 +462,7 @@ public class UploaderIntegrationTest {
 
     transport.send(Event.ofData("", event));
     verify(mockBackend, times(1))
-            .send(eq(BackendRequest.create(Arrays.asList(oldestEvent, siblingEvent))));
+        .send(eq(BackendRequest.create(Arrays.asList(oldestEvent, siblingEvent))));
   }
 
   @Test
@@ -474,23 +474,21 @@ public class UploaderIntegrationTest {
 
     String randomId = "myId";
 
-
     EventInternal targetEvent = makeEventWithPseudonymousId(null);
     EventInternal otherEvent = makeEventWithPseudonymousId(randomId);
     EventInternal siblingEvent = makeEventWithPseudonymousId(randomId);
-
 
     EventContext event = EventContext.builder().setPseudonymousId(randomId).build();
 
     when(mockRegistry.get(mockBackendName)).thenReturn(mockBackend);
 
     Transport<String> transport =
-            runtime
-                    .newFactory(new TestDestination(mockBackendName, null))
-                    .getTransport(testTransport, String.class, Encoding.of("proto"), String::getBytes);
+        runtime
+            .newFactory(new TestDestination(mockBackendName, null))
+            .getTransport(testTransport, String.class, Encoding.of("proto"), String::getBytes);
 
     TransportContext TRANSPORT_CONTEXT =
-            TransportContext.builder().setBackendName(mockBackendName).build();
+        TransportContext.builder().setBackendName(mockBackendName).build();
 
     store.persist(TRANSPORT_CONTEXT, targetEvent);
     store.persist(TRANSPORT_CONTEXT, otherEvent);
@@ -498,6 +496,6 @@ public class UploaderIntegrationTest {
 
     transport.send(Event.ofData("", event));
     verify(mockBackend, times(1))
-            .send(eq(BackendRequest.create(Collections.singletonList(targetEvent))));
+        .send(eq(BackendRequest.create(Collections.singletonList(targetEvent))));
   }
 }

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -118,7 +118,8 @@ public class AlarmManagerScheduler implements WorkScheduler {
     boolean hasPendingEvents = force && eventStore.hasPendingEventsFor(transportContext);
 
     long scheduleDelay =
-        config.getScheduleDelay(transportContext.getPriority(), backendTime, attemptNumber, hasPendingEvents);
+        config.getScheduleDelay(
+            transportContext.getPriority(), backendTime, attemptNumber, hasPendingEvents);
 
     Logging.d(
         LOG_TAG,

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -115,9 +115,10 @@ public class AlarmManagerScheduler implements WorkScheduler {
     }
 
     long backendTime = eventStore.getNextCallTime(transportContext);
+    boolean hasPendingEvents = eventStore.hasPendingEventsFor(transportContext);
 
     long scheduleDelay =
-        config.getScheduleDelay(transportContext.getPriority(), backendTime, attemptNumber);
+        config.getScheduleDelay(transportContext.getPriority(), backendTime, attemptNumber, hasPendingEvents);
 
     Logging.d(
         LOG_TAG,

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerScheduler.java
@@ -115,7 +115,7 @@ public class AlarmManagerScheduler implements WorkScheduler {
     }
 
     long backendTime = eventStore.getNextCallTime(transportContext);
-    boolean hasPendingEvents = eventStore.hasPendingEventsFor(transportContext);
+    boolean hasPendingEvents = force && eventStore.hasPendingEventsFor(transportContext);
 
     long scheduleDelay =
         config.getScheduleDelay(transportContext.getPriority(), backendTime, attemptNumber, hasPendingEvents);

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
@@ -140,7 +140,8 @@ public class JobInfoScheduler implements WorkScheduler {
         "Scheduling upload for context %s with jobId=%d in %dms(Backend next call timestamp %d). Attempt %d",
         transportContext,
         jobId,
-        config.getScheduleDelay(transportContext.getPriority(), nextCallTime, attemptNumber, hasPendingEvents),
+        config.getScheduleDelay(
+            transportContext.getPriority(), nextCallTime, attemptNumber, hasPendingEvents),
         nextCallTime,
         attemptNumber);
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
@@ -135,8 +135,6 @@ public class JobInfoScheduler implements WorkScheduler {
     }
     builder.setExtras(bundle);
 
-
-
     Logging.d(
         LOG_TAG,
         "Scheduling upload for context %s with jobId=%d in %dms(Backend next call timestamp %d). Attempt %d",

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
@@ -115,7 +115,7 @@ public class JobInfoScheduler implements WorkScheduler {
     }
 
     long nextCallTime = eventStore.getNextCallTime(transportContext);
-    boolean hasPendingEvents = eventStore.hasPendingEventsFor(transportContext);
+    boolean hasPendingEvents = force && eventStore.hasPendingEventsFor(transportContext);
 
     // Schedule the build.
     JobInfo.Builder builder =

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoScheduler.java
@@ -115,6 +115,7 @@ public class JobInfoScheduler implements WorkScheduler {
     }
 
     long nextCallTime = eventStore.getNextCallTime(transportContext);
+    boolean hasPendingEvents = eventStore.hasPendingEventsFor(transportContext);
 
     // Schedule the build.
     JobInfo.Builder builder =
@@ -122,7 +123,8 @@ public class JobInfoScheduler implements WorkScheduler {
             new JobInfo.Builder(jobId, serviceComponent),
             transportContext.getPriority(),
             nextCallTime,
-            attemptNumber);
+            attemptNumber,
+            hasPendingEvents);
 
     PersistableBundle bundle = new PersistableBundle();
     bundle.putInt(ATTEMPT_NUMBER, attemptNumber);
@@ -133,12 +135,14 @@ public class JobInfoScheduler implements WorkScheduler {
     }
     builder.setExtras(bundle);
 
+
+
     Logging.d(
         LOG_TAG,
         "Scheduling upload for context %s with jobId=%d in %dms(Backend next call timestamp %d). Attempt %d",
         transportContext,
         jobId,
-        config.getScheduleDelay(transportContext.getPriority(), nextCallTime, attemptNumber),
+        config.getScheduleDelay(transportContext.getPriority(), nextCallTime, attemptNumber, hasPendingEvents),
         nextCallTime,
         attemptNumber);
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/SchedulerConfig.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/SchedulerConfig.java
@@ -133,12 +133,18 @@ public abstract class SchedulerConfig {
     }
   }
 
-  public long getScheduleDelay(Priority priority, long minTimestamp, int attemptNumber) {
+  public long getScheduleDelay(Priority priority, long minTimestamp, int attemptNumber, boolean skipDelta) {
     long timeDiff = minTimestamp - getClock().getTime();
     ConfigValue config = getValues().get(priority);
 
-    long delay = Math.max(adjustedExponentialBackoff(attemptNumber, config.getDelta()), timeDiff);
+    long delta = (skipDelta) ? 1 : config.getDelta();
+
+    long delay = Math.max(adjustedExponentialBackoff(attemptNumber, delta), timeDiff);
     return Math.min(delay, config.getMaxAllowedDelay());
+  }
+
+  public long getScheduleDelay(Priority priority, long minTimestamp, int attemptNumber) {
+    return getScheduleDelay(priority, minTimestamp, attemptNumber, false);
   }
 
   private long adjustedExponentialBackoff(int attemptNumber, long delta) {
@@ -153,11 +159,17 @@ public abstract class SchedulerConfig {
 
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
   public JobInfo.Builder configureJob(
-      JobInfo.Builder builder, Priority priority, long minimumTimestamp, int attemptNumber) {
-    long latency = getScheduleDelay(priority, minimumTimestamp, attemptNumber);
+      JobInfo.Builder builder, Priority priority, long minimumTimestamp, int attemptNumber, boolean skipDelta) {
+    long latency = getScheduleDelay(priority, minimumTimestamp, attemptNumber, skipDelta);
     builder.setMinimumLatency(latency); // wait at least
     populateFlags(builder, getValues().get(priority).getFlags());
     return builder;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  public JobInfo.Builder configureJob(
+          JobInfo.Builder builder, Priority priority, long minimumTimestamp, int attemptNumber) {
+    return configureJob(builder, priority, minimumTimestamp, attemptNumber, false);
   }
 
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/SchedulerConfig.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/SchedulerConfig.java
@@ -133,7 +133,8 @@ public abstract class SchedulerConfig {
     }
   }
 
-  public long getScheduleDelay(Priority priority, long minTimestamp, int attemptNumber, boolean skipDelta) {
+  public long getScheduleDelay(
+      Priority priority, long minTimestamp, int attemptNumber, boolean skipDelta) {
     long timeDiff = minTimestamp - getClock().getTime();
     ConfigValue config = getValues().get(priority);
 
@@ -159,7 +160,11 @@ public abstract class SchedulerConfig {
 
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
   public JobInfo.Builder configureJob(
-      JobInfo.Builder builder, Priority priority, long minimumTimestamp, int attemptNumber, boolean skipDelta) {
+      JobInfo.Builder builder,
+      Priority priority,
+      long minimumTimestamp,
+      int attemptNumber,
+      boolean skipDelta) {
     long latency = getScheduleDelay(priority, minimumTimestamp, attemptNumber, skipDelta);
     builder.setMinimumLatency(latency); // wait at least
     populateFlags(builder, getValues().get(priority).getFlags());
@@ -168,7 +173,7 @@ public abstract class SchedulerConfig {
 
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
   public JobInfo.Builder configureJob(
-          JobInfo.Builder builder, Priority priority, long minimumTimestamp, int attemptNumber) {
+      JobInfo.Builder builder, Priority priority, long minimumTimestamp, int attemptNumber) {
     return configureJob(builder, priority, minimumTimestamp, attemptNumber, false);
   }
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -17,6 +17,8 @@ package com.google.android.datatransport.runtime.scheduling.jobscheduling;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.google.android.datatransport.Encoding;
@@ -153,7 +155,7 @@ public class Uploader {
         }
 
         if (transportContext.shouldUploadClientHealthMetrics()) {
-          eventInternals.add(createMetricsEvent(backend));
+          eventInternals.add(createMetricsEvent(backend, targetPseudonymousId));
         }
 
         response =
@@ -227,7 +229,7 @@ public class Uploader {
   }
 
   @VisibleForTesting
-  public EventInternal createMetricsEvent(TransportBackend backend) {
+  public EventInternal createMetricsEvent(TransportBackend backend, @Nullable String pseudonymousId) {
     ClientMetrics clientMetrics =
         guard.runCriticalSection(clientHealthMetricsStore::loadClientMetrics);
     return backend.decorate(
@@ -235,6 +237,7 @@ public class Uploader {
             .setEventMillis(clock.getTime())
             .setUptimeMillis(uptimeClock.getTime())
             .setTransportName(CLIENT_HEALTH_METRICS_LOG_SOURCE)
+            .setPseudonymousId(pseudonymousId)
             .setEncodedPayload(
                 new EncodedPayload(Encoding.of("proto"), clientMetrics.toByteArray()))
             .build());

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -17,7 +17,6 @@ package com.google.android.datatransport.runtime.scheduling.jobscheduling;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
@@ -145,13 +144,13 @@ public class Uploader {
         String targetPseudonymousId = oldestEvent.getEvent().getPseudonymousId();
 
         for (PersistedEvent persistedEvent : persistedEvents) {
-            EventInternal event = persistedEvent.getEvent();
-            String pseudonymousId = event.getPseudonymousId();
+          EventInternal event = persistedEvent.getEvent();
+          String pseudonymousId = event.getPseudonymousId();
 
-            if(Objects.equals(targetPseudonymousId, pseudonymousId)) {
-                eventInternals.add(event);
-                sentEvents.add(persistedEvent);
-            }
+          if (Objects.equals(targetPseudonymousId, pseudonymousId)) {
+            eventInternals.add(event);
+            sentEvents.add(persistedEvent);
+          }
         }
 
         if (transportContext.shouldUploadClientHealthMetrics()) {
@@ -222,14 +221,15 @@ public class Uploader {
           return null;
         });
 
-    if(eventStore.hasPendingEventsFor(transportContext)) {
-        workScheduler.schedule(transportContext, attemptNumber, true);
+    if (eventStore.hasPendingEventsFor(transportContext)) {
+      workScheduler.schedule(transportContext, attemptNumber, true);
     }
     return response;
   }
 
   @VisibleForTesting
-  public EventInternal createMetricsEvent(TransportBackend backend, @Nullable String pseudonymousId) {
+  public EventInternal createMetricsEvent(
+      TransportBackend backend, @Nullable String pseudonymousId) {
     ClientMetrics clientMetrics =
         guard.runCriticalSection(clientHealthMetricsStore::loadClientMetrics);
     return backend.decorate(

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -190,6 +190,7 @@ public class Uploader {
                   return null;
                 });
           }
+          break;
         } else if (response.getStatus() == BackendResponse.Status.INVALID_PAYLOAD) {
           Map<String, Integer> countMap = new HashMap<>();
           for (PersistedEvent persistedEvent : sentEvents) {
@@ -218,6 +219,10 @@ public class Uploader {
               transportContext, clock.getTime() + finalMaxNextRequestWaitMillis);
           return null;
         });
+
+    if(eventStore.hasPendingEventsFor(transportContext)) {
+        workScheduler.schedule(transportContext, attemptNumber, true);
+    }
     return response;
   }
 

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -114,13 +114,6 @@ public class Uploader {
         });
   }
 
-  private Boolean processResponse(BackendResponse response) {
-
-      if(response.getStatus().)
-
-          return true;
-  }
-
   @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
   @CanIgnoreReturnValue
   public BackendResponse logAndUpdateState(TransportContext transportContext, int attemptNumber) {

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -193,7 +193,7 @@ public class Uploader {
           break;
         } else if (response.getStatus() == BackendResponse.Status.INVALID_PAYLOAD) {
           Map<String, Integer> countMap = new HashMap<>();
-          for (PersistedEvent persistedEvent : sentEvents) {
+          for (PersistedEvent sentEvent : sentEvents) {
             String logSource = persistedEvent.getEvent().getTransportName();
             if (!countMap.containsKey(logSource)) {
               countMap.put(logSource, 1);

--- a/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
+++ b/transport/transport-runtime/src/main/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/Uploader.java
@@ -140,13 +140,13 @@ public class Uploader {
         List<EventInternal> eventInternals = new ArrayList<>();
 
         PersistedEvent oldestEvent = persistedEvents.iterator().next();
-        String targetPseudoId = oldestEvent.getEvent().getPseudonymousId();
+        String targetPseudonymousId = oldestEvent.getEvent().getPseudonymousId();
 
         for (PersistedEvent persistedEvent : persistedEvents) {
             EventInternal event = persistedEvent.getEvent();
-            String pseudoId = event.getPseudonymousId();
+            String pseudonymousId = event.getPseudonymousId();
 
-            if(Objects.equals(targetPseudoId, pseudoId)) {
+            if(Objects.equals(targetPseudonymousId, pseudonymousId)) {
                 eventInternals.add(event);
                 sentEvents.add(persistedEvent);
             }
@@ -194,7 +194,7 @@ public class Uploader {
         } else if (response.getStatus() == BackendResponse.Status.INVALID_PAYLOAD) {
           Map<String, Integer> countMap = new HashMap<>();
           for (PersistedEvent sentEvent : sentEvents) {
-            String logSource = persistedEvent.getEvent().getTransportName();
+            String logSource = sentEvent.getEvent().getTransportName();
             if (!countMap.containsKey(logSource)) {
               countMap.put(logSource, 1);
             } else {

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerSchedulerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerSchedulerTest.java
@@ -33,7 +33,6 @@ import android.net.Uri;
 import android.util.Base64;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.datatransport.Priority;
-import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
@@ -204,9 +203,6 @@ public class AlarmManagerSchedulerTest {
     scheduler.schedule(TRANSPORT_CONTEXT, 1, true);
 
     verify(alarmManager, times(1))
-            .set(
-                    eq(AlarmManager.ELAPSED_REALTIME),
-                    eq(INITIAL_TIMESTAMP + 1),
-                    any());
+        .set(eq(AlarmManager.ELAPSED_REALTIME), eq(INITIAL_TIMESTAMP + 1), any());
   }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoSchedulerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoSchedulerTest.java
@@ -16,14 +16,8 @@ package com.google.android.datatransport.runtime.scheduling.jobscheduling;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static com.google.common.truth.Truth.assertThat;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
-import android.app.AlarmManager;
 import android.app.job.JobInfo;
 import android.app.job.JobScheduler;
 import android.content.Context;

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
@@ -220,4 +220,15 @@ public class UploaderTest {
                   return false;
                 })));
   }
+
+  @Test
+  public void upload_shouldBatchSamePseudonymousIds() {
+    // TODO()
+
+  }
+
+  @Test
+  public void upload_shouldBatchOldestEventType() {
+    // TODO()
+  }
 }

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
@@ -40,7 +40,6 @@ import com.google.android.datatransport.runtime.scheduling.persistence.InMemoryE
 import com.google.android.datatransport.runtime.scheduling.persistence.PersistedEvent;
 import com.google.android.datatransport.runtime.synchronization.SynchronizationGuard;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -117,15 +116,15 @@ public class UploaderTest {
 
   private EventInternal makeEventWithPseudonymousId(String id) {
     return EventInternal.builder()
-            .setTransportName("43")
-            .setEventMillis(1)
-            .setUptimeMillis(2)
-            .setEncodedPayload(
-                    new EncodedPayload(Encoding.of("proto"), "Hello".getBytes(Charset.defaultCharset())))
-            .addMetadata("key1", "value1")
-            .addMetadata("key2", "value2")
-            .setPseudonymousId(id)
-            .build();
+        .setTransportName("43")
+        .setEventMillis(1)
+        .setUptimeMillis(2)
+        .setEncodedPayload(
+            new EncodedPayload(Encoding.of("proto"), "Hello".getBytes(Charset.defaultCharset())))
+        .addMetadata("key1", "value1")
+        .addMetadata("key2", "value2")
+        .setPseudonymousId(id)
+        .build();
   }
 
   @Before
@@ -262,15 +261,15 @@ public class UploaderTest {
 
     uploader.logAndUpdateState(TRANSPORT_CONTEXT, 1);
     verify(mockBackend, times(1))
-            .send(
-                    argThat(
-                            (backendRequest -> {
-                              List<EventInternal> events = StreamSupport
-                                      .stream(backendRequest.getEvents().spliterator(), false)
-                                      .collect(Collectors.toList());
+        .send(
+            argThat(
+                (backendRequest -> {
+                  List<EventInternal> events =
+                      StreamSupport.stream(backendRequest.getEvents().spliterator(), false)
+                          .collect(Collectors.toList());
 
-                              return events.equals(targetEvents);
-                            })));
+                  return events.equals(targetEvents);
+                })));
   }
 
   @Test
@@ -309,15 +308,15 @@ public class UploaderTest {
 
     uploader.logAndUpdateState(TRANSPORT_CONTEXT, 1);
     verify(mockBackend, times(1))
-            .send(
-                    argThat(
-                            (backendRequest -> {
-                              List<EventInternal> events = StreamSupport
-                                      .stream(backendRequest.getEvents().spliterator(), false)
-                                      .collect(Collectors.toList());
+        .send(
+            argThat(
+                (backendRequest -> {
+                  List<EventInternal> events =
+                      StreamSupport.stream(backendRequest.getEvents().spliterator(), false)
+                          .collect(Collectors.toList());
 
-                              return events.equals(targetEvents);
-                            })));
+                  return events.equals(targetEvents);
+                })));
   }
 
   @Test


### PR DESCRIPTION
Per [b/327603525](https://b.corp.google.com/issues/327603525),

This adds support for batching the new `PseudonymousId`. Events are batched according to age- the oldest event will be batched with its type. For example:

If the oldest event does **_not_** have a `PseudonymousId`, then all events without a `PseudonymousId` will be sent.
If the oldest event **_does_** have a `PseudonymousId`, then all events with the **_SAME_** `PseudonymousId` will be sent.

The following needs to be complete before merging:

- [x] Unit testing
- [x] Changelog files updated