### PR TITLE
m144_1 mergeback

### DIFF
--- a/firebase-config/CHANGELOG.md
+++ b/firebase-config/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Unreleased
-* [fixed] Fixed a bug that could cause a crash if the app was backgrounded
-  while it was listening for real-time Remote Config updates. For more information, see
-  <a href="https://github.com/firebase/firebase-android-sdk/issues/5751"
-     class="external">GitHub Issue #5751</a>.
 
+# 21.6.3
+* [fixed] Fixed a bug that could cause a crash if the app was backgrounded
+  while it was listening for real-time Remote Config updates. For more information, see #5751
 
 # 21.6.2
 * [fixed] Fixed an issue that could cause [remote_config] personalizations to be logged early in

--- a/firebase-config/gradle.properties
+++ b/firebase-config/gradle.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version=21.6.3
-latestReleasedVersion=21.6.2
+version=21.6.4
+latestReleasedVersion=21.6.3
 android.enableUnitTestBinaryResources=true
 


### PR DESCRIPTION
Per [b/329272808](https://b.corp.google.com/issues/329272808),

This is the mergeback for the previous hotfix release (m144_1)- to avoid pulling config into the current release.

NO_RELEASE_CHANGE