### PR TITLE
Fix compatibility issues with Crashlytics

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [fixed] Fixed version compatibility issues with other Firebase libraries.
 
 # 19.0.0
 * [fixed] Force validation or rotation of FIDs.

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -75,10 +75,7 @@ dependencies {
     api 'com.google.firebase:firebase-encoders-json:18.0.0'
     api("com.google.firebase:firebase-installations:17.2.0")
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
-    api('com.google.firebase:firebase-measurement-connector:18.0.2') {
-         exclude group: 'com.google.firebase', module: 'firebase-common'
-         exclude group: 'com.google.firebase', module: 'firebase-components'
-     }
+    api("com.google.firebase:firebase-measurement-connector:20.0.1")
 
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.datatransport:transport-backend-cct:3.1.9'

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -75,7 +75,7 @@ dependencies {
     api 'com.google.firebase:firebase-encoders-json:18.0.0'
     api("com.google.firebase:firebase-installations:17.2.0")
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
-    api("com.google.firebase:firebase-measurement-connector:20.0.1")
+    api("com.google.firebase:firebase-measurement-connector:19.0.0")
 
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.datatransport:transport-backend-cct:3.1.9'

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -75,7 +75,7 @@ dependencies {
     api 'com.google.firebase:firebase-encoders-json:18.0.0'
     api("com.google.firebase:firebase-installations:17.2.0")
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
-    api("com.google.firebase:firebase-measurement-connector:19.0.0")
+    api("com.google.firebase:firebase-measurement-connector:20.0.1")
 
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.datatransport:transport-backend-cct:3.1.9'


### PR DESCRIPTION
Fix compatibility issues with Crashlytics.

Tested manually with a test app. Not sure why we had an old version pinned with exclude rules?

Should we do something with the version catalog instead? Keep all the SDK's dependencies pinned to versions, but those versions are defined consistently with the BoM.