### PR TITLE
Rename Vertex exception

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,2 +1,3 @@
 # Unreleased
 * [feature] Added support for `responseMimeType` in `GenerationConfig`.
+* [changed] Renamed `GoogleGenerativeAIException` to `FirebaseVertexAIException`.

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -29,9 +29,9 @@ import com.google.firebase.vertexai.internal.util.toPublic
 import com.google.firebase.vertexai.type.Content
 import com.google.firebase.vertexai.type.CountTokensResponse
 import com.google.firebase.vertexai.type.FinishReason
+import com.google.firebase.vertexai.type.FirebaseVertexAIException
 import com.google.firebase.vertexai.type.GenerateContentResponse
 import com.google.firebase.vertexai.type.GenerationConfig
-import com.google.firebase.vertexai.type.GoogleGenerativeAIException
 import com.google.firebase.vertexai.type.PromptBlockedException
 import com.google.firebase.vertexai.type.RequestOptions
 import com.google.firebase.vertexai.type.ResponseStoppedException
@@ -130,7 +130,7 @@ internal constructor(
     try {
       controller.generateContent(constructRequest(*prompt)).toPublic().validate()
     } catch (e: Throwable) {
-      throw GoogleGenerativeAIException.from(e)
+      throw FirebaseVertexAIException.from(e)
     }
 
   /**
@@ -142,7 +142,7 @@ internal constructor(
   fun generateContentStream(vararg prompt: Content): Flow<GenerateContentResponse> =
     controller
       .generateContentStream(constructRequest(*prompt))
-      .catch { throw GoogleGenerativeAIException.from(it) }
+      .catch { throw FirebaseVertexAIException.from(it) }
       .map { it.toPublic().validate() }
 
   /**

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Exceptions.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Exceptions.kt
@@ -16,25 +16,25 @@
 
 package com.google.firebase.vertexai.type
 
-import com.google.firebase.vertexai.GenerativeModel
+import com.google.firebase.vertexai.FirebaseVertexAI
 import com.google.firebase.vertexai.internal.util.toPublic
 import kotlinx.coroutines.TimeoutCancellationException
 
-/** Parent class for any errors that occur from [GenerativeModel]. */
-sealed class GoogleGenerativeAIException(message: String, cause: Throwable? = null) :
+/** Parent class for any errors that occur from the [FirebaseVertexAI] SDK. */
+sealed class FirebaseVertexAIException(message: String, cause: Throwable? = null) :
   RuntimeException(message, cause) {
 
   companion object {
 
     /**
-     * Converts a [Throwable] to a [GoogleGenerativeAIException].
+     * Converts a [Throwable] to a [FirebaseVertexAIException].
      *
      * Will populate default messages as expected, and propagate the provided [cause] through the
      * resulting exception.
      */
-    fun from(cause: Throwable): GoogleGenerativeAIException =
+    fun from(cause: Throwable): FirebaseVertexAIException =
       when (cause) {
-        is GoogleGenerativeAIException -> cause
+        is FirebaseVertexAIException -> cause
         is com.google.ai.client.generativeai.common.GoogleGenerativeAIException ->
           when (cause) {
             is com.google.ai.client.generativeai.common.SerializationException ->
@@ -68,15 +68,15 @@ sealed class GoogleGenerativeAIException(message: String, cause: Throwable? = nu
 
 /** Something went wrong while trying to deserialize a response from the server. */
 class SerializationException(message: String, cause: Throwable? = null) :
-  GoogleGenerativeAIException(message, cause)
+  FirebaseVertexAIException(message, cause)
 
 /** The server responded with a non 200 response code. */
 class ServerException(message: String, cause: Throwable? = null) :
-  GoogleGenerativeAIException(message, cause)
+  FirebaseVertexAIException(message, cause)
 
 /** The server responded that the API Key is no valid. */
 class InvalidAPIKeyException(message: String, cause: Throwable? = null) :
-  GoogleGenerativeAIException(message, cause)
+  FirebaseVertexAIException(message, cause)
 
 /**
  * A request was blocked for some reason.
@@ -87,7 +87,7 @@ class InvalidAPIKeyException(message: String, cause: Throwable? = null) :
  */
 // TODO(rlazo): Add secondary constructor to pass through the message?
 class PromptBlockedException(val response: GenerateContentResponse, cause: Throwable? = null) :
-  GoogleGenerativeAIException(
+  FirebaseVertexAIException(
     "Prompt was blocked: ${response.promptFeedback?.blockReason?.name}",
     cause
   )
@@ -101,7 +101,7 @@ class PromptBlockedException(val response: GenerateContentResponse, cause: Throw
  */
 // TODO(rlazo): Add secondary constructor to pass through the message?
 class UnsupportedUserLocationException(cause: Throwable? = null) :
-  GoogleGenerativeAIException("User location is not supported for the API use.", cause)
+  FirebaseVertexAIException("User location is not supported for the API use.", cause)
 
 /**
  * Some form of state occurred that shouldn't have.
@@ -109,7 +109,7 @@ class UnsupportedUserLocationException(cause: Throwable? = null) :
  * Usually indicative of consumer error.
  */
 class InvalidStateException(message: String, cause: Throwable? = null) :
-  GoogleGenerativeAIException(message, cause)
+  FirebaseVertexAIException(message, cause)
 
 /**
  * A request was stopped during generation for some reason.
@@ -117,7 +117,7 @@ class InvalidStateException(message: String, cause: Throwable? = null) :
  * @property response the full server response for the request
  */
 class ResponseStoppedException(val response: GenerateContentResponse, cause: Throwable? = null) :
-  GoogleGenerativeAIException(
+  FirebaseVertexAIException(
     "Content generation stopped. Reason: ${response.candidates.first().finishReason?.name}",
     cause
   )
@@ -128,7 +128,7 @@ class ResponseStoppedException(val response: GenerateContentResponse, cause: Thr
  * Usually occurs due to a user specified [timeout][RequestOptions.timeout].
  */
 class RequestTimeoutException(message: String, cause: Throwable? = null) :
-  GoogleGenerativeAIException(message, cause)
+  FirebaseVertexAIException(message, cause)
 
 /**
  * The specified Vertex AI location is invalid.
@@ -137,8 +137,8 @@ class RequestTimeoutException(message: String, cause: Throwable? = null) :
  * [Vertex AI locations](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#available-regions)
  */
 class InvalidLocationException(location: String, cause: Throwable? = null) :
-  GoogleGenerativeAIException("Invalid location \"${location}\"", cause)
+  FirebaseVertexAIException("Invalid location \"${location}\"", cause)
 
 /** Catch all case for exceptions not explicitly expected. */
 class UnknownException(message: String, cause: Throwable? = null) :
-  GoogleGenerativeAIException(message, cause)
+  FirebaseVertexAIException(message, cause)


### PR DESCRIPTION
Per [b/339846019](https://b.corp.google.com/issues/339846019),

This renames the `GoogleGenerativeAIException` to `FirebaseVertexAIException` in the Vertex SDK, to not only better align with the actual product name- but other Firebase products as well.