### PR TITLE
Fix grpc shutdown

### DIFF
--- a/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestDataConnectFactory.kt
+++ b/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestDataConnectFactory.kt
@@ -63,8 +63,7 @@ class TestDataConnectFactory(val firebaseAppFactory: TestFirebaseAppFactory) :
   }
 
   override fun destroyInstance(instance: FirebaseDataConnect) {
-    instance.close()
-    runBlocking { instance.awaitClose() }
+    runBlocking { instance.suspendingClose() }
   }
 
   data class Params(

--- a/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestDataConnectFactory.kt
+++ b/firebase-dataconnect/androidTestutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestDataConnectFactory.kt
@@ -20,6 +20,7 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.dataconnect.*
 import com.google.firebase.util.nextAlphanumericString
 import kotlin.random.Random
+import kotlinx.coroutines.runBlocking
 
 /**
  * A JUnit test rule that creates instances of [FirebaseDataConnect] for use during testing, and
@@ -63,6 +64,7 @@ class TestDataConnectFactory(val firebaseAppFactory: TestFirebaseAppFactory) :
 
   override fun destroyInstance(instance: FirebaseDataConnect) {
     instance.close()
+    runBlocking { instance.awaitClose() }
   }
 
   data class Params(

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
@@ -21,7 +21,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
 import com.google.firebase.app
 import com.google.firebase.dataconnect.core.FirebaseDataConnectFactory
-import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
 
@@ -155,8 +155,8 @@ public interface FirebaseDataConnect : AutoCloseable {
    * To start the Data Connect emulator from the command line, first install Firebase Tools as
    * documented at https://firebase.google.com/docs/emulator-suite/install_and_configure then run
    * `firebase emulators:start --only auth,dataconnect`. Enabling the "auth" emulator is only needed
-   * if using [FirebaseAuth] to authenticate users. You may also need to specify `--project
-   * <projectId>` if the Firebase tools are unable to auto-detect the project ID.
+   * if using [com.google.firebase.auth.FirebaseAuth] to authenticate users. You may also need to
+   * specify `--project <projectId>` if the Firebase tools are unable to auto-detect the project ID.
    *
    * @param host The host name or IP address of the Data Connect emulator to which to connect. The
    * default value, 10.0.2.2, is a magic IP address that the Android Emulator aliases to the host
@@ -202,35 +202,36 @@ public interface FirebaseDataConnect : AutoCloseable {
    * This method returns immediately, possibly before in-flight queries and mutations are completed.
    * Any future attempts to execute queries or mutations returned from [query] or [mutation] will
    * immediately fail. To wait for the in-flight queries and mutations to complete, call
-   * [awaitClose].
+   * [suspendingClose] instead.
    *
-   * It is safe to call this method multiple times; subsequent invocations have no effect and return
-   * as if successful.
+   * It is safe to call this method multiple times. On subsequent invocations, if the previous
+   * closing attempt failed then it will be re-tried.
    *
    * After this method returns, calling [FirebaseDataConnect.Companion.getInstance] with the same
    * [app] and [config] will return a new instance, rather than returning this instance.
    *
-   * @see awaitClose
+   * @see suspendingClose
    */
   override fun close()
 
   /**
-   * Suspends the calling coroutine until this [FirebaseDataConnect] instance is closed.
+   * A version of [close] that has the same semantics, but suspends until the asynchronous work is
+   * complete.
    *
-   * The [close] method starts some asynchronous work, such as stopping in-flight queries and
-   * mutations. The [close] method will return immediately, even if that asynchronous work has not
-   * yet completed. This method allows callers to wait for the asynchronous work to complete.
+   * If the asynchronous work fails, then the exception from the asynchronous work is rethrown by
+   * this method.
    *
-   * This method awaits the result of the most recent invocation of [close]. The calling coroutine
-   * is suspended until the asynchronous work has completed; if it completed successfully then the
-   * calling coroutine will be resumed and this method will return; otherwise, if it completed
-   * unsuccessfully, then the exception that caused the asynchronous work to fail will be thrown,
-   * which may be [CancellationException] if the asynchronous work was cancelled. If [close] is
-   * never called then the calling coroutine will be suspended indefinitely.
+   * Using this method in tests may be useful to ensure that this object is fully shut down after
+   * each test case. This is especially true if tests create [FirebaseDataConnect] in rapid
+   * succession which could starve resources if they are all active simultaneously. In those cases,
+   * it may be a good idea to call [suspendingClose] instead of [close] to ensure that each instance
+   * is fully shut down before a new one is created. In normal production applications, where
+   * instances of [FirebaseDataConnect] are created infrequently, calling [close] should be
+   * sufficient, and avoids having to create a [CoroutineScope] just to close the object.
    *
    * @see close
    */
-  public suspend fun awaitClose()
+  public suspend fun suspendingClose()
 
   /**
    * Compares this object with another object for equality, using the `===` operator.

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectAuth.kt
@@ -30,7 +30,7 @@ internal class DataConnectAuth(
   deferredAuthProvider: com.google.firebase.inject.Deferred<InternalAuthProvider>,
   blockingExecutor: Executor,
   parentLogger: Logger,
-) : AutoCloseable {
+) {
   private val logger =
     Logger("DataConnectAuth").apply { debug { "Created by ${parentLogger.nameWithId}" } }
 
@@ -51,7 +51,7 @@ internal class DataConnectAuth(
     }
   }
 
-  override fun close() = runBlocking {
+  suspend fun close() {
     logger.debug { "close()" }
     mutex.withLock {
       closed = true

--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcRPCs.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.core
+
+import android.content.Context
+import com.google.android.gms.security.ProviderInstaller
+import google.firebase.dataconnect.proto.ConnectorServiceGrpcKt
+import google.firebase.dataconnect.proto.ExecuteMutationRequest
+import google.firebase.dataconnect.proto.ExecuteMutationResponse
+import google.firebase.dataconnect.proto.ExecuteQueryRequest
+import google.firebase.dataconnect.proto.ExecuteQueryResponse
+import io.grpc.ManagedChannelBuilder
+import io.grpc.Metadata
+import io.grpc.android.AndroidChannelBuilder
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+internal interface DataConnectGrpcRPCs {
+
+  suspend fun executeMutation(
+    request: ExecuteMutationRequest,
+    headers: Metadata
+  ): ExecuteMutationResponse
+
+  suspend fun executeQuery(request: ExecuteQueryRequest, headers: Metadata): ExecuteQueryResponse
+
+  suspend fun close()
+}
+
+internal class DataConnectGrpcRPCsImpl(
+  context: Context,
+  host: String,
+  sslEnabled: Boolean,
+  private val coroutineDispatcher: CoroutineDispatcher,
+) : DataConnectGrpcRPCs {
+
+  private val logger =
+    Logger("DataConnectGrpcRPCsImpl").apply { debug { "host=$host sslEnabled=$sslEnabled" } }
+
+  private val mutex = Mutex()
+  private var closed = false
+
+  private val grpcChannel = run {
+    // Upgrade the Android security provider using Google Play Services.
+    //
+    // We need to upgrade the Security Provider before any network channels are initialized
+    // because okhttp maintains a list of supported providers that is initialized when the JVM
+    // first resolves the static dependencies of ManagedChannel.
+    //
+    // If initialization fails for any reason, then a warning is logged and the original,
+    // un-upgraded security provider is used.
+    try {
+      ProviderInstaller.installIfNeeded(context)
+    } catch (e: Exception) {
+      logger.warn(e) { "Failed to update ssl context" }
+    }
+
+    ManagedChannelBuilder.forTarget(host).let {
+      if (!sslEnabled) {
+        it.usePlaintext()
+      }
+
+      // Ensure gRPC recovers from a dead connection. This is not typically necessary, as
+      // the OS will usually notify gRPC when a connection dies. But not always. This acts as a
+      // failsafe.
+      it.keepAliveTime(30, TimeUnit.SECONDS)
+
+      it.executor(coroutineDispatcher.asExecutor())
+
+      // Wrap the `ManagedChannelBuilder` in an `AndroidChannelBuilder`. This allows the channel
+      // to respond more gracefully to network change events, such as switching from cellular to
+      // wifi.
+      AndroidChannelBuilder.usingBuilder(it).context(context).build()
+    }
+  }
+
+  private val grpcStub = ConnectorServiceGrpcKt.ConnectorServiceCoroutineStub(grpcChannel)
+
+  override suspend fun executeMutation(request: ExecuteMutationRequest, headers: Metadata) =
+    grpcStub.executeMutation(request, headers)
+
+  override suspend fun executeQuery(request: ExecuteQueryRequest, headers: Metadata) =
+    grpcStub.executeQuery(request, headers)
+
+  override suspend fun close() {
+    mutex.withLock { closed = true }
+
+    // Avoid blocking the calling thread by running potentially-blocking code on the dispatcher
+    // given to the constructor, which should have similar semantics to [Dispatchers.IO].
+    withContext(coroutineDispatcher) {
+      grpcChannel.shutdownNow()
+      grpcChannel.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS)
+    }
+  }
+}
+
+internal interface DataConnectGrpcRPCsFactory {
+
+  val host: String
+  val sslEnabled: Boolean
+
+  fun newInstance(): DataConnectGrpcRPCs
+}
+
+internal class DataConnectGrpcRPCsFactoryImpl(
+  private val context: Context,
+  override val host: String,
+  override val sslEnabled: Boolean,
+  private val coroutineDispatcher: CoroutineDispatcher,
+) : DataConnectGrpcRPCsFactory {
+  override fun newInstance() =
+    DataConnectGrpcRPCsImpl(context, host, sslEnabled, coroutineDispatcher)
+}


### PR DESCRIPTION
`DataConnectGrpcClient` failed to actually shut down the underlying grpc `ManagedChannel`, causing resource exhaustion in the integration tests. This PR fixes this, and also refactors creating the grpc objects to facilitate future unit testing.