### PR TITLE
Fix makeReleaseNotes

### DIFF
--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -21,6 +21,9 @@ firebaseLibrary {
     libraryGroup("common")
     testLab.enabled = true
     publishSources = true
+    releaseNotes {
+        enabled = false
+    }
 }
 
 android {


### PR DESCRIPTION
Per [b/353766765](https://b.corp.google.com/issues/353766765),

This fixes the issues with the `makeReleaseNotes` task when running against common. We don't publish release notes for common, but somehow made it this far without release notes disabled for it?

NO_RELEASE_CHANGE