### PR TITLE
Add missing changelog entries

### DIFF
--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Updated `firebase-crashlytics` dependency to v18.6.3
 
 # 18.6.0
 * [changed] Updated `firebase-crashlytics` dependency to v18.6.0

--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 * [changed] Updated `firebase-crashlytics` dependency to v18.6.3
 
+
 # 18.6.0
 * [changed] Updated `firebase-crashlytics` dependency to v18.6.0
 

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [feature] Updated `firebase-sessions` dependency.
 
 
 # 18.6.2

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -93,7 +93,7 @@ dependencies {
     implementation("com.google.firebase:firebase-common-ktx:20.4.2")
     implementation("com.google.firebase:firebase-components:17.1.5")
     implementation("com.google.firebase:firebase-installations:17.2.0")
-    implementation("com.google.firebase:firebase-sessions:1.2.1") {
+    implementation(project(":firebase-sessions")) {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -93,10 +93,7 @@ dependencies {
     implementation("com.google.firebase:firebase-common-ktx:20.4.2")
     implementation("com.google.firebase:firebase-components:17.1.5")
     implementation("com.google.firebase:firebase-installations:17.2.0")
-    implementation(project(":firebase-sessions")) {
-         exclude group: 'com.google.firebase', module: 'firebase-common'
-         exclude group: 'com.google.firebase', module: 'firebase-components'
-     }
+    implementation(project(":firebase-sessions"))
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"


### PR DESCRIPTION
Per [b/330156705](https://b.corp.google.com/issues/330156705),

Sessions is invoking the release of Crashlytics. As such, there needs to be changelog entries on both Crashlytics and the NDK reflecting their respective dependency bumps. This adds those changelogs.

This PR also fixes the following:

- [b/330156817](https://b.corp.google.com/issues/330156817) - Ensure there's a project level dependency between sessions and crashlytics