### PR TITLE
Fix compile type transformations

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
+++ b/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
@@ -46,12 +46,12 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-common:20.4.2'
-    implementation 'com.google.firebase:firebase-common-ktx:20.4.2'
-    implementation 'com.google.firebase:firebase-components:17.1.5'
-    implementation project(':appcheck:firebase-appcheck')
-    implementation project(':appcheck:firebase-appcheck-debug')
-    implementation 'com.google.firebase:firebase-appcheck-interop:17.0.0'
+    api 'com.google.firebase:firebase-common:20.4.2'
+    api 'com.google.firebase:firebase-common-ktx:20.4.2'
+    api 'com.google.firebase:firebase-components:17.1.5'
+    api project(':appcheck:firebase-appcheck')
+    api project(':appcheck:firebase-appcheck-debug')
+    api 'com.google.firebase:firebase-appcheck-interop:17.0.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation "androidx.test:core:$androidxTestCoreVersion"

--- a/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
+++ b/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
@@ -46,30 +46,31 @@ android {
 }
 
 dependencies {
-    api 'com.google.firebase:firebase-common:20.4.2'
-    api 'com.google.firebase:firebase-common-ktx:20.4.2'
-    api 'com.google.firebase:firebase-components:17.1.5'
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
     api project(':appcheck:firebase-appcheck')
     api project(':appcheck:firebase-appcheck-debug')
     api 'com.google.firebase:firebase-appcheck-interop:17.0.0'
+    api 'com.google.firebase:firebase-common:20.4.2'
+    api 'com.google.firebase:firebase-common-ktx:20.4.2'
+    api 'com.google.firebase:firebase-components:17.1.5'
+
+    implementation "androidx.test:core:$androidxTestCoreVersion"
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation "androidx.test:core:$androidxTestCoreVersion"
 
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-
+    testImplementation project(':appcheck:firebase-appcheck-safetynet')
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation project(':appcheck:firebase-appcheck-safetynet')
 
     androidTestImplementation project(':firebase-storage')
-    androidTestImplementation 'junit:junit:4.13-beta-2'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.13-beta-2'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
 }
 

--- a/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
+++ b/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
@@ -43,24 +43,25 @@ android {
 }
 
 dependencies {
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
+    api project(':appcheck:firebase-appcheck')
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-common:20.4.2'
     api 'com.google.firebase:firebase-common-ktx:20.4.2'
     api 'com.google.firebase:firebase-components:17.1.5'
-    api project(':appcheck:firebase-appcheck')
+
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
     testImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation 'androidx.test:rules:1.2.0'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation 'androidx.test:rules:1.2.0'
 }

--- a/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
+++ b/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
@@ -43,11 +43,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-common:20.4.2'
-    implementation 'com.google.firebase:firebase-common-ktx:20.4.2'
-    implementation 'com.google.firebase:firebase-components:17.1.5'
-    implementation project(':appcheck:firebase-appcheck')
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-common:20.4.2'
+    api 'com.google.firebase:firebase-common-ktx:20.4.2'
+    api 'com.google.firebase:firebase-components:17.1.5'
+    api project(':appcheck:firebase-appcheck')
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
 

--- a/appcheck/firebase-appcheck-interop/firebase-appcheck-interop.gradle
+++ b/appcheck/firebase-appcheck-interop/firebase-appcheck-interop.gradle
@@ -47,10 +47,10 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
 
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation 'androidx.test:rules:1.2.0'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation 'androidx.test:rules:1.2.0'
 }

--- a/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
+++ b/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
@@ -43,24 +43,25 @@ android {
 }
 
 dependencies {
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
+    api project(':appcheck:firebase-appcheck')
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-common:20.4.2'
     api 'com.google.firebase:firebase-common-ktx:20.4.2'
     api 'com.google.firebase:firebase-components:17.1.5'
-    api project(':appcheck:firebase-appcheck')
+
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.android.play:integrity:1.2.0'
-
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
     testImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.6'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
 }

--- a/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
+++ b/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
@@ -43,11 +43,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-common:20.4.2'
-    implementation 'com.google.firebase:firebase-common-ktx:20.4.2'
-    implementation 'com.google.firebase:firebase-components:17.1.5'
-    implementation project(':appcheck:firebase-appcheck')
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-common:20.4.2'
+    api 'com.google.firebase:firebase-common-ktx:20.4.2'
+    api 'com.google.firebase:firebase-components:17.1.5'
+    api project(':appcheck:firebase-appcheck')
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.android.play:integrity:1.2.0'

--- a/appcheck/firebase-appcheck-safetynet/firebase-appcheck-safetynet.gradle
+++ b/appcheck/firebase-appcheck-safetynet/firebase-appcheck-safetynet.gradle
@@ -42,26 +42,27 @@ android {
 }
 
 dependencies {
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+    javadocClasspath 'org.checkerframework:checker-qual:2.5.2'
+
+    api project(':appcheck:firebase-appcheck')
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-common:20.4.2'
     api 'com.google.firebase:firebase-common-ktx:20.4.2'
     api 'com.google.firebase:firebase-components:17.1.5'
-    api project(':appcheck:firebase-appcheck')
-    implementation 'com.google.android.gms:play-services-base:18.0.1'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation 'com.google.android.gms:play-services-safetynet:18.0.0'
 
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    javadocClasspath 'org.checkerframework:checker-qual:2.5.2'
+    implementation 'com.google.android.gms:play-services-base:18.0.1'
+    implementation 'com.google.android.gms:play-services-safetynet:18.0.0'
+    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
 
     testImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation 'androidx.test:rules:1.2.0'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation 'androidx.test:rules:1.2.0'
 }

--- a/appcheck/firebase-appcheck-safetynet/firebase-appcheck-safetynet.gradle
+++ b/appcheck/firebase-appcheck-safetynet/firebase-appcheck-safetynet.gradle
@@ -42,11 +42,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-common:20.4.2'
-    implementation 'com.google.firebase:firebase-common-ktx:20.4.2'
-    implementation 'com.google.firebase:firebase-components:17.1.5'
-    implementation project(':appcheck:firebase-appcheck')
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-common:20.4.2'
+    api 'com.google.firebase:firebase-common-ktx:20.4.2'
+    api 'com.google.firebase:firebase-components:17.1.5'
+    api project(':appcheck:firebase-appcheck')
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.android.gms:play-services-safetynet:18.0.0'

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-base:18.1.0'
-    implementation 'com.google.android.gms:play-services-tasks:18.1.0'
+    api 'com.google.android.gms:play-services-tasks:18.1.0'
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api "com.google.firebase:firebase-appcheck-interop:17.1.0"
     api("com.google.firebase:firebase-common:20.4.2")

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -62,11 +62,11 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-base:18.1.0'
     implementation 'com.google.android.gms:play-services-tasks:18.1.0'
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation "com.google.firebase:firebase-appcheck-interop:17.1.0"
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api "com.google.firebase:firebase-appcheck-interop:17.1.0"
     api("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -45,39 +45,43 @@ android {
 }
 
 dependencies {
-    androidTestImplementation "androidx.annotation:annotation:1.0.0"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
-    androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
-    androidTestImplementation project(':appcheck:firebase-appcheck')
-    androidTestImplementation(project(":integ-testing")){
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-        exclude group: 'com.google.firebase', module: 'firebase-components'
-    }
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-base:18.1.0'
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
     api 'com.google.android.gms:play-services-tasks:18.1.0'
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api "com.google.firebase:firebase-appcheck-interop:17.1.0"
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
     api("com.google.firebase:firebase-components:17.1.5")
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.13-beta-2'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation 'org.mockito:mockito-inline:2.25.0'
+
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.google.android.gms:play-services-base:18.1.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
     testImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation 'androidx.test:rules:1.2.0'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13-beta-2'
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation 'org.mockito:mockito-inline:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation project(':appcheck:firebase-appcheck')
+    androidTestImplementation(project(":integ-testing")){
+        exclude group: 'com.google.firebase', module: 'firebase-common'
+        exclude group: 'com.google.firebase', module: 'firebase-components'
+    }
+    androidTestImplementation "androidx.annotation:annotation:1.0.0"
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
 }

--- a/appcheck/firebase-appcheck/ktx/ktx.gradle
+++ b/appcheck/firebase-appcheck/ktx/ktx.gradle
@@ -53,17 +53,20 @@ android {
 }
 
 dependencies {
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
     api(project(":appcheck:firebase-appcheck"))
-    androidTestImplementation 'com.google.firebase:firebase-appcheck-interop:17.1.0'
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
+
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'com.google.firebase:firebase-appcheck-interop:17.1.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
 }

--- a/appcheck/firebase-appcheck/test-app/test-app.gradle
+++ b/appcheck/firebase-appcheck/test-app/test-app.gradle
@@ -35,10 +35,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-
     // Firebase dependencies
     implementation project(":appcheck:firebase-appcheck")
     implementation project(":appcheck:firebase-appcheck-debug")
