### PR TITLE
Log analytics for proxied notifications.

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 * [changed] Switched Firelog to use the new TransportBackend.
+* [changed] Log analytics for notifications displayed by Google Play services on
+  behalf of the app.
 
 # 23.4.1
 * [changed] Bump internal dependencies.

--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -102,7 +102,7 @@ dependencies {
         implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
         implementation 'com.google.android.gms:play-services-base:18.0.1'
         implementation "com.google.android.gms:play-services-basement:18.1.0"
-        implementation 'com.google.android.gms:play-services-cloud-messaging:17.1.0'
+        implementation 'com.google.android.gms:play-services-cloud-messaging:17.2.0'
         implementation 'com.google.android.gms:play-services-stats:17.0.2'
         implementation "com.google.android.gms:play-services-tasks:18.0.1"
         implementation "com.google.errorprone:error_prone_annotations:2.9.0"

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/GmsRpc.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/GmsRpc.java
@@ -20,6 +20,7 @@ import android.util.Base64;
 import android.util.Log;
 import androidx.annotation.AnyThread;
 import androidx.annotation.VisibleForTesting;
+import com.google.android.gms.cloudmessaging.CloudMessage;
 import com.google.android.gms.cloudmessaging.Rpc;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -215,6 +216,14 @@ class GmsRpc {
 
     Task<Bundle> rpcTask = startRpc(to, scope, extras);
     return extractResponseWhenComplete(rpcTask);
+  }
+
+  Task<Void> setRetainProxiedNotifications(boolean retain) {
+    return rpc.setRetainProxiedNotifications(retain);
+  }
+
+  Task<CloudMessage> getProxyNotificationData() {
+    return rpc.getProxiedNotificationData();
   }
 
   private Task<Bundle> startRpc(String to, String scope, Bundle extras) {

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/ProxyNotificationPreferences.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/ProxyNotificationPreferences.java
@@ -14,11 +14,13 @@
 package com.google.firebase.messaging;
 
 import static com.google.firebase.messaging.ProxyNotificationPreferences.PreferenceKeys.KEY_PROXY_NOTIFICATION_INITIALIZED;
+import static com.google.firebase.messaging.ProxyNotificationPreferences.PreferenceKeys.KEY_PROXY_NOTIFICATION_RETENTION;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 import androidx.annotation.StringDef;
 import androidx.annotation.WorkerThread;
+import com.google.android.gms.common.util.PlatformVersion;
 
 /**
  * Firebase helper class to store and retrieve firebase related preference values.
@@ -50,12 +52,41 @@ final class ProxyNotificationPreferences {
   }
 
   @WorkerThread
+  static void setProxyRetention(Context context, GmsRpc gmsRpc, boolean retention) {
+    if (!PlatformVersion.isAtLeastQ()) {
+      // Proxy supported on Q+.
+      return;
+    }
+    SharedPreferences preferences = getPreference(context);
+    if (!isProxyNotificationRetentionSet(preferences, retention)) {
+      gmsRpc
+          .setRetainProxiedNotifications(retention)
+          .addOnSuccessListener(
+              Runnable::run, unused -> setProxyRetentionPreferences(context, retention));
+    }
+  }
+
+  @WorkerThread
   static boolean isProxyNotificationInitialized(Context context) {
     return getPreference(context).getBoolean(KEY_PROXY_NOTIFICATION_INITIALIZED, false);
   }
 
-  @StringDef({KEY_PROXY_NOTIFICATION_INITIALIZED})
+  @WorkerThread
+  static boolean isProxyNotificationRetentionSet(SharedPreferences preferences, boolean retention) {
+    return preferences.contains(KEY_PROXY_NOTIFICATION_RETENTION)
+        && preferences.getBoolean(KEY_PROXY_NOTIFICATION_RETENTION, false) == retention;
+  }
+
+  @WorkerThread
+  static void setProxyRetentionPreferences(Context context, boolean retention) {
+    SharedPreferences.Editor preferencesEditor = getPreference(context).edit();
+    preferencesEditor.putBoolean(KEY_PROXY_NOTIFICATION_RETENTION, retention);
+    preferencesEditor.apply();
+  }
+
+  @StringDef({KEY_PROXY_NOTIFICATION_INITIALIZED, KEY_PROXY_NOTIFICATION_RETENTION})
   @interface PreferenceKeys {
     String KEY_PROXY_NOTIFICATION_INITIALIZED = "proxy_notification_initialized";
+    String KEY_PROXY_NOTIFICATION_RETENTION = "proxy_retention";
   }
 }

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/FirebaseMessagingRoboTest.java
@@ -17,7 +17,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.messaging.FirebaseMessaging.GMS_PACKAGE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -33,18 +39,25 @@ import android.os.Binder;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import androidx.test.core.app.ApplicationProvider;
+import com.google.android.datatransport.Encoding;
+import com.google.android.datatransport.Transformer;
+import com.google.android.datatransport.Transport;
 import com.google.android.datatransport.TransportFactory;
+import com.google.android.gms.cloudmessaging.CloudMessage;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.analytics.connector.AnalyticsConnector;
 import com.google.firebase.components.ComponentDiscoveryService;
 import com.google.firebase.events.Subscriber;
 import com.google.firebase.heartbeatinfo.HeartBeatInfo;
 import com.google.firebase.iid.internal.FirebaseInstanceIdInternal;
 import com.google.firebase.inject.Provider;
 import com.google.firebase.installations.FirebaseInstallationsApi;
+import com.google.firebase.messaging.reporting.MessagingClientEventExtension;
 import com.google.firebase.messaging.shadows.ShadowPreconditions;
 import com.google.firebase.messaging.testing.FakeScheduledExecutorService;
 import com.google.firebase.messaging.testing.FirebaseIidRoboTestHelper;
@@ -84,10 +97,8 @@ public final class FirebaseMessagingRoboTest {
   private static final Provider<TransportFactory> EMPTY_TRANSPORT_FACTORY = () -> null;
 
   private Application context;
-  private FirebaseMessaging firebaseMessaging;
   private final FakeScheduledExecutorService fakeScheduledExecutorService =
       new FakeScheduledExecutorService();
-  private TopicsSubscriber topicSubscriber;
 
   @Before
   public void setUp() throws InterruptedException, ExecutionException, TimeoutException {
@@ -108,10 +119,6 @@ public final class FirebaseMessagingRoboTest {
             .setApiKey(API_KEY)
             .setGcmSenderId(FirebaseIidRoboTestHelper.SENDER_ID)
             .build());
-    firebaseMessaging = FirebaseMessaging.getInstance();
-    // Making sure Topic subscriber task succeeds before proceeding with tests.
-    topicSubscriber = Tasks.await(firebaseMessaging.getTopicsSubscriberTask(), 5, SECONDS);
-    clearTopicOperations();
 
     // To make sure proxy initialization happens before test execution.
     ProxyNotificationInitializer.initialize(context);
@@ -224,7 +231,7 @@ public final class FirebaseMessagingRoboTest {
     FirebaseApp.getInstance().setDataCollectionDefaultEnabled(false);
     editManifestApplicationMetadata().remove("firebase_messaging_auto_init_enabled");
 
-    assertThat(firebaseMessaging.isAutoInitEnabled()).isFalse();
+    assertThat(FirebaseMessaging.getInstance().isAutoInitEnabled()).isFalse();
   }
 
   /** Test that setting auto-init at runtime overrides the default setting. */
@@ -243,9 +250,9 @@ public final class FirebaseMessagingRoboTest {
     FirebaseApp.getInstance().setDataCollectionDefaultEnabled(false);
     editManifestApplicationMetadata().remove("firebase_messaging_auto_init_enabled");
 
-    firebaseMessaging.setAutoInitEnabled(true);
+    FirebaseMessaging.getInstance().setAutoInitEnabled(true);
 
-    assertThat(firebaseMessaging.isAutoInitEnabled()).isTrue();
+    assertThat(FirebaseMessaging.getInstance().isAutoInitEnabled()).isTrue();
   }
 
   /** Test that setting auto-init enabled at runtime overrides the manifest value. */
@@ -373,6 +380,9 @@ public final class FirebaseMessagingRoboTest {
   @Test
   @Config(sdk = VERSION_CODES.Q)
   public void isProxyNotificationEnabledDefaultsToTrueForNewerDevices() {
+    GmsRpc mockGmsRpc = mock(GmsRpc.class);
+    when(mockGmsRpc.setRetainProxiedNotifications(anyBoolean())).thenReturn(Tasks.forResult(null));
+    when(mockGmsRpc.getProxyNotificationData()).thenReturn(Tasks.forResult(null));
     FirebaseMessaging messaging =
         new FirebaseMessaging(
             FirebaseApp.getInstance(),
@@ -380,7 +390,7 @@ public final class FirebaseMessagingRoboTest {
             EMPTY_TRANSPORT_FACTORY,
             mock(Subscriber.class),
             mock(Metadata.class),
-            mock(GmsRpc.class),
+            mockGmsRpc,
             Runnable::run,
             Runnable::run,
             Runnable::run);
@@ -457,6 +467,277 @@ public final class FirebaseMessagingRoboTest {
     Tasks.await(FirebaseMessaging.getInstance().setNotificationDelegationEnabled(true));
 
     assertThat(FirebaseMessaging.getInstance().isNotificationDelegationEnabled()).isFalse();
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void initialProxy_noGoogleAnalyticsNoBigQuery() {
+    // Delete SharedPreferences to clear out the RetainProxiedNotifications setting.
+    context.deleteSharedPreferences("com.google.firebase.messaging");
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+
+    createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ false);
+
+    // GA not present and BigQuery export not enabled, shouldn't retain proxy notifications.
+    verify(mockGmsRpc).setRetainProxiedNotifications(false);
+    verify(mockGmsRpc, never()).getProxyNotificationData();
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void initialProxy_googleAnalyticsNoBigQuery() {
+    // Delete SharedPreferences to clear out the RetainProxiedNotifications setting.
+    context.deleteSharedPreferences("com.google.firebase.messaging");
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+
+    createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ true);
+
+    // GA present and BigQuery export not enabled, should retain proxy notifications.
+    verify(mockGmsRpc).setRetainProxiedNotifications(true);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void initialProxy_noGoogleAnalyticsBigQuery() {
+    // Delete SharedPreferences to clear out the RetainProxiedNotifications setting.
+    context.deleteSharedPreferences("com.google.firebase.messaging");
+    editManifestApplicationMetadata()
+        .putBoolean("delivery_metrics_exported_to_big_query_enabled", true);
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+
+    createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ false);
+
+    // GA not present and BigQuery export enabled, should retain proxy notifications.
+    verify(mockGmsRpc).setRetainProxiedNotifications(true);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void initialProxy_googleAnalyticsBigQuery() {
+    // Delete SharedPreferences to clear out the RetainProxiedNotifications setting.
+    context.deleteSharedPreferences("com.google.firebase.messaging");
+    // Enable BigQuery export.
+    editManifestApplicationMetadata()
+        .putBoolean("delivery_metrics_exported_to_big_query_enabled", true);
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+
+    createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ true);
+
+    // GA present and BigQuery export enabled, should retain proxy notifications.
+    verify(mockGmsRpc).setRetainProxiedNotifications(true);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.P)
+  public void initialProxy_preQ() {
+    // Delete SharedPreferences to clear out the RetainProxiedNotifications setting.
+    context.deleteSharedPreferences("com.google.firebase.messaging");
+    // Enable BigQuery export.
+    editManifestApplicationMetadata()
+        .putBoolean("delivery_metrics_exported_to_big_query_enabled", true);
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+
+    createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ true);
+
+    // Shouldn't set retention on a version that doesn't support proxy.
+    verify(mockGmsRpc, never()).setRetainProxiedNotifications(anyBoolean());
+    verify(mockGmsRpc, never()).getProxyNotificationData();
+  }
+
+  private static class FakeFirelogTransportFactory implements TransportFactory {
+    final Transport<?> mockTransport;
+
+    FakeFirelogTransportFactory(Transport<?> transport) {
+      mockTransport = transport;
+    }
+
+    @Override
+    public <T> Transport<T> getTransport(
+        String name, Class<T> payloadType, Transformer<T, byte[]> payloadTransformer) {
+      throw new IllegalStateException("unimplemented");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Transport<T> getTransport(
+        String name,
+        Class<T> payloadType,
+        Encoding payloadEncoding,
+        Transformer<T, byte[]> payloadTransformer) {
+      return (Transport<T>) mockTransport;
+    }
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  @SuppressWarnings("unchecked")
+  public void initializeProxy_handlesProxyNotifications() {
+    // Enable BigQuery export so that it will try to log to Firelog if it receives proxy data.
+    editManifestApplicationMetadata()
+        .putBoolean("delivery_metrics_exported_to_big_query_enabled", true);
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+    when(mockGmsRpc.getProxyNotificationData())
+        .thenReturn(
+            Tasks.forResult(new CloudMessage(new Intent())),
+            Tasks.forResult(new CloudMessage(new Intent())),
+            Tasks.forResult(null));
+    Transport<MessagingClientEventExtension> mockTransport = mock(Transport.class);
+
+    FirebaseMessaging unused =
+        new FirebaseMessaging(
+            FirebaseApp.getInstance(),
+            /* iid= */ null,
+            () -> new FakeFirelogTransportFactory(mockTransport),
+            mock(Subscriber.class),
+            mock(Metadata.class),
+            mockGmsRpc,
+            Runnable::run,
+            Runnable::run,
+            Runnable::run);
+
+    // Should have logged to Firelog twice, once for each notification returned.
+    verify(mockTransport, times(2)).send(any());
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  @SuppressWarnings("unchecked")
+  public void initializeProxy_handlesNoPendingProxyNotifications() {
+    // Enable BigQuery export so that it will try to log to Firelog if it receives proxy data.
+    editManifestApplicationMetadata()
+        .putBoolean("delivery_metrics_exported_to_big_query_enabled", true);
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+    when(mockGmsRpc.getProxyNotificationData()).thenReturn(Tasks.forResult(null));
+    Transport<MessagingClientEventExtension> mockTransport = mock(Transport.class);
+
+    FirebaseMessaging unused =
+        new FirebaseMessaging(
+            FirebaseApp.getInstance(),
+            /* iid= */ null,
+            () -> new FakeFirelogTransportFactory(mockTransport),
+            mock(Subscriber.class),
+            mock(Metadata.class),
+            mockGmsRpc,
+            Runnable::run,
+            Runnable::run,
+            Runnable::run);
+
+    // Should have tried to retrieve data, but should not have logged since there is no pending
+    // proxy notification data.
+    verify(mockGmsRpc).getProxyNotificationData();
+    verify(mockTransport, never()).send(any());
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void setDeliveryMetricsExportToBigQuery_enablesProxyRetention() {
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+    FirebaseMessaging messaging =
+        createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ false);
+    clearInvocations(mockGmsRpc);
+
+    messaging.setDeliveryMetricsExportToBigQuery(true);
+
+    // Enabling BigQuery should start retaining proxy notifications.
+    verify(mockGmsRpc).setRetainProxiedNotifications(true);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void setDeliveryMetricsExportToBigQuery_disablesProxyRetention() {
+    // Enable BigQuery export.
+    editManifestApplicationMetadata()
+        .putBoolean("delivery_metrics_exported_to_big_query_enabled", true);
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+    // Create an instance that should retain proxy notifications because BigQuery is enabled.
+    FirebaseMessaging messaging =
+        createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ false);
+    clearInvocations(mockGmsRpc);
+
+    messaging.setDeliveryMetricsExportToBigQuery(false);
+
+    // Disabling BigQuery should stop retaining proxy notifications.
+    verify(mockGmsRpc).setRetainProxiedNotifications(false);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void setDeliveryMetricsExportToBigQuery_noProxyRetentionChange() {
+    // Enable BigQuery export.
+    editManifestApplicationMetadata()
+        .putBoolean("delivery_metrics_exported_to_big_query_enabled", true);
+    // Create an instance that should retain proxy notifications due to AnalyticsConnector and
+    // BigQuery enabled.
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+    FirebaseMessaging messaging =
+        createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ true);
+    clearInvocations(mockGmsRpc);
+
+    messaging.setDeliveryMetricsExportToBigQuery(false);
+
+    // Disabling BigQuery should keep retaining proxy notifications since AnalyticsConnector is
+    // still present.
+    verify(mockGmsRpc, never()).setRetainProxiedNotifications(anyBoolean());
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void setNotificationDelegationEnabled_disablesProxyRetention() throws Exception {
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+    // Create an instance that should save that proxy notifications are retained.
+    FirebaseMessaging messaging =
+        createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ true);
+    clearInvocations(mockGmsRpc);
+
+    Tasks.await(messaging.setNotificationDelegationEnabled(false));
+
+    // Disabling proxy should stop retaining proxy notifications.
+    ShadowLooper.idleMainLooper();
+    verify(mockGmsRpc).setRetainProxiedNotifications(false);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void setNotificationDelegationEnabled_enablesProxyRetention() throws Exception {
+    GmsRpc mockGmsRpc = createMockGmsRpc();
+    // Create an instance that should retain proxy notifications, but disable proxy notifications.
+    FirebaseMessaging messaging =
+        createFirebaseMessageInstance(mockGmsRpc, /* analyticsConnectorPresent= */ true);
+    Tasks.await(messaging.setNotificationDelegationEnabled(false));
+    ShadowLooper.idleMainLooper();
+    clearInvocations(mockGmsRpc);
+
+    Tasks.await(messaging.setNotificationDelegationEnabled(true));
+
+    // Enabling proxy should start retaining proxy notifications again.
+    ShadowLooper.idleMainLooper();
+    verify(mockGmsRpc).setRetainProxiedNotifications(true);
+  }
+
+  private GmsRpc createMockGmsRpc() {
+    GmsRpc mockGmsRpc = mock(GmsRpc.class);
+    when(mockGmsRpc.setRetainProxiedNotifications(anyBoolean())).thenReturn(Tasks.forResult(null));
+    when(mockGmsRpc.getProxyNotificationData()).thenReturn(Tasks.forResult(null));
+    return mockGmsRpc;
+  }
+
+  @CanIgnoreReturnValue
+  private FirebaseMessaging createFirebaseMessageInstance(
+      GmsRpc gmsRpc, boolean analyticsConnectorPresent) {
+    FirebaseApp firebaseAppSpy = spy(FirebaseApp.getInstance());
+    when(firebaseAppSpy.get(AnalyticsConnector.class))
+        .thenReturn(analyticsConnectorPresent ? mock(AnalyticsConnector.class) : null);
+
+    return new FirebaseMessaging(
+        firebaseAppSpy,
+        /* iid= */ null,
+        () -> mock(TransportFactory.class),
+        mock(Subscriber.class),
+        mock(Metadata.class),
+        gmsRpc,
+        Runnable::run,
+        Runnable::run,
+        Runnable::run);
   }
 
   /*

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/GmsRpcRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/GmsRpcRoboTest.java
@@ -26,10 +26,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Application;
+import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
+import com.google.android.gms.cloudmessaging.CloudMessage;
 import com.google.android.gms.cloudmessaging.Rpc;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -240,6 +242,27 @@ public class GmsRpcRoboTest {
   @Test
   public void testUnsubscribeFromToken_propagatesIoException() {
     testPropagatesIoException(() -> gmsRpc.unsubscribeFromTopic("cachedToken", "topic"));
+  }
+
+  @Test
+  public void setRetainProxiedNotifications() {
+    when(internalRpc.setRetainProxiedNotifications(anyBoolean())).thenReturn(Tasks.forResult(null));
+
+    Task<Void> resultTask = gmsRpc.setRetainProxiedNotifications(true);
+
+    assertThat(resultTask.isSuccessful()).isTrue();
+    verify(internalRpc).setRetainProxiedNotifications(true);
+  }
+
+  @Test
+  public void getProxyNotificationData() {
+    CloudMessage proxyData = new CloudMessage(new Intent());
+    when(internalRpc.getProxiedNotificationData()).thenReturn(Tasks.forResult(proxyData));
+
+    Task<CloudMessage> resultTask = gmsRpc.getProxyNotificationData();
+
+    assertThat(resultTask.isSuccessful()).isTrue();
+    assertThat(resultTask.getResult()).isEqualTo(proxyData);
   }
 
   @Test

--- a/firebase-messaging/src/test/java/com/google/firebase/messaging/ProxyNotificationPreferencesRoboTest.java
+++ b/firebase-messaging/src/test/java/com/google/firebase/messaging/ProxyNotificationPreferencesRoboTest.java
@@ -1,0 +1,84 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.google.firebase.messaging;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.os.Build.VERSION_CODES;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.android.gms.tasks.Tasks;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/** Robolectric tests for ProxyNotificationPreferences. */
+@RunWith(RobolectricTestRunner.class)
+public class ProxyNotificationPreferencesRoboTest {
+
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
+  private Context context;
+  @Mock private GmsRpc mockGmsRpc;
+
+  @Before
+  public void setUp() {
+    context = ApplicationProvider.getApplicationContext();
+    when(mockGmsRpc.setRetainProxiedNotifications(anyBoolean())).thenReturn(Tasks.forResult(null));
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void setProxyRetention() {
+    ProxyNotificationPreferences.setProxyRetention(context, mockGmsRpc, true);
+
+    verify(mockGmsRpc).setRetainProxiedNotifications(true);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void setProxyRetention_sameTwiceSetOnce() {
+    ProxyNotificationPreferences.setProxyRetention(context, mockGmsRpc, true);
+    ProxyNotificationPreferences.setProxyRetention(context, mockGmsRpc, true);
+
+    verify(mockGmsRpc).setRetainProxiedNotifications(true);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.Q)
+  public void setProxyRetention_differentChanges() {
+    ProxyNotificationPreferences.setProxyRetention(context, mockGmsRpc, true);
+    ProxyNotificationPreferences.setProxyRetention(context, mockGmsRpc, false);
+
+    verify(mockGmsRpc).setRetainProxiedNotifications(true);
+    verify(mockGmsRpc).setRetainProxiedNotifications(false);
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.P)
+  public void setProxyRetention_preQ() {
+    ProxyNotificationPreferences.setProxyRetention(context, mockGmsRpc, true);
+
+    verify(mockGmsRpc, never()).setRetainProxiedNotifications(anyBoolean());
+  }
+}


### PR DESCRIPTION
- Add setting of proxy notification retention based on whether the app uses Google Analytics or has BigQuery export enabled.
- Add retrieval and logging to GA or BigQuery of proxied notifications at startup.