### PR TITLE
Added keep rule for Crashlytics Build ID resource names

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * [fixed] Force validation or rotation of FIDs.
+* [fixed] Added keep rule for shrinkage of Crashlytics build resources in strict mode.
 
 # 18.6.3
 

--- a/firebase-crashlytics/src/main/res/values/firebase_crashlytics_keep.xml
+++ b/firebase-crashlytics/src/main/res/values/firebase_crashlytics_keep.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@string/com.google.firebase.crashlytics_*" />


### PR DESCRIPTION
Proposed fix for #5859, previously regressed issue from #5562.

The issue affects both `firebase-crashlytics` and `firebase-crashlytics-ndk. This behavior is triggered when `isShrinkResources` is enabled and when "strict" rule. is added to resource shrinkage. e.g.
```
<?xml version="1.0" encoding="utf-8"?>
<resources xmlns:tools="http://schemas.android.com/tools"
    tools:shrinkMode="strict" />
```

b/311837855 advises that if strict mode is used, the keep rule is needed for getIdentifier constants.

Simulated tests by publishing local copy of the `firebase-crashlytics`, and `firebase-crashlytics-ndk`. Then testing with sample app variant that includes `isShrinkResources` enabled in `build.gradle`

```
buildTypes {
    release {
            isShrinkResources = true
            isMinifyEnabled = true
    }
}
```
