### PR TITLE
Safely handle unbinding service connection

### DIFF
--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -4,7 +4,7 @@
   (GitHub [#5859](https://github.com/firebase/firebase-android-sdk/issues/5859))
 * [fixed] Safely unbind to release service connection.
   (GitHub [#5869](https://github.com/firebase/firebase-android-sdk/issues/5869))
-* 
+
 # 1.2.3
 
 * [fixed] Force validation or rotation of FIDs.

--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [fixed] Handled datastore writes when device has full internal memory more gracefully.
   (GitHub [#5859](https://github.com/firebase/firebase-android-sdk/issues/5859))
-* [fixed] Safely unbind to release service connection.
+* [fixed] Safely unbind malfunctioned session lifecycle service to release service connections.
   (GitHub [#5869](https://github.com/firebase/firebase-android-sdk/issues/5869))
 
 # 1.2.3

--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [fixed] Handled datastore writes when device has full internal memory more gracefully.
   (GitHub [#5859](https://github.com/firebase/firebase-android-sdk/issues/5859))
-* [fixed] Safely unbind malfunctioned session lifecycle service to release service connections.
+* [fixed] Safely unbind malfunctioning session lifecycle service to release service connections.
   (GitHub [#5869](https://github.com/firebase/firebase-android-sdk/issues/5869))
 
 # 1.2.3

--- a/firebase-sessions/CHANGELOG.md
+++ b/firebase-sessions/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
 * [fixed] Handled datastore writes when device has full internal memory more gracefully.
-
+  (GitHub [#5859](https://github.com/firebase/firebase-android-sdk/issues/5859))
+* [fixed] Safely unbind to release service connection.
+  (GitHub [#5869](https://github.com/firebase/firebase-android-sdk/issues/5869))
+* 
 # 1.2.3
 
 * [fixed] Force validation or rotation of FIDs.

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
@@ -56,19 +56,19 @@ internal class SessionLifecycleServiceBinderImpl(private val firebaseApp: Fireba
         }
       if (!isServiceBound) {
         unbindServiceSafely(appContext, serviceConnection)
+        Log.i(TAG, "Session lifecycle service binding failed.")
       }
     }
   }
 
-  private fun unbindServiceSafely(appContext: Context, serviceConnection: ServiceConnection) {
+  private fun unbindServiceSafely(appContext: Context, serviceConnection: ServiceConnection) =
     try {
       appContext.unbindService(serviceConnection)
     } catch (ex: IllegalArgumentException) {
       Log.w(TAG, "Session lifecycle service binding failed.", ex)
     }
-  }
 
-  companion object {
+  private companion object {
     const val TAG = "LifecycleServiceBinder"
   }
 }

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
@@ -55,9 +55,17 @@ internal class SessionLifecycleServiceBinderImpl(private val firebaseApp: Fireba
           false
         }
       if (!isServiceBound) {
-        appContext.unbindService(serviceConnection)
+        unbindServiceSafely(appContext, serviceConnection)
         Log.i(TAG, "Session lifecycle service binding failed.")
       }
+    }
+  }
+
+  private fun unbindServiceSafely(appContext: Context, serviceConnection: ServiceConnection){
+    try {
+      appContext.unbindService(serviceConnection)
+    } catch (exception: IllegalArgumentException) {
+      Log.i(TAG, "Session lifecycle service binding failed.")
     }
   }
 

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
@@ -56,7 +56,6 @@ internal class SessionLifecycleServiceBinderImpl(private val firebaseApp: Fireba
         }
       if (!isServiceBound) {
         unbindServiceSafely(appContext, serviceConnection)
-        Log.i(TAG, "Session lifecycle service binding failed.")
       }
     }
   }
@@ -64,8 +63,8 @@ internal class SessionLifecycleServiceBinderImpl(private val firebaseApp: Fireba
   private fun unbindServiceSafely(appContext: Context, serviceConnection: ServiceConnection) {
     try {
       appContext.unbindService(serviceConnection)
-    } catch (exception: IllegalArgumentException) {
-      Log.i(TAG, "Session lifecycle service binding failed.")
+    } catch (ex: IllegalArgumentException) {
+      Log.w(TAG, "Session lifecycle service binding failed.", ex)
     }
   }
 

--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/SessionLifecycleServiceBinder.kt
@@ -61,7 +61,7 @@ internal class SessionLifecycleServiceBinderImpl(private val firebaseApp: Fireba
     }
   }
 
-  private fun unbindServiceSafely(appContext: Context, serviceConnection: ServiceConnection){
+  private fun unbindServiceSafely(appContext: Context, serviceConnection: ServiceConnection) {
     try {
       appContext.unbindService(serviceConnection)
     } catch (exception: IllegalArgumentException) {


### PR DESCRIPTION
Fix for #5869.

`Fatal Exception: java.lang.IllegalArgumentException: Service not registered: [obfuscated]` happens when the context calls `unbindService` on a service connection that has not been bounded. Either due to `SecurityException` or the existing service cannot be found from the map of services that has been bounded.

Simulating tests by calling `unbindService` without initially calling `bindService` will result to the same stacktrace as with the issue:
```
java.lang.IllegalArgumentException: Service not registered: com.example.testunbinding.MainActivity$onCreate$serviceConnection$1@8988566
                                                                                                    	at android.app.LoadedApk.forgetServiceDispatcher(LoadedApk.java:1289)
                                                                                                    	at android.app.ContextImpl.unbindService(ContextImpl.java:1511)
                                                                                                    	at android.content.ContextWrapper.unbindService(ContextWrapper.java:648)
                                                                                                    	at com.example.testunbinding.MainActivity.onCreate$lambda$0(MainActivity.kt:48)
                                                                                                    	at com.example.testunbinding.MainActivity.$r8$lambda$mcIw03Dd4PpO0vDw0ScUjxsazkw(MainActivity.kt)
                                                                                                    	at com.example.testunbinding.MainActivity$$ExternalSyntheticLambda0.onClick(D8$$SyntheticClass:0)
```

I've verified that the try-catch for `IllegalArgumentException` works.