### PR TITLE
DataConnectGrpcRPCs.kt: fix strict mode violations when initializing grpc

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/FirebaseDataConnect.kt
@@ -88,8 +88,10 @@ import kotlinx.serialization.SerializationStrategy
  *
  * ##### 16.0.0-alpha05 (not yet released)
  * - Fixed [close] to _actually_ close the underlying grpc network resources; also, added
- * [suspendingClose] to allow callers to wait for the asynchronous closing work to complete
- * (#6003)[https://github.com/firebase/firebase-android-sdk/pull/6003])
+ * [suspendingClose] to allow callers to wait for the asynchronous closing work to complete (
+ * [#6003](https://github.com/firebase/firebase-android-sdk/pull/6003]))
+ * - Fixed a StrictMode violation upon the first network request being sent (
+ * [#6005](https://github.com/firebase/firebase-android-sdk/pull/6005))
  *
  * ##### 16.0.0-alpha04 (May 29, 2024)
  * - Fixed time zone issues when serializing java.util.Date objects (


### PR DESCRIPTION
The strict mode violations were fixed by simply moving the grpc initialization onto another coroutine dispatcher.

Here are the violations that are fixed by this PR:

```
StrictMode policy violation: android.os.strictmode.CustomViolation: gcore.dynamite
	at android.os.StrictMode$AndroidBlockGuardPolicy.onCustomSlowCall(StrictMode.java:1625)
	at android.os.StrictMode.noteSlowCall(StrictMode.java:2693)
	at amyr.a(:com.google.android.gms@242013041@24.20.13 (190800-633713831):3)
	at com.google.android.gms.chimera.container.GmsModuleChimeraProvider.query(:com.google.android.gms@242013041@24.20.13 (190800-633713831):135)
	at aiym.query(:com.google.android.gms@242013041@24.20.13 (190800-633713831):3)
	at android.content.ContentProvider.query(ContentProvider.java:1455)
	at oxt.superQuery(:com.google.android.gms@242013041@24.20.13 (190800-633713831):2)
	at com.google.android.chimera.ContentProvider.query(:com.google.android.gms@242013041@24.20.13 (190800-633713831):2)
	at aiym.query(:com.google.android.gms@242013041@24.20.13 (190800-633713831):13)
	at android.content.ContentProvider.query(ContentProvider.java:1551)
	at oxt.superQuery(:com.google.android.gms@242013041@24.20.13 (190800-633713831):1)
	at com.google.android.chimera.ContentProvider.query(:com.google.android.gms@242013041@24.20.13 (190800-633713831):1)
	at oxt.query(:com.google.android.gms@242013041@24.20.13 (190800-633713831):2)
	at android.content.ContentProvider$Transport.query(ContentProvider.java:285)
	at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:107)
	at android.os.Binder.execTransactInternal(Binder.java:1280)
	at android.os.Binder.execTransact(Binder.java:1244)
# via Binder call with stack:
	at android.os.StrictMode.readAndHandleBinderCallViolations(StrictMode.java:2496)
	at android.os.Parcel.readExceptionCode(Parcel.java:2956)
	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:139)
	at android.content.ContentProviderProxy.query(ContentProviderNative.java:481)
	at android.content.ContentResolver.query(ContentResolver.java:1219)
	at android.content.ContentResolver.query(ContentResolver.java:1151)
	at android.content.ContentResolver.query(ContentResolver.java:1107)
	at com.google.android.gms.dynamite.DynamiteModule.zzb(com.google.android.gms:play-services-basement@@18.3.0:10)
	at com.google.android.gms.dynamite.DynamiteModule.zza(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.android.gms.dynamite.zze.zzb(com.google.android.gms:play-services-basement@@18.3.0:1)
	at com.google.android.gms.dynamite.zzj.selectModule(com.google.android.gms:play-services-basement@@18.3.0:3)
	at com.google.android.gms.dynamite.DynamiteModule.load(com.google.android.gms:play-services-basement@@18.3.0:7)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:5)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at libcore.io.BlockGuardOs.open(BlockGuardOs.java:269)
	at libcore.io.ForwardingOs.open(ForwardingOs.java:563)
	at android.app.ActivityThread$AndroidOs.open(ActivityThread.java:7758)
	at libcore.io.IoUtils.canOpenReadOnly(IoUtils.java:331)
	at dalvik.system.DexPathList$NativeLibraryElement.findNativeLibrary(DexPathList.java:883)
	at dalvik.system.DexPathList.findLibrary(DexPathList.java:594)
	at dalvik.system.BaseDexClassLoader.findLibrary(BaseDexClassLoader.java:371)
	at java.lang.Runtime.loadLibrary0(Runtime.java:1051)
	at java.lang.Runtime.loadLibrary0(Runtime.java:998)
	at java.lang.System.loadLibrary(System.java:1661)
	at amwm.g(:com.google.android.gms@242013041@24.20.13 (190800-633713831):22)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.b(:com.google.android.gms@242013041@24.20.13 (190800-633713831):27)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):25)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):28)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.security.ProviderInstaller.zzc(com.google.android.gms:play-services-basement@@18.3.0:2)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at java.io.UnixFileSystem.getLastModifiedTime(UnixFileSystem.java:289)
	at java.io.File.lastModified(File.java:937)
	at java.util.zip.ZipFile.<init>(ZipFile.java:265)
	at java.util.zip.ZipFile.<init>(ZipFile.java:187)
	at java.util.jar.JarFile.<init>(JarFile.java:169)
	at java.util.jar.JarFile.<init>(JarFile.java:106)
	at libcore.io.ClassPathURLStreamHandler.<init>(ClassPathURLStreamHandler.java:46)
	at dalvik.system.DexPathList$NativeLibraryElement.maybeInit(DexPathList.java:858)
	at dalvik.system.DexPathList$NativeLibraryElement.findNativeLibrary(DexPathList.java:879)
	at dalvik.system.DexPathList.findLibrary(DexPathList.java:594)
	at dalvik.system.BaseDexClassLoader.findLibrary(BaseDexClassLoader.java:371)
	at java.lang.Runtime.loadLibrary0(Runtime.java:1051)
	at java.lang.Runtime.loadLibrary0(Runtime.java:998)
	at java.lang.System.loadLibrary(System.java:1661)
	at amwm.g(:com.google.android.gms@242013041@24.20.13 (190800-633713831):22)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.b(:com.google.android.gms@242013041@24.20.13 (190800-633713831):27)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):25)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):28)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.security.ProviderInstaller.zzc(com.google.android.gms:play-services-basement@@18.3.0:2)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at java.io.UnixFileSystem.getBooleanAttributes(UnixFileSystem.java:250)
	at java.io.File.isDirectory(File.java:843)
	at java.io.File.toURI(File.java:728)
	at libcore.io.ClassPathURLStreamHandler.<init>(ClassPathURLStreamHandler.java:51)
	at dalvik.system.DexPathList$NativeLibraryElement.maybeInit(DexPathList.java:858)
	at dalvik.system.DexPathList$NativeLibraryElement.findNativeLibrary(DexPathList.java:879)
	at dalvik.system.DexPathList.findLibrary(DexPathList.java:594)
	at dalvik.system.BaseDexClassLoader.findLibrary(BaseDexClassLoader.java:371)
	at java.lang.Runtime.loadLibrary0(Runtime.java:1051)
	at java.lang.Runtime.loadLibrary0(Runtime.java:998)
	at java.lang.System.loadLibrary(System.java:1661)
	at amwm.g(:com.google.android.gms@242013041@24.20.13 (190800-633713831):22)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.b(:com.google.android.gms@242013041@24.20.13 (190800-633713831):27)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):25)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):28)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.security.ProviderInstaller.zzc(com.google.android.gms:play-services-basement@@18.3.0:2)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at java.io.UnixFileSystem.getLastModifiedTime(UnixFileSystem.java:289)
	at java.io.File.lastModified(File.java:937)
	at java.util.zip.ZipFile.<init>(ZipFile.java:265)
	at java.util.zip.ZipFile.<init>(ZipFile.java:187)
	at java.util.jar.JarFile.<init>(JarFile.java:169)
	at java.util.jar.JarFile.<init>(JarFile.java:106)
	at libcore.io.ClassPathURLStreamHandler.<init>(ClassPathURLStreamHandler.java:46)
	at dalvik.system.DexPathList$Element.maybeInit(DexPathList.java:750)
	at dalvik.system.DexPathList$Element.findResource(DexPathList.java:777)
	at dalvik.system.DexPathList.findResource(DexPathList.java:554)
	at dalvik.system.BaseDexClassLoader.findResource(BaseDexClassLoader.java:313)
	at java.lang.ClassLoader.getResource(ClassLoader.java:793)
	at dalvik.system.BaseDexClassLoader.findResource(BaseDexClassLoader.java:307)
	at java.lang.ClassLoader.getResource(ClassLoader.java:793)
	at java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:987)
	at java.lang.Class.getResourceAsStream(Class.java:2246)
	at com.google.android.gms.org.conscrypt.Conscrypt.<clinit>(:com.google.android.gms@242013041@24.20.13 (190800-633713831):9)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.b(:com.google.android.gms@242013041@24.20.13 (190800-633713831):99)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):25)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):28)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.security.ProviderInstaller.zzc(com.google.android.gms:play-services-basement@@18.3.0:2)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at java.io.UnixFileSystem.getBooleanAttributes(UnixFileSystem.java:250)
	at java.io.File.isDirectory(File.java:843)
	at java.io.File.toURI(File.java:728)
	at libcore.io.ClassPathURLStreamHandler.<init>(ClassPathURLStreamHandler.java:51)
	at dalvik.system.DexPathList$Element.maybeInit(DexPathList.java:750)
	at dalvik.system.DexPathList$Element.findResource(DexPathList.java:777)
	at dalvik.system.DexPathList.findResource(DexPathList.java:554)
	at dalvik.system.BaseDexClassLoader.findResource(BaseDexClassLoader.java:313)
	at java.lang.ClassLoader.getResource(ClassLoader.java:793)
	at dalvik.system.BaseDexClassLoader.findResource(BaseDexClassLoader.java:307)
	at java.lang.ClassLoader.getResource(ClassLoader.java:793)
	at java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:987)
	at java.lang.Class.getResourceAsStream(Class.java:2246)
	at com.google.android.gms.org.conscrypt.Conscrypt.<clinit>(:com.google.android.gms@242013041@24.20.13 (190800-633713831):9)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.b(:com.google.android.gms@242013041@24.20.13 (190800-633713831):99)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):25)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):28)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.security.ProviderInstaller.zzc(com.google.android.gms:play-services-basement@@18.3.0:2)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at java.io.UnixFileSystem.getLastModifiedTime(UnixFileSystem.java:289)
	at java.io.File.lastModified(File.java:937)
	at java.util.zip.ZipFile.<init>(ZipFile.java:265)
	at java.util.zip.ZipFile.<init>(ZipFile.java:187)
	at java.util.jar.JarFile.<init>(JarFile.java:169)
	at java.util.jar.JarFile.<init>(JarFile.java:106)
	at libcore.io.ClassPathURLStreamHandler.<init>(ClassPathURLStreamHandler.java:46)
	at dalvik.system.DexPathList$Element.maybeInit(DexPathList.java:750)
	at dalvik.system.DexPathList$Element.findResource(DexPathList.java:777)
	at dalvik.system.DexPathList.findResource(DexPathList.java:554)
	at dalvik.system.BaseDexClassLoader.findResource(BaseDexClassLoader.java:313)
	at java.lang.ClassLoader.getResource(ClassLoader.java:793)
	at java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:987)
	at java.lang.Class.getResourceAsStream(Class.java:2246)
	at com.google.android.gms.org.conscrypt.Conscrypt.<clinit>(:com.google.android.gms@242013041@24.20.13 (190800-633713831):9)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.b(:com.google.android.gms@242013041@24.20.13 (190800-633713831):99)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):25)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):28)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.security.ProviderInstaller.zzc(com.google.android.gms:play-services-basement@@18.3.0:2)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at java.io.UnixFileSystem.getBooleanAttributes(UnixFileSystem.java:250)
	at java.io.File.isDirectory(File.java:843)
	at java.io.File.toURI(File.java:728)
	at libcore.io.ClassPathURLStreamHandler.<init>(ClassPathURLStreamHandler.java:51)
	at dalvik.system.DexPathList$Element.maybeInit(DexPathList.java:750)
	at dalvik.system.DexPathList$Element.findResource(DexPathList.java:777)
	at dalvik.system.DexPathList.findResource(DexPathList.java:554)
	at dalvik.system.BaseDexClassLoader.findResource(BaseDexClassLoader.java:313)
	at java.lang.ClassLoader.getResource(ClassLoader.java:793)
	at java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:987)
	at java.lang.Class.getResourceAsStream(Class.java:2246)
	at com.google.android.gms.org.conscrypt.Conscrypt.<clinit>(:com.google.android.gms@242013041@24.20.13 (190800-633713831):9)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.b(:com.google.android.gms@242013041@24.20.13 (190800-633713831):99)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):25)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):28)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.security.ProviderInstaller.zzc(com.google.android.gms:play-services-basement@@18.3.0:2)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
StrictMode policy violation: android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1658)
	at libcore.io.BlockGuardOs.open(BlockGuardOs.java:269)
	at libcore.io.ForwardingOs.open(ForwardingOs.java:563)
	at android.app.ActivityThread$AndroidOs.open(ActivityThread.java:7758)
	at libcore.io.IoUtils.canOpenReadOnly(IoUtils.java:331)
	at dalvik.system.DexPathList$NativeLibraryElement.findNativeLibrary(DexPathList.java:883)
	at dalvik.system.DexPathList.findLibrary(DexPathList.java:594)
	at dalvik.system.BaseDexClassLoader.findLibrary(BaseDexClassLoader.java:371)
	at java.lang.Runtime.loadLibrary0(Runtime.java:1051)
	at java.lang.Runtime.loadLibrary0(Runtime.java:998)
	at java.lang.System.loadLibrary(System.java:1661)
	at com.google.android.gms.org.conscrypt.NativeCryptoJni.init(:com.google.android.gms@242013041@24.20.13 (190800-633713831):21)
	at com.google.android.gms.org.conscrypt.NativeCrypto.<clinit>(:com.google.android.gms@242013041@24.20.13 (190800-633713831):1)
	at com.google.android.gms.org.conscrypt.OpenSSLProvider.<init>(:com.google.android.gms@242013041@24.20.13 (190800-633713831):4)
	at com.google.android.gms.org.conscrypt.Conscrypt$ProviderBuilder.build(:com.google.android.gms@242013041@24.20.13 (190800-633713831):9)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.b(:com.google.android.gms@242013041@24.20.13 (190800-633713831):113)
	at com.google.android.gms.providerinstaller.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):25)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(:com.google.android.gms@242013041@24.20.13 (190800-633713831):28)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.google.android.gms.security.ProviderInstaller.zzc(com.google.android.gms:play-services-basement@@18.3.0:2)
	at com.google.android.gms.security.ProviderInstaller.installIfNeeded(com.google.android.gms:play-services-basement@@18.3.0:12)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invokeSuspend(DataConnectGrpcRPCs.kt:76)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcChannel$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invokeSuspend(DataConnectGrpcRPCs.kt:102)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:8)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl$lazyGrpcStub$1.invoke(Unknown Source:2)
	at com.google.firebase.dataconnect.util.SuspendingLazy.getLocked(Util.kt:282)
	at com.google.firebase.dataconnect.core.DataConnectGrpcRPCsImpl.executeQuery(DataConnectGrpcRPCs.kt:157)
	at com.google.firebase.dataconnect.core.DataConnectGrpcClient.executeQuery(DataConnectGrpcClient.kt:105)
	at com.google.firebase.dataconnect.core.LiveQuery.doExecute(OldQueryManager.kt:161)
	at com.google.firebase.dataconnect.core.LiveQuery.access$doExecute(OldQueryManager.kt:53)
	at com.google.firebase.dataconnect.core.LiveQuery$execute$newJob$1$1$1.invokeSuspend(OldQueryManager.kt:112)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
	at com.google.firebase.concurrent.CustomThreadFactory.lambda$newThread$0$com-google-firebase-concurrent-CustomThreadFactory(CustomThreadFactory.java:47)
	at com.google.firebase.concurrent.CustomThreadFactory$$ExternalSyntheticLambda0.run(Unknown Source:4)
	at java.lang.Thread.run(Thread.java:1012)
```