### PR TITLE
Add responseMimeType support

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,1 +1,2 @@
 # Unreleased
+* [feature] Added support for `responseMimeType` in `GenerationConfig`.

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
@@ -108,7 +108,8 @@ internal fun GenerationConfig.toInternal() =
     topK = topK,
     candidateCount = candidateCount,
     maxOutputTokens = maxOutputTokens,
-    stopSequences = stopSequences
+    stopSequences = stopSequences,
+    responseMimeType = responseMimeType
   )
 
 internal fun com.google.firebase.vertexai.type.HarmCategory.toInternal() =

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
@@ -25,6 +25,9 @@ package com.google.firebase.vertexai.type
  * @property candidateCount The max *unique* responses to return
  * @property maxOutputTokens The max tokens to generate per response
  * @property stopSequences A list of strings to stop generation on occurrence of
+ * * @property responseMimeType Response type for generated candidate text. See the
+ * [vertex docs](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/GenerationConfig)
+ * for a list of supported types.
  */
 class GenerationConfig
 private constructor(
@@ -33,7 +36,8 @@ private constructor(
   val topP: Float?,
   val candidateCount: Int?,
   val maxOutputTokens: Int?,
-  val stopSequences: List<String>?
+  val stopSequences: List<String>?,
+  val responseMimeType: String?
 ) {
 
   class Builder {
@@ -43,6 +47,7 @@ private constructor(
     @JvmField var candidateCount: Int? = null
     @JvmField var maxOutputTokens: Int? = null
     @JvmField var stopSequences: List<String>? = null
+    @JvmField var responseMimeType: String? = null
 
     fun build() =
       GenerationConfig(
@@ -51,7 +56,9 @@ private constructor(
         topP = topP,
         candidateCount = candidateCount,
         maxOutputTokens = maxOutputTokens,
-        stopSequences = stopSequences
+        stopSequences = stopSequences,
+        responseMimeType = responseMimeType,
+        responseMimeType = responseMimeType
       )
   }
 

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
@@ -57,7 +57,6 @@ private constructor(
         candidateCount = candidateCount,
         maxOutputTokens = maxOutputTokens,
         stopSequences = stopSequences,
-        responseMimeType = responseMimeType,
         responseMimeType = responseMimeType
       )
   }


### PR DESCRIPTION
Per [b/338382359](https://b.corp.google.com/issues/338382359),

This adds support for the `response_mime_type` property of `GenerationConfig`. Although, this won't properly work until `generativeai:common` releases again. Schema support will be provided in a follow up PR.