### PR TITLE
Update vertexAI changelog entries around schema changes

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
-* [changed] Breaking Change: renamed `Schema.int` to `Schema.long` and added a 32 bit int type
-* [changed] Breaking Change: renamed `Schema.num` to `Schema.double`
+* [changed] Breaking Change: changed `Schema.int` to return 32 bit integers instead of 64 bit (long).
+* [changed] Added `Schema.long` to return 64-bit integer numbers.
+* [changed] Added `Schema.double` to handle floating point numbers.
+* [changed] Marked `Schema.num` as deprecated, prefer using `Schema.double`.
 * [fixed] Fixed an issue with decoding JSON literals (#6028).
 
 # 16.0.0-beta01


### PR DESCRIPTION
We are being more explicit about the changes, as only one change is
truly breaking. There's a single breaking API change, while the other
is marking as deprecated, but not removing, another API.