### PR TITLE
Faster tests

### DIFF
--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
@@ -41,7 +41,6 @@ import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/AggregationTest.java
@@ -42,14 +42,15 @@ import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Collections;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class AggregationTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsServerApplicationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsServerApplicationTest.java
@@ -16,6 +16,7 @@ package com.google.firebase.firestore;
 
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testDocument;
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testFirestore;
+import static com.google.firebase.firestore.testutil.IntegrationTestUtil.testInMemoryFirestore;
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.waitFor;
 import static com.google.firebase.firestore.testutil.IntegrationTestUtil.waitForException;
 import static com.google.firebase.firestore.testutil.TestUtil.map;
@@ -62,7 +63,7 @@ public class ArrayTransformsServerApplicationTest {
   @Test
   public void updateWithNoCachedBaseDoc() {
     // Write an initial document in an isolated Firestore instance so it's not stored in our cache.
-    waitFor(testFirestore().document(docRef.getPath()).set(map("array", asList(42L))));
+    waitFor(testInMemoryFirestore().document(docRef.getPath()).set(map("array", asList(42L))));
 
     waitFor(docRef.update(map("array", FieldValue.arrayUnion(1L, 2L))));
 
@@ -74,7 +75,7 @@ public class ArrayTransformsServerApplicationTest {
   @Test
   public void mergeSetWithNoCachedBaseDoc() {
     // Write an initial document in an isolated Firestore instance so it's not stored in our cache.
-    waitFor(testFirestore().document(docRef.getPath()).set(map("array", asList(42L))));
+    waitFor(testInMemoryFirestore().document(docRef.getPath()).set(map("array", asList(42L))));
 
     waitFor(docRef.set(map("array", FieldValue.arrayUnion(1L, 2L)), SetOptions.merge()));
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsServerApplicationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsServerApplicationTest.java
@@ -24,6 +24,9 @@ import static org.junit.Assert.assertEquals;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.firestore.FirebaseFirestoreException.Code;
+import com.google.firebase.firestore.testutil.IntegrationTestUtil;
+
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,6 +45,11 @@ public class ArrayTransformsServerApplicationTest {
   @Before
   public void setUp() {
     docRef = testDocument();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    IntegrationTestUtil.tearDown();
   }
 
   @Test

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ArrayTransformsTest.java
@@ -26,6 +26,7 @@ import com.google.firebase.firestore.testutil.EventAccumulator;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,8 +60,12 @@ public class ArrayTransformsTest {
   }
 
   @After
-  public void tearDown() {
+  public void after() {
     listenerRegistration.remove();
+  }
+
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
@@ -177,10 +177,7 @@ public class BundleTest {
   public void testLoadedDocumentsShouldNotBeGarbageCollectedRightAway() throws Exception {
     // This test really only makes sense with memory persistence, as SQLite persistence only ever
     // lazily deletes data
-    db.setFirestoreSettings(
-        new FirebaseFirestoreSettings.Builder()
-            .setLocalCacheSettings(MemoryCacheSettings.newBuilder().build())
-            .build());
+    db.setFirestoreSettings(IntegrationTestUtil.newInMemoryTestSettings());
 
     InputStream bundle = new ByteArrayInputStream(createBundle());
     LoadBundleTask bundleTask = db.loadBundle(bundle); // Test the InputStream overload
@@ -188,7 +185,7 @@ public class BundleTest {
     verifySuccessProgress(result);
 
     // Read a different collection. This will trigger GC.
-    Tasks.await(db.collection("foo").get());
+    Tasks.await(db.collection("coll-other").get());
 
     // Read the loaded documents, expecting them to exist in cache. With memory GC, the documents
     // would get GC-ed if we did not hold the document keys in an "umbrella" target. See

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
@@ -188,7 +188,7 @@ public class BundleTest {
     verifySuccessProgress(result);
 
     // Read a different collection. This will trigger GC.
-    Tasks.await(db.collection("coll-other").get());
+    Tasks.await(db.collection("foo").get());
 
     // Read the loaded documents, expecting them to exist in cache. With memory GC, the documents
     // would get GC-ed if we did not hold the document keys in an "umbrella" target. See

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/BundleTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,8 +86,8 @@ public class BundleTest {
     db = testFirestore();
   }
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
@@ -41,7 +41,6 @@ import com.google.firebase.firestore.Query.Direction;
 import com.google.firebase.firestore.testutil.CompositeIndexTestHelper;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CompositeIndexQueryTest.java
@@ -42,6 +42,7 @@ import com.google.firebase.firestore.testutil.CompositeIndexTestHelper;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -64,8 +65,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class CompositeIndexQueryTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
@@ -36,7 +36,6 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Collections;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CountTest.java
@@ -37,14 +37,15 @@ import com.google.firebase.firestore.model.DatabaseId;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Collections;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class CountTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CursorTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CursorTest.java
@@ -33,7 +33,6 @@ import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CursorTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/CursorTest.java
@@ -34,14 +34,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class CursorTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/DocumentSnapshotTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/DocumentSnapshotTest.java
@@ -23,13 +23,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class DocumentSnapshotTest {
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/DocumentSnapshotTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/DocumentSnapshotTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FieldsTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FieldsTest.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FieldsTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FieldsTest.java
@@ -32,14 +32,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class FieldsTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -70,8 +71,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class FirestoreTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/FirestoreTest.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/IndexingTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/IndexingTest.java
@@ -29,14 +29,15 @@ import com.google.firebase.firestore.testutil.Assert;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class IndexingTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/IndexingTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/IndexingTest.java
@@ -28,7 +28,6 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.testutil.Assert;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.concurrent.ExecutionException;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ListenerRegistrationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ListenerRegistrationTest.java
@@ -26,7 +26,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.concurrent.Semaphore;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ListenerRegistrationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ListenerRegistrationTest.java
@@ -27,6 +27,7 @@ import androidx.test.rule.ActivityTestRule;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.concurrent.Semaphore;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,8 +35,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class ListenerRegistrationTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/NumericTransformsTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/NumericTransformsTest.java
@@ -28,6 +28,7 @@ import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,8 +59,12 @@ public class NumericTransformsTest {
   }
 
   @After
-  public void tearDown() {
+  public void after() {
     listenerRegistration.remove();
+  }
+
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -229,8 +230,8 @@ public class POJOTest {
     }
   }
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/POJOTest.java
@@ -32,7 +32,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/QueryTest.java
@@ -60,14 +60,15 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class QueryTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
@@ -36,6 +36,7 @@ import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,12 +81,16 @@ public class ServerTimestampTest {
   }
 
   @After
-  public void tearDown() {
+  public void after() {
     listenerRegistration.remove();
+  }
+
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 
-  // Returns the expected data, with an arbitrary timestamp substituted in.
+    // Returns the expected data, with an arbitrary timestamp substituted in.
   private Map<String, Object> expectedDataWithTimestamp(Object timestamp) {
     return map("a", 42L, "when", timestamp, "deep", map("when", timestamp));
   }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ServerTimestampTest.java
@@ -90,7 +90,7 @@ public class ServerTimestampTest {
     IntegrationTestUtil.tearDown();
   }
 
-    // Returns the expected data, with an arbitrary timestamp substituted in.
+  // Returns the expected data, with an arbitrary timestamp substituted in.
   private Map<String, Object> expectedDataWithTimestamp(Object timestamp) {
     return map("a", 42L, "when", timestamp, "deep", map("when", timestamp));
   }

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SmokeTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SmokeTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,8 +39,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class SmokeTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SmokeTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SmokeTest.java
@@ -30,7 +30,6 @@ import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SnapshotListenerSourceTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SnapshotListenerSourceTest.java
@@ -31,7 +31,6 @@ import com.google.firebase.firestore.testutil.EventAccumulator;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SnapshotListenerSourceTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SnapshotListenerSourceTest.java
@@ -32,14 +32,15 @@ import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class SnapshotListenerSourceTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SourceTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SourceTest.java
@@ -32,7 +32,6 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SourceTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/SourceTest.java
@@ -33,6 +33,7 @@ import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.firebase.firestore.testutil.IntegrationTestUtil;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,8 +41,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public final class SourceTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -227,8 +228,8 @@ public class TransactionTest {
     }
   }
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TransactionTest.java
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TypeTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TypeTest.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TypeTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/TypeTest.java
@@ -31,14 +31,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class TypeTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -52,6 +52,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,8 +61,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class ValidationTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -51,7 +51,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -461,35 +461,42 @@ public class ValidationTest {
     ListenerRegistration listenerRegistration =
         collection.addSnapshotListener(
             (snapshot, error) -> {
-              assertNotNull(snapshot);
+              try {
+                assertNotNull(snapshot);
 
-              // Skip the initial empty snapshot.
-              if (snapshot.isEmpty()) return;
+                // Skip the initial empty snapshot.
+                if (snapshot.isEmpty()) return;
 
-              assertThat(snapshot.getDocuments()).hasSize(1);
-              DocumentSnapshot docSnap = snapshot.getDocuments().get(0);
+                assertThat(snapshot.getDocuments()).hasSize(1);
+                DocumentSnapshot docSnap = snapshot.getDocuments().get(0);
 
-              if (snapshot.getMetadata().hasPendingWrites()) {
-                // Offline snapshot. Since the server timestamp is uncommitted, we shouldn't be able
-                // to query by it.
-                assertThrows(
-                    IllegalArgumentException.class,
-                    () ->
-                        collection
-                            .orderBy("timestamp")
-                            .endAt(docSnap)
-                            .addSnapshotListener((snapshot2, error2) -> {}));
-                // Use `trySetResult` since the callbacks fires twice if the WatchStream
-                // acknowledges the Write before the WriteStream.
-                offlineCallbackDone.trySetResult(null);
-              } else {
-                // Online snapshot. Since the server timestamp is committed, we should be able to
-                // query by it.
-                collection
-                    .orderBy("timestamp")
-                    .endAt(docSnap)
-                    .addSnapshotListener((snapshot2, error2) -> {});
-                onlineCallbackDone.trySetResult(null);
+                if (snapshot.getMetadata().hasPendingWrites()) {
+                  // Offline snapshot. Since the server timestamp is uncommitted, we shouldn't be able
+                  // to query by it.
+                  assertThrows(
+                          IllegalArgumentException.class,
+                          () ->
+                                  collection
+                                          .orderBy("timestamp")
+                                          .endAt(docSnap)
+                                          .addSnapshotListener((snapshot2, error2) -> {
+                                          }));
+                  // Use `trySetResult` since the callbacks fires twice if the WatchStream
+                  // acknowledges the Write before the WriteStream.
+                  offlineCallbackDone.trySetResult(null);
+                } else {
+                  // Online snapshot. Since the server timestamp is committed, we should be able to
+                  // query by it.
+                  collection
+                          .orderBy("timestamp")
+                          .endAt(docSnap)
+                          .addSnapshotListener((snapshot2, error2) -> {
+                          });
+                  onlineCallbackDone.trySetResult(null);
+                }
+              } catch (Exception e) {
+                offlineCallbackDone.trySetException(e);
+                onlineCallbackDone.trySetException(e);
               }
             });
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/ValidationTest.java
@@ -518,8 +518,9 @@ public class ValidationTest {
 
   @Test
   public void queryOrderByKeyBoundsMustBeStringsWithoutSlashes() {
-    Query query = testFirestore().collection("collection").orderBy(FieldPath.documentId());
-    Query cgQuery = testFirestore().collectionGroup("collection").orderBy(FieldPath.documentId());
+    FirebaseFirestore firestore = testFirestore();
+    Query query = firestore.collection("collection").orderBy(FieldPath.documentId());
+    Query cgQuery = firestore.collectionGroup("collection").orderBy(FieldPath.documentId());
     expectError(
         () -> query.startAt(1),
         "Invalid query. Expected a string for document ID in startAt(), but got 1.");

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
@@ -37,14 +37,15 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class WriteBatchTest {
 
-  @After
-  public void tearDown() {
+  @AfterClass
+  public static void tearDown() {
     IntegrationTestUtil.tearDown();
   }
 

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/WriteBatchTest.java
@@ -36,7 +36,6 @@ import com.google.firebase.firestore.util.Util;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -58,7 +58,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 class MockCredentialsProvider extends EmptyCredentialsProvider {
 
@@ -121,7 +120,7 @@ public class IntegrationTestUtil {
   private static final FirestoreProvider provider = new FirestoreProvider();
 
   private static boolean strictModeEnabled = false;
-  private static AtomicBoolean backendPrimed = new AtomicBoolean(false);
+  private static boolean backendPrimed = false;
 
   // FirebaseOptions needed to create a test FirebaseApp.
   private static final FirebaseOptions OPTIONS =
@@ -210,8 +209,9 @@ public class IntegrationTestUtil {
     return firestore;
   }
 
-  private static void primeBackend() {
-    if (backendPrimed.compareAndSet(false, true)) {
+  private static synchronized void primeBackend() {
+    if (!backendPrimed) {
+      backendPrimed = true;
       TaskCompletionSource<Void> watchInitialized = new TaskCompletionSource<>();
       TaskCompletionSource<Void> watchUpdateReceived = new TaskCompletionSource<>();
       DocumentReference docRef = testDocument();

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -196,6 +196,7 @@ public class IntegrationTestUtil {
 
   /** Initializes a new Firestore instance that uses the default project. */
   public static FirebaseFirestore testFirestore() {
+    Arrays.com
     return testFirestore(newTestSettings());
   }
 
@@ -204,49 +205,7 @@ public class IntegrationTestUtil {
    * provided settings.
    */
   public static FirebaseFirestore testFirestore(FirebaseFirestoreSettings settings) {
-    FirebaseFirestore firestore = testFirestore(provider.projectId(), Level.DEBUG, settings);
-    primeBackend();
-    return firestore;
-  }
-
-  private static synchronized void primeBackend() {
-    if (!backendPrimed) {
-      backendPrimed = true;
-      TaskCompletionSource<Void> watchInitialized = new TaskCompletionSource<>();
-      TaskCompletionSource<Void> watchUpdateReceived = new TaskCompletionSource<>();
-      DocumentReference docRef = testDocument();
-      ListenerRegistration listenerRegistration =
-          docRef.addSnapshotListener(
-              (snapshot, error) -> {
-                if (error == null) {
-                  if ("done".equals(snapshot.get("value"))) {
-                    watchUpdateReceived.setResult(null);
-                  } else {
-                    watchInitialized.setResult(null);
-                  }
-                } else {
-                  watchUpdateReceived.trySetException(error);
-                  watchInitialized.trySetException(error);
-                }
-              });
-
-      // Wait for watch to initialize and deliver first event.
-      waitFor(watchInitialized.getTask());
-
-      // Use a transaction to perform a write without triggering any local events.
-      waitFor(docRef
-          .getFirestore()
-          .runTransaction(
-              transaction -> {
-                transaction.set(docRef, map("value", "done"));
-                return null;
-              }));
-
-      // Wait to see the write on the watch stream.
-      waitFor(watchUpdateReceived.getTask(), PRIMING_TIMEOUT_MS);
-
-      listenerRegistration.remove();
-    }
+    return testFirestore(provider.projectId(), Level.DEBUG, settings);
   }
 
   /** Initializes a new Firestore instance that uses a non-existing default project. */

--- a/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
+++ b/firebase-firestore/src/androidTest/java/com/google/firebase/firestore/testutil/IntegrationTestUtil.java
@@ -196,7 +196,6 @@ public class IntegrationTestUtil {
 
   /** Initializes a new Firestore instance that uses the default project. */
   public static FirebaseFirestore testFirestore() {
-    Arrays.com
     return testFirestore(newTestSettings());
   }
 


### PR DESCRIPTION
- Fix testing bug where host was not being set correctly for testing against nightly.
- Make teardown concurrent to speed up tests.
- Avoid running clear persistence when using in memory cache.
- Use in memory persistence more in tests to avoid creating SQLite databases that then need to be cleared.
- Remove logic to prime database, because this was being executed many times due to test runner. Also, this doesn't actually help prevent timeout because time spent on priming database is included in timeout.