### PR TITLE
Update the URL for the Metric Service

### DIFF
--- a/ci/fireci/fireciplugins/binary_size.py
+++ b/ci/fireci/fireciplugins/binary_size.py
@@ -38,7 +38,7 @@ _logger = logging.getLogger('fireci.binary_size')
 )
 @click.option(
   '--metrics-service-url',
-  default='https://api.firebase-sdk-health-metrics.com',
+  default='https://metric-service-tv5rmd4a6q-uc.a.run.app',
   help='The URL to the metrics service, which persists data and calculates diff.'
 )
 @click.option(

--- a/ci/fireci/fireciplugins/coverage.py
+++ b/ci/fireci/fireciplugins/coverage.py
@@ -38,7 +38,7 @@ _logger = logging.getLogger('fireci.coverage')
 )
 @click.option(
   '--metrics-service-url',
-  default='https://api.firebase-sdk-health-metrics.com',
+  default='https://metric-service-tv5rmd4a6q-uc.a.run.app',
   help='The URL to the metrics service, which persists data and calculates diff.'
 )
 @click.option(

--- a/ci/fireci/fireciplugins/macrobenchmark/commands.py
+++ b/ci/fireci/fireciplugins/macrobenchmark/commands.py
@@ -181,7 +181,7 @@ def ci(pull_request: bool, changed_modules_file: Path, repeat: int):
     startup_time_data = {'log': log, 'ftlResults': ftl_results}
 
     if ftl_results:
-      metric_service_url = 'https://api.firebase-sdk-health-metrics.com'
+      metric_service_url = 'https://metric-service-tv5rmd4a6q-uc.a.run.app'
       access_token = ci_utils.gcloud_identity_token()
       uploader.post_report(
         test_report=startup_time_data,


### PR DESCRIPTION
The custom domain "firebase-sdk-health-metrics.com" currently associated with the Metric Service will be deprecated eventually, due to the acquisition of Google Domains by Squarespace.

Switching to the original URL created by Google Cloud Run (which hosts the Metric Service) to avoid service disruption.

See b/303931111 for more details.