### PR TITLE
Move Timestamp to common

### DIFF
--- a/firebase-common/api.txt
+++ b/firebase-common/api.txt
@@ -58,6 +58,21 @@ package com.google.firebase {
     ctor public FirebaseTooManyRequestsException(@NonNull String);
   }
 
+  public final class Timestamp implements java.lang.Comparable<com.google.firebase.Timestamp> android.os.Parcelable {
+    ctor public Timestamp(long, int);
+    ctor protected Timestamp(@NonNull android.os.Parcel);
+    ctor public Timestamp(@NonNull java.util.Date);
+    method public static void checkArgument(boolean, @Nullable String, @Nullable java.lang.Object...);
+    method public int compareTo(@NonNull com.google.firebase.Timestamp);
+    method public int describeContents();
+    method public int getNanoseconds();
+    method public long getSeconds();
+    method @NonNull public static com.google.firebase.Timestamp now();
+    method @NonNull public java.util.Date toDate();
+    method public void writeToParcel(@NonNull android.os.Parcel, int);
+    field @NonNull public static final android.os.Parcelable.Creator<com.google.firebase.Timestamp> CREATOR;
+  }
+
 }
 
 package com.google.firebase.ktx {
@@ -87,6 +102,13 @@ package com.google.firebase.provider {
     method public boolean onCreate();
     method @Nullable public android.database.Cursor query(@NonNull android.net.Uri, @Nullable String[], @Nullable String, @Nullable String[], @Nullable String);
     method public int update(@NonNull android.net.Uri, @Nullable android.content.ContentValues, @Nullable String, @Nullable String[]);
+  }
+
+}
+
+package com.google.firebase.util {
+
+  public final class RandomUtilKt {
   }
 
 }

--- a/firebase-common/api.txt
+++ b/firebase-common/api.txt
@@ -62,7 +62,6 @@ package com.google.firebase {
     ctor public Timestamp(long, int);
     ctor protected Timestamp(@NonNull android.os.Parcel);
     ctor public Timestamp(@NonNull java.util.Date);
-    method public static void checkArgument(boolean, @Nullable String, @Nullable java.lang.Object...);
     method public int compareTo(@NonNull com.google.firebase.Timestamp);
     method public int describeContents();
     method public int getNanoseconds();
@@ -102,13 +101,6 @@ package com.google.firebase.provider {
     method public boolean onCreate();
     method @Nullable public android.database.Cursor query(@NonNull android.net.Uri, @Nullable String[], @Nullable String, @Nullable String[], @Nullable String);
     method public int update(@NonNull android.net.Uri, @Nullable android.content.ContentValues, @Nullable String, @Nullable String[]);
-  }
-
-}
-
-package com.google.firebase.util {
-
-  public final class RandomUtilKt {
   }
 
 }

--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -83,6 +83,8 @@ dependencies {
         exclude("com.google.firebase","firebase-common")
         exclude("com.google.firebase","firebase-common-ktx")
     }
+    // TODO(Remove when FirbaseAppTest has been modernized to use LiveData)
+    androidTestImplementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.junit)

--- a/firebase-common/src/main/java/com/google/firebase/Timestamp.java
+++ b/firebase-common/src/main/java/com/google/firebase/Timestamp.java
@@ -157,7 +157,7 @@ public final class Timestamp implements Comparable<Timestamp>, Parcelable {
   }
 
   // TODO(Remove when migrated to Kotlin)
