### PR TITLE
Move location parameter to FirebaseVertexAI instance

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAI.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAI.kt
@@ -34,6 +34,7 @@ import com.google.firebase.vertexai.type.ToolConfig
 class FirebaseVertexAI
 internal constructor(
   private val firebaseApp: FirebaseApp,
+  private val location: String,
   private val appCheckProvider: Provider<InteropAppCheckTokenProvider>,
   private val internalAuthProvider: Provider<InternalAuthProvider>,
 ) {
@@ -49,8 +50,6 @@ internal constructor(
    * @param tools the list of tools to make available to the model
    * @param toolConfig the configuration that defines how the model handles the tools provided
    * @param systemInstruction contains a [Content] that directs the model to behave a certain way
-   * @param location location identifier, defaults to `us-central1`; see available
-   * [Vertex AI regions](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#available-regions)
    */
   @JvmOverloads
   fun generativeModel(
@@ -61,7 +60,6 @@ internal constructor(
     tools: List<Tool>? = null,
     toolConfig: ToolConfig? = null,
     systemInstruction: Content? = null,
-    location: String = "us-central1"
   ): GenerativeModel {
     if (location.trim().isEmpty() || location.contains("/")) {
       throw InvalidLocationException(location)
@@ -84,11 +82,22 @@ internal constructor(
     /** The [FirebaseVertexAI] instance for the default [FirebaseApp] */
     @JvmStatic
     val instance: FirebaseVertexAI
-      get() = Firebase.app[FirebaseVertexAI::class.java]
+      get() = getInstance(location = "us-central1")
 
-    /** Returns the [FirebaseVertexAI] instance for the provided [FirebaseApp] */
+    /**
+     *  Returns the [FirebaseVertexAI] instance for the provided [FirebaseApp] and [location]
+     *
+     * @param location location identifier, defaults to `us-central1`; see available
+     * [Vertex AI regions](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#available-regions)
+     */
     @JvmStatic
-    fun getInstance(app: FirebaseApp): FirebaseVertexAI = app[FirebaseVertexAI::class.java]
+    fun getInstance(
+      app: FirebaseApp = Firebase.app,
+      location: String
+    ): FirebaseVertexAI {
+      val multiResourceComponent = app[FirebaseVertexAIMultiResourceComponent::class.java]
+      return multiResourceComponent.get(location)
+    }
   }
 }
 
@@ -97,4 +106,7 @@ val Firebase.vertexAI: FirebaseVertexAI
   get() = FirebaseVertexAI.instance
 
 /** Returns the [FirebaseVertexAI] instance of a given [FirebaseApp]. */
-fun Firebase.vertexAI(app: FirebaseApp): FirebaseVertexAI = FirebaseVertexAI.getInstance(app)
+fun Firebase.vertexAI(
+  app: FirebaseApp = Firebase.app,
+  location: String = "us-central1"
+): FirebaseVertexAI = FirebaseVertexAI.getInstance(app, location)

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAIMultiResourceComponent.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAIMultiResourceComponent.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.vertexai
+
+import androidx.annotation.GuardedBy
+import com.google.firebase.FirebaseApp
+import com.google.firebase.appcheck.interop.InteropAppCheckTokenProvider
+import com.google.firebase.auth.internal.InternalAuthProvider
+import com.google.firebase.inject.Provider
+
+/** Multi-resource container for Firebase Vertex AI */
+internal class FirebaseVertexAIMultiResourceComponent(
+  private val app: FirebaseApp,
+  private val appCheckProvider: Provider<InteropAppCheckTokenProvider>,
+  private val internalAuthProvider: Provider<InternalAuthProvider>
+) {
+
+  @GuardedBy("this") private val instances: MutableMap<String, FirebaseVertexAI> = mutableMapOf()
+
+  fun get(location: String): FirebaseVertexAI =
+    synchronized(this) {
+      instances[location]
+        ?: FirebaseVertexAI(app, location, appCheckProvider, internalAuthProvider).also {
+          instances[location] = it
+        }
+    }
+}

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAIRegistrar.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAIRegistrar.kt
@@ -35,16 +35,16 @@ import com.google.firebase.platforminfo.LibraryVersionComponent
 internal class FirebaseVertexAIRegistrar : ComponentRegistrar {
   override fun getComponents() =
     listOf(
-      Component.builder(FirebaseVertexAI::class.java)
+      Component.builder(FirebaseVertexAIMultiResourceComponent::class.java)
         .name(LIBRARY_NAME)
         .add(Dependency.required(firebaseApp))
         .add(Dependency.optionalProvider(appCheckInterop))
         .add(Dependency.optionalProvider(internalAuthProvider))
         .factory { container ->
-          FirebaseVertexAI(
+          FirebaseVertexAIMultiResourceComponent(
             container[firebaseApp],
             container.getProvider(appCheckInterop),
-            container.getProvider(internalAuthProvider),
+            container.getProvider(internalAuthProvider)
           )
         }
         .build(),


### PR DESCRIPTION
They were previously part of the `generativeModel` call