### PR TITLE
Implement centralized config for Release Note generation

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
+++ b/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
@@ -21,6 +21,11 @@ firebaseLibrary {
     libraryGroup "appcheck"
     testLab.enabled = true
     publishSources = true
+    releaseNotes {
+        name.set("{{app_check}} Debug Testing")
+        versionName.set("appcheck-debug-testing")
+        hasKTX.set(false)
+    }
 }
 
 android {

--- a/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
+++ b/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
@@ -19,6 +19,11 @@ plugins {
 firebaseLibrary {
     libraryGroup "appcheck"
     publishSources = true
+    releaseNotes {
+        name.set("{{app_check}} Debug")
+        versionName.set("appcheck-debug")
+        hasKTX.set(false)
+    }
 }
 
 android {

--- a/appcheck/firebase-appcheck-interop/firebase-appcheck-interop.gradle
+++ b/appcheck/firebase-appcheck-interop/firebase-appcheck-interop.gradle
@@ -19,7 +19,9 @@ plugins {
 firebaseLibrary {
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
+++ b/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
@@ -19,6 +19,11 @@ plugins {
 firebaseLibrary {
     libraryGroup "appcheck"
     publishSources = true
+    releaseNotes {
+        name.set("{{app_check}} Play integrity")
+        versionName.set("appcheck-playintegrity")
+        hasKTX.set(false)
+    }
 }
 
 android {

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -20,6 +20,10 @@ plugins {
 firebaseLibrary {
     libraryGroup "appcheck"
     publishSources = true
+    releaseNotes {
+        name.set("{{app_check}}")
+        versionName.set("appcheck")
+    }
 }
 
 android {

--- a/appcheck/firebase-appcheck/ktx/ktx.gradle
+++ b/appcheck/firebase-appcheck/ktx/ktx.gradle
@@ -21,7 +21,9 @@ firebaseLibrary {
     libraryGroup "appcheck"
     testLab.enabled = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/FirebaseLibraryExtension.java
@@ -37,9 +37,6 @@ public class FirebaseLibraryExtension {
   /** Indicates whether the library has public javadoc. */
   public boolean publishJavadoc = true;
 
-  /** Indicates whether release notes are published for the library. */
-  public boolean publishReleaseNotes = true;
-
   /** Indicates whether sources are published alongside the library. */
   public boolean publishSources;
 
@@ -53,6 +50,9 @@ public class FirebaseLibraryExtension {
 
   /** Firebase Test Lab configuration/ */
   public final FirebaseTestLabExtension testLab;
+
+  /** Release notes configuration. */
+  public final ReleaseNotesConfigurationExtension releaseNotes;
 
   public Property<String> groupId;
   public Property<String> artifactId;
@@ -83,6 +83,10 @@ public class FirebaseLibraryExtension {
     this.testLab = new FirebaseTestLabExtension(project.getObjects());
     this.artifactId = project.getObjects().property(String.class);
     this.groupId = project.getObjects().property(String.class);
+    this.releaseNotes = project.getExtensions().create("releaseNotes", ReleaseNotesConfigurationExtension.class);
+    this.releaseNotes.getEnabled().convention(true);
+    this.releaseNotes.getHasKTX().convention(true);
+    this.releaseNotes.getArtifactName().convention(project.getName());
 
     if ("ktx".equals(project.getName()) && project.getParent() != null) {
       artifactId.set(new DefaultProvider<>(() -> project.getParent().getName() + "-ktx"));
@@ -125,6 +129,10 @@ public class FirebaseLibraryExtension {
   /** Provides a hook to customize pom generation. */
   public void customizePom(Action<MavenPom> action) {
     customizePomAction = action;
+  }
+
+  public void releaseNotes(Action<ReleaseNotesConfigurationExtension> action) {
+    action.execute(releaseNotes);
   }
 
   public void applyPomCustomization(MavenPom pom) {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/MoveUnreleasedChangesTask.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/MoveUnreleasedChangesTask.kt
@@ -87,18 +87,22 @@ abstract class MoveUnreleasedChangesTask : DefaultTask() {
    * Ensures the entry is only created if the library has a KTX lib to begin with, and adds template
    * subtext if it lacks any changes.
    *
-   * @see convertToMetadata
+   * @see ReleaseNotesConfigurationExtension
    * @see KTXTransitiveReleaseText
    */
   private fun createEntryForKTX(release: ReleaseEntry): ReleaseContent? {
-    val metadata = convertToMetadata(project.name)
+    val releaseNotesConfig = project.firebaseLibrary.releaseNotes
 
     val nonEmptyKTXContent = release.ktx?.takeIf { it.hasContent() }
 
     val ktxContent =
-      nonEmptyKTXContent ?: ReleaseContent(KTXTransitiveReleaseText(project.name), emptyList())
+      nonEmptyKTXContent
+        ?: ReleaseContent(
+          KTXTransitiveReleaseText(releaseNotesConfig.artifactName.get()),
+          emptyList()
+        )
 
-    return ktxContent.takeIf { metadata.hasKTX }
+    return ktxContent.takeIf { releaseNotesConfig.hasKTX.get() }
   }
 
   private fun configure() {

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ReleaseNotesConfigurationExtension.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/ReleaseNotesConfigurationExtension.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.gradle.plugins
+
+import org.gradle.api.provider.Property
+
+/**
+ * Configuration options for release note generation of libraries.
+ *
+ * Also facilitates the centralization of certain externally defined data (usually defined on G3).
+ * As we can't link G3 files on GitHub, if you're setting up a new SDK and are unsure what release
+ * note mappings your SDK has (or will have) ask Rachel or the ACore team for the relevant variable
+ * mappings.
+ *
+ * @property enabled Whether to generate release notes for this library. Defaults to true.
+ *
+ * @property name The variable name mapping for this library, defined on G3.
+ *
+ * @property versionName The version name mapping for this library, defined on G3.
+ *
+ * @property hasKTX The library has a sub module with the suffix '-ktx' that releases alongside this
+ * library, and should have the transitive text added to the release notes. Defaults to true. Will
+ * likely be removed when we officially drop KTX libraries.
+ *
+ * @property artifactName The name of the generation artifact. _Only_ required if your project's
+ * name is different than your generated artifact name. Defaults to the project name.
+ *
+ * @see MakeReleaseNotesTask
+ */
+abstract class ReleaseNotesConfigurationExtension {
+  abstract val enabled: Property<Boolean>
+  abstract val name: Property<String>
+  abstract val versionName: Property<String>
+  abstract val hasKTX: Property<Boolean>
+  abstract val artifactName: Property<String>
+}

--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/SdkUtil.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/SdkUtil.kt
@@ -23,7 +23,6 @@ import java.io.IOException
 import java.util.Properties
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.tasks.StopActionException
 
 val Project.sdkDir: File
   get() {
@@ -58,85 +57,8 @@ val Project.androidJar: File?
 fun KTXTransitiveReleaseText(projectName: String) =
   """
       |The Kotlin extensions library transitively includes the updated
-      |`${ProjectNameToKTXPlaceholder(projectName)}` library. The Kotlin extensions library has no additional
+      |`$projectName` library. The Kotlin extensions library has no additional
       |updates.
     """
     .trimMargin()
     .trim()
-
-/**
- * Maps a project's name to a KTX suitable placeholder.
- *
- * Some libraries produce artifacts with different coordinates than their project name. This method
- * helps to map that gap for [KTXTransitiveReleaseText].
- */
-fun ProjectNameToKTXPlaceholder(projectName: String) =
-  when (projectName) {
-    "firebase-perf" -> "firebase-performance"
-    "firebase-appcheck" -> "firebase-appcheck"
-    else -> projectName
-  }
-
-/**
- * Provides extra metadata needed to create release notes for a given project.
- *
- * This data is needed for g3 internal mappings, and does not really have any implications for
- * public repo actions.
- *
- * @property name The variable name for a project in a release note
- * @property vesionName The variable name given to the versions of a project
- * @property hasKTX The module has a KTX submodule (not to be confused with having KTX files)
- * @see MakeReleaseNotesTask
- */
-data class ReleaseNotesMetadata(
-  val name: String,
-  val versionName: String,
-  val hasKTX: Boolean = true
-)
-
-/**
- * Maps the name of a project to its potential [ReleaseNotesMetadata].
- *
- * @throws StopActionException If a mapping is not found
- */
-// TODO() - Should we expose these as firebaselib configuration points; especially for new SDKS?
-fun convertToMetadata(string: String) =
-  when (string) {
-    "firebase-abt" -> ReleaseNotesMetadata("{{ab_testing}}", "ab_testing", false)
-    "firebase-appdistribution" -> ReleaseNotesMetadata("{{appdistro}}", "app-distro", false)
-    "firebase-appdistribution-api" -> ReleaseNotesMetadata("{{appdistro}} API", "app-distro-api")
-    "firebase-config" -> ReleaseNotesMetadata("{{remote_config}}", "remote-config")
-    "firebase-crashlytics" -> ReleaseNotesMetadata("{{crashlytics}}", "crashlytics")
-    "firebase-crashlytics-ndk" ->
-      ReleaseNotesMetadata("{{crashlytics}} NDK", "crashlytics-ndk", false)
-    "firebase-database" -> ReleaseNotesMetadata("{{database}}", "realtime-database")
-    "firebase-dynamic-links" -> ReleaseNotesMetadata("{{ddls}}", "dynamic-links")
-    "firebase-firestore" -> ReleaseNotesMetadata("{{firestore}}", "firestore")
-    "firebase-functions" -> ReleaseNotesMetadata("{{functions_client}}", "functions-client")
-    "firebase-dynamic-module-support" ->
-      ReleaseNotesMetadata(
-        "Dynamic feature modules support",
-        "dynamic-feature-modules-support",
-        false
-      )
-    "firebase-inappmessaging" -> ReleaseNotesMetadata("{{inappmessaging}}", "inappmessaging")
-    "firebase-inappmessaging-display" ->
-      ReleaseNotesMetadata("{{inappmessaging}} Display", "inappmessaging-display")
-    "firebase-installations" -> ReleaseNotesMetadata("{{firebase_installations}}", "installations")
-    "firebase-messaging" -> ReleaseNotesMetadata("{{messaging_longer}}", "messaging")
-    "firebase-messaging-directboot" ->
-      ReleaseNotesMetadata("Cloud Messaging Direct Boot", "messaging-directboot", false)
-    "firebase-ml-modeldownloader" ->
-      ReleaseNotesMetadata("{{firebase_ml}}", "firebaseml-modeldownloader")
-    "firebase-perf" -> ReleaseNotesMetadata("{{perfmon}}", "performance")
-    "firebase-storage" -> ReleaseNotesMetadata("{{firebase_storage_full}}", "storage")
-    "firebase-appcheck" -> ReleaseNotesMetadata("{{app_check}}", "appcheck")
-    "firebase-appcheck-debug" ->
-      ReleaseNotesMetadata("{{app_check}} Debug", "appcheck-debug", false)
-    "firebase-appcheck-debug-testing" ->
-      ReleaseNotesMetadata("{{app_check}} Debug Testing", "appcheck-debug-testing", false)
-    "firebase-appcheck-playintegrity" ->
-      ReleaseNotesMetadata("{{app_check}} Play integrity", "appcheck-playintegrity", false)
-    "firebase-vertexai" -> ReleaseNotesMetadata("{{firebase_vertexai}}", "vertex-ai", false)
-    else -> throw StopActionException("No metadata mapping found for project: $string")
-  }

--- a/buildSrc/src/test/resources/BasicProject/firebase-storage/build.gradle
+++ b/buildSrc/src/test/resources/BasicProject/firebase-storage/build.gradle
@@ -16,6 +16,13 @@ plugins {
     id 'firebase-library'
 }
 
+firebaseLibrary {
+    releaseNotes {
+        name.set("{{firebase_storage_full}}")
+        versionName.set("storage")
+    }
+}
+
 android{
     namespace 'com.example.firebase-storage'
     compileSdkVersion 26

--- a/encoders/firebase-decoders-json/firebase-decoders-json.gradle
+++ b/encoders/firebase-decoders-json/firebase-decoders-json.gradle
@@ -19,7 +19,9 @@ plugins {
 firebaseLibrary {
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/encoders/firebase-encoders-json/firebase-encoders-json.gradle
+++ b/encoders/firebase-encoders-json/firebase-encoders-json.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/encoders/firebase-encoders-proto/firebase-encoders-proto.gradle
+++ b/encoders/firebase-encoders-proto/firebase-encoders-proto.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 java {

--- a/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
+++ b/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
@@ -19,7 +19,9 @@ plugins {
 firebaseLibrary {
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/encoders/firebase-encoders/firebase-encoders.gradle
+++ b/encoders/firebase-encoders/firebase-encoders.gradle
@@ -19,7 +19,9 @@ plugins {
 firebaseLibrary {
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 java {

--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -20,6 +20,11 @@ firebaseLibrary {
     testLab.enabled = false
     publishSources = true
     publishJavadoc = false
+    releaseNotes {
+        name.set("{{ab_testing}}")
+        versionName.set("ab_testing")
+        hasKTX.set(false)
+    }
 }
 
 android {

--- a/firebase-annotations/firebase-annotations.gradle.kts
+++ b/firebase-annotations/firebase-annotations.gradle.kts
@@ -19,7 +19,9 @@ plugins {
 firebaseLibrary {
   publishSources = true
   publishJavadoc = false
-  publishReleaseNotes = false
+  releaseNotes { 
+    enabled.set(false)
+}
 }
 
 java {

--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -20,6 +20,10 @@ plugins {
 firebaseLibrary {
     libraryGroup "appdistribution"
     previewMode = "beta"
+    releaseNotes {
+        name.set("{{appdistro}} API")
+        versionName.set("app-distro-api")
+    }
 }
 
 android {

--- a/firebase-appdistribution-api/ktx/ktx.gradle
+++ b/firebase-appdistribution-api/ktx/ktx.gradle
@@ -21,7 +21,9 @@ firebaseLibrary {
     libraryGroup "appdistribution"
     testLab.enabled = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
     previewMode = "beta"
 }

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -21,6 +21,11 @@ firebaseLibrary {
     libraryGroup "appdistribution"
     publishJavadoc = false
     previewMode = "beta"
+    releaseNotes {
+        name.set("{{appdistro}}")
+        versionName.set("app-distro")
+        hasKTX.set(false)
+    }
 }
 
 android {

--- a/firebase-common/ktx/ktx.gradle.kts
+++ b/firebase-common/ktx/ktx.gradle.kts
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup("common")
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/firebase-components/firebase-components.gradle.kts
+++ b/firebase-components/firebase-components.gradle.kts
@@ -19,7 +19,9 @@ plugins {
 firebaseLibrary {
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
+++ b/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
@@ -22,6 +22,11 @@ firebaseLibrary {
   testLab.enabled = false
   publishSources = true
   publishJavadoc = false
+  releaseNotes {
+    name.set("Dynamic feature modules support")
+    versionName.set("dynamic-feature-modules-support")
+    hasKTX.set(false)
+  }
 }
 
 android {

--- a/firebase-config-interop/firebase-config-interop.gradle.kts
+++ b/firebase-config-interop/firebase-config-interop.gradle.kts
@@ -21,7 +21,9 @@ plugins {
 firebaseLibrary {
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes {
+        enabled.set(false)
+    }
 }
 
 android {

--- a/firebase-config/firebase-config.gradle.kts
+++ b/firebase-config/firebase-config.gradle.kts
@@ -23,7 +23,10 @@ firebaseLibrary {
     libraryGroup("config")
     testLab.enabled = true
     publishSources = true
-
+    releaseNotes {
+        name.set("{{remote_config}}")
+        versionName.set("remote-config")
+    }
 }
 
 android {

--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup "config"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -23,6 +23,11 @@ firebaseLibrary {
         enabled = true
         device 'model=panther,version=33' // Pixel7
     }
+    releaseNotes {
+        name.set("{{crashlytics}} NDK")
+        versionName.set("crashlytics-ndk")
+        hasKTX.set(false)
+    }
     testLab.enabled = true
     publishJavadoc = false
 }

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -24,6 +24,10 @@ firebaseLibrary {
         enabled = true
         device 'model=panther,version=33'
     }
+    releaseNotes {
+        name.set("{{crashlytics}}")
+        versionName.set("crashlytics")
+    }
 }
 
 android {

--- a/firebase-crashlytics/ktx/ktx.gradle
+++ b/firebase-crashlytics/ktx/ktx.gradle
@@ -21,7 +21,9 @@ firebaseLibrary {
   libraryGroup "crashlytics"
   testLab.enabled = true
   publishJavadoc = false
-  publishReleaseNotes = false
+  releaseNotes { 
+    enabled.set(false)
+}
   publishSources = true
 }
 

--- a/firebase-database-collection/firebase-database-collection.gradle.kts
+++ b/firebase-database-collection/firebase-database-collection.gradle.kts
@@ -17,7 +17,9 @@ plugins { id("firebase-library") }
 firebaseLibrary {
   publishSources = true
   publishJavadoc = false
-  publishReleaseNotes = false
+  releaseNotes {
+    enabled.set(false)
+  }
 }
 
 android {

--- a/firebase-database/firebase-database.gradle.kts
+++ b/firebase-database/firebase-database.gradle.kts
@@ -22,6 +22,10 @@ firebaseLibrary {
   libraryGroup("database")
   testLab.enabled = true
   publishSources = true
+  releaseNotes {
+    name.set("{{database}}")
+    versionName.set("realtime-database")
+  }
 }
 
 android {

--- a/firebase-database/ktx/ktx.gradle.kts
+++ b/firebase-database/ktx/ktx.gradle.kts
@@ -23,7 +23,9 @@ group = "com.google.firebase"
 firebaseLibrary {
   libraryGroup("database")
   publishJavadoc = false
-  publishReleaseNotes = false
+  releaseNotes { 
+    enabled.set(false)
+}
   publishSources = true
 }
 

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -18,7 +18,9 @@ plugins {
 
 firebaseLibrary {
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -21,6 +21,10 @@ firebaseLibrary {
     libraryGroup "dynamic-links"
     testLab.enabled = false
     publishSources = true
+    releaseNotes {
+        name.set("{{ddls}}")
+        versionName.set("dynamic-links")
+    }
 }
 
 android {

--- a/firebase-dynamic-links/ktx/ktx.gradle
+++ b/firebase-dynamic-links/ktx/ktx.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup "dynamic-links"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -26,6 +26,10 @@ firebaseLibrary {
         enabled = true
         timeout = '45m'
     }
+    releaseNotes {
+        name.set("{{firestore}}")
+        versionName.set("firestore")
+    }
 }
 
 protobuf {

--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -23,7 +23,9 @@ firebaseLibrary {
     libraryGroup "firestore"
     publishSources = true
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -23,6 +23,10 @@ firebaseLibrary {
     libraryGroup("functions")
     testLab.enabled = true
     publishSources = true
+    releaseNotes {
+        name.set("{{functions_client}}")
+        versionName.set("functions-client")
+    }
 }
 
 android {

--- a/firebase-functions/ktx/ktx.gradle.kts
+++ b/firebase-functions/ktx/ktx.gradle.kts
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
   libraryGroup("functions")
   publishJavadoc = false
-  publishReleaseNotes = false
+  releaseNotes { 
+    enabled.set(false)
+}
   publishSources = true
   testLab.enabled = true
 }

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -21,6 +21,10 @@ plugins {
 firebaseLibrary {
     libraryGroup "inappmessaging"
     testLab.enabled = true
+    releaseNotes {
+        name.set("{{inappmessaging}} Display")
+        versionName.set("inappmessaging-display")
+    }
 }
 
 android {

--- a/firebase-inappmessaging-display/ktx/ktx.gradle
+++ b/firebase-inappmessaging-display/ktx/ktx.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup "inappmessaging"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -22,6 +22,10 @@ plugins {
 firebaseLibrary {
     libraryGroup "inappmessaging"
     testLab.enabled = true
+    releaseNotes {
+        name.set("{{inappmessaging}}")
+        versionName.set("inappmessaging")
+    }
 }
 
 protobuf {

--- a/firebase-inappmessaging/ktx/ktx.gradle
+++ b/firebase-inappmessaging/ktx/ktx.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup "inappmessaging"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-installations-interop/firebase-installations-interop.gradle
+++ b/firebase-installations-interop/firebase-installations-interop.gradle
@@ -19,7 +19,9 @@ plugins {
 
 firebaseLibrary {
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -20,6 +20,10 @@ plugins {
 
 firebaseLibrary {
     libraryGroup "installations"
+    releaseNotes {
+        name.set("{{firebase_installations}}")
+        versionName.set("installations")
+    }
 }
 
 android {

--- a/firebase-installations/ktx/ktx.gradle
+++ b/firebase-installations/ktx/ktx.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup "installations"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-messaging-directboot/firebase-messaging-directboot.gradle
+++ b/firebase-messaging-directboot/firebase-messaging-directboot.gradle
@@ -20,6 +20,11 @@ firebaseLibrary {
     testLab.enabled = false
     publishJavadoc = false
     libraryGroup "messaging"
+    releaseNotes {
+        name.set("Cloud Messaging Direct Boot")
+        versionName.set("messaging-directboot")
+        hasKTX.set(false)
+    }
 }
 
 android {

--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -55,6 +55,10 @@ protobuf {
 firebaseLibrary {
     libraryGroup "messaging"
     testLab.enabled = false
+    releaseNotes {
+        name.set("{{messaging_longer}}")
+        versionName.set("messaging")
+    }
 }
 
 android {

--- a/firebase-messaging/ktx/ktx.gradle
+++ b/firebase-messaging/ktx/ktx.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup "messaging"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
+++ b/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
@@ -24,6 +24,10 @@ firebaseLibrary {
     libraryGroup "ml-modeldownloader"
     testLab.enabled = true
     publishJavadoc = true
+    releaseNotes {
+        name.set("{{firebase_ml}}")
+        versionName.set("firebaseml-modeldownloader")
+    }
 }
 
 protobuf {

--- a/firebase-ml-modeldownloader/ktx/ktx.gradle
+++ b/firebase-ml-modeldownloader/ktx/ktx.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup "ml-modeldownloader"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
     testLab.enabled = false
 }

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -27,6 +27,11 @@ firebaseLibrary {
     // Disabling Test Lab as there are no instrumentation tests for the SDK currently.
     // When we add instrumentation tests in the future, this needs to be enabled.
     testLab.enabled = false // Runs SDK Instrumentation Tests on Firebase Test Lab.
+    releaseNotes {
+        name.set("{{perfmon}}")
+        versionName.set("performance")
+        artifactName.set("firebase-performance")
+    }
 }
 
 protobuf {

--- a/firebase-perf/ktx/ktx.gradle
+++ b/firebase-perf/ktx/ktx.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary {
     libraryGroup "perf"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -28,7 +28,9 @@ firebaseLibrary {
   testLab.enabled = true
   publishSources = true
   publishJavadoc = false
-  publishReleaseNotes = false
+  releaseNotes { 
+    enabled.set(false)
+}
 }
 
 android {

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -24,6 +24,10 @@ firebaseLibrary {
     testLab.enabled = true
     publishJavadoc = true
     publishSources = true
+    releaseNotes {
+        name.set("{{firebase_storage_full}}")
+        versionName.set("storage")
+    }
 }
 
 android {

--- a/firebase-storage/ktx/ktx.gradle
+++ b/firebase-storage/ktx/ktx.gradle
@@ -22,7 +22,9 @@ group = "com.google.firebase"
 firebaseLibrary {
     libraryGroup "storage"
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     publishSources = true
 }
 

--- a/firebase-vertexai/firebase-vertexai.gradle.kts
+++ b/firebase-vertexai/firebase-vertexai.gradle.kts
@@ -26,6 +26,11 @@ firebaseLibrary {
   publishSources = true
   publishJavadoc = true
   previewMode = "beta"
+  releaseNotes {
+    name.set("{{firebase_vertexai}}")
+    versionName.set("vertex-ai")
+    hasKTX.set(false)
+  }
 }
 
 android {

--- a/protolite-well-known-types/protolite-well-known-types.gradle
+++ b/protolite-well-known-types/protolite-well-known-types.gradle
@@ -19,7 +19,9 @@ plugins {
 
 firebaseLibrary {
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 protobuf {

--- a/transport/transport-api/transport-api.gradle
+++ b/transport/transport-api/transport-api.gradle
@@ -18,7 +18,9 @@ plugins {
 
 firebaseLibrary{
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 android {

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -20,7 +20,9 @@ plugins {
 firebaseLibrary{
     libraryGroup("transport")
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
 }
 
 protobuf {

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -52,7 +52,9 @@ protobuf {
 firebaseLibrary {
     libraryGroup("transport")
     publishJavadoc = false
-    publishReleaseNotes = false
+    releaseNotes { 
+        enabled.set(false)
+    }
     testLab {
         enabled = true
 


### PR DESCRIPTION
Per [b/352342089](https://b.corp.google.com/issues/352342089),

This implements a new extension through `FirebaseLibrary` called `ReleaseNotesConfigurationExtension`. This can be configured through the `releaseNotes` helper method that takes an `Action` argument; similar to what we do with `FirebaseTestLabExtension` and `FirebaseStaticAnalysis`.

The goal of this move is to not only allow teams to modify their release notes metadata, but provide an obvious indicator of release note configuration that must be changed to properly generate release notes. This way, we avoid accidentally _not_ generating release notes for libraries that should otherwise have them.

Furthermore, this opens the door for exposing more release note configurations to product teams (such as `annotationsNotToDisplay`, `suppressedFiles`, `includedHeadTagsPath`, `package-list` mappings, etc.,).

NO_RELEASE_CHANGE