### PR TITLE
Explicitly keep default constructor in subtypes of ComponentRegistrar

### DIFF
--- a/firebase-components/proguard.txt
+++ b/firebase-components/proguard.txt
@@ -1,5 +1,5 @@
 -dontwarn com.google.firebase.components.Component$Instantiation
 -dontwarn com.google.firebase.components.Component$ComponentType
 
--keep class * implements com.google.firebase.components.ComponentRegistrar
+-keep class * implements com.google.firebase.components.ComponentRegistrar { void <init>(); }
 -keep,allowshrinking interface com.google.firebase.components.ComponentRegistrar


### PR DESCRIPTION
This is needed since newer versions of R8 no longer implicitly keeps the default constructor in full mode: https://r8.googlesource.com/r8/+/06e32a8d0d2e7e28bc4e597e4ce96e2e0c229d08