### PR TITLE
Fix CLA issues in workflows

### DIFF
--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.GOOGLE_OSS_BOT_TOKEN }}
+          committer: google-oss-bot <google-oss-bot@google.com>
+          assignees: ${{ github.actor }}
           base: 'releases/${{ inputs.name }}'
           branch: 'releases/${{ inputs.name }}.release'
           add-paths: release.json,release_report.md,release_report.json

--- a/.github/workflows/create_releases.yml
+++ b/.github/workflows/create_releases.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GOOGLE_OSS_BOT_TOKEN }}
-          committer: google-oss-bot <google-oss-bot@google.com>
-          assignees: ${{ github.actor }}
           base: 'releases/${{ inputs.name }}'
           branch: 'releases/${{ inputs.name }}.release'
           add-paths: release.json,release_report.md,release_report.json

--- a/.github/workflows/post_release_cleanup.yml
+++ b/.github/workflows/post_release_cleanup.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.GOOGLE_OSS_BOT_TOKEN }}
+          committer: google-oss-bot <google-oss-bot@google.com>
+          assignees: ${{ github.actor }}
           base: 'main'
           branch: 'releases/${{ inputs.name }}.mergeback'
           add-paths: |


### PR DESCRIPTION
Per [b/353295303](https://b.corp.google.com/issues/353295303),

This updates our `post_release_cleanup` workflow to use the `google-oss-bot` as the signee. This should allow the workflow to pass CLA, as `github-actions` is not supported.

Note that while `create_release` _does_ create a PR that could take advantage of this, we've chosen to keep it in a state where the CLA fails; such that the PR is not accidentally merged (as _that_ PR should _not_ be merged).