### PR TITLE
New Crashlytics file system v3 to avoid long file names

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Update the internal file system to handle long file names.
 
 # 19.0.1
 * [changed] Improve cold initialization time.

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/SessionReportingCoordinatorTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -265,7 +266,7 @@ public class SessionReportingCoordinatorTest {
     reportingCoordinator.onBeginSession(sessionId, timestamp);
     reportingCoordinator.persistNonFatalEvent(mockException, mockThread, sessionId, timestamp);
 
-    verify(mockEventAppBuilder, never()).setCustomAttributes(any());
+    verify(mockEventAppBuilder, never()).setCustomAttributes(anyList());
     verify(mockEventAppBuilder, never()).build();
     verify(mockEventBuilder, never()).setApp(mockEventApp);
     verify(mockEventBuilder).build();
@@ -286,7 +287,7 @@ public class SessionReportingCoordinatorTest {
     reportingCoordinator.onBeginSession(sessionId, timestamp);
     reportingCoordinator.persistNonFatalEvent(mockException, mockThread, sessionId, timestamp);
 
-    verify(mockEventAppBuilder, never()).setCustomAttributes(any());
+    verify(mockEventAppBuilder, never()).setCustomAttributes(anyList());
     verify(mockEventAppBuilder, never()).build();
     verify(mockEventBuilder, never()).setApp(mockEventApp);
     verify(reportMetadata).getRolloutsState();
@@ -386,7 +387,7 @@ public class SessionReportingCoordinatorTest {
     reportingCoordinator.onBeginSession(sessionId, timestamp);
     reportingCoordinator.persistFatalEvent(mockException, mockThread, sessionId, timestamp);
 
-    verify(mockEventAppBuilder, never()).setCustomAttributes(any());
+    verify(mockEventAppBuilder, never()).setCustomAttributes(anyList());
     verify(mockEventAppBuilder, never()).build();
     verify(mockEventBuilder, never()).setApp(mockEventApp);
     verify(mockEventBuilder).build();
@@ -407,7 +408,7 @@ public class SessionReportingCoordinatorTest {
     reportingCoordinator.onBeginSession(sessionId, timestamp);
     reportingCoordinator.persistFatalEvent(mockException, mockThread, sessionId, timestamp);
 
-    verify(mockEventAppBuilder, never()).setCustomAttributes(any());
+    verify(mockEventAppBuilder, never()).setCustomAttributes(anyList());
     verify(mockEventAppBuilder, never()).build();
     verify(mockEventBuilder, never()).setApp(mockEventApp);
     verify(reportMetadata).getRolloutsState();
@@ -497,7 +498,8 @@ public class SessionReportingCoordinatorTest {
     when(reportSender.enqueueReport(mockReport1, false)).thenReturn(successfulTask);
     when(reportSender.enqueueReport(mockReport2, false)).thenReturn(failedTask);
 
-    when(idManager.fetchTrueFid(any())).thenReturn(new FirebaseInstallationId("fid", "authToken"));
+    when(idManager.fetchTrueFid(anyBoolean()))
+        .thenReturn(new FirebaseInstallationId("fid", "authToken"));
     reportingCoordinator.sendReports(Runnable::run);
 
     verify(reportSender).enqueueReport(mockReport1, false);
@@ -528,8 +530,8 @@ public class SessionReportingCoordinatorTest {
     when(mockEventBuilder.build()).thenReturn(mockEvent);
     when(mockEvent.getApp()).thenReturn(mockEventApp);
     when(mockEventApp.toBuilder()).thenReturn(mockEventAppBuilder);
-    when(mockEventAppBuilder.setCustomAttributes(any())).thenReturn(mockEventAppBuilder);
-    when(mockEventAppBuilder.setInternalKeys(any())).thenReturn(mockEventAppBuilder);
+    when(mockEventAppBuilder.setCustomAttributes(anyList())).thenReturn(mockEventAppBuilder);
+    when(mockEventAppBuilder.setInternalKeys(anyList())).thenReturn(mockEventAppBuilder);
     when(mockEventAppBuilder.build()).thenReturn(mockEventApp);
     when(dataCapture.captureEventData(
             any(Throwable.class),

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/persistence/FileStoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/persistence/FileStoreTest.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.crashlytics.internal.persistence;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.firebase.crashlytics.internal.persistence.FileStore.sanitizeName;
 
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
@@ -29,6 +30,11 @@ public class FileStoreTest extends CrashlyticsTestCase {
   protected void setUp() throws Exception {
     super.setUp();
     fileStore = new FileStore(getContext());
+  }
+
+  public void testProcessName() {
+    // If this test fails, the test setup is missing a process name so fileStore is using v1.
+    assertThat(fileStore.processName).isEqualTo("com.google.firebase.crashlytics.test");
   }
 
   public void testGetCommonFile() {
@@ -128,9 +134,13 @@ public class FileStoreTest extends CrashlyticsTestCase {
     assertEquals(0, fileStore.getNativeReports().size());
   }
 
-  public void testSanitizeName() {
-    assertEquals(
-        "com.google.my.awesome.app_big.stuff.Happens_Here123___",
-        sanitizeName("com.google.my.awesome.app:big.stuff.Happens_Here123$%^"));
+  public void testSanitizeShortName() {
+    assertThat(sanitizeName("com.google.Process_Name123$%^"))
+        .isEqualTo("com.google.Process_Name123___");
+  }
+
+  public void testSanitizeLongName() {
+    assertThat(sanitizeName("com.google.my.awesome.app:big.stuff.Happens_Here123$%^"))
+        .isEqualTo("ef6c01fc7a1a8d10ecb062a81707f769d39d4210");
   }
 }


### PR DESCRIPTION
New Crashlytics file system v3 to avoid long file names. Shorten the Crashlytics folder name itself. If a file name is longer than 40 chars, hash it to a 40 char hash. Also use the new `ProcessDetailsProvider` to get the process name on older Android versions so they can take advantage of the process-aware file system. 