@@ -46,6 +42,9 @@ dependencies {
     implementation project(":appcheck:firebase-appcheck-playintegrity")
     implementation project(":appcheck:firebase-appcheck-safetynet")
     implementation project(":firebase-storage")
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
 }
 
 // ==========================================================================

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/BaseFirebaseLibraryPlugin.kt
@@ -151,7 +151,6 @@ abstract class BaseFirebaseLibraryPlugin : Plugin<Project> {
    * The transformations are done lazily via the [withXml][MavenPom.withXml] provider.
    *
    * @param pom the [MavenPom] to prepare
-   * @see [convertToCompileDependency]
    * @see [addTypeWithAARSupport]
    */
   // TODO(b/270576405): Combine with applyPomCustomization when migrating FirebaseLibraryExtension
@@ -160,24 +159,9 @@ abstract class BaseFirebaseLibraryPlugin : Plugin<Project> {
       val dependencies = asElement().findElementsByTag("dependency")
       val androidDependencies = resolveAndroidDependencies()
       for (dependency in dependencies) {
-        convertToCompileDependency(dependency)
         addTypeWithAARSupport(dependency, androidDependencies)
       }
     }
-  }
-
-  /**
-   * Adds + configures the `scope` element as a direct descendant of the provided [Element].
-   *
-   * Sets the [textContent][Element.getTextContent] of `scope` to "compile"- regardless of its
-   * initial value. This is needed to avoid a breaking change until the bug below is fixed.
-   *
-   * @param dependency the element to append the `scope` to
-   * @see applyPomTransformations
-   */
-  // TODO(b/277605778): Remove after configurations have been migrated to the right type
-  private fun convertToCompileDependency(dependency: Element) {
-    dependency.findOrCreate("scope").textContent = "compile"
   }
 
   /**

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/PublishingPluginTests.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/PublishingPluginTests.kt
@@ -16,7 +16,6 @@
 
 package com.google.firebase.gradle.plugins
 
-import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -182,7 +181,8 @@ class PublishingPluginTests {
   fun `Publish project should correctly set dependency types`() {
     with(controller) {
       val dagger = Artifact("com.google.dagger", "dagger", "2.22", scope = "runtime")
-      val daggerAndroid = Artifact("com.google.dagger", "dagger-android-support", "2.22", Type.AAR, "compile")
+      val daggerAndroid =
+        Artifact("com.google.dagger", "dagger-android-support", "2.22", Type.AAR, "compile")
 
       val project1 = Project(name = "childProject1", version = "1.0", latestReleasedVersion = "0.8")
       val project2 =
@@ -198,7 +198,8 @@ class PublishingPluginTests {
 
       project2.pom.let {
         it.artifact.version shouldBe project2.version
-        it.dependencies shouldContainExactlyInAnyOrder listOf(project1.toArtifact(), dagger, daggerAndroid)
+        it.dependencies shouldContainExactlyInAnyOrder
+          listOf(project1.toArtifact(), dagger, daggerAndroid)
       }
     }
   }

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/PublishingPluginTests.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/PublishingPluginTests.kt
@@ -17,6 +17,7 @@
 package com.google.firebase.gradle.plugins
 
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -180,8 +181,8 @@ class PublishingPluginTests {
   @Test
   fun `Publish project should correctly set dependency types`() {
     with(controller) {
-      val dagger = Artifact("com.google.dagger", "dagger", "2.22")
-      val daggerAndroid = Artifact("com.google.dagger", "dagger-android-support", "2.22", Type.AAR)
+      val dagger = Artifact("com.google.dagger", "dagger", "2.22", scope = "runtime")
+      val daggerAndroid = Artifact("com.google.dagger", "dagger-android-support", "2.22", Type.AAR, "compile")
 
       val project1 = Project(name = "childProject1", version = "1.0", latestReleasedVersion = "0.8")
       val project2 =
@@ -189,7 +190,7 @@ class PublishingPluginTests {
           name = "childProject2",
           version = "0.9",
           projectDependencies = setOf(project1),
-          externalDependencies = setOf(dagger.copy(scope = ""), daggerAndroid.copy(scope = ""))
+          externalDependencies = setOf(dagger, daggerAndroid)
         )
 
       withProjects(project1, project2)
@@ -197,7 +198,7 @@ class PublishingPluginTests {
 
       project2.pom.let {
         it.artifact.version shouldBe project2.version
-        it.dependencies shouldContainExactly listOf(project1.toArtifact(), dagger, daggerAndroid)
+        it.dependencies shouldContainExactlyInAnyOrder listOf(project1.toArtifact(), dagger, daggerAndroid)
       }
     }
   }

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/publishing.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/publishing.kt
@@ -75,7 +75,7 @@ data class Artifact(
 ) {
   val simpleDepString = "$groupId:$artifactId:$version"
 
-  val configuration = if(scope == "compile") "api" else "implementation"
+  val configuration = if (scope == "compile") "api" else "implementation"
 }
 
 data class Pom(

--- a/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/publishing.kt
+++ b/buildSrc/src/test/kotlin/com/google/firebase/gradle/plugins/publishing.kt
@@ -53,7 +53,7 @@ data class Project(
 
             dependencies {
             ${projectDependencies.joinToString("\n") { "implementation project(':${it.name}')" }}
-            ${externalDependencies.joinToString("\n") { "implementation '${it.simpleDepString}'" }}
+            ${externalDependencies.joinToString("\n") { "${it.configuration} '${it.simpleDepString}'" }}
             }
             """
   }
@@ -71,10 +71,11 @@ data class Artifact(
   val artifactId: String,
   val version: String,
   val type: Type = Type.JAR,
-  val scope: String = "compile"
+  val scope: String = "runtime"
 ) {
-  val simpleDepString: String
-    get() = "$groupId:$artifactId:$version"
+  val simpleDepString = "$groupId:$artifactId:$version"
+
+  val configuration = if(scope == "compile") "api" else "implementation"
 }
 
 data class Pom(

--- a/encoders/firebase-decoders-json/firebase-decoders-json.gradle
+++ b/encoders/firebase-decoders-json/firebase-decoders-json.gradle
@@ -48,11 +48,10 @@ dependencies {
 
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.13-rc-1'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.13-rc-1'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }
 
 tasks.withType(JavaCompile) {

--- a/encoders/firebase-encoders-json/firebase-encoders-json.gradle
+++ b/encoders/firebase-encoders-json/firebase-encoders-json.gradle
@@ -49,7 +49,7 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.firebase:firebase-encoders:17.0.0'
+    api 'com.google.firebase:firebase-encoders:17.0.0'
 
     testImplementation 'androidx.test:runner:1.3.0'
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"

--- a/encoders/firebase-encoders-json/firebase-encoders-json.gradle
+++ b/encoders/firebase-encoders-json/firebase-encoders-json.gradle
@@ -48,16 +48,16 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
     api 'com.google.firebase:firebase-encoders:17.0.0'
+
+    implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'androidx.test:runner:1.3.0'
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.13'
     testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }
 
 tasks.withType(JavaCompile) {

--- a/encoders/firebase-encoders-proto/firebase-encoders-proto.gradle
+++ b/encoders/firebase-encoders-proto/firebase-encoders-proto.gradle
@@ -36,19 +36,19 @@ protobuf {
 
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
     api 'com.google.firebase:firebase-encoders:17.0.0'
+
+    implementation 'androidx.annotation:annotation:1.1.0'
 
     annotationProcessor project(':encoders:firebase-encoders-processor')
 
     testAnnotationProcessor project(':encoders:firebase-encoders-processor')
 
     testImplementation 'com.google.guava:guava:31.0-jre'
-    testImplementation 'junit:junit:4.13.1'
     testImplementation "com.google.protobuf:protobuf-java-util:$protobufJavaUtilVersion"
-    testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-
+    testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
+    testImplementation 'junit:junit:4.13.1'
 }
 
 tasks.withType(JavaCompile) {

--- a/encoders/firebase-encoders-proto/firebase-encoders-proto.gradle
+++ b/encoders/firebase-encoders-proto/firebase-encoders-proto.gradle
@@ -37,7 +37,7 @@ protobuf {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.firebase:firebase-encoders:17.0.0'
+    api 'com.google.firebase:firebase-encoders:17.0.0'
 
     annotationProcessor project(':encoders:firebase-encoders-processor')
 

--- a/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
+++ b/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
@@ -45,8 +45,8 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.firebase:firebase-encoders:17.0.0'
-    implementation 'com.google.firebase:firebase-encoders-json:18.0.0'
+    api 'com.google.firebase:firebase-encoders:17.0.0'
+    api 'com.google.firebase:firebase-encoders-json:18.0.0'
 
     testImplementation 'androidx.test:runner:1.3.0'
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"

--- a/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
+++ b/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
@@ -44,15 +44,15 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
     api 'com.google.firebase:firebase-encoders:17.0.0'
     api 'com.google.firebase:firebase-encoders-json:18.0.0'
 
+    implementation 'androidx.annotation:annotation:1.1.0'
+
     testImplementation 'androidx.test:runner:1.3.0'
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.13'
     testImplementation 'com.google.truth:truth:1.0.1'
+    testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/encoders/firebase-encoders/firebase-encoders.gradle
+++ b/encoders/firebase-encoders/firebase-encoders.gradle
@@ -31,9 +31,8 @@ java {
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    testImplementation 'junit:junit:4.13'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-
+    testImplementation 'junit:junit:4.13'
 }
 
 tasks.withType(JavaCompile) {

--- a/encoders/protoc-gen-firebase-encoders/protoc-gen-firebase-encoders.gradle
+++ b/encoders/protoc-gen-firebase-encoders/protoc-gen-firebase-encoders.gradle
@@ -37,13 +37,13 @@ jar {
 
 
 dependencies {
-
+    implementation 'com.google.dagger:dagger:2.43.2'
+    implementation 'com.google.guava:guava:30.0-jre'
     implementation "com.google.protobuf:protobuf-java:3.21.9"
     implementation 'com.squareup:javapoet:1.13.0'
-    implementation 'com.google.guava:guava:30.0-jre'
-    implementation 'com.google.dagger:dagger:2.43.2'
+
     kapt 'com.google.dagger:dagger-compiler:2.43.2'
 
-    testImplementation 'junit:junit:4.13.1'
     testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation 'junit:junit:4.13.1'
 }

--- a/encoders/protoc-gen-firebase-encoders/tests/tests.gradle
+++ b/encoders/protoc-gen-firebase-encoders/tests/tests.gradle
@@ -47,11 +47,11 @@ protobuf {
 }
 
 dependencies {
+    testAnnotationProcessor project(":encoders:firebase-encoders-processor")
+
     testImplementation project(":encoders:firebase-encoders")
     testImplementation project(":encoders:firebase-encoders-proto")
     testImplementation "com.google.protobuf:protobuf-java:3.21.9"
-    testImplementation 'junit:junit:4.13.1'
     testImplementation "com.google.truth:truth:1.0.1"
-
-    testAnnotationProcessor project(":encoders:firebase-encoders-processor")
+    testImplementation 'junit:junit:4.13.1'
 }

--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -50,15 +50,17 @@ android {
 dependencies {
     api 'com.google.firebase:firebase-common:20.4.2'
     api 'com.google.firebase:firebase-components:17.1.5'
+
+    implementation 'com.google.android.gms:play-services-basement:18.1.0'
     implementation ('com.google.firebase:firebase-measurement-connector:18.0.0') {
         exclude group: "com.google.firebase", module: "firebase-common"
     }
-    implementation 'com.google.android.gms:play-services-basement:18.1.0'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation 'com.google.truth:truth:0.44'
-    testImplementation 'junit:junit:4.13-beta-2'
+
     testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'io.grpc:grpc-testing:1.12.0'
     testImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation 'com.google.truth:truth:0.44'
+    testImplementation 'io.grpc:grpc-testing:1.12.0'
+    testImplementation 'junit:junit:4.13-beta-2'
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -48,8 +48,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-common:20.4.2'
-    implementation 'com.google.firebase:firebase-components:17.1.5'
+    api 'com.google.firebase:firebase-common:20.4.2'
+    api 'com.google.firebase:firebase-components:17.1.5'
     implementation ('com.google.firebase:firebase-measurement-connector:18.0.0') {
         exclude group: "com.google.firebase", module: "firebase-common"
     }

--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -53,7 +53,7 @@ dependencies {
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
     api("com.google.firebase:firebase-components:17.1.5")

--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -44,25 +44,30 @@ android {
 }
 
 dependencies {
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation "org.mockito:mockito-android:3.4.0"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
-    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'androidx.annotation:annotation:1.1.0'
     api 'com.google.android.gms:play-services-tasks:18.0.1'
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
     api("com.google.firebase:firebase-components:17.1.5")
+
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
+
+    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
+
+    testImplementation project(':firebase-appdistribution-api')
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-inline:3.4.0'
-    testImplementation project(':firebase-appdistribution-api')
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation "org.mockito:mockito-android:3.4.0"
 }

--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -54,9 +54,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/firebase-appdistribution-api/ktx/ktx.gradle
+++ b/firebase-appdistribution-api/ktx/ktx.gradle
@@ -53,16 +53,19 @@ android {
 }
 
 dependencies {
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
     api(project(":firebase-appdistribution-api"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
+
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
 }

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -52,55 +52,57 @@ thirdPartyLicenses {
 }
 
 dependencies {
+    vendor (libs.dagger.dagger) {
+        exclude group: "javax.inject", module: "javax.inject"
+    }
+
     api("com.google.firebase:firebase-appdistribution-api:16.0.0-beta11") {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
+    api 'com.google.firebase:firebase-common:20.4.2'
     api 'com.google.firebase:firebase-components:17.1.5'
     api('com.google.firebase:firebase-installations-interop:17.1.0') {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    api 'com.google.firebase:firebase-common:20.4.2'
-    testImplementation project(path: ':firebase-appdistribution')
-    testImplementation(project(":integ-testing")){
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-        exclude group: 'com.google.firebase', module: 'firebase-components'
-    }
+
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation "androidx.browser:browser:1.3.0"
+    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    implementation libs.javax.inject
+
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
+
     runtimeOnly('com.google.firebase:firebase-installations:17.1.3') {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
 
-    implementation libs.javax.inject
-    vendor (libs.dagger.dagger) {
-        exclude group: "javax.inject", module: "javax.inject"
-    }
+    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
     annotationProcessor libs.dagger.compiler
 
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation 'org.mockito:mockito-inline:3.4.0'
+    testImplementation project(path: ':firebase-appdistribution')
+    testImplementation(project(":integ-testing")){
+        exclude group: 'com.google.firebase', module: 'firebase-common'
+        exclude group: 'com.google.firebase', module: 'firebase-components'
+    }
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-
-    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
-    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation "androidx.browser:browser:1.3.0"
-    implementation "androidx.constraintlayout:constraintlayout:2.1.4"
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-inline:3.4.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 
     androidTestImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "androidx.annotation:annotation:1.0.0"
     androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation "androidx.annotation:annotation:1.0.0"
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
 }

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -52,16 +52,16 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    implementation("com.google.firebase:firebase-appdistribution-api:16.0.0-beta11") {
+    api("com.google.firebase:firebase-appdistribution-api:16.0.0-beta11") {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    implementation 'com.google.firebase:firebase-components:17.1.5'
-    implementation('com.google.firebase:firebase-installations-interop:17.1.0') {
+    api 'com.google.firebase:firebase-components:17.1.5'
+    api('com.google.firebase:firebase-installations-interop:17.1.0') {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    implementation 'com.google.firebase:firebase-common:20.4.2'
+    api 'com.google.firebase:firebase-common:20.4.2'
     testImplementation project(path: ':firebase-appdistribution')
     testImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -71,31 +71,30 @@ dependencies {
     // TODO(rachelprince): Add flag to build with public version of SDK
     println("Building with HEAD version ':firebase-appdistribution' of SDK")
 
-    // All variants use the API
-    implementation project(':firebase-appdistribution-api:ktx')
+    version ':firebase-appdistribution'
 
     // In this test project we also need to explicitly declare these dependencies
     implementation project(':firebase-appdistribution-api')
-    implementation 'com.google.firebase:firebase-common-ktx:20.3.1'
+    // All variants use the API
+    implementation project(':firebase-appdistribution-api:ktx')
+    implementation "androidx.activity:activity-ktx:1.6.0"
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation "androidx.core:core:1.9.0"
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation "androidx.fragment:fragment-ktx:1.5.3"
     implementation "com.google.android.gms:play-services-tasks:18.0.2"
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.firebase:firebase-common-ktx:20.3.1'
+    // Shake detection
+    implementation 'com.squareup:seismic:1.0.3'
+    // Other dependencies
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     // Beta flavor uses the full implementation
     betaImplementation project(':firebase-appdistribution')
 
-    // Other dependencies
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "androidx.activity:activity-ktx:1.6.0"
-    implementation "androidx.fragment:fragment-ktx:1.5.3"
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation "androidx.core:core:1.9.0"
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.6.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-
     testImplementation 'junit:junit:4.13.2'
-
-    // Shake detection
-    implementation 'com.squareup:seismic:1.0.3'
 }
 
 // This allows the app to connect to Firebase on the CI.

--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -83,6 +83,9 @@ dependencies {
         exclude("com.google.firebase","firebase-common")
         exclude("com.google.firebase","firebase-common-ktx")
     }
+
+    // TODO(Remove when FirbaseAppTest has been modernized to use LiveData)
+    androidTestImplementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.junit)

--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -54,8 +54,8 @@ android {
 dependencies {
     api(libs.kotlin.coroutines.tasks)
 
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-annotations:16.2.0")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-annotations:16.2.0")
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.futures)
     implementation(libs.kotlin.stdlib)

--- a/firebase-components/firebase-components.gradle.kts
+++ b/firebase-components/firebase-components.gradle.kts
@@ -42,7 +42,7 @@ android {
 }
 
 dependencies {
-  implementation("com.google.firebase:firebase-annotations:16.2.0")
+  api("com.google.firebase:firebase-annotations:16.2.0")
   implementation(libs.androidx.annotation)
   implementation(libs.errorprone.annotations)
 

--- a/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
+++ b/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
@@ -44,6 +44,6 @@ android {
 
 dependencies {
   implementation("com.google.android.play:feature-delivery:2.0.0")
-  implementation("com.google.firebase:firebase-common:20.3.1")
-  implementation("com.google.firebase:firebase-components:17.1.0")
+  api("com.google.firebase:firebase-common:20.3.1")
+  api("com.google.firebase:firebase-components:17.1.0")
 }

--- a/firebase-config-interop/firebase-config-interop.gradle.kts
+++ b/firebase-config-interop/firebase-config-interop.gradle.kts
@@ -44,8 +44,8 @@ android {
 }
 
 dependencies {
-    implementation("com.google.firebase:firebase-encoders-json:18.0.1")
-    implementation("com.google.firebase:firebase-encoders:17.0.0")
+    api("com.google.firebase:firebase-encoders-json:18.0.1")
+    api("com.google.firebase:firebase-encoders:17.0.0")
 
     compileOnly("com.google.auto.value:auto-value-annotations:1.10.1")
 

--- a/firebase-config/bandwagoner/bandwagoner.gradle
+++ b/firebase-config/bandwagoner/bandwagoner.gradle
@@ -64,6 +64,8 @@ firebaseTestLab {
 }
 
 dependencies {
+    api 'com.google.auto.value:auto-value-annotations:1.6.5'
+
     // Depend on development artifacts for Remote Config.
     implementation(project(":firebase-config")) {
         exclude group: 'com.google.firebase', module: 'firebase-common'
@@ -73,7 +75,18 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-
+    implementation(project(":firebase-installations")) {
+        exclude group: 'com.google.firebase', module: 'firebase-common'
+        exclude group: 'com.google.firebase', module: 'firebase-components'
+    }
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.core:core:1.0.2'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.test.espresso:espresso-idling-resource:3.2.0'
+    implementation 'com.google.android.gms:play-services-basement:18.1.0'
+    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    implementation 'com.google.android.material:material:1.0.0'
     // This is required since a `project` dependency on frc does not expose the APIs of its
     // "implementation" dependencies. The alternative would be to make common an "api" dep of remote-config.
     // Released artifacts don't need these dependencies since they don't use `project` to refer
@@ -81,36 +94,20 @@ dependencies {
     implementation("com.google.firebase:firebase-common:20.4.2")
     implementation("com.google.firebase:firebase-common-ktx:20.4.2")
     implementation("com.google.firebase:firebase-components:17.1.5")
-
     implementation("com.google.firebase:firebase-installations-interop:17.1.1") {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    implementation(project(":firebase-installations")) {
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-        exclude group: 'com.google.firebase', module: 'firebase-components'
-    }
-
-    implementation 'com.google.android.gms:play-services-basement:18.1.0'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-
     // Support Libraries
     implementation 'com.google.guava:guava:28.1-android'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4"
 
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.core:core:1.0.2'
-    implementation 'com.google.android.material:material:1.0.0'
-    api 'com.google.auto.value:auto-value-annotations:1.6.5'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.2'
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.2.0'
 
-    androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.2.0'
 }
 
 ext.packageName = "com.googletest.firebase.remoteconfig.bandwagoner"

--- a/firebase-config/firebase-config.gradle.kts
+++ b/firebase-config/firebase-config.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     // Kotlin & Android
     implementation(libs.kotlin.stdlib)
     implementation("androidx.annotation:annotation:1.1.0")
-    implementation("com.google.android.gms:play-services-tasks:18.0.1")
+    api("com.google.android.gms:play-services-tasks:18.0.1")
 
     // Annotations and static analysis
     annotationProcessor("com.google.auto.value:auto-value:1.6.6")

--- a/firebase-config/firebase-config.gradle.kts
+++ b/firebase-config/firebase-config.gradle.kts
@@ -53,21 +53,21 @@ android {
 
 dependencies {
     // Firebase
-    implementation("com.google.firebase:firebase-config-interop:16.0.1")
-    implementation("com.google.firebase:firebase-annotations:16.2.0")
-    implementation("com.google.firebase:firebase-installations-interop:17.1.0")
-    implementation("com.google.firebase:firebase-abt:21.1.1") {
+    api("com.google.firebase:firebase-config-interop:16.0.1")
+    api("com.google.firebase:firebase-annotations:16.2.0")
+    api("com.google.firebase:firebase-installations-interop:17.1.0")
+    api("com.google.firebase:firebase-abt:21.1.1") {
          exclude(group = "com.google.firebase", module = "firebase-common")
          exclude(group = "com.google.firebase", module = "firebase-components")
      }
-    implementation("com.google.firebase:firebase-measurement-connector:18.0.0") {
+    api("com.google.firebase:firebase-measurement-connector:18.0.0") {
          exclude(group = "com.google.firebase", module = "firebase-common")
          exclude(group = "com.google.firebase", module = "firebase-components")
      }
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-installations:17.2.0")
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-installations:17.2.0")
 
     // Kotlin & Android
     implementation(libs.kotlin.stdlib)

--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -44,19 +44,21 @@ android {
 }
 
 dependencies {
+    api(project(":firebase-config"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-config"))
     api("com.google.firebase:firebase-installations:17.2.0")
-    implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
+
     implementation('com.google.firebase:firebase-abt:21.1.1') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
+    implementation("com.google.firebase:firebase-components:17.1.5")
+    implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -105,21 +105,22 @@ thirdPartyLicenses {
 }
 
 dependencies {
+    api project(':firebase-crashlytics')
     api "com.google.firebase:firebase-common:20.4.2"
     api "com.google.firebase:firebase-common-ktx:20.4.2"
     api "com.google.firebase:firebase-components:17.1.5"
-    api project(':firebase-crashlytics')
+
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
 
     testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.3'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 
-    androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
-    androidTestImplementation 'org.mockito:mockito-core:3.4.3'
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation "com.google.protobuf:protobuf-javalite:$javaliteVersion"
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
-    androidTestImplementation "com.google.protobuf:protobuf-javalite:$javaliteVersion"
+    androidTestImplementation 'org.mockito:mockito-core:3.4.3'
 }

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -105,10 +105,10 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    implementation "com.google.firebase:firebase-common:20.4.2"
-    implementation "com.google.firebase:firebase-common-ktx:20.4.2"
-    implementation "com.google.firebase:firebase-components:17.1.5"
-    implementation project(':firebase-crashlytics')
+    api "com.google.firebase:firebase-common:20.4.2"
+    api "com.google.firebase:firebase-common-ktx:20.4.2"
+    api "com.google.firebase:firebase-components:17.1.5"
+    api project(':firebase-crashlytics')
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
 
     testImplementation 'androidx.test:runner:1.4.0'

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -75,25 +75,25 @@ dependencies {
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
     annotationProcessor project(":encoders:firebase-encoders-processor")
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
-    implementation 'com.google.firebase:firebase-config-interop:16.0.0'
+    api 'com.google.firebase:firebase-config-interop:16.0.0'
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.datatransport:transport-backend-cct:3.1.9'
     implementation 'com.google.android.datatransport:transport-runtime:3.1.9'
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-encoders-json:18.0.0'
-    implementation 'com.google.firebase:firebase-encoders:17.0.0'
-    implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
-    implementation('com.google.firebase:firebase-measurement-connector:18.0.2') {
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-encoders-json:18.0.0'
+    api 'com.google.firebase:firebase-encoders:17.0.0'
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api('com.google.firebase:firebase-measurement-connector:18.0.2') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
     implementation(libs.androidx.annotation)
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-installations:17.2.0")
-    implementation(project(":firebase-sessions"))
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-installations:17.2.0")
+    api(project(":firebase-sessions"))
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -76,7 +76,7 @@ dependencies {
     annotationProcessor project(":encoders:firebase-encoders-processor")
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
     api 'com.google.firebase:firebase-config-interop:16.0.0'
-    implementation "com.google.android.gms:play-services-tasks:18.0.1"
+    api "com.google.android.gms:play-services-tasks:18.0.1"
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.datatransport:transport-backend-cct:3.1.9'
     implementation 'com.google.android.datatransport:transport-runtime:3.1.9'

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -59,45 +59,50 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'com.google.firebase:firebase-encoders-json:18.0.0'
-    androidTestImplementation 'com.google.protobuf:protobuf-java:3.21.9'
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
-    androidTestImplementation 'org.mockito:mockito-core:3.4.3'
-    androidTestImplementation(libs.androidx.test.junit)
-    androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation(libs.truth)
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
 
-    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    annotationProcessor project(":encoders:firebase-encoders-processor")
-    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
-    api 'com.google.firebase:firebase-config-interop:16.0.0'
+    api(project(":firebase-sessions"))
     api "com.google.android.gms:play-services-tasks:18.0.1"
-    implementation 'com.google.android.datatransport:transport-api:3.0.0'
-    implementation 'com.google.android.datatransport:transport-backend-cct:3.1.9'
-    implementation 'com.google.android.datatransport:transport-runtime:3.1.9'
     api 'com.google.firebase:firebase-annotations:16.2.0'
-    api 'com.google.firebase:firebase-encoders-json:18.0.0'
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api 'com.google.firebase:firebase-config-interop:16.0.0'
     api 'com.google.firebase:firebase-encoders:17.0.0'
+    api 'com.google.firebase:firebase-encoders-json:18.0.0'
+    api("com.google.firebase:firebase-installations:17.2.0")
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
     api('com.google.firebase:firebase-measurement-connector:18.0.2') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
+
+    implementation 'com.google.android.datatransport:transport-api:3.0.0'
+    implementation 'com.google.android.datatransport:transport-backend-cct:3.1.9'
+    implementation 'com.google.android.datatransport:transport-runtime:3.1.9'
     implementation(libs.androidx.annotation)
-    api("com.google.firebase:firebase-common:20.4.2")
-    api("com.google.firebase:firebase-common-ktx:20.4.2")
-    api("com.google.firebase:firebase-components:17.1.5")
-    api("com.google.firebase:firebase-installations:17.2.0")
-    api(project(":firebase-sessions"))
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
+
+    annotationProcessor project(":encoders:firebase-encoders-processor")
+    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'androidx.test:runner:1.4.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.3'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation 'com.google.firebase:firebase-encoders-json:18.0.0'
+    androidTestImplementation 'com.google.protobuf:protobuf-java:3.21.9'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
+    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
+    androidTestImplementation 'org.mockito:mockito-core:3.4.3'
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.truth)
 }

--- a/firebase-crashlytics/ktx/ktx.gradle
+++ b/firebase-crashlytics/ktx/ktx.gradle
@@ -46,11 +46,13 @@ android {
 }
 
 dependencies {
+    api(project(":firebase-crashlytics"))
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+
+    implementation("com.google.firebase:firebase-components:17.1.5")
+
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.truth)
-    api("com.google.firebase:firebase-common:20.4.2")
-    api("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-crashlytics"))
 }

--- a/firebase-database/firebase-database.gradle.kts
+++ b/firebase-database/firebase-database.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation(libs.bundles.playservices)
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.playservices.tasks)
+    api(libs.playservices.tasks)
 
     testImplementation("com.fasterxml.jackson.core:jackson-core:2.13.1")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")

--- a/firebase-database/firebase-database.gradle.kts
+++ b/firebase-database/firebase-database.gradle.kts
@@ -55,15 +55,15 @@ android {
 }
 
 dependencies {
-    implementation("com.google.firebase:firebase-appcheck-interop:17.1.0")
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-auth-interop:20.0.0") {
+    api("com.google.firebase:firebase-appcheck-interop:17.1.0")
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-auth-interop:20.0.0") {
      exclude(group = "com.google.firebase", module = "firebase-common")
      exclude(group = "com.google.firebase", module = "firebase-components")
    }
-    implementation("com.google.firebase:firebase-database-collection:18.0.1")
+    api("com.google.firebase:firebase-database-collection:18.0.1")
     implementation(libs.androidx.annotation)
     implementation(libs.bundles.playservices)
     implementation(libs.kotlin.stdlib)

--- a/firebase-database/src/androidTest/java/com/google/firebase/database/EventTest.java
+++ b/firebase-database/src/androidTest/java/com/google/firebase/database/EventTest.java
@@ -282,6 +282,9 @@ public class EventTest {
     ZombieVerifier.verifyRepoZombies(refs);
 
     writer.setValue(42);
+
+    IntegrationTestHelpers.waitForRoundtrip(reader);
+    IntegrationTestHelpers.waitForRoundtrip(writer);
     assertTrue(writeHelper.waitForEvents());
     assertTrue(writeHelper2.waitForEvents());
     assertTrue(readHelper.waitForEvents());

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -47,8 +47,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-common:20.4.2'
-    implementation 'com.google.firebase:firebase-components:17.1.5'
+    api 'com.google.firebase:firebase-common:20.4.2'
+    api 'com.google.firebase:firebase-components:17.1.5'
     implementation 'com.google.android.datatransport:transport-api:3.1.0'
     implementation 'com.google.android.datatransport:transport-runtime:3.2.0'
     implementation 'com.google.android.datatransport:transport-backend-cct:3.2.0'

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -49,14 +49,15 @@ android {
 dependencies {
     api 'com.google.firebase:firebase-common:20.4.2'
     api 'com.google.firebase:firebase-components:17.1.5'
-    implementation 'com.google.android.datatransport:transport-api:3.1.0'
-    implementation 'com.google.android.datatransport:transport-runtime:3.2.0'
-    implementation 'com.google.android.datatransport:transport-backend-cct:3.2.0'
-    implementation 'androidx.annotation:annotation:1.1.0'
 
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.12'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.google.android.datatransport:transport-api:3.1.0'
+    implementation 'com.google.android.datatransport:transport-backend-cct:3.2.0'
+    implementation 'com.google.android.datatransport:transport-runtime:3.2.0'
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation 'androidx.test:runner:1.2.0'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
     api('com.google.firebase:firebase-auth-interop:20.0.0') {
          exclude group: "com.google.firebase", module: "firebase-common"
      }

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -51,37 +51,42 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'com.google.android.gms:play-services-base:18.0.1'
-    implementation 'com.google.android.gms:play-services-basement:18.1.0'
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    javadocClasspath 'org.checkerframework:checker-qual:2.5.2'
+
     api 'com.google.android.gms:play-services-tasks:18.0.1'
     api('com.google.firebase:firebase-auth-interop:20.0.0') {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
-    api('com.google.firebase:firebase-measurement-connector:19.0.0') {
-         exclude group: 'com.google.firebase', module: 'firebase-common'
-     }
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
     api("com.google.firebase:firebase-components:17.1.5")
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
-    javadocClasspath 'org.checkerframework:checker-qual:2.5.2'
+    api('com.google.firebase:firebase-measurement-connector:19.0.0') {
+         exclude group: 'com.google.firebase', module: 'firebase-common'
+     }
+
+    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'com.google.android.gms:play-services-base:18.0.1'
+    implementation 'com.google.android.gms:play-services-basement:18.1.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
     testAnnotationProcessor "com.google.auto.value:auto-value:1.6.3"
-    testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'com.android.support.test:runner:1.0.2'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
-    testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation('com.google.android.gms:play-services-appinvite:18.0.0') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-dynamic-links'
      }
+    testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation 'org.mockito:mockito-core:3.3.3'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'
 }

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -56,15 +56,15 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation('com.google.firebase:firebase-auth-interop:20.0.0') {
+    api('com.google.firebase:firebase-auth-interop:20.0.0') {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
-    implementation('com.google.firebase:firebase-measurement-connector:19.0.0') {
+    api('com.google.firebase:firebase-measurement-connector:19.0.0') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
      }
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
     javadocClasspath 'org.checkerframework:checker-qual:2.5.2'

--- a/firebase-dynamic-links/ktx/ktx.gradle
+++ b/firebase-dynamic-links/ktx/ktx.gradle
@@ -44,13 +44,15 @@ android {
 }
 
 dependencies {
+    api(project(":firebase-dynamic-links"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-dynamic-links"))
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -143,16 +143,16 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-appcheck-interop:17.0.0'
-    implementation 'com.google.firebase:firebase-database-collection:18.0.1'
-    implementation project(':protolite-well-known-types')
-    implementation('com.google.firebase:firebase-auth-interop:19.0.2') {
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-appcheck-interop:17.0.0'
+    api 'com.google.firebase:firebase-database-collection:18.0.1'
+    api project(':protolite-well-known-types')
+    api('com.google.firebase:firebase-auth-interop:19.0.2') {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
     testCompileOnly "com.google.protobuf:protobuf-java:$protocVersion"
     testImplementation "androidx.test:core:$androidxTestCoreVersion"

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -142,7 +142,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-appcheck-interop:17.0.0'
     api 'com.google.firebase:firebase-database-collection:18.0.1'

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -118,55 +118,63 @@ googleJavaFormat {
 }
 
 dependencies {
-    androidTestAnnotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    androidTestImplementation "androidx.annotation:annotation:1.1.0"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'androidx.test:runner:1.5.2'
-    androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-    androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'org.mockito:mockito-android:2.25.0'
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
-    androidTestImplementation("com.google.truth:truth:$googleTruthVersion") {
-         exclude group: "org.codehaus.mojo", module: "animal-sniffer-annotations"
-     }
-    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
-    compileOnly 'javax.annotation:jsr250-api:1.0'
-    implementation "io.grpc:grpc-android:$grpcVersion"
-    implementation "io.grpc:grpc-okhttp:$grpcVersion"
-    implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"
-    implementation "io.grpc:grpc-stub:$grpcVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-base:18.0.1'
-    implementation 'com.google.android.gms:play-services-basement:18.1.0'
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
+    api project(':protolite-well-known-types')
     api 'com.google.android.gms:play-services-tasks:18.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-appcheck-interop:17.0.0'
-    api 'com.google.firebase:firebase-database-collection:18.0.1'
-    api project(':protolite-well-known-types')
     api('com.google.firebase:firebase-auth-interop:19.0.2') {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
     api("com.google.firebase:firebase-components:17.1.5")
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    testCompileOnly "com.google.protobuf:protobuf-java:$protocVersion"
+    api 'com.google.firebase:firebase-database-collection:18.0.1'
+
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.google.android.gms:play-services-base:18.0.1'
+    implementation 'com.google.android.gms:play-services-basement:18.1.0'
+    implementation "io.grpc:grpc-android:$grpcVersion"
+    implementation "io.grpc:grpc-okhttp:$grpcVersion"
+    implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"
+    implementation "io.grpc:grpc-stub:$grpcVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
+    compileOnly 'javax.annotation:jsr250-api:1.0'
+
+    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
+
+    androidTestAnnotationProcessor 'com.google.auto.value:auto-value:1.6.5'
+
+    testImplementation project(':firebase-database-collection')
+    testImplementation project(':firebase-firestore')
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     testImplementation 'com.google.android.gms:play-services-tasks:18.0.1'
     testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation project(':firebase-database-collection')
-    testImplementation project(':firebase-firestore')
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    testCompileOnly "com.google.protobuf:protobuf-java:$protocVersion"
+
+    androidTestImplementation "androidx.annotation:annotation:1.1.0"
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+    androidTestImplementation("com.google.truth:truth:$googleTruthVersion") {
+         exclude group: "org.codehaus.mojo", module: "animal-sniffer-annotations"
+     }
+    androidTestImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'org.mockito:mockito-android:2.25.0'
+    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
 }
 
 gradle.projectsEvaluated {

--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -54,17 +54,20 @@ tasks.withType(Test) {
 }
 
 dependencies {
+    api(project(":firebase-firestore"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-firestore"))
-    testCompileOnly "com.google.protobuf:protobuf-java:$protocVersion"
+
+    testImplementation project(':firebase-database-collection')
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     testImplementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation project(':firebase-database-collection')
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    testCompileOnly "com.google.protobuf:protobuf-java:$protocVersion"
 }

--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.playservices.base)
     implementation(libs.playservices.basement)
-    implementation(libs.playservices.tasks)
+    api(libs.playservices.tasks)
 
     annotationProcessor(libs.autovalue)
     annotationProcessor(libs.dagger.compiler)

--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -50,19 +50,19 @@ dependencies {
     javadocClasspath(libs.autovalue.annotations)
     javadocClasspath(libs.findbugs.jsr305)
 
-    implementation("com.google.firebase:firebase-appcheck-interop:17.1.0")
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-annotations:16.2.0")
-    implementation("com.google.firebase:firebase-auth-interop:18.0.0") {
+    api("com.google.firebase:firebase-appcheck-interop:17.1.0")
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-annotations:16.2.0")
+    api("com.google.firebase:firebase-auth-interop:18.0.0") {
        exclude(group = "com.google.firebase", module = "firebase-common")
    }
-    implementation("com.google.firebase:firebase-iid:21.1.0") {
+    api("com.google.firebase:firebase-iid:21.1.0") {
        exclude(group = "com.google.firebase", module = "firebase-common")
        exclude(group = "com.google.firebase", module = "firebase-components")
    }
-    implementation("com.google.firebase:firebase-iid-interop:17.1.0")
+    api("com.google.firebase:firebase-iid-interop:17.1.0")
     implementation(libs.androidx.annotation)
     implementation(libs.javax.inject)
     implementation(libs.kotlin.stdlib)

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -111,10 +111,10 @@ dependencies {
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
     implementation 'javax.inject:javax.inject:1'
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation(project(":firebase-inappmessaging"))
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api(project(":firebase-inappmessaging"))
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation "com.google.truth:truth:1.0"

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -78,29 +78,15 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    androidTestImplementation "androidx.annotation:annotation:1.0.0"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.dexmaker:dexmaker:1.2"
-    androidTestImplementation "com.linkedin.dexmaker:dexmaker-mockito:2.28.1"
-    androidTestImplementation "org.mockito:mockito-core:2.25.0"
-    androidTestImplementation 'androidx.annotation:annotation:1.1.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation ("com.google.firebase:firebase-analytics:17.4.0") {
-         exclude group: "com.google.firebase", module: "firebase-common"
-         exclude group: "com.google.firebase", module: "firebase-components"
-         exclude group: "com.google.firebase", module: "firebase-installations-interop"
-         exclude group: "com.google.firebase", module: "firebase-installations"
+    vendor (libs.dagger.dagger) {
+         exclude group: "javax.inject", module: "javax.inject"
      }
-    androidTestImplementation(project(":integ-testing")){
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-        exclude group: 'com.google.firebase', module: 'firebase-components'
-    }
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
-    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
-    annotationProcessor libs.dagger.compiler
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
+    api(project(":firebase-inappmessaging"))
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.browser:browser:1.0.0'
@@ -111,22 +97,41 @@ dependencies {
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
     implementation 'javax.inject:javax.inject:1'
-    api("com.google.firebase:firebase-common:20.4.2")
-    api("com.google.firebase:firebase-common-ktx:20.4.2")
-    api("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-inappmessaging"))
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
+    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
+    annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
+    annotationProcessor libs.dagger.compiler
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "com.google.truth:truth:1.0"
-    testImplementation "junit:junit:4.12"
-    testImplementation "org.mockito:mockito-core:2.25.0"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'com.google.guava:guava:30.1-android'
-    testImplementation 'junit:junit:4.12'
     testImplementation ("com.google.firebase:firebase-analytics:17.0.0") {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
-    vendor (libs.dagger.dagger) {
-         exclude group: "javax.inject", module: "javax.inject"
+    testImplementation 'com.google.guava:guava:30.1-android'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation "com.google.truth:truth:1.0"
+    testImplementation "junit:junit:4.12"
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.mockito:mockito-core:2.25.0"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation(project(":integ-testing")){
+        exclude group: 'com.google.firebase', module: 'firebase-common'
+        exclude group: 'com.google.firebase', module: 'firebase-components'
+    }
+    androidTestImplementation "androidx.annotation:annotation:1.0.0"
+    androidTestImplementation 'androidx.annotation:annotation:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "com.google.dexmaker:dexmaker:1.2"
+    androidTestImplementation ("com.google.firebase:firebase-analytics:17.4.0") {
+         exclude group: "com.google.firebase", module: "firebase-common"
+         exclude group: "com.google.firebase", module: "firebase-components"
+         exclude group: "com.google.firebase", module: "firebase-installations-interop"
+         exclude group: "com.google.firebase", module: "firebase-installations"
      }
+    androidTestImplementation "com.linkedin.dexmaker:dexmaker-mockito:2.28.1"
+    androidTestImplementation "org.mockito:mockito-core:2.25.0"
 }

--- a/firebase-inappmessaging-display/ktx/ktx.gradle
+++ b/firebase-inappmessaging-display/ktx/ktx.gradle
@@ -45,16 +45,18 @@ android {
 }
 
 dependencies {
-    api("com.google.firebase:firebase-common:20.4.2")
-    api("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
     api(project(":firebase-inappmessaging"))
     api(project(":firebase-inappmessaging-display"))
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+
+    implementation("com.google.firebase:firebase-components:17.1.5")
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.12'
     testImplementation ("com.google.firebase:firebase-analytics:17.0.0") {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -129,26 +129,26 @@ dependencies {
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.auto.value:auto-value-annotations:1.8.1'
-    implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.14'
     implementation 'javax.inject:javax.inject:1'
-    implementation project(':protolite-well-known-types')
-    implementation('com.google.firebase:firebase-abt:21.1.1') {
+    api project(':protolite-well-known-types')
+    api('com.google.firebase:firebase-abt:21.1.1') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
-    implementation('com.google.firebase:firebase-measurement-connector:18.0.2') {
+    api('com.google.firebase:firebase-measurement-connector:18.0.2') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
      }
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-datatransport:18.2.0"){
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-datatransport:18.2.0"){
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
-    implementation("com.google.firebase:firebase-installations:17.2.0")
+    api("com.google.firebase:firebase-installations:17.2.0")
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -102,44 +102,15 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.27'
-    androidTestImplementation "androidx.annotation:annotation:1.0.0"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation "io.grpc:grpc-testing:$grpcVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
-    androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'org.awaitility:awaitility:3.1.0'
-    androidTestImplementation(project(":integ-testing")){
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-        exclude group: 'com.google.firebase', module: 'firebase-components'
-    }
+    vendor (libs.dagger.dagger) {
+         exclude group: "javax.inject", module: "javax.inject"
+     }
 
-    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
-    annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
-    annotationProcessor libs.dagger.compiler
-    compileOnly 'javax.annotation:jsr250-api:1.0'
-    implementation "io.grpc:grpc-okhttp:$grpcVersion"
-    implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"
-    implementation "io.grpc:grpc-stub:$grpcVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.datatransport:transport-api:3.0.0'
-    api 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation 'com.google.auto.value:auto-value-annotations:1.8.1'
-    api 'com.google.firebase:firebase-installations-interop:17.1.0'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
-    implementation 'io.reactivex.rxjava2:rxjava:2.1.14'
-    implementation 'javax.inject:javax.inject:1'
     api project(':protolite-well-known-types')
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
     api('com.google.firebase:firebase-abt:21.1.1') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
-     }
-    api('com.google.firebase:firebase-measurement-connector:18.0.2') {
-         exclude group: 'com.google.firebase', module: 'firebase-common'
      }
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
@@ -149,24 +120,59 @@ dependencies {
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
     api("com.google.firebase:firebase-installations:17.2.0")
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "io.grpc:grpc-testing:$grpcVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'androidx.test:runner:1.3.0'
-    testImplementation 'com.google.guava:guava:30.1-android'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.13.1'
-    testImplementation 'org.mockito:mockito-core:1.10.19'
-    testImplementation ("org.robolectric:robolectric:$robolectricVersion") {
-         exclude group: 'com.google.protobuf', module: 'protobuf-java'
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api('com.google.firebase:firebase-measurement-connector:18.0.2') {
+         exclude group: 'com.google.firebase', module: 'firebase-common'
      }
+
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.google.android.datatransport:transport-api:3.0.0'
+    implementation 'com.google.auto.value:auto-value-annotations:1.8.1'
+    implementation "io.grpc:grpc-okhttp:$grpcVersion"
+    implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"
+    implementation "io.grpc:grpc-stub:$grpcVersion"
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.14'
+    implementation 'javax.inject:javax.inject:1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
+    compileOnly 'javax.annotation:jsr250-api:1.0'
+
+    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
+    annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
+    annotationProcessor libs.dagger.compiler
+
+    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.27'
+
     testImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    vendor (libs.dagger.dagger) {
-         exclude group: "javax.inject", module: "javax.inject"
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation 'androidx.test:runner:1.3.0'
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    testImplementation 'com.google.guava:guava:30.1-android'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation "io.grpc:grpc-testing:$grpcVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation ("org.robolectric:robolectric:$robolectricVersion") {
+         exclude group: 'com.google.protobuf', module: 'protobuf-java'
      }
+
+    androidTestImplementation(project(":integ-testing")){
+        exclude group: 'com.google.firebase', module: 'firebase-common'
+        exclude group: 'com.google.firebase', module: 'firebase-components'
+    }
+    androidTestImplementation "androidx.annotation:annotation:1.0.0"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
+    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
+    androidTestImplementation "io.grpc:grpc-testing:$grpcVersion"
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.awaitility:awaitility:3.1.0'
 }

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -127,7 +127,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.auto.value:auto-value-annotations:1.8.1'
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'

--- a/firebase-inappmessaging/ktx/ktx.gradle
+++ b/firebase-inappmessaging/ktx/ktx.gradle
@@ -44,12 +44,14 @@ android {
 }
 
 dependencies {
+    api(project(":firebase-inappmessaging"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-inappmessaging"))
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-installations-interop/firebase-installations-interop.gradle
+++ b/firebase-installations-interop/firebase-installations-interop.gradle
@@ -43,9 +43,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
 
+    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
+
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"
 }

--- a/firebase-installations-interop/firebase-installations-interop.gradle
+++ b/firebase-installations-interop/firebase-installations-interop.gradle
@@ -44,7 +44,7 @@ android {
 
 dependencies {
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-annotations:16.2.0'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"

--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -44,37 +44,43 @@ android {
 }
 
 dependencies {
-    androidTestImplementation "androidx.annotation:annotation:1.0.0"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
-    androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
-    androidTestImplementation(project(":integ-testing")){
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-        exclude group: 'com.google.firebase', module: 'firebase-components'
-    }
-    annotationProcessor "com.google.auto.value:auto-value:1.6.2"
-    api("com.google.firebase:firebase-installations-interop:17.1.1")
-    compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+
     api 'com.google.android.gms:play-services-tasks:18.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
-    api 'com.google.firebase:firebase-installations-interop:17.1.0'
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
     api("com.google.firebase:firebase-components:17.1.5")
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation 'org.mockito:mockito-inline:2.25.0'
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api("com.google.firebase:firebase-installations-interop:17.1.1")
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
+    compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
+
+    annotationProcessor "com.google.auto.value:auto-value:1.6.2"
+
     testImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation 'org.mockito:mockito-inline:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation(project(":integ-testing")){
+        exclude group: 'com.google.firebase', module: 'firebase-common'
+        exclude group: 'com.google.firebase', module: 'firebase-components'
+    }
+    androidTestImplementation "androidx.annotation:annotation:1.0.0"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+    androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
 }

--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -60,11 +60,11 @@ dependencies {
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"

--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -59,7 +59,7 @@ dependencies {
     api("com.google.firebase:firebase-installations-interop:17.1.1")
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
     api("com.google.firebase:firebase-common:20.4.2")

--- a/firebase-installations/ktx/ktx.gradle
+++ b/firebase-installations/ktx/ktx.gradle
@@ -43,15 +43,15 @@ android {
 }
 
 dependencies {
+    api(project(":firebase-installations"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-installations"))
     api("com.google.firebase:firebase-installations-interop:17.1.1")
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+
+    implementation("com.google.firebase:firebase-components:17.1.5")
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.13'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-installations/src/androidTest/java/com/google/firebase/installations/local/PersistedInstallationEntrySubject.java
+++ b/firebase-installations/src/androidTest/java/com/google/firebase/installations/local/PersistedInstallationEntrySubject.java
@@ -19,13 +19,12 @@ import static com.google.common.truth.Truth.assertAbout;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
 import com.google.firebase.installations.local.PersistedInstallation.RegistrationStatus;
-import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 public final class PersistedInstallationEntrySubject extends Subject {
 
   // User-defined entry point
   public static PersistedInstallationEntrySubject assertThat(
-      @NullableDecl PersistedInstallationEntry persistedInstallationEntry) {
+       PersistedInstallationEntry persistedInstallationEntry) {
     return assertAbout(PERSISTED_INSTALLATION_ENTRY_SUBJECT_FACTORY)
         .that(persistedInstallationEntry);
   }
@@ -45,13 +44,13 @@ public final class PersistedInstallationEntrySubject extends Subject {
 
   /**
    * Constructor for use by subclasses. If you want to create an instance of this class itself, call
-   * {@link Subject#check(String, Object ...) check(...)}{@code .that(actual)}.
+   * {@link Subject#check(String, Object...)}}{@code .that(actual)}.
    *
    * @param metadata
    * @param actual
    */
   protected PersistedInstallationEntrySubject(
-      FailureMetadata metadata, @NullableDecl PersistedInstallationEntry actual) {
+      FailureMetadata metadata, PersistedInstallationEntry actual) {
     super(metadata, actual);
     this.actual = actual;
   }

