### PR TITLE
Add namespace to firebase-appdistribution/test-app/test-app.gradle

### DIFF
--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -20,6 +20,7 @@ plugins {
 }
 
 android {
+    namespace "com.google.firebase.appdistribution.testapp"
     compileSdk 33
 
     defaultConfig {


### PR DESCRIPTION
Doesn't build without this right now.