### PR TITLE
Upgrade Crashlytics dep versions

### DIFF
--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -62,47 +62,47 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    javadocClasspath(libs.findbugs.jsr305)
 
     api(project(":firebase-sessions"))
-    api "com.google.android.gms:play-services-tasks:18.0.1"
-    api 'com.google.firebase:firebase-annotations:16.2.0'
+    api(libs.playservices.tasks)
+    api("com.google.firebase:firebase-annotations:16.2.0")
     api("com.google.firebase:firebase-common:21.0.0")
     api("com.google.firebase:firebase-common-ktx:21.0.0")
     api("com.google.firebase:firebase-components:18.0.0")
-    api 'com.google.firebase:firebase-config-interop:16.0.0'
-    api 'com.google.firebase:firebase-encoders:17.0.0'
-    api 'com.google.firebase:firebase-encoders-json:18.0.0'
-    api("com.google.firebase:firebase-installations:17.2.0")
-    api 'com.google.firebase:firebase-installations-interop:17.1.0'
+    api("com.google.firebase:firebase-config-interop:16.0.1")
+    api("com.google.firebase:firebase-encoders:17.0.0")
+    api("com.google.firebase:firebase-encoders-json:18.0.1")
+    api("com.google.firebase:firebase-installations:18.0.0")
+    api("com.google.firebase:firebase-installations-interop:17.2.0")
     api("com.google.firebase:firebase-measurement-connector:20.0.1")
 
-    implementation 'com.google.android.datatransport:transport-api:3.0.0'
-    implementation 'com.google.android.datatransport:transport-backend-cct:3.1.9'
-    implementation 'com.google.android.datatransport:transport-runtime:3.1.9'
+    implementation("com.google.android.datatransport:transport-api:3.2.0")
+    implementation("com.google.android.datatransport:transport-backend-cct:3.3.0")
+    implementation("com.google.android.datatransport:transport-runtime:3.3.0")
     implementation(libs.androidx.annotation)
     compileOnly(libs.errorprone.annotations)
 
-    compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
+    compileOnly(libs.autovalue.annotations)
 
-    annotationProcessor project(":encoders:firebase-encoders-processor")
-    annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
+    annotationProcessor(project(":encoders:firebase-encoders-processor"))
+    annotationProcessor(libs.autovalue)
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.4.3'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.test.runner)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.robolectric)
 
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation 'com.google.firebase:firebase-encoders-json:18.0.0'
-    androidTestImplementation 'com.google.protobuf:protobuf-java:3.21.9'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
-    androidTestImplementation 'org.mockito:mockito-core:3.4.3'
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation("com.google.firebase:firebase-encoders-json:18.0.1")
+    androidTestImplementation("com.google.protobuf:protobuf-java:3.21.11")
+    androidTestImplementation(libs.truth)
+    androidTestImplementation("com.linkedin.dexmaker:dexmaker:2.28.3")
+    androidTestImplementation(libs.mockito.dexmaker)
+    androidTestImplementation("org.mockito:mockito-core:4.7.0")
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.truth)

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/RemoteConfigDeferredProxyTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/RemoteConfigDeferredProxyTest.java
@@ -14,7 +14,7 @@
 
 package com.google.firebase.crashlytics.internal;
 
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
@@ -50,6 +50,6 @@ public class RemoteConfigDeferredProxyTest {
               }
             });
     proxy.setupListener(userMetadata);
-    verify(interop).registerRolloutsStateSubscriber(eq("firebase"), anyObject());
+    verify(interop).registerRolloutsStateSubscriber(eq("firebase"), any());
   }
 }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CommonUtilsTest.java
@@ -14,8 +14,8 @@
 
 package com.google.firebase.crashlytics.internal.common;
 
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsControllerTest.java
@@ -19,7 +19,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.android.gms.tasks.Task;
@@ -124,7 +124,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
     await(controller.loadSettingsData(networkExecutor));
     assertEquals(cachedSettings, controller.getSettingsSync());
 
-    verifyZeroInteractions(mockSettingsSpiCall);
+    verifyNoMoreInteractions(mockSettingsSpiCall);
     verify(mockCachedSettingsIo).readCachedSettings();
     verify(mockSettingsJsonParser).parseSettingsJson(cachedJson);
     verify(mockCurrentTimeProvider, times(2)).getCurrentTimeMillis();
@@ -239,7 +239,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
     controller.loadSettingsData(SettingsCacheBehavior.IGNORE_CACHE_EXPIRATION, networkExecutor);
     assertEquals(cachedSettings, controller.getSettingsSync());
 
-    verifyZeroInteractions(mockSettingsSpiCall);
+    verifyNoMoreInteractions(mockSettingsSpiCall);
     verify(mockCachedSettingsIo).readCachedSettings();
     verify(mockSettingsJsonParser).parseSettingsJson(cachedJson);
     verify(mockCurrentTimeProvider, times(2)).getCurrentTimeMillis();
@@ -376,7 +376,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
 
     verify(mockSettingsSpiCall).invoke(any(SettingsRequest.class), eq(true));
     verify(mockCachedSettingsIo, times(2)).readCachedSettings();
-    verifyZeroInteractions(mockSettingsJsonParser);
+    verifyNoMoreInteractions(mockSettingsJsonParser);
     verify(mockCurrentTimeProvider).getCurrentTimeMillis();
   }
 

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -61,23 +61,23 @@ dependencies {
   api("com.google.firebase:firebase-common-ktx:21.0.0")
 
   api("com.google.firebase:firebase-components:18.0.0")
-  api("com.google.firebase:firebase-installations-interop:17.1.1") {
+  api("com.google.firebase:firebase-installations-interop:17.2.0") {
     exclude(group = "com.google.firebase", module = "firebase-common")
     exclude(group = "com.google.firebase", module = "firebase-components")
   }
   implementation("androidx.datastore:datastore-preferences:1.0.0")
-  implementation("com.google.android.datatransport:transport-api:3.0.0")
+  implementation("com.google.android.datatransport:transport-api:3.2.0")
   api("com.google.firebase:firebase-annotations:16.2.0")
   api("com.google.firebase:firebase-encoders:17.0.0")
   api("com.google.firebase:firebase-encoders-json:18.0.1")
   implementation(libs.androidx.annotation)
   compileOnly(libs.errorprone.annotations)
 
-  runtimeOnly("com.google.firebase:firebase-installations:17.2.0") {
+  runtimeOnly("com.google.firebase:firebase-installations:18.0.0") {
     exclude(group = "com.google.firebase", module = "firebase-common")
     exclude(group = "com.google.firebase", module = "firebase-components")
   }
-  runtimeOnly("com.google.firebase:firebase-datatransport:18.1.8") {
+  runtimeOnly("com.google.firebase:firebase-datatransport:19.0.0") {
     exclude(group = "com.google.firebase", module = "firebase-common")
     exclude(group = "com.google.firebase", module = "firebase-components")
   }


### PR DESCRIPTION
Update Crashlytics and AQS dep versions. Fixed some of the tests because of changes to Mockito. The Mockito version in the Android tests is still pinned a bit old, because after that version a lot more things break.