### PR TITLE
Ensure that ODFs are never processed on the main thread

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Unreleased
-
+* [feature] Added the `isCrashlyticsCollectionEnabled` API to check if Crashlytics collection is enabled.
+  ([Github #5919](//github.com/firebase/firebase-android-sdk/issues/5919))
+* [fixed] Ensure that on-demand fatal events are never processed on the main thread.
 
 # 19.0.3
 * [changed] Update the internal file system to handle long file names.
-* [feature] Added the `isCrashlyticsCollectionEnabled` API to check if Crashlytics collection is enabled. 
-  ([Github #5919](//github.com/firebase/firebase-android-sdk/issues/5919))
 
 
 ## Kotlin

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -250,9 +250,12 @@ class CrashlyticsController {
               }
             });
 
+    // Block until the task completes to prevent the process from ending early.
     try {
-      // TODO(mrober): Don't block the main thread ever for on-demand fatals.
-      Utils.awaitEvenIfOnMainThread(handleUncaughtExceptionTask);
+      // Do not block on ODFs, in case they get triggered from the main thread.
+      if (!isOnDemand) {
+        Utils.awaitEvenIfOnMainThread(handleUncaughtExceptionTask);
+      }
     } catch (TimeoutException e) {
       Logger.getLogger().e("Cannot send reports. Timed out while fetching settings.");
     } catch (Exception e) {

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiterRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/DataCollectionArbiterRobolectricTest.java
@@ -15,16 +15,14 @@
 package com.google.firebase.crashlytics.internal.common;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static com.google.common.truth.Truth.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Context;
 import android.os.Bundle;
-
 import com.google.firebase.FirebaseApp;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +35,7 @@ public class DataCollectionArbiterRobolectricTest {
   private FirebaseApp firebaseApp;
 
   private static final String FIREBASE_CRASHLYTICS_COLLECTION_ENABLED =
-          "firebase_crashlytics_collection_enabled";
+      "firebase_crashlytics_collection_enabled";
 
   @Before
   public void setUp() {
@@ -54,7 +52,7 @@ public class DataCollectionArbiterRobolectricTest {
   public void testSetCrashlyticsDataCollectionEnabled_overridesOtherSettings() {
     // Ensure that Manifest metadata is set to false.
     editManifestApplicationMetadata(testContext)
-            .putBoolean(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED, false);
+        .putBoolean(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED, false);
 
     // Mock FirebaseApp to return default data collection as false.
     when(firebaseApp.isDataCollectionDefaultEnabled()).thenReturn(false);
@@ -70,21 +68,21 @@ public class DataCollectionArbiterRobolectricTest {
     assertThat(arbiter.isAutomaticDataCollectionEnabled()).isFalse();
 
     arbiter.setCrashlyticsDataCollectionEnabled(null);
-    //Expecting `false` result since manifest metadata value is `false`
+    // Expecting `false` result since manifest metadata value is `false`
     assertThat(arbiter.isAutomaticDataCollectionEnabled()).isFalse();
   }
 
   @Test
   public void testManifestMetadata_respectedWhenNoOverride() {
     editManifestApplicationMetadata(testContext)
-            .putBoolean(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED, true);
+        .putBoolean(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED, true);
 
     DataCollectionArbiter arbiter = getDataCollectionArbiter(firebaseApp);
 
     assertThat(arbiter.isAutomaticDataCollectionEnabled()).isTrue();
 
     editManifestApplicationMetadata(testContext)
-            .putBoolean(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED, false);
+        .putBoolean(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED, false);
 
     arbiter = getDataCollectionArbiter(firebaseApp);
 
@@ -93,8 +91,7 @@ public class DataCollectionArbiterRobolectricTest {
 
   @Test
   public void testDefaultDataCollection_usedWhenNoOverrideOrManifestSetting() {
-    editManifestApplicationMetadata(testContext)
-            .remove(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED);
+    editManifestApplicationMetadata(testContext).remove(FIREBASE_CRASHLYTICS_COLLECTION_ENABLED);
 
     DataCollectionArbiter arbiter = getDataCollectionArbiter(firebaseApp);
 
@@ -104,13 +101,14 @@ public class DataCollectionArbiterRobolectricTest {
     when(firebaseApp.isDataCollectionDefaultEnabled()).thenReturn(false);
     assertThat(arbiter.isAutomaticDataCollectionEnabled()).isFalse();
 
-    //No Test of `null` return for firebaseApp.isDataCollectionDefaultEnabled(), since it will never return `null` value
+    // No Test of `null` return for firebaseApp.isDataCollectionDefaultEnabled(), since it will
+    // never return `null` value
   }
 
   private Bundle editManifestApplicationMetadata(Context context) {
     return shadowOf(context.getPackageManager())
-            .getInternalMutablePackageInfo(context.getPackageName())
-            .applicationInfo
-            .metaData;
+        .getInternalMutablePackageInfo(context.getPackageName())
+        .applicationInfo
+        .metaData;
   }
 }


### PR DESCRIPTION
Never block the main thread on ODFs.

This also removed the executor shutdown hook. My experimentation showed it was very unreliable. Instead, we force an await at the end of the uncaught exception handler to block the process from ending before sending the report to Firelog. This also changed the timeout on main thread from 3 seconds to 2.75, this is to give just a little bit more time in case customers have multiple uncaught exception handlers chained up. Also simplified the nasty `awaitEvenIfOnMainThread` to just use a Tasks method. I hope to eventually not need this method anymore. All this will help migrate to the Firebase common executors.