### PR TITLE
Fix JSON literal parsing in VertexAI

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -2,4 +2,4 @@
 * [feature] Added support for `responseMimeType` in `GenerationConfig`.
 * [changed] Renamed `GoogleGenerativeAIException` to `FirebaseVertexAIException`.
 * [changed] Updated the KDocs for various classes and functions.
-
+* [fixed] Fixed an issue with decoding JSON literals (#6028).

--- a/firebase-vertexai/firebase-vertexai.gradle.kts
+++ b/firebase-vertexai/firebase-vertexai.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
   implementation("com.google.firebase:firebase-components:18.0.0")
   implementation("com.google.firebase:firebase-annotations:16.2.0")
   implementation("com.google.firebase:firebase-appcheck-interop:17.1.0")
-  implementation("com.google.ai.client.generativeai:common:0.7.0")
+  implementation("com.google.ai.client.generativeai:common:0.7.1")
   implementation(libs.androidx.annotation)
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
   implementation("androidx.core:core-ktx:1.12.0")


### PR DESCRIPTION
Per [b/346811894](https://b.corp.google.com/issues/346811894),

This fixes an issue with the VertexAI SDK failing to decode json literals. More specifically, the fix was applied to `generativeai:common` with `0.7.1`, and this PR bumps said dependency to bring in the change.

Fixes #6028 