### PR TITLE
Comment the equals() and hashCode() methods in GeneratedConnector and GeneratedConnector

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/generated/GeneratedConnector.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/generated/GeneratedConnector.kt
@@ -50,14 +50,20 @@ public interface GeneratedConnector {
    * @param other The object to compare to this for equality.
    * @return `other === this`
    */
-  override fun equals(other: Any?): Boolean
+  // TODO: Uncomment equals() once the codegen changes in cl/634029357 are released in the latest
+  //  firestore-tools for a month or so, as adding this method is a breaking change as it forces the
+  //  generated classes to explicitly override this method.
+  // override fun equals(other: Any?): Boolean
 
   /**
    * Calculates and returns the hash code for this object.
    *
    * @return the hash code for this object.
    */
-  override fun hashCode(): Int
+  // TODO: Uncomment hashCode() once the codegen changes in cl/634029357 are released in the latest
+  //  firestore-tools for a month or so, as adding this method is a breaking change as it forces the
+  //  generated classes to explicitly override this method.
+  // override fun hashCode(): Int
 
   /**
    * Returns a string representation of this object, useful for debugging.

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/generated/GeneratedOperation.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/generated/GeneratedOperation.kt
@@ -76,14 +76,20 @@ public interface GeneratedOperation<Connector : GeneratedConnector, Data, Variab
    * @param other The object to compare to this for equality.
    * @return `other === this`
    */
-  override fun equals(other: Any?): Boolean
+  // TODO: Uncomment equals() once the codegen changes in cl/634029357 are released in the latest
+  //  firestore-tools for a month or so, as adding this method is a breaking change as it forces the
+  //  generated classes to explicitly override this method.
+  // override fun equals(other: Any?): Boolean
 
   /**
    * Calculates and returns the hash code for this object.
    *
    * @return the hash code for this object.
    */
-  override fun hashCode(): Int
+  // TODO: Uncomment hashCode() once the codegen changes in cl/634029357 are released in the latest
+  //  firestore-tools for a month or so, as adding this method is a breaking change as it forces the
+  //  generated classes to explicitly override this method.
+  // override fun hashCode(): Int
 
   /**
    * Returns a string representation of this object, useful for debugging.


### PR DESCRIPTION
From b/340910059: In order to document the behavior of the equals() and hashCode() methods of the generated classes, these methods were added to the GeneratedConnector and GeneratedOperation interfaces in the Android Core SDK; however, adding these methods is a breaking change that requires the implementing classes to explicitly define them, rather than inheriting the (correct) default behavior from kotlin.Any. Since the released codegen does not explicitly define these methods it fails to compile. However, once the codegen that does define those methods is sufficiently soaked, they should be uncommented.