### PR TITLE
Handle when the session lifecycle service binding fails

### DIFF
--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
   testImplementation(libs.truth)
 
   androidTestImplementation(libs.androidx.test.junit)
+  androidTestImplementation(libs.androidx.test.rules)
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.truth)
 }

--- a/firebase-sessions/src/androidTest/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinderTest.kt
+++ b/firebase-sessions/src/androidTest/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinderTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.sessions
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ServiceTestRule
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SessionLifecycleServiceBinderTest {
+  @get:Rule val serviceRule = ServiceTestRule()
+
+  @Test
+  fun bindSessionLifecycleService() {
+    val serviceConnection =
+      object : ServiceConnection {
+        var connected: Boolean = false
+
+        override fun onServiceConnected(className: ComponentName?, serviceBinder: IBinder?) {
+          connected = true
+        }
+
+        override fun onServiceDisconnected(className: ComponentName?) {
+          connected = false
+        }
+      }
+
+    val sessionLifecycleServiceIntent =
+      Intent(ApplicationProvider.getApplicationContext(), SessionLifecycleService::class.java)
+
+    serviceRule.bindService(
+      sessionLifecycleServiceIntent,
+      serviceConnection,
+      Context.BIND_IMPORTANT or Context.BIND_AUTO_CREATE,
+    )
+
+    assertThat(serviceConnection.connected).isTrue()
+  }
+}

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
@@ -49,11 +49,22 @@ internal class SessionLifecycleServiceBinderImpl(private val firebaseApp: Fireba
       // This is necessary for the onBind() to be called by each process
       intent.action = android.os.Process.myPid().toString()
       intent.putExtra(SessionLifecycleService.CLIENT_CALLBACK_MESSENGER, callback)
-      appContext.bindService(
-        intent,
-        serviceConnection,
-        Context.BIND_IMPORTANT or Context.BIND_AUTO_CREATE
-      )
+
+      val isServiceBound =
+        try {
+          appContext.bindService(
+            intent,
+            serviceConnection,
+            Context.BIND_IMPORTANT or Context.BIND_AUTO_CREATE,
+          )
+        } catch (ex: SecurityException) {
+          Log.w(TAG, "Failed to bind session lifecycle service to application.", ex)
+          false
+        }
+      if (!isServiceBound) {
+        appContext.unbindService(serviceConnection)
+        Log.i(TAG, "Session lifecycle service binding failed.")
+      }
     }
   }
 


### PR DESCRIPTION
Pair with @PolinaGo. This fixes #5718.