### PR TITLE
Improve cold initialization time

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Improve cold initialization time.
 
 # 19.0.0
 * [fixed] Force validation or rotation of FIDs.

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
@@ -497,7 +497,7 @@ public class SessionReportingCoordinatorTest {
     when(reportSender.enqueueReport(mockReport1, false)).thenReturn(successfulTask);
     when(reportSender.enqueueReport(mockReport2, false)).thenReturn(failedTask);
 
-    when(idManager.fetchTrueFid()).thenReturn(new FirebaseInstallationId("fid", "authToken"));
+    when(idManager.fetchTrueFid(any())).thenReturn(new FirebaseInstallationId("fid", "authToken"));
     reportingCoordinator.sendReports(Runnable::run);
 
     verify(reportSender).enqueueReport(mockReport1, false);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinator.java
@@ -233,17 +233,17 @@ public class SessionReportingCoordinator implements CrashlyticsLifecycleEvents {
   }
 
   /**
-   * Ensure reportToSend has a populated fid.
+   * Ensure reportToSend has a populated fid and auth token.
    *
    * <p>This is needed because it's possible to capture reports while data collection is disabled,
    * and then upload the report later by calling sendUnsentReports or enabling data collection.
    */
   private CrashlyticsReportWithSessionId ensureHasFid(CrashlyticsReportWithSessionId reportToSend) {
-    // Only do the update if the fid is already missing from the report.
+    // Only do the update if the fid or auth token is already missing from the report.
     if (reportToSend.getReport().getFirebaseInstallationId() == null
         || reportToSend.getReport().getFirebaseAuthenticationToken() == null) {
       // Fetch the true fid, regardless of automatic data collection since it's uploading.
-      FirebaseInstallationId firebaseInstallationId = idManager.fetchTrueFid();
+      FirebaseInstallationId firebaseInstallationId = idManager.fetchTrueFid(/* validate= */ true);
       return CrashlyticsReportWithSessionId.create(
           reportToSend
               .getReport()


### PR DESCRIPTION
Improve cold initialization time by not validating the fid on init. We only need to detect if the fid has changed on initialization, we don't care if it's valid. Changing it, deleting it, manipulating it, whatever... should cause the Crashlytics id to rotate. That will still happen after this change.

In my local experiments, this improved the cold init time from about 300 ms to 50 ms. This does not affect warm init, when the fid and auth token are already cached. On the first report, if the auth token has not yet been fetched, it will get fetched at upload time. If validating the fid caused the fid to rotate, the Crashlytics id will also rotate on the next launch.