### PR TITLE
Fix firestore-ktx deps

### DIFF
--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -55,8 +55,8 @@ tasks.withType(Test) {
 
 dependencies {
     api(project(":firebase-firestore"))
-    api("com.google.firebase:firebase-common:20.4.2")
-    api("com.google.firebase:firebase-common-ktx:20.4.2")
+    api(project(":firebase-common"))
+    api(project(":firebase-common:ktx"))
 
     implementation("com.google.firebase:firebase-components:17.1.5")
 

--- a/subprojects.cfg
+++ b/subprojects.cfg
@@ -31,7 +31,7 @@ firebase-datatransport
 # firebase-dynamic-links
 # firebase-dynamic-links:ktx
 firebase-firestore
-# firebase-firestore:ktx
+firebase-firestore:ktx
 firebase-functions
 # firebase-functions:ktx
 firebase-messaging


### PR DESCRIPTION
Per [b/335686707](https://b.corp.google.com/issues/335686707),

This fixes an issue where `firestore-ktx` was breaking from the building change in firestore and common- due to timestamp being moved from the former to the latter.