### PR TITLE
Inject firebase common executors to Crashlytics

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
@@ -497,7 +497,7 @@ public class SessionReportingCoordinatorTest {
     when(reportSender.enqueueReport(mockReport1, false)).thenReturn(successfulTask);
     when(reportSender.enqueueReport(mockReport2, false)).thenReturn(failedTask);
 
-    when(idManager.fetchTrueFid(any())).thenReturn(new FirebaseInstallationId("fid", "authToken"));
+    when(idManager.fetchTrueFid(anyBoolean())).thenReturn(new FirebaseInstallationId("fid", "authToken"));
     reportingCoordinator.sendReports(Runnable::run);
 
     verify(reportSender).enqueueReport(mockReport1, false);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -24,6 +24,8 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.analytics.connector.AnalyticsConnector;
+import com.google.firebase.annotations.concurrent.Background;
+import com.google.firebase.annotations.concurrent.Blocking;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
@@ -68,7 +70,9 @@ public class FirebaseCrashlytics {
       @NonNull FirebaseInstallationsApi firebaseInstallationsApi,
       @NonNull Deferred<CrashlyticsNativeComponent> nativeComponent,
       @NonNull Deferred<AnalyticsConnector> analyticsConnector,
-      @NonNull Deferred<FirebaseRemoteConfigInterop> remoteConfigInteropDeferred) {
+      @NonNull Deferred<FirebaseRemoteConfigInterop> remoteConfigInteropDeferred,
+      @Background ExecutorService liteExecutorService,
+      @Blocking ExecutorService blockingExecutorService) {
 
     Context context = app.getApplicationContext();
     final String appIdentifier = context.getPackageName();


### PR DESCRIPTION
According to the documentation [here](https://firebase.github.io/firebase-android-sdk/components/executors/). Inject Firebase common executors for later refactor work.

Crashlytics will need at least 2 types of executors: background(for disk I/O writes), blocking(networking calls)