### PR TITLE
Change default port of useEmulator() to 9399 (was 9510).

### DIFF
--- a/firebase-dataconnect/emulator/emulator_noauth.sh
+++ b/firebase-dataconnect/emulator/emulator_noauth.sh
@@ -22,6 +22,7 @@ readonly CLI_ARGS=(
   -logtostderr
   -v=9
   dev
+  -listen=127.0.0.1:9399
   -service_location=us-central1
   -config_dir=dataconnect
   -local_connection_string='postgresql://postgres:postgres@localhost:5432?sslmode=disable'

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
@@ -157,7 +157,7 @@ public interface FirebaseDataConnect : AutoCloseable {
    * @param port The TCP port of the Data Connect emulator to which to connect. The default value is
    * the default port used
    */
-  public fun useEmulator(host: String = "10.0.2.2", port: Int = 9510)
+  public fun useEmulator(host: String = "10.0.2.2", port: Int = 9399)
 
   /**
    * Creates and returns a [QueryRef] for running the specified query.

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
@@ -88,7 +88,9 @@ import kotlinx.serialization.SerializationStrategy
  * ##### 16.0.0-alpha04 (not yet released)
  * - Fixed time zone issues when serializing java.util.Date objects (
  * [#5976](https://github.com/firebase/firebase-android-sdk/pull/5976))
- * - XXXX
+ * - Changed default port of useEmulator() to 9399 (was 9510); this goes with a change to the Data
+ * Connect Emulator v1.1.18 that changes the default port to 9399. (
+ * [#5996](https://github.com/firebase/firebase-android-sdk/pull/5996))
  *
  * ##### 16.0.0-alpha03 (May 15, 2024)
  * - KDoc comments added.


### PR DESCRIPTION
In cl/636395279 the grpc and http ports were combined. Also, that CL changes the --grpc_port and --http_port flags into a single flag: --listen, whose default value is 127.0.0.1:3628. This change will be included in the v1.1.18 release of the Data Connect emulator, and will be used by firestore-tools with https://github.com/firebase/firebase-tools/pull/7211 merged in.