-  public static void checkArgument(
+  private static void checkArgument(
       boolean expression,
       @Nullable String errorMessageTemplate,
       @Nullable Object... errorMessageArgs) {

--- a/firebase-common/src/main/java/com/google/firebase/Timestamp.java
+++ b/firebase-common/src/main/java/com/google/firebase/Timestamp.java
@@ -17,9 +17,7 @@ package com.google.firebase;
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.NonNull;
-
 import java.util.Date;
-
 import javax.annotation.Nullable;
 
 /**
@@ -150,7 +148,7 @@ public final class Timestamp implements Comparable<Timestamp>, Parcelable {
   }
 
   private static void validateRange(long seconds, int nanoseconds) {
-    checkArgument(nanoseconds >= 0, String.format("Timestamp nanoseconds out of range: %s", nanoseconds));
+    checkArgument(nanoseconds >= 0, "Timestamp nanoseconds out of range: %s", nanoseconds);
     checkArgument(nanoseconds < 1e9, "Timestamp nanoseconds out of range: %s", nanoseconds);
     // Midnight at the beginning of 1/1/1 is the earliest supported timestamp.
     checkArgument(seconds >= -62135596800L, "Timestamp seconds out of range: %s", seconds);
@@ -160,9 +158,9 @@ public final class Timestamp implements Comparable<Timestamp>, Parcelable {
 
   // TODO(Remove when migrated to Kotlin)
   public static void checkArgument(
-          boolean expression,
-          @Nullable String errorMessageTemplate,
-          @Nullable Object... errorMessageArgs) {
+      boolean expression,
+      @Nullable String errorMessageTemplate,
+      @Nullable Object... errorMessageArgs) {
     if (!expression) {
       throw new IllegalArgumentException(String.format(errorMessageTemplate, errorMessageArgs));
     }

--- a/firebase-common/src/main/java/com/google/firebase/Timestamp.java
+++ b/firebase-common/src/main/java/com/google/firebase/Timestamp.java
@@ -14,12 +14,13 @@
 
 package com.google.firebase;
 
-import static com.google.firebase.firestore.util.Preconditions.checkArgument;
-
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.NonNull;
+
 import java.util.Date;
+
+import javax.annotation.Nullable;
 
 /**
  * A Timestamp represents a point in time independent of any time zone or calendar, represented as
@@ -149,12 +150,22 @@ public final class Timestamp implements Comparable<Timestamp>, Parcelable {
   }
 
   private static void validateRange(long seconds, int nanoseconds) {
-    checkArgument(nanoseconds >= 0, "Timestamp nanoseconds out of range: %s", nanoseconds);
+    checkArgument(nanoseconds >= 0, String.format("Timestamp nanoseconds out of range: %s", nanoseconds));
     checkArgument(nanoseconds < 1e9, "Timestamp nanoseconds out of range: %s", nanoseconds);
     // Midnight at the beginning of 1/1/1 is the earliest supported timestamp.
     checkArgument(seconds >= -62135596800L, "Timestamp seconds out of range: %s", seconds);
     // This will break in the year 10,000.
     checkArgument(seconds < 253402300800L, "Timestamp seconds out of range: %s", seconds);
+  }
+
+  // TODO(Remove when migrated to Kotlin)
+  public static void checkArgument(
+          boolean expression,
+          @Nullable String errorMessageTemplate,
+          @Nullable Object... errorMessageArgs) {
+    if (!expression) {
+      throw new IllegalArgumentException(String.format(errorMessageTemplate, errorMessageArgs));
+    }
   }
 
   private final long seconds;

--- a/firebase-common/src/main/java/com/google/firebase/util/package-info.java
+++ b/firebase-common/src/main/java/com/google/firebase/util/package-info.java
@@ -1,0 +1,16 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @hide */
+package com.google.firebase.util;

--- a/firebase-common/src/test/java/com/google/firebase/TimestampTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/TimestampTest.java
@@ -14,10 +14,11 @@
 
 package com.google.firebase;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.google.firebase.firestore.testutil.Assert.assertThrows;
-
 import android.os.Parcel;
+
+import com.google.common.truth.Truth;
+import com.google.firebase.common.testutil.Assert;
+
 import java.util.Date;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,18 +33,18 @@ public class TimestampTest {
     // Very carefully construct an Date that won't lose precision with milliseconds.
     Date input = new Date(22501);
     Timestamp actual = new Timestamp(input);
-    assertThat(actual.getSeconds()).isEqualTo(22);
-    assertThat(actual.getNanoseconds()).isEqualTo(501000000);
+    Truth.assertThat(actual.getSeconds()).isEqualTo(22);
+    Truth.assertThat(actual.getNanoseconds()).isEqualTo(501000000);
     Timestamp expected = new Timestamp(22, 501000000);
-    assertThat(actual).isEqualTo(expected);
+    Truth.assertThat(actual).isEqualTo(expected);
 
     // And with a negative millis.
     input = new Date(-1250);
     actual = new Timestamp(input);
-    assertThat(actual.getSeconds()).isEqualTo(-2);
-    assertThat(actual.getNanoseconds()).isEqualTo(750000000);
+    Truth.assertThat(actual.getSeconds()).isEqualTo(-2);
+    Truth.assertThat(actual.getNanoseconds()).isEqualTo(750000000);
     expected = new Timestamp(-2, 750000000);
-    assertThat(actual).isEqualTo(expected);
+    Truth.assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -58,17 +59,17 @@ public class TimestampTest {
       new Timestamp(12346, 0)
     };
     for (int i = 0; i < timestamps.length - 1; ++i) {
-      assertThat(timestamps[i].compareTo(timestamps[i + 1])).isEqualTo(-1);
-      assertThat(timestamps[i + 1].compareTo(timestamps[i])).isEqualTo(1);
+      Truth.assertThat(timestamps[i].compareTo(timestamps[i + 1])).isEqualTo(-1);
+      Truth.assertThat(timestamps[i + 1].compareTo(timestamps[i])).isEqualTo(1);
     }
   }
 
   @Test
   public void testRejectBadDates() {
-    assertThrows(IllegalArgumentException.class, () -> new Timestamp(new Date(-70000000000000L)));
-    assertThrows(IllegalArgumentException.class, () -> new Timestamp(new Date(300000000000000L)));
-    assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, -1));
-    assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, 1000000000));
+    Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(new Date(-70000000000000L)));
+    Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(new Date(300000000000000L)));
+    Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, -1));
+    Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, 1000000000));
   }
 
   @Test
