### PR TITLE
Fix flaky test

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/analytics/BlockingAnalyticsEventLoggerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/analytics/BlockingAnalyticsEventLoggerTest.java
@@ -18,9 +18,13 @@ import static com.google.firebase.crashlytics.internal.analytics.BlockingAnalyti
 import static org.junit.Assert.*;
 
 import android.os.Bundle;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -38,7 +42,19 @@ public class BlockingAnalyticsEventLoggerTest {
 
   @Before
   public void setUp() throws Exception {
+    FirebaseApp.initializeApp(
+        ApplicationProvider.getApplicationContext(),
+        new FirebaseOptions.Builder()
+            .setApplicationId("1:1:android:1")
+            .setApiKey("API-KEY-API-KEY-API-KEY-API-KEY-API-KEY")
+            .setProjectId("project-id")
+            .build());
     MockitoAnnotations.initMocks(this);
+  }
+
+  @After
+  public void cleanUp() {
+    FirebaseApp.clearInstancesForTest();
   }
 
   @Test

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessions.kt
@@ -32,6 +32,7 @@ internal class FirebaseSessions(
   private val firebaseApp: FirebaseApp,
   private val settings: SessionsSettings,
   backgroundDispatcher: CoroutineContext,
+  lifecycleServiceBinder: SessionLifecycleServiceBinder,
 ) {
 
   init {
@@ -50,7 +51,7 @@ internal class FirebaseSessions(
             Log.d(TAG, "Sessions SDK disabled. Not listening to lifecycle events.")
           } else {
             val lifecycleClient = SessionLifecycleClient(backgroundDispatcher)
-            lifecycleClient.bindToService()
+            lifecycleClient.bindToService(lifecycleServiceBinder)
             SessionsActivityLifecycleCallbacks.lifecycleClient = lifecycleClient
 
             firebaseApp.addLifecycleEventListener { _, _ ->

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/FirebaseSessionsRegistrar.kt
@@ -45,11 +45,13 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
         .add(Dependency.required(firebaseApp))
         .add(Dependency.required(sessionsSettings))
         .add(Dependency.required(backgroundDispatcher))
+        .add(Dependency.required(sessionLifecycleServiceBinder))
         .factory { container ->
           FirebaseSessions(
             container[firebaseApp],
             container[sessionsSettings],
             container[backgroundDispatcher],
+            container[sessionLifecycleServiceBinder],
           )
         }
         .eagerInDefaultApp()
@@ -97,7 +99,7 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
         .factory { container ->
           SessionDatastoreImpl(
             container[firebaseApp].applicationContext,
-            container[backgroundDispatcher]
+            container[backgroundDispatcher],
           )
         }
         .build(),
@@ -120,5 +122,7 @@ internal class FirebaseSessionsRegistrar : ComponentRegistrar {
       qualified(Blocking::class.java, CoroutineDispatcher::class.java)
     private val transportFactory = unqualified(TransportFactory::class.java)
     private val sessionsSettings = unqualified(SessionsSettings::class.java)
+    private val sessionLifecycleServiceBinder =
+      unqualified(SessionLifecycleServiceBinder::class.java)
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleClient.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleClient.kt
@@ -101,10 +101,10 @@ internal class SessionLifecycleClient(private val backgroundDispatcher: Coroutin
    * Binds to the [SessionLifecycleService] and passes a callback [Messenger] that will be used to
    * relay session updates to this client.
    */
-  fun bindToService() {
-    SessionLifecycleServiceBinder.instance.bindToService(
+  fun bindToService(sessionLifecycleServiceBinder: SessionLifecycleServiceBinder) {
+    sessionLifecycleServiceBinder.bindToService(
       Messenger(ClientUpdateHandler(backgroundDispatcher)),
-      serviceConnection
+      serviceConnection,
     )
   }
 
@@ -152,7 +152,7 @@ internal class SessionLifecycleClient(private val backgroundDispatcher: Coroutin
       if (subscribers.isEmpty()) {
         Log.d(
           TAG,
-          "Sessions SDK did not have any dependent SDKs register as dependencies. Events will not be sent."
+          "Sessions SDK did not have any dependent SDKs register as dependencies. Events will not be sent.",
         )
       } else if (subscribers.values.none { it.isDataCollectionEnabled }) {
         Log.d(TAG, "Data Collection is disabled for all subscribers. Skipping this Event")

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
@@ -32,11 +32,6 @@ internal fun interface SessionLifecycleServiceBinder {
    * callback will be used to relay session updates to this client.
    */
   fun bindToService(callback: Messenger, serviceConnection: ServiceConnection)
-
-  companion object {
-    val instance: SessionLifecycleServiceBinder
-      get() = Firebase.app[SessionLifecycleServiceBinder::class.java]
-  }
 }
 
 internal class SessionLifecycleServiceBinderImpl(private val firebaseApp: FirebaseApp) :

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
@@ -21,9 +21,7 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.os.Messenger
 import android.util.Log
-import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
-import com.google.firebase.app
 
 /** Interface for binding with the [SessionLifecycleService]. */
 internal fun interface SessionLifecycleServiceBinder {

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionLifecycleClientTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionLifecycleClientTest.kt
@@ -47,6 +47,7 @@ import org.robolectric.Shadows.shadowOf
 @RunWith(RobolectricTestRunner::class)
 internal class SessionLifecycleClientTest {
   private lateinit var fakeService: FakeSessionLifecycleServiceBinder
+  private lateinit var lifecycleServiceBinder: FakeSessionLifecycleServiceBinder
 
   @Before
   fun setUp() {
@@ -57,9 +58,10 @@ internal class SessionLifecycleClientTest {
           .setApplicationId(FakeFirebaseApp.MOCK_APP_ID)
           .setApiKey(FakeFirebaseApp.MOCK_API_KEY)
           .setProjectId(FakeFirebaseApp.MOCK_PROJECT_ID)
-          .build()
+          .build(),
       )
-    fakeService = firebaseApp.get(FakeSessionLifecycleServiceBinder::class.java)
+    fakeService = firebaseApp[FakeSessionLifecycleServiceBinder::class.java]
+    lifecycleServiceBinder = firebaseApp[FakeSessionLifecycleServiceBinder::class.java]
   }
 
   @After
@@ -75,7 +77,7 @@ internal class SessionLifecycleClientTest {
     runTest(UnconfinedTestDispatcher()) {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       addSubscriber(true, SessionSubscriber.Name.CRASHLYTICS)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       waitForMessages()
       assertThat(fakeService.clientCallbacks).hasSize(1)
@@ -87,7 +89,7 @@ internal class SessionLifecycleClientTest {
     runTest(UnconfinedTestDispatcher()) {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       addSubscriber(true, SessionSubscriber.Name.CRASHLYTICS)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
       client.foregrounded()
       client.backgrounded()
 
@@ -103,7 +105,7 @@ internal class SessionLifecycleClientTest {
     runTest(UnconfinedTestDispatcher()) {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       addSubscriber(true, SessionSubscriber.Name.CRASHLYTICS)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
       client.foregrounded()
       client.backgrounded()
       client.foregrounded()
@@ -123,7 +125,7 @@ internal class SessionLifecycleClientTest {
     runTest(UnconfinedTestDispatcher()) {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       addSubscriber(true, SessionSubscriber.Name.CRASHLYTICS)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       fakeService.serviceDisconnected()
@@ -139,7 +141,7 @@ internal class SessionLifecycleClientTest {
     runTest(UnconfinedTestDispatcher()) {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       addSubscriber(true, SessionSubscriber.Name.CRASHLYTICS)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       fakeService.serviceDisconnected()
@@ -157,7 +159,7 @@ internal class SessionLifecycleClientTest {
     runTest(UnconfinedTestDispatcher()) {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       addSubscriber(true, SessionSubscriber.Name.CRASHLYTICS)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       fakeService.serviceDisconnected()
@@ -174,7 +176,7 @@ internal class SessionLifecycleClientTest {
   fun doesNotSendLifecycleEventsWithoutSubscribers() =
     runTest(UnconfinedTestDispatcher()) {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       client.foregrounded()
@@ -190,7 +192,7 @@ internal class SessionLifecycleClientTest {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       addSubscriber(collectionEnabled = false, SessionSubscriber.Name.CRASHLYTICS)
       addSubscriber(collectionEnabled = false, SessionSubscriber.Name.MATT_SAYS_HI)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       client.foregrounded()
@@ -206,7 +208,7 @@ internal class SessionLifecycleClientTest {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       addSubscriber(collectionEnabled = true, SessionSubscriber.Name.CRASHLYTICS)
       addSubscriber(collectionEnabled = false, SessionSubscriber.Name.MATT_SAYS_HI)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       client.foregrounded()
@@ -220,7 +222,7 @@ internal class SessionLifecycleClientTest {
   fun handleSessionUpdate_noSubscribers() =
     runTest(UnconfinedTestDispatcher()) {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       fakeService.broadcastSession("123")
@@ -234,7 +236,7 @@ internal class SessionLifecycleClientTest {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       val crashlyticsSubscriber = addSubscriber(true, SessionSubscriber.Name.CRASHLYTICS)
       val mattSaysHiSubscriber = addSubscriber(true, SessionSubscriber.Name.MATT_SAYS_HI)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       fakeService.broadcastSession("123")
@@ -250,7 +252,7 @@ internal class SessionLifecycleClientTest {
       val client = SessionLifecycleClient(backgroundDispatcher() + coroutineContext)
       val crashlyticsSubscriber = addSubscriber(true, SessionSubscriber.Name.CRASHLYTICS)
       val mattSaysHiSubscriber = addSubscriber(false, SessionSubscriber.Name.MATT_SAYS_HI)
-      client.bindToService()
+      client.bindToService(lifecycleServiceBinder)
 
       fakeService.serviceConnected()
       fakeService.broadcastSession("123")
@@ -262,7 +264,7 @@ internal class SessionLifecycleClientTest {
 
   private fun addSubscriber(
     collectionEnabled: Boolean,
-    name: SessionSubscriber.Name
+    name: SessionSubscriber.Name,
   ): FakeSessionSubscriber {
     val fakeSubscriber = FakeSessionSubscriber(collectionEnabled, sessionSubscriberName = name)
     FirebaseSessionsDependencies.addDependency(name)

--- a/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionsActivityLifecycleCallbacksTest.kt
+++ b/firebase-sessions/src/test/kotlin/com/google/firebase/sessions/SessionsActivityLifecycleCallbacksTest.kt
@@ -46,6 +46,7 @@ import org.robolectric.Shadows
 @RunWith(AndroidJUnit4::class)
 internal class SessionsActivityLifecycleCallbacksTest {
   private lateinit var fakeService: FakeSessionLifecycleServiceBinder
+  private lateinit var lifecycleServiceBinder: FakeSessionLifecycleServiceBinder
   private val fakeActivity = Activity()
 
   @Before
@@ -69,9 +70,10 @@ internal class SessionsActivityLifecycleCallbacksTest {
           .setApplicationId(FakeFirebaseApp.MOCK_APP_ID)
           .setApiKey(FakeFirebaseApp.MOCK_API_KEY)
           .setProjectId(FakeFirebaseApp.MOCK_PROJECT_ID)
-          .build()
+          .build(),
       )
-    fakeService = firebaseApp.get(FakeSessionLifecycleServiceBinder::class.java)
+    fakeService = firebaseApp[FakeSessionLifecycleServiceBinder::class.java]
+    lifecycleServiceBinder = firebaseApp[FakeSessionLifecycleServiceBinder::class.java]
   }
 
   @After
@@ -91,7 +93,7 @@ internal class SessionsActivityLifecycleCallbacksTest {
       SessionsActivityLifecycleCallbacks.onActivityResumed(fakeActivity)
 
       // Settings fetched and set the lifecycle client.
-      lifecycleClient.bindToService()
+      lifecycleClient.bindToService(lifecycleServiceBinder)
       fakeService.serviceConnected()
       SessionsActivityLifecycleCallbacks.lifecycleClient = lifecycleClient
 
@@ -106,7 +108,7 @@ internal class SessionsActivityLifecycleCallbacksTest {
       val lifecycleClient = SessionLifecycleClient(backgroundDispatcher(coroutineContext))
 
       // Set lifecycle client before any foreground happened.
-      lifecycleClient.bindToService()
+      lifecycleClient.bindToService(lifecycleServiceBinder)
       fakeService.serviceConnected()
       SessionsActivityLifecycleCallbacks.lifecycleClient = lifecycleClient
 


### PR DESCRIPTION
This fixes flaky test due to "default firebase app not initialized" when running crashlytics or sessions tests.

Removes the `instance` function from the companion object of the binder, and pass it in the FirebaseSessions ctor instead. 