### PR TITLE
Stop mocking EventInternal

### DIFF
--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerSchedulerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/AlarmManagerSchedulerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.AdditionalMatchers.gt;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
@@ -32,7 +31,9 @@ import android.content.Intent;
 import android.net.Uri;
 import android.util.Base64;
 import androidx.test.core.app.ApplicationProvider;
+import com.google.android.datatransport.Encoding;
 import com.google.android.datatransport.Priority;
+import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
@@ -199,7 +200,17 @@ public class AlarmManagerSchedulerTest {
   @Test
   public void schedule_shouldExcludeThePriorityDelta_whenForcedAndPending() {
     TransportContext context = TransportContext.builder().setBackendName("backend1").build();
-    store.persist(context, mock(EventInternal.class));
+    EventInternal event =
+        EventInternal.builder()
+            .setEventMillis(1)
+            .setUptimeMillis(1)
+            .setTransportName("")
+            .setEncodedPayload(
+                new EncodedPayload(
+                    Encoding.of("proto"), "World".getBytes(Charset.defaultCharset())))
+            .build();
+
+    store.persist(context, event);
     scheduler.schedule(TRANSPORT_CONTEXT, 1, true);
 
     verify(alarmManager, times(1))

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoSchedulerTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/JobInfoSchedulerTest.java
@@ -16,7 +16,6 @@ package com.google.android.datatransport.runtime.scheduling.jobscheduling;
 
 import static android.os.Build.VERSION_CODES.LOLLIPOP;
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.mock;
 
 import android.app.job.JobInfo;
 import android.app.job.JobScheduler;
@@ -24,7 +23,9 @@ import android.content.Context;
 import android.os.PersistableBundle;
 import android.util.Base64;
 import androidx.test.core.app.ApplicationProvider;
+import com.google.android.datatransport.Encoding;
 import com.google.android.datatransport.Priority;
+import com.google.android.datatransport.runtime.EncodedPayload;
 import com.google.android.datatransport.runtime.EventInternal;
 import com.google.android.datatransport.runtime.TransportContext;
 import com.google.android.datatransport.runtime.scheduling.persistence.EventStore;
@@ -251,7 +252,17 @@ public class JobInfoSchedulerTest {
   @Test
   public void schedule_shouldExcludeThePriorityDelta_whenForcedAndPending() {
     TransportContext context = TransportContext.builder().setBackendName("backend1").build();
-    store.persist(context, mock(EventInternal.class));
+    EventInternal event =
+        EventInternal.builder()
+            .setEventMillis(1)
+            .setUptimeMillis(1)
+            .setTransportName("")
+            .setEncodedPayload(
+                new EncodedPayload(
+                    Encoding.of("proto"), "World".getBytes(Charset.defaultCharset())))
+            .build();
+
+    store.persist(context, event);
     scheduler.schedule(TRANSPORT_CONTEXT, 1, true);
 
     assertThat(jobScheduler.getAllPendingJobs()).hasSize(1);


### PR DESCRIPTION
Per [b/329880433](https://b.corp.google.com/issues/329880433),

This fixes a complaint from TAP about us mocking an autovalue class. Apparently, it's mean to mock auto value classes. Instead, we should be nice and create instances of them. So we are no longer mocking `EventInternal`.
