### PR TITLE
User action refactor

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -186,7 +186,8 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
               sessionReportingCoordinator,
               nativeComponent,
               analyticsEventLogger,
-              mock(CrashlyticsAppQualitySessionsSubscriber.class));
+              mock(CrashlyticsAppQualitySessionsSubscriber.class),
+              new CrashlyticsWorker(TestOnlyExecutors.background()));
       return controller;
     }
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -93,7 +93,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     final String id = "id012345";
     crashlyticsCore.setUserId(id);
-
+    crashlyticsCore.commonWorker.await();
     assertEquals(id, metadata.getUserId());
 
     final StringBuffer idBuffer = new StringBuffer(id);
@@ -104,11 +104,13 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     final String superLongId = longId + "more chars";
 
     crashlyticsCore.setUserId(superLongId);
+    crashlyticsCore.commonWorker.await();
     assertEquals(longId, metadata.getUserId());
 
     final String key1 = "key1";
     final String value1 = "value1";
     crashlyticsCore.setCustomKey(key1, value1);
+    crashlyticsCore.commonWorker.await();
     assertEquals(value1, metadata.getCustomKeys().get(key1));
 
     // Adding an existing key with the same value should return false
@@ -122,6 +124,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     // test truncation of custom keys and attributes
     crashlyticsCore.setCustomKey(superLongId, superLongValue);
+    crashlyticsCore.commonWorker.await();
     assertNull(metadata.getCustomKeys().get(superLongId));
     assertEquals(longValue, metadata.getCustomKeys().get(longId));
 
@@ -130,23 +133,28 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
       final String key = "key" + i;
       final String value = "value" + i;
       crashlyticsCore.setCustomKey(key, value);
+      crashlyticsCore.commonWorker.await();
       assertEquals(value, metadata.getCustomKeys().get(key));
     }
     // should be full now, extra key, value pairs will be dropped.
     final String key = "new key";
     crashlyticsCore.setCustomKey(key, "some value");
+    crashlyticsCore.commonWorker.await();
     assertFalse(metadata.getCustomKeys().containsKey(key));
 
     // should be able to update existing keys
     crashlyticsCore.setCustomKey(key1, longValue);
+    crashlyticsCore.commonWorker.await();
     assertEquals(longValue, metadata.getCustomKeys().get(key1));
 
     // when we set a key to null, it should still exist with an empty value
     crashlyticsCore.setCustomKey(key1, null);
+    crashlyticsCore.commonWorker.await();
     assertEquals("", metadata.getCustomKeys().get(key1));
 
     // keys and values are trimmed.
     crashlyticsCore.setCustomKey(" " + key1 + " ", " " + longValue + " ");
+    crashlyticsCore.commonWorker.await();
     assertTrue(metadata.getCustomKeys().containsKey(key1));
     assertEquals(longValue, metadata.getCustomKeys().get(key1));
   }
@@ -197,6 +205,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     keysAndValues.put(intKey, String.valueOf(intValue));
 
     crashlyticsCore.setCustomKeys(keysAndValues);
+    crashlyticsCore.commonWorker.await();
 
     assertEquals(stringValue, metadata.getCustomKeys().get(stringKey));
     assertEquals(trimmedValue, metadata.getCustomKeys().get(trimmedKey));
@@ -217,6 +226,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
       addlKeysAndValues.put(key, value);
     }
     crashlyticsCore.setCustomKeys(addlKeysAndValues);
+    crashlyticsCore.commonWorker.await();
 
     // Ensure all keys have been set
     assertEquals(UserMetadata.MAX_ATTRIBUTES, metadata.getCustomKeys().size(), DELTA);
@@ -234,6 +244,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
       extraKeysAndValues.put(key, value);
     }
     crashlyticsCore.setCustomKeys(extraKeysAndValues);
