### PR TITLE
Fix m150  issues

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -864,7 +864,7 @@ class CrashlyticsController {
 
   private static boolean firebaseCrashExists() {
     try {
-      final Class clazz = Class.forName("com.google.firebase.crash.FirebaseCrash");
+      final Class<?> clazz = Class.forName("com.google.firebase.crash.FirebaseCrash");
       return true;
     } catch (ClassNotFoundException e) {
       return false;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/persistence/FileStore.java
@@ -74,6 +74,7 @@ public class FileStore {
   private final File priorityReportsDir;
   private final File nativeReportsDir;
 
+  @SuppressWarnings("KotlinInternal")
   public FileStore(Context context) {
     processName =
         ProcessDetailsProvider.INSTANCE.getCurrentProcessDetails(context).getProcessName();


### PR DESCRIPTION
Per [b/353751840](https://b.corp.google.com/issues/353751840),

This fixes the issues that were causing tests to fail when trying to copy the changes into head. More specifically:

- It suppresses a Kotlin Internal usage- as it's a false positive (they live under the same package, which is _okay'd_ internally)
- It adds a type to a `Class` usage- as this seems to be required at head

NO_RELEASE_CHANGE