### PR TITLE
Cleanup Uploader tests

### DIFF
--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/jobscheduling/UploaderTest.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -93,7 +94,7 @@ public class UploaderTest {
           .build();
   private static final int MANY_EVENT_COUNT = 1000;
 
-  private final EventStore store = spy(new InMemoryEventStore());
+  private final InMemoryEventStore store = spy(new InMemoryEventStore());
   private final EventStore mockStore = mock(EventStore.class);
   private BackendRegistry mockRegistry = mock(BackendRegistry.class);
   private TransportBackend mockBackend = mock(TransportBackend.class);
@@ -130,6 +131,11 @@ public class UploaderTest {
   @Before
   public void setUp() {
     when(mockRegistry.get(BACKEND_NAME)).thenReturn(mockBackend);
+  }
+
+  @After
+  public void cleanUp() {
+    store.reset();
   }
 
   @Test

--- a/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/InMemoryEventStore.java
+++ b/transport/transport-runtime/src/test/java/com/google/android/datatransport/runtime/scheduling/persistence/InMemoryEventStore.java
@@ -114,6 +114,12 @@ public class InMemoryEventStore implements EventStore {
     return results;
   }
 
+  public void reset() {
+    store.clear();
+    backendCallTime.clear();
+    idCounter.set(0);
+  }
+
   @Override
   public int cleanUp() {
     return 0;


### PR DESCRIPTION
Per [b/330185088](https://b.corp.google.com/issues/330185088),

This adds a cleanup step to our uploader tests. This hasn't been needed up until now, as tests have not only *not* cared about the order of events- but they make use of all the events they store. With the addition of our new tests, this is no longer the case. Depending on the order these new tests run it, it can produce a pass or fail for certain tests that are ascertaining the order of the events.

As such, the store will now be wiped after each test.