### PR TITLE
Decouple user metadata from Crashlytics backend worker

### DIFF
--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -93,6 +93,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.3'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation(project(":integ-testing"))
 
     androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
     androidTestImplementation 'androidx.test:runner:1.4.0'
@@ -106,4 +107,5 @@ dependencies {
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.truth)
+    androidTestImplementation(project(":integ-testing"))
 }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -34,6 +34,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
@@ -179,7 +180,8 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
               sessionReportingCoordinator,
               nativeComponent,
               analyticsEventLogger,
-              mock(CrashlyticsAppQualitySessionsSubscriber.class));
+              mock(CrashlyticsAppQualitySessionsSubscriber.class),
+              TestOnlyExecutors.background());
       return controller;
     }
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreInitializationTest.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 
 public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
 
@@ -143,6 +144,7 @@ public class CrashlyticsCoreInitializationTest extends CrashlyticsTestCase {
           new UnavailableAnalyticsEventLogger(),
           fileStore,
           crashHandlerExecutor,
+          TestOnlyExecutors.background(),
           mock(CrashlyticsAppQualitySessionsSubscriber.class),
           mock(RemoteConfigDeferredProxy.class));
     }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -28,6 +28,7 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.BuildConfig;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
@@ -49,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
 
@@ -428,6 +430,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
               new UnavailableAnalyticsEventLogger(),
               new FileStore(context),
               new SameThreadExecutorService(),
+              TestOnlyExecutors.background(),
               mock(CrashlyticsAppQualitySessionsSubscriber.class),
               mock(RemoteConfigDeferredProxy.class));
       return crashlyticsCore;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java
@@ -115,6 +115,7 @@ public class FirebaseCrashlytics {
             analyticsDeferredProxy.getAnalyticsEventLogger(),
             fileStore,
             crashHandlerExecutor,
+            backgroundExecutorService,
             sessionsSubscriber,
             remoteConfigDeferredProxy);
 

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
@@ -28,6 +28,7 @@ import android.app.ApplicationExitInfo;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
@@ -175,7 +176,8 @@ public class CrashlyticsControllerRobolectricTest {
             mockSessionReportingCoordinator,
             MISSING_NATIVE_COMPONENT,
             mock(AnalyticsEventLogger.class),
-            mock(CrashlyticsAppQualitySessionsSubscriber.class));
+            mock(CrashlyticsAppQualitySessionsSubscriber.class),
+            TestOnlyExecutors.background());
     controller.openSession(SESSION_ID);
     return controller;
   }


### PR DESCRIPTION
Remove `CrashlyticsBackgroundWorker` from `UserMetaData`, use Firebase background common executor for user metadata logging such as user id, custom key value, internal key value and rollouts.

Test:
Checking with log and see key data is writing from different Firebase background common thread
![Screenshot 2024-07-03 at 4 08 00 PM](https://github.com/firebase/firebase-android-sdk/assets/16548721/0f210bd6-9155-46d3-ad50-7522fd812b8b)

Also same unit test is tested on current implementation with Crashlytics Background Worker. Current way of doing it is actually less efficient since everything is run on the same Junit Test Thread, every iteration of change it need to update the writes to disk (where as the new implementation log you can see we skipped a lot writing entry):
![Screenshot 2024-07-03 at 4 01 17 PM](https://github.com/firebase/firebase-android-sdk/assets/16548721/9e356e36-9094-45d8-a32b-f5e3c2e79e2e)




