### PR TITLE
Make the settings cache load lazy, improving init time

### DIFF
--- a/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
+++ b/firebase-sessions/src/main/kotlin/com/google/firebase/sessions/settings/RemoteSettings.kt
@@ -41,7 +41,7 @@ internal class RemoteSettings(
   private val configsFetcher: CrashlyticsSettingsFetcher,
   dataStore: DataStore<Preferences>,
 ) : SettingsProvider {
-  private val settingsCache = SettingsCache(dataStore)
+  private val settingsCache by lazy { SettingsCache(dataStore) }
   private val fetchInProgress = Mutex()
 
   override val sessionEnabled: Boolean?


### PR DESCRIPTION
This is part of an effort to prevent ANRs.

The Sessions sdk was blocking the main thread for a split second to load the cache from disk. By making the cache lazy, it is still safe to fetch it anytime and assume it is loaded at any time, but it will not block initialization, instead it will block the first read. The first time Sessions reads from the cache is in a background thread, so it will be loaded then. But if we ever tried to read the cache after say a failed initiation, we can still safely assume when we get `settingsCache` it will have loaded from disk.