@@ -81,7 +82,7 @@ public class TimestampTest {
     parcel.setDataPosition(0);
 
     Timestamp recreated = Timestamp.CREATOR.createFromParcel(parcel);
-    assertThat(recreated).isEqualTo(timestamp);
+    Truth.assertThat(recreated).isEqualTo(timestamp);
 
     parcel.recycle();
   }

--- a/firebase-common/src/test/java/com/google/firebase/TimestampTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/TimestampTest.java
@@ -15,10 +15,8 @@
 package com.google.firebase;
 
 import android.os.Parcel;
-
 import com.google.common.truth.Truth;
 import com.google.firebase.common.testutil.Assert;
-
 import java.util.Date;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,8 +64,10 @@ public class TimestampTest {
 
   @Test
   public void testRejectBadDates() {
-    Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(new Date(-70000000000000L)));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(new Date(300000000000000L)));
+    Assert.assertThrows(
+        IllegalArgumentException.class, () -> new Timestamp(new Date(-70000000000000L)));
+    Assert.assertThrows(
+        IllegalArgumentException.class, () -> new Timestamp(new Date(300000000000000L)));
     Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, -1));
     Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, 1000000000));
   }

--- a/firebase-common/src/test/java/com/google/firebase/TimestampTest.java
+++ b/firebase-common/src/test/java/com/google/firebase/TimestampTest.java
@@ -14,9 +14,10 @@
 
 package com.google.firebase;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.common.testutil.Assert.assertThrows;
+
 import android.os.Parcel;
