### PR TITLE
Update libcrashlytics to support 16 kb page sizes

### DIFF
--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Update libcrashlytics to support 16 kb page sizes.
 
 # 19.0.1
 * [changed] Updated `firebase-crashlytics` dependency to v19.0.1

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-common/Android.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-common/Android.mk
@@ -38,7 +38,7 @@ LOCAL_CPPFLAGS := \
     -fsingle-precision-constant \
     -ffast-math \
 
-LOCAL_LDFLAGS := -flto -Wl,--gc-sections -Wl,--exclude-libs,ALL -Wl,-z,norelro
+LOCAL_LDFLAGS := -flto -Wl,--gc-sections -Wl,--exclude-libs,ALL -Wl,-z,norelro -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS := -llog -lz -ldl
 
 # Include all .cpp files in /src

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-handler/Android.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-handler/Android.mk
@@ -19,7 +19,7 @@ LOCAL_CPPFLAGS := \
     -fvisibility=hidden \
     -nostdlib++ \
 
-LOCAL_LDFLAGS := -Wl,--gc-sections -Wl,--exclude-libs,ALL -Wl,-z,norelro
+LOCAL_LDFLAGS := -Wl,--gc-sections -Wl,--exclude-libs,ALL -Wl,-z,norelro -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS := -llog -lz
 
 # Include all .cpp files in /src

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-trampoline/Android.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics-trampoline/Android.mk
@@ -23,7 +23,7 @@ LOCAL_CPPFLAGS := \
     -fno-unroll-loops \
     -fno-ident \
 
-LOCAL_LDFLAGS := -Wl,--gc-sections -Wl,-z,norelro
+LOCAL_LDFLAGS := -Wl,--gc-sections -Wl,-z,norelro -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS := -llog
 
 LOCAL_SRC_FILES := $(LOCAL_PATH)/src/handler_trampoline.cpp

--- a/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/Android.mk
+++ b/firebase-crashlytics-ndk/src/main/jni/libcrashlytics/Android.mk
@@ -36,7 +36,7 @@ LOCAL_CPPFLAGS := \
     -fsingle-precision-constant \
     -ffast-math \
 
-LOCAL_LDFLAGS := -flto -Wl,--gc-sections, -Wl,--exclude-libs,ALL -Wl,-z,norelro
+LOCAL_LDFLAGS := -flto -Wl,--gc-sections, -Wl,--exclude-libs,ALL -Wl,-z,norelro -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS := -llog
 
 # Include all .cpp files in /src


### PR DESCRIPTION
Update libcrashlytics to support 16 kb page sizes.

Tested using the instructions in [Verifying Your App](https://docs.google.com/document/d/11EG6_7vqIxvi517mivD34tBV_3k5SmpaTzaqMElvPXI/edit?resourcekey=0-rUve940xNkPV9DkvYgVBGw&tab=t.0#bookmark=id.rmsr6g9is475)

1. ```bash
    $ adb shell getconf PAGE_SIZE
    16384
    ```
2. ```bash
    out/lib/arm64-v8a/libcrashlytics-handler.so: ALIGNED (2**14)
    out/lib/arm64-v8a/libapp.so: ALIGNED (2**14)
    out/lib/arm64-v8a/libcrashlytics.so: ALIGNED (2**14)
    out/lib/arm64-v8a/libcrashlytics-trampoline.so: ALIGNED (2**14)
    out/lib/arm64-v8a/libcrashlytics-common.so: ALIGNED (2**14)
    ```
3. ```bash
    $ /google/src/head/depot/google3/third_party/java/android/android_sdk_linux/platform-tools/zipalign -c -P 16 -v 4 app-test.apk
    ...
    11172592 resources.arsc (OK)
    Verification succesful
    ```

Also tested on emulator with Android API VanillaIceCream (Google APIs Page Size 16KB) image. And tested on a physical device, though not 16k, for regressions.