### PR TITLE
improve java interoperability

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAI.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAI.kt
@@ -44,6 +44,7 @@ class FirebaseVertexAI(
    * @param toolConfig the configuration that defines how the model handles the tools provided
    * @param requestOptions configuration options to utilize during backend communication
    */
+  @JvmOverloads
   fun generativeModel(
     modelName: String,
     generationConfig: GenerationConfig? = null,
@@ -64,9 +65,11 @@ class FirebaseVertexAI(
     )
 
   companion object {
+    @JvmStatic
     val instance: FirebaseVertexAI
       get() = Firebase.app[FirebaseVertexAI::class.java]
 
+    @JvmStatic
     fun getInstance(app: FirebaseApp): FirebaseVertexAI = app[FirebaseVertexAI::class.java]
 
     private val LOCATION = "us-central1"


### PR DESCRIPTION
`@JvmStatic` should allow Java developers to use:
```java
FirebaseVertexAI instance = FirebaseVertexAI.getInstance()
```

instead of:
```java
FirebaseVertexAI instance = FirebaseVertexAI.Companion.getInstance()
```

And `@JvmOverloads` should generate method overloads that substitute default parameter values so that developers don't need to pass all the parameters when calling `FirebaseVertexAI.getInstance().generativeModel(...)`.