-import com.google.common.truth.Truth;
-import com.google.firebase.common.testutil.Assert;
 import java.util.Date;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,18 +32,18 @@ public class TimestampTest {
     // Very carefully construct an Date that won't lose precision with milliseconds.
     Date input = new Date(22501);
     Timestamp actual = new Timestamp(input);
-    Truth.assertThat(actual.getSeconds()).isEqualTo(22);
-    Truth.assertThat(actual.getNanoseconds()).isEqualTo(501000000);
+    assertThat(actual.getSeconds()).isEqualTo(22);
+    assertThat(actual.getNanoseconds()).isEqualTo(501000000);
     Timestamp expected = new Timestamp(22, 501000000);
-    Truth.assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isEqualTo(expected);
 
     // And with a negative millis.
     input = new Date(-1250);
     actual = new Timestamp(input);
-    Truth.assertThat(actual.getSeconds()).isEqualTo(-2);
-    Truth.assertThat(actual.getNanoseconds()).isEqualTo(750000000);
+    assertThat(actual.getSeconds()).isEqualTo(-2);
+    assertThat(actual.getNanoseconds()).isEqualTo(750000000);
     expected = new Timestamp(-2, 750000000);
-    Truth.assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -57,19 +58,17 @@ public class TimestampTest {
       new Timestamp(12346, 0)
     };
     for (int i = 0; i < timestamps.length - 1; ++i) {
-      Truth.assertThat(timestamps[i].compareTo(timestamps[i + 1])).isEqualTo(-1);
-      Truth.assertThat(timestamps[i + 1].compareTo(timestamps[i])).isEqualTo(1);
+      assertThat(timestamps[i].compareTo(timestamps[i + 1])).isEqualTo(-1);
+      assertThat(timestamps[i + 1].compareTo(timestamps[i])).isEqualTo(1);
     }
   }
 
   @Test
   public void testRejectBadDates() {
-    Assert.assertThrows(
-        IllegalArgumentException.class, () -> new Timestamp(new Date(-70000000000000L)));
-    Assert.assertThrows(
-        IllegalArgumentException.class, () -> new Timestamp(new Date(300000000000000L)));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, -1));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, 1000000000));
+    assertThrows(IllegalArgumentException.class, () -> new Timestamp(new Date(-70000000000000L)));
+    assertThrows(IllegalArgumentException.class, () -> new Timestamp(new Date(300000000000000L)));
+    assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, -1));
+    assertThrows(IllegalArgumentException.class, () -> new Timestamp(0, 1000000000));
   }
 
   @Test
@@ -82,7 +81,7 @@ public class TimestampTest {
     parcel.setDataPosition(0);
 
     Timestamp recreated = Timestamp.CREATOR.createFromParcel(parcel);
-    Truth.assertThat(recreated).isEqualTo(timestamp);
+    assertThat(recreated).isEqualTo(timestamp);
 
     parcel.recycle();
   }

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -121,8 +121,8 @@ package com.google.firebase.firestore {
     method @NonNull public com.google.firebase.firestore.SnapshotMetadata getMetadata();
     method @NonNull public com.google.firebase.firestore.DocumentReference getReference();
     method @Nullable public String getString(@NonNull String);
-    method @Nullable public Timestamp getTimestamp(@NonNull String);
-    method @Nullable public Timestamp getTimestamp(@NonNull String, @NonNull com.google.firebase.firestore.DocumentSnapshot.ServerTimestampBehavior);
+    method @Nullable public com.google.firebase.Timestamp getTimestamp(@NonNull String);
+    method @Nullable public com.google.firebase.Timestamp getTimestamp(@NonNull String, @NonNull com.google.firebase.firestore.DocumentSnapshot.ServerTimestampBehavior);
     method @Nullable public <T> T toObject(@NonNull Class<T>);
     method @Nullable public <T> T toObject(@NonNull Class<T>, @NonNull com.google.firebase.firestore.DocumentSnapshot.ServerTimestampBehavior);
   }

--- a/firebase-firestore/api.txt
+++ b/firebase-firestore/api.txt
@@ -1,22 +1,4 @@
 // Signature format: 2.0
