### PR TITLE
Add release metadata for Vertex

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/SdkUtil.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/SdkUtil.kt
@@ -137,5 +137,6 @@ fun convertToMetadata(string: String) =
       ReleaseNotesMetadata("{{app_check}} Debug Testing", "appcheck-debug-testing", false)
     "firebase-appcheck-playintegrity" ->
       ReleaseNotesMetadata("{{app_check}} Play integrity", "appcheck-playintegrity", false)
+    "firebase-vertexai" -> ReleaseNotesMetadata("{{firebase_vertexai}}", "vertex-ai", false)
     else -> throw StopActionException("No metadata mapping found for project: $string")
   }

--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [changed] Updated `firebase-crashlytics` dependency to v19.0.3
 
 # 19.0.2
 * [changed] Update libcrashlytics to support 16 kb page sizes.


### PR DESCRIPTION
Per [b/352147122](https://b.corp.google.com/issues/352147122),

This adds release metadata for Vertex, so that it can properly generate release notes.

This PR also fixes the following:

- [b/352147570](https://b.corp.google.com/issues/352147570) -> Add missing changelog entry for crashlytics ndk

NO_RELEASE_CHANGE