--- a/firebase-installations/src/androidTest/java/com/google/firebase/installations/local/PersistedInstallationEntrySubject.java
+++ b/firebase-installations/src/androidTest/java/com/google/firebase/installations/local/PersistedInstallationEntrySubject.java
@@ -24,7 +24,7 @@ public final class PersistedInstallationEntrySubject extends Subject {
 
   // User-defined entry point
   public static PersistedInstallationEntrySubject assertThat(
-       PersistedInstallationEntry persistedInstallationEntry) {
+      PersistedInstallationEntry persistedInstallationEntry) {
     return assertAbout(PERSISTED_INSTALLATION_ENTRY_SUBJECT_FACTORY)
         .that(persistedInstallationEntry);
   }

--- a/firebase-messaging-directboot/firebase-messaging-directboot.gradle
+++ b/firebase-messaging-directboot/firebase-messaging-directboot.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    implementation project(':firebase-messaging')
+    api project(':firebase-messaging')
 
     implementation 'com.google.android.gms:play-services-cloud-messaging:17.0.2'
     implementation "com.google.errorprone:error_prone_annotations:2.9.0"

--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -93,8 +93,8 @@ dependencies {
     implementation "com.google.android.gms:play-services-basement:18.1.0"
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
     implementation "com.google.errorprone:error_prone_annotations:2.9.0"
-    implementation "com.google.firebase:firebase-encoders-proto:16.0.0"
-    implementation "com.google.firebase:firebase-iid-interop:17.1.0"
+    api "com.google.firebase:firebase-encoders-proto:16.0.0"
+    api "com.google.firebase:firebase-iid-interop:17.1.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'com.google.android.datatransport:transport-api:3.1.0'
@@ -103,18 +103,18 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-cloud-messaging:17.1.0'
     implementation 'com.google.android.gms:play-services-stats:17.0.2'
-    implementation 'com.google.firebase:firebase-encoders-json:18.0.0'
-    implementation 'com.google.firebase:firebase-encoders:17.0.0'
-    implementation('com.google.firebase:firebase-datatransport:18.1.7') {
+    api 'com.google.firebase:firebase-encoders-json:18.0.0'
+    api 'com.google.firebase:firebase-encoders:17.0.0'
+    api('com.google.firebase:firebase-datatransport:18.1.7') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
-    implementation('com.google.firebase:firebase-installations-interop:17.1.0')
-    implementation('com.google.firebase:firebase-measurement-connector:19.0.0')
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-installations:17.2.0")
+    api('com.google.firebase:firebase-installations-interop:17.1.0')
+    api('com.google.firebase:firebase-measurement-connector:19.0.0')
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-installations:17.2.0")
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
     testAnnotationProcessor "com.google.auto.value:auto-value:1.6.3"
     testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'

--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -23,7 +23,7 @@ protobuf {
     dependencies {
         // Include the project dependency directly
         protobuild project(path: ':encoders:protoc-gen-firebase-encoders', configuration: 'shadow')
-    }
+}
     protoc {
         artifact = "com.google.protobuf:protoc:$protocVersion"
     }
@@ -79,69 +79,76 @@ android {
 }
 
 dependencies {
-    androidTestImplementation "androidx.annotation:annotation:1.0.0"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
-    androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
-    androidTestImplementation(project(":integ-testing")){
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-        exclude group: 'com.google.firebase', module: 'firebase-components' }
-    annotationProcessor project(":encoders:firebase-encoders-processor")
-    implementation "com.google.android.gms:play-services-basement:18.1.0"
-    implementation "com.google.android.gms:play-services-tasks:18.0.1"
-    implementation "com.google.errorprone:error_prone_annotations:2.9.0"
-    api "com.google.firebase:firebase-encoders-proto:16.0.0"
-    api "com.google.firebase:firebase-iid-interop:17.1.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'com.google.android.datatransport:transport-api:3.1.0'
-    implementation 'com.google.android.datatransport:transport-backend-cct:3.1.8'
-    implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
-    implementation 'com.google.android.gms:play-services-base:18.0.1'
-    implementation 'com.google.android.gms:play-services-cloud-messaging:17.1.0'
-    implementation 'com.google.android.gms:play-services-stats:17.0.2'
-    api 'com.google.firebase:firebase-encoders-json:18.0.0'
-    api 'com.google.firebase:firebase-encoders:17.0.0'
-    api('com.google.firebase:firebase-datatransport:18.1.7') {
+        javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+
+        api("com.google.firebase:firebase-common:20.4.2")
+        api("com.google.firebase:firebase-common-ktx:20.4.2")
+        api("com.google.firebase:firebase-components:17.1.5")
+        api('com.google.firebase:firebase-datatransport:18.1.7') {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
-    api('com.google.firebase:firebase-installations-interop:17.1.0')
-    api('com.google.firebase:firebase-measurement-connector:19.0.0')
-    api("com.google.firebase:firebase-common:20.4.2")
-    api("com.google.firebase:firebase-common-ktx:20.4.2")
-    api("com.google.firebase:firebase-components:17.1.5")
-    api("com.google.firebase:firebase-installations:17.2.0")
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    testAnnotationProcessor "com.google.auto.value:auto-value:1.6.3"
-    testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'androidx.core:core:1.6.0'
-    testImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
-    testImplementation 'androidx.test.ext:truth:1.4.0'
-    testImplementation 'androidx.test.services:test-services:1.2.0'
-    testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation 'com.android.support.test:runner:1.0.2'
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-    testImplementation 'com.google.android.gms:play-services-cloud-messaging:17.0.1'
-    testImplementation 'com.google.android.gms:play-services-vision:20.1.3'
-    testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.13-beta-2'
-    testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation ("com.google.api-client:google-api-client:1.30.9") {
+        api 'com.google.firebase:firebase-encoders:17.0.0'
+        api 'com.google.firebase:firebase-encoders-json:18.0.0'
+        api "com.google.firebase:firebase-encoders-proto:16.0.0"
+        api "com.google.firebase:firebase-iid-interop:17.1.0"
+        api("com.google.firebase:firebase-installations:17.2.0")
+        api('com.google.firebase:firebase-installations-interop:17.1.0')
+        api('com.google.firebase:firebase-measurement-connector:19.0.0')
+
+        implementation 'androidx.annotation:annotation:1.2.0'
+        implementation 'com.google.android.datatransport:transport-api:3.1.0'
+        implementation 'com.google.android.datatransport:transport-backend-cct:3.1.8'
+        implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
+        implementation 'com.google.android.gms:play-services-base:18.0.1'
+        implementation "com.google.android.gms:play-services-basement:18.1.0"
+        implementation 'com.google.android.gms:play-services-cloud-messaging:17.1.0'
+        implementation 'com.google.android.gms:play-services-stats:17.0.2'
+        implementation "com.google.android.gms:play-services-tasks:18.0.1"
+        implementation "com.google.errorprone:error_prone_annotations:2.9.0"
+        implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
+        annotationProcessor project(":encoders:firebase-encoders-processor")
+
+        testAnnotationProcessor "com.google.auto.value:auto-value:1.6.3"
+
+        testImplementation 'androidx.core:core:1.6.0'
+        testImplementation "androidx.test:core:$androidxTestCoreVersion"
+        testImplementation 'androidx.test:rules:1.2.0'
+        testImplementation 'androidx.test:runner:1.2.0'
+        testImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
+        testImplementation 'androidx.test.ext:truth:1.4.0'
+        testImplementation 'androidx.test.services:test-services:1.2.0'
+        testImplementation 'com.android.support.test:runner:1.0.2'
+        testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+        testImplementation 'com.google.android.gms:play-services-cloud-messaging:17.0.1'
+        testImplementation 'com.google.android.gms:play-services-vision:20.1.3'
+        testImplementation ("com.google.api-client:google-api-client:1.30.9") {
          exclude group: "org.apache.httpcomponents", module: "httpclient"
      }
-    testImplementation ("com.google.firebase:firebase-iid:21.1.0") {
+        testImplementation ("com.google.firebase:firebase-iid:21.1.0") {
          exclude group: "com.google.firebase", module: "firebase-common"
          exclude group: "com.google.firebase", module: "firebase-components"
          exclude group: "com.google.firebase", module: "firebase-installations-interop"
          exclude group: "com.google.firebase", module: "firebase-installations"
      }
+        testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
+        testImplementation "com.google.truth:truth:$googleTruthVersion"
+        testImplementation 'junit:junit:4.12'
+        testImplementation 'junit:junit:4.13-beta-2'
+        testImplementation 'org.mockito:mockito-core:2.25.0'
+        testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+        testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'
+
+        androidTestImplementation(project(":integ-testing")){
+        exclude group: 'com.google.firebase', module: 'firebase-common'
+        exclude group: 'com.google.firebase', module: 'firebase-components' }
+        androidTestImplementation "androidx.annotation:annotation:1.0.0"
+        androidTestImplementation 'androidx.test:runner:1.2.0'
+        androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+        androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+        androidTestImplementation 'junit:junit:4.12'
+        androidTestImplementation 'org.mockito:mockito-core:2.25.0'
+        androidTestImplementation 'org.mockito:mockito-inline:2.25.0'
 }

--- a/firebase-messaging/ktx/ktx.gradle
+++ b/firebase-messaging/ktx/ktx.gradle
@@ -43,12 +43,14 @@ android {
 }
 
 dependencies {
+    api(project(":firebase-messaging"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-messaging"))
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
+++ b/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
@@ -70,55 +70,62 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    androidTestImplementation "androidx.annotation:annotation:1.1.0"
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.13.1'
-    annotationProcessor "com.google.auto.value:auto-value:1.6.5"
-    annotationProcessor libs.dagger.compiler
-    annotationProcessor project(":encoders:firebase-encoders-processor")
-    compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.datatransport:transport-api:3.0.0'
-    implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+
+    vendor (libs.dagger.dagger) {
+         exclude group: "javax.inject", module: "javax.inject"
+     }
+
     api 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation 'com.google.auto.service:auto-service-annotations:1.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
-    api 'com.google.firebase:firebase-encoders-json:18.0.0'
-    api 'com.google.firebase:firebase-encoders:17.0.0'
-    api 'com.google.firebase:firebase-installations-interop:17.1.0'
-    implementation 'javax.inject:javax.inject:1'
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
     api('com.google.firebase:firebase-datatransport:18.2.0'){
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
-    api("com.google.firebase:firebase-common:20.4.2")
-    api("com.google.firebase:firebase-common-ktx:20.4.2")
-    api("com.google.firebase:firebase-components:17.1.5")
+    api 'com.google.firebase:firebase-encoders:17.0.0'
+    api 'com.google.firebase:firebase-encoders-json:18.0.0'
     api("com.google.firebase:firebase-installations:17.2.0")
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
+
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.google.android.datatransport:transport-api:3.0.0'
+    implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
+    implementation 'com.google.auto.service:auto-service-annotations:1.0.1'
+    implementation 'javax.inject:javax.inject:1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
+    compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"
+
+    annotationProcessor project(":encoders:firebase-encoders-processor")
+    annotationProcessor "com.google.auto.value:auto-value:1.6.5"
+    annotationProcessor libs.dagger.compiler
+
+    testImplementation(project(":integ-testing")) {
+        exclude group: 'com.google.firebase', module: 'firebase-common'
+        exclude group: 'com.google.firebase', module: 'firebase-components'
+    }
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation 'androidx.test:runner:1.5.1'
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    testImplementation 'com.github.tomakehurst:wiremock-standalone:2.26.3'
     testImplementation "com.google.protobuf:protobuf-java-util:$protobufJavaUtilVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'androidx.test:runner:1.5.1'
-    testImplementation 'com.github.tomakehurst:wiremock-standalone:2.26.3'
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.apache.httpcomponents:httpclient-android:4.3.5.1'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.mockito:mockito-core:3.6.0'
-    testImplementation(project(":integ-testing")) {
-        exclude group: 'com.google.firebase', module: 'firebase-common'
-        exclude group: 'com.google.firebase', module: 'firebase-components'
-    }
-    vendor (libs.dagger.dagger) {
-         exclude group: "javax.inject", module: "javax.inject"
-     }
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation "androidx.annotation:annotation:1.1.0"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.13.1'
 }
 
 // ==========================================================================

--- a/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
+++ b/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
@@ -85,19 +85,19 @@ dependencies {
     implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.auto.service:auto-service-annotations:1.0.1'
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-encoders-json:18.0.0'
-    implementation 'com.google.firebase:firebase-encoders:17.0.0'
-    implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-encoders-json:18.0.0'
+    api 'com.google.firebase:firebase-encoders:17.0.0'
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
     implementation 'javax.inject:javax.inject:1'
-    implementation('com.google.firebase:firebase-datatransport:18.2.0'){
+    api('com.google.firebase:firebase-datatransport:18.2.0'){
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-installations:17.2.0")
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-installations:17.2.0")
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation "androidx.test:core:$androidxTestCoreVersion"

--- a/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
+++ b/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
@@ -83,7 +83,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.auto.service:auto-service-annotations:1.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-encoders-json:18.0.0'

--- a/firebase-ml-modeldownloader/ktx/ktx.gradle
+++ b/firebase-ml-modeldownloader/ktx/ktx.gradle
@@ -43,14 +43,16 @@ android {
 }
 
 dependencies {
+    api(project(":firebase-ml-modeldownloader"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-ml-modeldownloader"))
+
+    testImplementation 'androidx.test:runner:1.5.1'
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'androidx.test:runner:1.5.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.6.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-ml-modeldownloader/ml-data-collection-tests/ml-data-collection-tests.gradle
+++ b/firebase-ml-modeldownloader/ml-data-collection-tests/ml-data-collection-tests.gradle
@@ -42,13 +42,14 @@ android {
 }
 
 dependencies {
+    implementation project(':firebase-ml-modeldownloader')
+    implementation 'androidx.core:core:1.2.0'
     implementation 'com.google.firebase:firebase-common:20.4.2'
     implementation 'com.google.firebase:firebase-common-ktx:20.4.2'
-    implementation project(':firebase-ml-modeldownloader')
+
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'junit:junit:4.12'
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    implementation 'androidx.core:core:1.2.0'
+    testImplementation 'junit:junit:4.12'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -105,16 +105,16 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.dagger:dagger:2.27'
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
-    implementation 'com.google.firebase:protolite-well-known-types:18.0.0'
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api 'com.google.firebase:protolite-well-known-types:18.0.0'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
-    implementation("com.google.firebase:firebase-config:21.5.0")
-    implementation("com.google.firebase:firebase-installations:17.2.0")
-    implementation(project(':firebase-sessions')) {
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-config:21.5.0")
+    api("com.google.firebase:firebase-installations:17.2.0")
+    api(project(':firebase-sessions')) {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-common-ktx'
          exclude group: 'com.google.firebase', module: 'firebase-components'

--- a/firebase-perf/ktx/ktx.gradle
+++ b/firebase-perf/ktx/ktx.gradle
@@ -44,14 +44,17 @@ android {
 }
 
 dependencies {
+    api(project(":firebase-perf"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-perf"))
-    testCompileOnly "com.google.protobuf:protobuf-java:3.21.9"
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    testCompileOnly "com.google.protobuf:protobuf-java:3.21.9"
 }

--- a/firebase-segmentation/firebase-segmentation.gradle
+++ b/firebase-segmentation/firebase-segmentation.gradle
@@ -39,13 +39,13 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-annotations:16.2.0'
-    implementation 'com.google.firebase:firebase-common:20.3.1'
-    implementation 'com.google.firebase:firebase-components:17.1.0'
-    implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api 'com.google.firebase:firebase-common:20.3.1'
+    api 'com.google.firebase:firebase-components:17.1.0'
+    api 'com.google.firebase:firebase-installations-interop:17.1.0'
     runtimeOnly project(':firebase-installations')
 
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"

--- a/firebase-segmentation/firebase-segmentation.gradle
+++ b/firebase-segmentation/firebase-segmentation.gradle
@@ -39,22 +39,24 @@ android {
 }
 
 dependencies {
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+
+    api 'com.google.android.gms:play-services-tasks:18.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api 'com.google.firebase:firebase-common:20.3.1'
     api 'com.google.firebase:firebase-components:17.1.0'
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
-    runtimeOnly project(':firebase-installations')
-
-    api 'com.google.android.gms:play-services-tasks:18.0.1'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
+
+    runtimeOnly project(':firebase-installations')
+
     annotationProcessor "com.google.auto.value:auto-value:1.6.2"
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-inline:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -54,16 +54,16 @@ dependencies {
   api("com.google.firebase:firebase-common:20.4.2")
   api("com.google.firebase:firebase-common-ktx:20.4.2")
 
-  implementation("com.google.firebase:firebase-components:17.1.5")
-  implementation("com.google.firebase:firebase-installations-interop:17.1.1") {
+  api("com.google.firebase:firebase-components:17.1.5")
+  api("com.google.firebase:firebase-installations-interop:17.1.1") {
     exclude(group = "com.google.firebase", module = "firebase-common")
     exclude(group = "com.google.firebase", module = "firebase-components")
   }
   implementation("androidx.datastore:datastore-preferences:1.0.0")
   implementation("com.google.android.datatransport:transport-api:3.0.0")
-  implementation("com.google.firebase:firebase-annotations:16.2.0")
-  implementation("com.google.firebase:firebase-encoders:17.0.0")
-  implementation("com.google.firebase:firebase-encoders-json:18.0.1")
+  api("com.google.firebase:firebase-annotations:16.2.0")
+  api("com.google.firebase:firebase-encoders:17.0.0")
+  api("com.google.firebase:firebase-encoders-json:18.0.1")
   implementation(libs.androidx.annotation)
 
   runtimeOnly("com.google.firebase:firebase-installations:17.2.0") {

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -88,16 +88,16 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation("com.google.firebase:firebase-appcheck-interop:17.1.0")
-    implementation('com.google.firebase:firebase-auth-interop:18.0.0') {
+    api("com.google.firebase:firebase-appcheck-interop:17.1.0")
+    api('com.google.firebase:firebase-auth-interop:18.0.0') {
          exclude group: "com.google.firebase", module: "firebase-common"
          exclude group: "com.google.firebase", module: "firebase-components"
          exclude group: "com.google.firebase", module: "firebase-annotations"
      }
-    implementation("com.google.firebase:firebase-annotations:16.2.0")
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
+    api("com.google.firebase:firebase-annotations:16.2.0")
+    api("com.google.firebase:firebase-common:20.4.2")
+    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api("com.google.firebase:firebase-components:17.1.5")
 
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
     javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
@@ -108,7 +108,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    implementation("com.google.firebase:firebase-appcheck:17.1.0") {
+    api("com.google.firebase:firebase-appcheck:17.1.0") {
         exclude group: "com.google.firebase", module: "firebase-common"
         exclude group: "com.google.firebase", module: "firebase-components"
         exclude group: "com.google.firebase", module: "firebase-annotations"

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -78,41 +78,44 @@ android {
 }
 
 dependencies {
-    androidTestImplementation "androidx.annotation:annotation:1.1.0"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-base:18.0.1'
-    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
+    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+
+    api("com.google.firebase:firebase-annotations:16.2.0")
+    api("com.google.firebase:firebase-appcheck:17.1.0") {
+        exclude group: "com.google.firebase", module: "firebase-common"
+        exclude group: "com.google.firebase", module: "firebase-components"
+        exclude group: "com.google.firebase", module: "firebase-annotations"
+    }
     api("com.google.firebase:firebase-appcheck-interop:17.1.0")
     api('com.google.firebase:firebase-auth-interop:18.0.0') {
          exclude group: "com.google.firebase", module: "firebase-common"
          exclude group: "com.google.firebase", module: "firebase-components"
          exclude group: "com.google.firebase", module: "firebase-annotations"
      }
-    api("com.google.firebase:firebase-annotations:16.2.0")
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
     api("com.google.firebase:firebase-components:17.1.5")
 
-    javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.google.android.gms:play-services-base:18.0.1'
+    implementation 'com.google.android.gms:play-services-tasks:18.0.1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'androidx.test:rules:1.2.0'
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    api("com.google.firebase:firebase-appcheck:17.1.0") {
-        exclude group: "com.google.firebase", module: "firebase-common"
-        exclude group: "com.google.firebase", module: "firebase-components"
-        exclude group: "com.google.firebase", module: "firebase-annotations"
-    }
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation "androidx.annotation:annotation:1.1.0"
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
 }
 
 // ==========================================================================

--- a/firebase-storage/ktx/ktx.gradle
+++ b/firebase-storage/ktx/ktx.gradle
@@ -57,16 +57,19 @@ android {
 }
 
 dependencies {
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'junit:junit:4.12'
+    api(project(":firebase-storage"))
     api("com.google.firebase:firebase-common:20.4.2")
     api("com.google.firebase:firebase-common-ktx:20.4.2")
+
     implementation("com.google.firebase:firebase-components:17.1.5")
-    api(project(":firebase-storage"))
+
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.3.3'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.12'
 }

--- a/firebase-storage/test-app/test-app.gradle
+++ b/firebase-storage/test-app/test-app.gradle
@@ -47,19 +47,17 @@ dependencies {
     exclude group: 'com.google.firebase', module: 'firebase-common'
     exclude group: 'com.google.firebase', module: 'firebase-components'
   }
-
+  implementation 'androidx.appcompat:appcompat:1.0.2'
+  implementation 'com.google.android.gms:play-services-base:18.0.1'
+  implementation 'com.google.android.gms:play-services-basement:18.1.0'
+  implementation 'com.google.android.material:material:1.0.0'
+  implementation 'com.google.firebase:firebase-auth:20+'
   // We intentionally use an open ended version to pick up any SNAPSHOT
   // versions published to the root project' s build/ directory.
   implementation 'com.google.firebase:firebase-common:19+'
-  implementation 'com.google.firebase:firebase-auth:20+'
-  implementation 'com.google.android.gms:play-services-basement:18.1.0'
-  implementation 'com.google.android.gms:play-services-base:18.0.1'
 
-  implementation 'com.google.android.material:material:1.0.0'
-  implementation 'androidx.appcompat:appcompat:1.0.2'
-
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
   androidTestImplementation 'androidx.test:rules:1.2.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
 

--- a/protolite-well-known-types/protolite-well-known-types.gradle
+++ b/protolite-well-known-types/protolite-well-known-types.gradle
@@ -62,9 +62,9 @@ android {
 
 
 dependencies {
-    implementation "com.google.protobuf:protobuf-javalite:$javaliteVersion"
-
     protobuf("com.google.api.grpc:proto-google-common-protos:1.18.0"){
         exclude group: "com.google.protobuf", module: "protobuf-java"
     }
+
+    implementation "com.google.protobuf:protobuf-javalite:$javaliteVersion"
 }

--- a/transport/transport-api/transport-api.gradle
+++ b/transport/transport-api/transport-api.gradle
@@ -38,9 +38,12 @@ android {
 }
 
 dependencies {
-    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
     implementation 'androidx.annotation:annotation:1.1.0'
+
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
+
     annotationProcessor "com.google.auto.value:auto-value:1.6.5"
-    testImplementation 'junit:junit:4.13-beta-3'
+
     testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.13-beta-3'
 }

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -55,10 +55,10 @@ android {
 }
 
 dependencies {
-    implementation project(':transport:transport-api')
-    implementation project(':transport:transport-runtime')
-    implementation 'com.google.firebase:firebase-encoders:17.0.0'
-    implementation 'com.google.firebase:firebase-encoders-json:18.0.0'
+    api project(':transport:transport-api')
+    api project(':transport:transport-runtime')
+    api 'com.google.firebase:firebase-encoders:17.0.0'
+    api 'com.google.firebase:firebase-encoders-json:18.0.0'
     implementation 'androidx.annotation:annotation:1.1.0'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -59,21 +59,22 @@ dependencies {
     api project(':transport:transport-runtime')
     api 'com.google.firebase:firebase-encoders:17.0.0'
     api 'com.google.firebase:firebase-encoders-json:18.0.0'
+
     implementation 'androidx.annotation:annotation:1.1.0'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"
 
-    annotationProcessor "com.google.auto.value:auto-value:1.6.5"
     annotationProcessor project(':encoders:firebase-encoders-processor')
+    annotationProcessor "com.google.auto.value:auto-value:1.6.5"
 
-    testImplementation "com.google.protobuf:protobuf-java-util:$protobufJavaUtilVersion"
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation 'com.github.tomakehurst:wiremock:3.0.1'
+    testImplementation "com.google.protobuf:protobuf-java-util:$protobufJavaUtilVersion"
     testImplementation "com.google.truth:truth:$googleTruthVersion"
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
-    testImplementation 'com.github.tomakehurst:wiremock:3.0.1'
+    testImplementation 'junit:junit:4.13.1'
     // Keep Robolectric to 4.3.1 for httpclient and TelephonyManager compatibility.
     testImplementation "org.robolectric:robolectric:4.3.1"
-    testImplementation 'junit:junit:4.13.1'
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/transport/transport-runtime-testing/transport-runtime-testing.gradle
+++ b/transport/transport-runtime-testing/transport-runtime-testing.gradle
@@ -35,14 +35,14 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.datatransport:transport-api:3.0.0'
-    implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
     implementation 'androidx.annotation:annotation:1.3.0'
-
+    implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.datatransport:transport-backend-cct:3.1.8'
-    androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
+
+    androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.13.2'
 }

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -96,37 +96,38 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    api project(':transport:transport-api')
-    implementation 'androidx.annotation:annotation:1.3.0'
-    implementation 'javax.inject:javax.inject:1'
-    api 'com.google.firebase:firebase-encoders:17.0.0'
-    api "com.google.firebase:firebase-encoders-proto:16.0.0"
-    annotationProcessor project(":encoders:firebase-encoders-processor")
-
     vendor (libs.dagger.dagger) {
         exclude group: "javax.inject", module: "javax.inject"
     }
-    annotationProcessor libs.dagger.compiler
+
+    api project(':transport:transport-api')
+    api 'com.google.firebase:firebase-encoders:17.0.0'
+    api "com.google.firebase:firebase-encoders-proto:16.0.0"
+
+    implementation 'androidx.annotation:annotation:1.3.0'
+    implementation 'javax.inject:javax.inject:1'
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"
     compileOnly "com.google.errorprone:error_prone_annotations:2.9.0"
 
+    annotationProcessor project(":encoders:firebase-encoders-processor")
     annotationProcessor "com.google.auto.value:auto-value:1.6.5"
-
-    testImplementation 'junit:junit:4.13-beta-2'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation 'org.mockito:mockito-core:2.25.0'
-
-    androidTestImplementation 'junit:junit:4.13-beta-3'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
-    androidTestImplementation 'org.mockito:mockito-android:2.25.0'
+    annotationProcessor libs.dagger.compiler
 
     androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.27'
+
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation 'junit:junit:4.13-beta-2'
+    testImplementation 'org.mockito:mockito-core:2.25.0'
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation 'junit:junit:4.13-beta-3'
+    androidTestImplementation 'org.mockito:mockito-android:2.25.0'
+    androidTestImplementation 'org.mockito:mockito-core:2.25.0'
 }

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -96,11 +96,11 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    implementation project(':transport:transport-api')
+    api project(':transport:transport-api')
     implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'javax.inject:javax.inject:1'
-    implementation 'com.google.firebase:firebase-encoders:17.0.0'
-    implementation "com.google.firebase:firebase-encoders-proto:16.0.0"
+    api 'com.google.firebase:firebase-encoders:17.0.0'
+    api "com.google.firebase:firebase-encoders-proto:16.0.0"
     annotationProcessor project(":encoders:firebase-encoders-processor")
 
     vendor (libs.dagger.dagger) {


### PR DESCRIPTION
Per [b/277605778](https://b.corp.google.com/issues/277605778),

This removes the step during our release generation where we were converting the scope of dependencies to compile. As such, all published libraries that had dependencies on firebase library were changed to `api` level dependencies. While this may not be necessary for a lot of them, it's a sufficient middle ground between all dependencies being `api` level and none. It should now be easier to deduce what exactly needs to be `api` level, and which does not.