-package com.google.firebase {
-
-  public final class Timestamp implements java.lang.Comparable<com.google.firebase.Timestamp> android.os.Parcelable {
-    ctor public Timestamp(long, int);
-    ctor protected Timestamp(@NonNull android.os.Parcel);
-    ctor public Timestamp(@NonNull java.util.Date);
-    method public int compareTo(@NonNull com.google.firebase.Timestamp);
-    method public int describeContents();
-    method public int getNanoseconds();
-    method public long getSeconds();
-    method @NonNull public static com.google.firebase.Timestamp now();
-    method @NonNull public java.util.Date toDate();
-    method public void writeToParcel(@NonNull android.os.Parcel, int);
-    field @NonNull public static final android.os.Parcelable.Creator<com.google.firebase.Timestamp> CREATOR;
-  }
-
-}
-
 package com.google.firebase.firestore {
 
   public abstract class AggregateField {
@@ -139,8 +121,8 @@ package com.google.firebase.firestore {
     method @NonNull public com.google.firebase.firestore.SnapshotMetadata getMetadata();
     method @NonNull public com.google.firebase.firestore.DocumentReference getReference();
     method @Nullable public String getString(@NonNull String);
-    method @Nullable public com.google.firebase.Timestamp getTimestamp(@NonNull String);
-    method @Nullable public com.google.firebase.Timestamp getTimestamp(@NonNull String, @NonNull com.google.firebase.firestore.DocumentSnapshot.ServerTimestampBehavior);
+    method @Nullable public Timestamp getTimestamp(@NonNull String);
+    method @Nullable public Timestamp getTimestamp(@NonNull String, @NonNull com.google.firebase.firestore.DocumentSnapshot.ServerTimestampBehavior);
     method @Nullable public <T> T toObject(@NonNull Class<T>);
     method @Nullable public <T> T toObject(@NonNull Class<T>, @NonNull com.google.firebase.firestore.DocumentSnapshot.ServerTimestampBehavior);
   }

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -150,9 +150,13 @@ dependencies {
     implementation('com.google.firebase:firebase-auth-interop:19.0.2') {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
-    implementation("com.google.firebase:firebase-common:20.4.2")
-    implementation("com.google.firebase:firebase-common-ktx:20.4.2")
-    implementation("com.google.firebase:firebase-components:17.1.5")
+    api(project(":firebase-common"))
+    implementation("com.google.firebase:firebase-common-ktx:20.4.2") {
+        exclude group: "com.google.firebase", module: "firebase-common"
+    }
+    implementation("com.google.firebase:firebase-components:17.1.5") {
+        exclude group: "com.google.firebase", module: "firebase-common"
+    }
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
     testCompileOnly "com.google.protobuf:protobuf-java:$protocVersion"
     testImplementation "androidx.test:core:$androidxTestCoreVersion"

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -127,7 +127,7 @@ dependencies {
     api('com.google.firebase:firebase-auth-interop:19.0.2') {
         exclude group: "com.google.firebase", module: "firebase-common"
     }
-    api("com.google.firebase:firebase-common:20.4.2")
+    api(project(":firebase-common"))
     api("com.google.firebase:firebase-common-ktx:20.4.2") {
         exclude group: "com.google.firebase", module: "firebase-common"
     }

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -32,7 +32,7 @@ firebase-datatransport
 firebase-dynamic-links
 firebase-dynamic-links:ktx
 firebase-firestore
-firebase-firestore:ktx
+# firebase-firestore:ktx
 firebase-functions
 firebase-functions:ktx
 firebase-messaging


### PR DESCRIPTION
Per [b/243534168](https://b.corp.google.com/issues/243534168),

This moves `Timestamp` from the firestore package to the common package-  as `Timestamp` actually lives under the `com.google.firebase` package name, but the file itself was residing in the firestore module.

This is intended to just be a near 1:1 move.