+    crashlyticsCore.commonWorker.await();
 
     // Make sure the extra keys were not added
     for (int i = UserMetadata.MAX_ATTRIBUTES; i < UserMetadata.MAX_ATTRIBUTES + 10; ++i) {
@@ -259,6 +270,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
     updatedKeysAndValues.put(intKey, String.valueOf(updatedIntValue));
 
     crashlyticsCore.setCustomKeys(updatedKeysAndValues);
+    crashlyticsCore.commonWorker.await();
 
     assertEquals(updatedStringValue, metadata.getCustomKeys().get(stringKey));
     assertFalse(Boolean.parseBoolean(metadata.getCustomKeys().get(booleanKey)));

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -23,7 +23,6 @@ import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicMarkableReference;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -47,7 +46,8 @@ public class UserMetadata {
   @VisibleForTesting public static final int MAX_ROLLOUT_ASSIGNMENTS = 128;
 
   private final MetaDataStore metaDataStore;
-  private final CrashlyticsWorker backgroundWorker;
+
+  @VisibleForTesting final CrashlyticsWorker diskWriteWorker;
   private String sessionIdentifier;
 
   // The following references contain a marker bit, which is true if the data maintained in the
@@ -69,9 +69,9 @@ public class UserMetadata {
   }
 
   public static UserMetadata loadFromExistingSession(
-      String sessionId, FileStore fileStore, CrashlyticsWorker commonWorker) {
+      String sessionId, FileStore fileStore, CrashlyticsWorker diskWriteWorker) {
     MetaDataStore store = new MetaDataStore(fileStore);
-    UserMetadata metadata = new UserMetadata(sessionId, fileStore, commonWorker);
+    UserMetadata metadata = new UserMetadata(sessionId, fileStore, diskWriteWorker);
     // We don't use the set methods in this class, because they will attempt to re-serialize the
     // data, which is unnecessary because we just read them from disk.
     metadata.customKeys.map.getReference().setKeys(store.readKeyData(sessionId, false));
@@ -82,10 +82,10 @@ public class UserMetadata {
   }
 
   public UserMetadata(
-      String sessionIdentifier, FileStore fileStore, CrashlyticsWorker commonWorker) {
+      String sessionIdentifier, FileStore fileStore, CrashlyticsWorker diskWriteWorker) {
     this.sessionIdentifier = sessionIdentifier;
     this.metaDataStore = new MetaDataStore(fileStore);
-    this.backgroundWorker = commonWorker;
+    this.diskWriteWorker = diskWriteWorker;
   }
 
   /**
@@ -99,15 +99,18 @@ public class UserMetadata {
       sessionIdentifier = sessionId;
       Map<String, String> keyData = customKeys.getKeys();
       List<RolloutAssignment> rolloutAssignments = rolloutsState.getRolloutAssignmentList();
-      if (getUserId() != null) {
-        metaDataStore.writeUserData(sessionId, getUserId());
-      }
-      if (!keyData.isEmpty()) {
-        metaDataStore.writeKeyData(sessionId, keyData);
-      }
-      if (!rolloutAssignments.isEmpty()) {
-        metaDataStore.writeRolloutState(sessionId, rolloutAssignments);
-      }
+      diskWriteWorker.submit(
+          () -> {
+            if (getUserId() != null) {
+              metaDataStore.writeUserData(sessionId, getUserId());
+            }
+            if (!keyData.isEmpty()) {
+              metaDataStore.writeKeyData(sessionId, keyData);
+            }
+            if (!rolloutAssignments.isEmpty()) {
+              metaDataStore.writeRolloutState(sessionId, rolloutAssignments);
+            }
+          });
     }
   }
 
@@ -129,11 +132,7 @@ public class UserMetadata {
       }
       userId.set(sanitizedNewId, true);
     }
-    backgroundWorker.submit(
-        () -> {
-          serializeUserDataIfNeeded();
-          return null;
-        });
+    diskWriteWorker.submit(this::serializeUserDataIfNeeded);
   }
 
   /** @return defensive copy of the custom keys. */
@@ -188,11 +187,9 @@ public class UserMetadata {
         return false;
       }
       List<RolloutAssignment> updatedRolloutAssignments = rolloutsState.getRolloutAssignmentList();
-      backgroundWorker.submit(
-          () -> {
-            metaDataStore.writeRolloutState(sessionIdentifier, updatedRolloutAssignments);
-            return null;
-          });
+
+      diskWriteWorker.submit(
+          () -> metaDataStore.writeRolloutState(sessionIdentifier, updatedRolloutAssignments));
       return true;
     }
   }
@@ -224,7 +221,7 @@ public class UserMetadata {
    */
   private class SerializeableKeysMap {
     final AtomicMarkableReference<KeysMap> map;
-    private final AtomicReference<Callable<Void>> queuedSerializer = new AtomicReference<>(null);
+    private final AtomicReference<Runnable> queuedSerializer = new AtomicReference<>(null);
     private final boolean isInternal;
 
     public SerializeableKeysMap(boolean isInternal) {
@@ -262,17 +259,16 @@ public class UserMetadata {
     }
 
     private void scheduleSerializationTaskIfNeeded() {
-      Callable<Void> newCallable =
+      Runnable newRunnable =
           () -> {
             queuedSerializer.set(null);
             serializeIfMarked();
-            return null;
           };
 
       // Don't schedule the task if there's another queued task waiting, because the already-queued
       // task will write the latest data.
-      if (queuedSerializer.compareAndSet(null, newCallable)) {
-        backgroundWorker.submit(newCallable);
+      if (queuedSerializer.compareAndSet(null, newRunnable)) {
+        diskWriteWorker.submit(newRunnable);
       }
     }
 

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
@@ -177,7 +177,8 @@ public class CrashlyticsControllerRobolectricTest {
             mockSessionReportingCoordinator,
             MISSING_NATIVE_COMPONENT,
             mock(AnalyticsEventLogger.class),
-            mock(CrashlyticsAppQualitySessionsSubscriber.class));
+            mock(CrashlyticsAppQualitySessionsSubscriber.class),
+            new CrashlyticsWorker(TestOnlyExecutors.background()));
     controller.openSession(SESSION_ID);
     return controller;
   }


### PR DESCRIPTION
- Creating common and disk worker based on Firebase background common executor
- Move all user action directly to background thread and remove some unnecessary task submit
- Add unit tests dependency for firebase common executor
- Decouple crashlytics backend handler from user metadata and use disk writing working for persistence write.