### PR TITLE
Changing caught exception type to fail safely on any exception type.

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/send/ReportQueue.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/send/ReportQueue.java
@@ -15,7 +15,6 @@
 package com.google.firebase.crashlytics.internal.send;
 
 import android.annotation.SuppressLint;
-import android.database.SQLException;
 import android.os.SystemClock;
 import com.google.android.datatransport.Event;
 import com.google.android.datatransport.Priority;
@@ -136,7 +135,7 @@ final class ReportQueue {
             () -> {
               try {
                 ForcedSender.sendBlocking(transport, Priority.HIGHEST);
-              } catch (SQLException ignored) {
+              } catch (Exception ignored) {
                 // best effort only.
               }
               latch.countDown();


### PR DESCRIPTION
Addressing issue #6001. This will avoid failing on the early upload and instead report the errors with either the next scheduled time by Firelog, or the next app launch