### PR TITLE
Migrate to Firebase common executors

### DIFF
--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -98,6 +98,7 @@ dependencies {
     testImplementation(libs.mockito.core)
     testImplementation(libs.robolectric)
     testImplementation(libs.truth)
+    testImplementation(project(":integ-testing"))
 
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsTestCase.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsTestCase.java
@@ -21,6 +21,8 @@ import junit.framework.TestCase;
 
 /** Base class for all our TestCases. */
 public class CrashlyticsTestCase extends TestCase {
+  // TODO(mrober): Setup the workers with test executors in here?
+
   protected Context getContext() {
     return ApplicationProvider.getApplicationContext();
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsTestCase.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsTestCase.java
@@ -21,8 +21,6 @@ import junit.framework.TestCase;
 
 /** Base class for all our TestCases. */
 public class CrashlyticsTestCase extends TestCase {
-  // TODO(mrober): Setup the workers with test executors in here?
-
   protected Context getContext() {
     return ApplicationProvider.getApplicationContext();
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerTest.java
@@ -34,8 +34,10 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
+import com.google.firebase.crashlytics.internal.CrashlyticsWorker;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.NativeSessionFileProvider;
 import com.google.firebase.crashlytics.internal.analytics.AnalyticsEventLogger;
@@ -55,12 +57,14 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 public class CrashlyticsControllerTest extends CrashlyticsTestCase {
   private static final String GOOGLE_APP_ID = "google:app:id";
   private static final String SESSION_ID = "session_id";
+
+  private final CrashlyticsWorker commonWorker =
+      new CrashlyticsWorker(TestOnlyExecutors.background());
 
   private Context testContext;
   private IdManager idManager;
@@ -99,6 +103,12 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
     when(testSettingsProvider.getSettingsAsync()).thenReturn(Tasks.forResult(testSettings));
   }
 
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+    commonWorker.await();
+  }
+
   /** A convenience class for building CrashlyticsController instances for testing. */
   private class ControllerBuilder {
     private DataCollectionArbiter dataCollectionArbiter;
@@ -106,7 +116,6 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
     private AnalyticsEventLogger analyticsEventLogger;
     private SessionReportingCoordinator sessionReportingCoordinator;
 
-    private CrashlyticsBackgroundWorker backgroundWorker;
     private LogFileManager logFileManager = null;
 
     private UserMetadata userMetadata = null;
@@ -118,8 +127,6 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
       analyticsEventLogger = mock(AnalyticsEventLogger.class);
 
       sessionReportingCoordinator = mockSessionReportingCoordinator;
-
-      backgroundWorker = new CrashlyticsBackgroundWorker(new SameThreadExecutorService());
     }
 
     ControllerBuilder setDataCollectionArbiter(DataCollectionArbiter arbiter) {
@@ -168,7 +175,7 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
       final CrashlyticsController controller =
           new CrashlyticsController(
               testContext.getApplicationContext(),
-              backgroundWorker,
+              commonWorker,
               idManager,
               dataCollectionArbiter,
               testFileStore,
@@ -208,6 +215,8 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
     controller.writeNonFatalException(thread, nonFatal);
     controller.doCloseSessions(testSettingsProvider);
 
+    commonWorker.await();
+
     verify(mockSessionReportingCoordinator)
         .persistNonFatalEvent(eq(nonFatal), eq(thread), eq(sessionId), anyLong());
   }
@@ -228,9 +237,8 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
         .persistFatalEvent(eq(fatal), eq(thread), eq(sessionId), anyLong());
   }
 
-  @Test
   @SdkSuppress(minSdkVersion = 30) // ApplicationExitInfo
-  public void testOnDemandFatal_callLogFatalException() {
+  public void testOnDemandFatal_callLogFatalException() throws Exception {
     Thread thread = Thread.currentThread();
     Exception fatal = new RuntimeException("Fatal");
     Thread.UncaughtExceptionHandler exceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
@@ -245,6 +253,8 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
             .build();
     controller.enableExceptionHandling(SESSION_ID, exceptionHandler, testSettingsProvider);
     controller.logFatalException(thread, fatal);
+
+    commonWorker.await();
 
     verify(mockUserMetadata).setNewSession(not(eq(SESSION_ID)));
   }
@@ -323,7 +333,9 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
     final CrashlyticsController controller =
         builder().setNativeComponent(mockNativeComponent).setLogFileManager(logFileManager).build();
 
-    controller.finalizeSessions(testSettingsProvider);
+    commonWorker.submit(() -> controller.finalizeSessions(testSettingsProvider));
+    commonWorker.await();
+
     verify(mockSessionReportingCoordinator)
         .finalizeSessionWithNativeEvent(eq(previousSessionId), any(), any());
     verify(mockSessionReportingCoordinator, never())
@@ -331,9 +343,10 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
   }
 
   @SdkSuppress(minSdkVersion = 30) // ApplicationExitInfo
-  public void testMissingNativeComponentCausesNoReports() {
+  public void testMissingNativeComponentCausesNoReports() throws Exception {
     final CrashlyticsController controller = createController();
-    controller.finalizeSessions(testSettingsProvider);
+    commonWorker.submit(() -> controller.finalizeSessions(testSettingsProvider));
+    commonWorker.await();
 
     List<String> sessions = testFileStore.getAllOpenSessionIds();
     for (String sessionId : sessions) {
@@ -384,7 +397,8 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
         testSettingsProvider, Thread.currentThread(), new RuntimeException());
 
     // This should not throw.
-    controller.finalizeSessions(testSettingsProvider);
+    commonWorker.submit(() -> controller.finalizeSessions(testSettingsProvider));
+    commonWorker.await();
   }
 
   @SdkSuppress(minSdkVersion = 30) // ApplicationExitInfo
@@ -535,7 +549,7 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
   }
 
   @SdkSuppress(minSdkVersion = 30) // ApplicationExitInfo
-  public void testFatalEvent_sendsAppExceptionEvent() {
+  public void testFatalEvent_sendsAppExceptionEvent() throws Exception {
     final String sessionId = "sessionId";
     final LogFileManager logFileManager = new LogFileManager(testFileStore);
     final AnalyticsEventLogger mockFirebaseAnalyticsLogger = mock(AnalyticsEventLogger.class);
@@ -548,10 +562,14 @@ public class CrashlyticsControllerTest extends CrashlyticsTestCase {
     when(mockSessionReportingCoordinator.listSortedOpenSessionIds())
         .thenReturn(new TreeSet<>(Collections.singleton(sessionId)));
 
-    controller.openSession(SESSION_ID);
-    controller.handleUncaughtException(
-        testSettingsProvider, Thread.currentThread(), new RuntimeException("Fatal"));
-    controller.finalizeSessions(testSettingsProvider);
+    commonWorker.submit(
+        () -> {
+          controller.openSession(SESSION_ID);
+          controller.handleUncaughtException(
+              testSettingsProvider, Thread.currentThread(), new RuntimeException("Fatal"));
+          controller.finalizeSessions(testSettingsProvider);
+        });
+    commonWorker.await();
 
     assertFirebaseAnalyticsCrashEvent(mockFirebaseAnalyticsLogger);
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -28,10 +28,12 @@ import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.BuildConfig;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
+import com.google.firebase.crashlytics.internal.CrashlyticsWorker;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.RemoteConfigDeferredProxy;
 import com.google.firebase.crashlytics.internal.analytics.UnavailableAnalyticsEventLogger;
@@ -427,9 +429,10 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
               breadcrumbSource,
               new UnavailableAnalyticsEventLogger(),
               new FileStore(context),
-              new SameThreadExecutorService(),
               mock(CrashlyticsAppQualitySessionsSubscriber.class),
-              mock(RemoteConfigDeferredProxy.class));
+              mock(RemoteConfigDeferredProxy.class),
+              new CrashlyticsWorker(TestOnlyExecutors.background()),
+              new CrashlyticsWorker(TestOnlyExecutors.background()));
       return crashlyticsCore;
     }
   }

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
@@ -16,8 +16,9 @@ package com.google.firebase.crashlytics.internal.metadata;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
-import com.google.firebase.crashlytics.internal.common.CrashlyticsBackgroundWorker;
+import com.google.firebase.crashlytics.internal.CrashlyticsWorker;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
 import java.io.File;
 import java.io.IOException;
@@ -57,7 +58,7 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
   }
 
   private FileStore fileStore;
-  private final CrashlyticsBackgroundWorker worker = new CrashlyticsBackgroundWorker(Runnable::run);
+  private final CrashlyticsWorker worker = new CrashlyticsWorker(TestOnlyExecutors.background());
 
   private MetaDataStore storeUnderTest;
 
@@ -178,7 +179,7 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
   }
 
   @Test
-  public void testUpdateSessionId_persistCustomKeysToNewSessionIfCustomKeysSet() {
+  public void testUpdateSessionId_persistCustomKeysToNewSessionIfCustomKeysSet() throws Exception {
     UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, worker);
     final Map<String, String> keys =
         new HashMap<String, String>() {
@@ -194,6 +195,9 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
         .isTrue();
 
     MetaDataStore metaDataStore = new MetaDataStore(fileStore);
+
+    worker.await();
+
     assertThat(metaDataStore.readKeyData(SESSION_ID_2)).isEqualTo(keys);
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
@@ -104,9 +104,10 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
     assertNull(userData.getUserId());
   }
 
-  public void testWriteUserData_emptyString() {
+  public void testWriteUserData_emptyString() throws Exception {
     storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1, "").getUserId());
     UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+    worker.await();
     assertEquals("", userData.getUserId());
   }
 
@@ -117,10 +118,11 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
     assertEquals(UNICODE, userData.getUserId());
   }
 
-  public void testWriteUserData_escaped() {
+  public void testWriteUserData_escaped() throws Exception {
     storeUnderTest.writeUserData(
         SESSION_ID_1, metadataWithUserId(SESSION_ID_1, ESCAPED).getUserId());
     UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+    worker.await();
     assertEquals(ESCAPED.trim(), userData.getUserId());
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
@@ -58,8 +58,8 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
   }
 
   private FileStore fileStore;
-  private final CrashlyticsWorker worker = new CrashlyticsWorker(TestOnlyExecutors.background());
 
+  private CrashlyticsWorker diskWriteWorker;
   private MetaDataStore storeUnderTest;
 
   @Override
@@ -67,6 +67,12 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
     super.setUp();
     fileStore = new FileStore(getContext());
     storeUnderTest = new MetaDataStore(fileStore);
+    diskWriteWorker = new CrashlyticsWorker(TestOnlyExecutors.background());
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    fileStore.deleteAllCrashlyticsFiles();
   }
 
   private UserMetadata metadataWithUserId(String sessionId) {
@@ -74,113 +80,179 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
   }
 
   private UserMetadata metadataWithUserId(String sessionId, String userId) {
-    UserMetadata metadata = new UserMetadata(sessionId, fileStore, worker);
+    UserMetadata metadata = new UserMetadata(sessionId, fileStore, diskWriteWorker);
     metadata.setUserId(userId);
     return metadata;
   }
 
-  public void testWriteUserData_allFields() {
-    storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1).getUserId());
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+  @Test
+  public void testWriteUserData_allFields() throws Exception {
+    diskWriteWorker.submit(
+        () -> {
+          storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1).getUserId());
+        });
+    diskWriteWorker.await();
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertEquals(USER_ID, userData.getUserId());
   }
 
-  public void testWriteUserData_noFields() {
-    storeUnderTest.writeUserData(
-        SESSION_ID_1, new UserMetadata(SESSION_ID_1, fileStore, null).getUserId());
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+  @Test
+  public void testWriteUserData_noFields() throws Exception {
+    diskWriteWorker.submit(
+        () -> {
+          storeUnderTest.writeUserData(
+              SESSION_ID_1, new UserMetadata(SESSION_ID_1, fileStore, null).getUserId());
+        });
+    diskWriteWorker.await();
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertNull(userData.getUserId());
   }
 
-  public void testWriteUserData_singleField() {
-    storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1).getUserId());
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+  @Test
+  public void testWriteUserData_singleField() throws Exception {
+    diskWriteWorker.submit(
+        () -> {
+          storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1).getUserId());
+        });
+    diskWriteWorker.await();
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertEquals(USER_ID, userData.getUserId());
   }
 
-  public void testWriteUserData_null() {
-    storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1, null).getUserId());
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+  @Test
+  public void testWriteUserData_null() throws Exception {
+    diskWriteWorker.submit(
+        () -> {
+          storeUnderTest.writeUserData(
+              SESSION_ID_1, metadataWithUserId(SESSION_ID_1, null).getUserId());
+        });
+    diskWriteWorker.await();
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertNull(userData.getUserId());
   }
 
-  public void testWriteUserData_emptyString() {
-    storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1, "").getUserId());
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+  @Test
+  public void testWriteUserData_emptyString() throws Exception {
+    diskWriteWorker.submit(
+        () -> {
+          storeUnderTest.writeUserData(
+              SESSION_ID_1, metadataWithUserId(SESSION_ID_1, "").getUserId());
+        });
+    diskWriteWorker.await();
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertEquals("", userData.getUserId());
   }
 
-  public void testWriteUserData_unicode() {
+  @Test
+  public void testWriteUserData_unicode() throws Exception {
     storeUnderTest.writeUserData(
         SESSION_ID_1, metadataWithUserId(SESSION_ID_1, UNICODE).getUserId());
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+    diskWriteWorker.await();
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertEquals(UNICODE, userData.getUserId());
   }
 
-  public void testWriteUserData_escaped() {
-    storeUnderTest.writeUserData(
-        SESSION_ID_1, metadataWithUserId(SESSION_ID_1, ESCAPED).getUserId());
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+  @Test
+  public void testWriteUserData_escaped() throws Exception {
+    diskWriteWorker.submit(
+        () -> {
+          storeUnderTest.writeUserData(
+              SESSION_ID_1, metadataWithUserId(SESSION_ID_1, ESCAPED).getUserId());
+        });
+    diskWriteWorker.await();
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertEquals(ESCAPED.trim(), userData.getUserId());
   }
 
+  @Test
   public void testWriteUserData_readDifferentSession() {
     storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1).getUserId());
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_2, fileStore, worker);
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_2, fileStore, diskWriteWorker);
     assertNull(userData.getUserId());
   }
 
+  @Test
   public void testReadUserData_corruptData() throws IOException {
     File file = storeUnderTest.getUserDataFileForSession(SESSION_ID_1);
     try (PrintWriter printWriter = new PrintWriter(file)) {
       printWriter.println("Matt says hi!");
     }
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertNull(userData.getUserId());
     assertFalse(file.exists());
   }
 
+  @Test
   public void testReadUserData_emptyData() throws IOException {
     File file = storeUnderTest.getUserDataFileForSession(SESSION_ID_1);
     file.createNewFile();
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertNull(userData.getUserId());
     assertFalse(file.exists());
   }
 
+  @Test
   public void testReadUserData_noStoredData() {
-    UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
+    UserMetadata userData =
+        UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, diskWriteWorker);
     assertNull(userData.getUserId());
   }
 
   @Test
-  public void testUpdateSessionId_notPersistUserIdToNewSessionIfNoUserIdSet() {
-    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, worker);
+  public void testUpdateSessionId_notPersistUserIdToNewSessionIfNoUserIdSet() throws Exception {
+    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, diskWriteWorker);
     userMetadata.setNewSession(SESSION_ID_2);
-    assertThat(fileStore.getSessionFile(SESSION_ID_2, UserMetadata.USERDATA_FILENAME).exists())
-        .isFalse();
+    diskWriteWorker.submit(
+        () -> {
+          assertThat(
+                  fileStore.getSessionFile(SESSION_ID_2, UserMetadata.USERDATA_FILENAME).exists())
+              .isFalse();
+        });
+    diskWriteWorker.await();
   }
 
   @Test
-  public void testUpdateSessionId_notPersistCustomKeysToNewSessionIfNoCustomKeysSet() {
-    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, worker);
+  public void testUpdateSessionId_notPersistCustomKeysToNewSessionIfNoCustomKeysSet()
+      throws Exception {
+    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, diskWriteWorker);
     userMetadata.setNewSession(SESSION_ID_2);
-    assertThat(fileStore.getSessionFile(SESSION_ID_2, UserMetadata.KEYDATA_FILENAME).exists())
-        .isFalse();
+    diskWriteWorker.submit(
+        () -> {
+          assertThat(fileStore.getSessionFile(SESSION_ID_2, UserMetadata.KEYDATA_FILENAME).exists())
+              .isFalse();
+        });
+    diskWriteWorker.await();
   }
 
   @Test
-  public void testUpdateSessionId_notPersistRolloutsToNewSessionIfNoRolloutsSet() {
-    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, worker);
+  public void testUpdateSessionId_notPersistRolloutsToNewSessionIfNoRolloutsSet() throws Exception {
+    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, diskWriteWorker);
     userMetadata.setNewSession(SESSION_ID_2);
-    assertThat(
-            fileStore.getSessionFile(SESSION_ID_2, UserMetadata.ROLLOUTS_STATE_FILENAME).exists())
-        .isFalse();
+
+    diskWriteWorker.submit(
+        () -> {
+          assertThat(
+                  fileStore
+                      .getSessionFile(SESSION_ID_2, UserMetadata.ROLLOUTS_STATE_FILENAME)
+                      .exists())
+              .isFalse();
+        });
+    diskWriteWorker.await();
   }
 
   @Test
   public void testUpdateSessionId_persistCustomKeysToNewSessionIfCustomKeysSet() throws Exception {
-    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, worker);
+    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, diskWriteWorker);
     final Map<String, String> keys =
         new HashMap<String, String>() {
           {
@@ -191,37 +263,74 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
         };
     userMetadata.setCustomKeys(keys);
     userMetadata.setNewSession(SESSION_ID_2);
-    assertThat(fileStore.getSessionFile(SESSION_ID_2, UserMetadata.KEYDATA_FILENAME).exists())
-        .isTrue();
+    diskWriteWorker.submit(
+        () -> {
+          assertThat(fileStore.getSessionFile(SESSION_ID_2, UserMetadata.KEYDATA_FILENAME).exists())
+              .isTrue();
+        });
+    diskWriteWorker.await();
 
     MetaDataStore metaDataStore = new MetaDataStore(fileStore);
-
-    worker.await();
-
     assertThat(metaDataStore.readKeyData(SESSION_ID_2)).isEqualTo(keys);
   }
 
   @Test
-  public void testUpdateSessionId_persistUserIdToNewSessionIfUserIdSet() {
+  public void testSetSameKeysRaceCondition_preserveLastEntryValue() throws Exception {
+    final Map<String, String> keys =
+        new HashMap<String, String>() {
+          {
+            put(KEY_1, "10000");
+            put(KEY_2, "20000");
+          }
+        };
+    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, diskWriteWorker);
+    for (int index = 0; index <= 10000; index++) {
+      userMetadata.setCustomKey(KEY_1, String.valueOf(index));
+      userMetadata.setCustomKey(KEY_2, String.valueOf(index * 2));
+    }
+    diskWriteWorker.submit(
+        () -> {
+          final Map<String, String> readKeys = storeUnderTest.readKeyData(SESSION_ID_1);
+          assertThat(readKeys.get(KEY_1)).isEqualTo("10000");
+          assertThat(readKeys.get(KEY_2)).isEqualTo("20000");
+          assertEqualMaps(keys, readKeys);
+        });
+    diskWriteWorker.await();
+  }
+
+  @Test
+  public void testUpdateSessionId_persistUserIdToNewSessionIfUserIdSet() throws Exception {
     String userId = "ThemisWang";
-    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, worker);
+    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, diskWriteWorker);
     userMetadata.setUserId(userId);
     userMetadata.setNewSession(SESSION_ID_2);
-    assertThat(fileStore.getSessionFile(SESSION_ID_2, UserMetadata.USERDATA_FILENAME).exists())
-        .isTrue();
+
+    diskWriteWorker.submit(
+        () -> {
+          assertThat(
+                  fileStore.getSessionFile(SESSION_ID_2, UserMetadata.USERDATA_FILENAME).exists())
+              .isTrue();
+        });
+    diskWriteWorker.await();
 
     MetaDataStore metaDataStore = new MetaDataStore(fileStore);
     assertThat(metaDataStore.readUserId(SESSION_ID_2)).isEqualTo(userId);
   }
 
   @Test
-  public void testUpdateSessionId_persistRolloutsToNewSessionIfRolloutsSet() {
-    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, worker);
+  public void testUpdateSessionId_persistRolloutsToNewSessionIfRolloutsSet() throws Exception {
+    UserMetadata userMetadata = new UserMetadata(SESSION_ID_1, fileStore, diskWriteWorker);
     userMetadata.updateRolloutsState(ROLLOUTS_STATE);
     userMetadata.setNewSession(SESSION_ID_2);
-    assertThat(
-            fileStore.getSessionFile(SESSION_ID_2, UserMetadata.ROLLOUTS_STATE_FILENAME).exists())
-        .isTrue();
+    diskWriteWorker.submit(
+        () -> {
+          assertThat(
+                  fileStore
+                      .getSessionFile(SESSION_ID_2, UserMetadata.ROLLOUTS_STATE_FILENAME)
+                      .exists())
+              .isTrue();
+        });
+    diskWriteWorker.await();
 
     MetaDataStore metaDataStore = new MetaDataStore(fileStore);
     assertThat(metaDataStore.readRolloutsState(SESSION_ID_2)).isEqualTo(ROLLOUTS_STATE);

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/metadata/MetaDataStoreTest.java
@@ -104,10 +104,9 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
     assertNull(userData.getUserId());
   }
 
-  public void testWriteUserData_emptyString() throws Exception {
+  public void testWriteUserData_emptyString() {
     storeUnderTest.writeUserData(SESSION_ID_1, metadataWithUserId(SESSION_ID_1, "").getUserId());
     UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
-    worker.await();
     assertEquals("", userData.getUserId());
   }
 
@@ -118,11 +117,10 @@ public class MetaDataStoreTest extends CrashlyticsTestCase {
     assertEquals(UNICODE, userData.getUserId());
   }
 
-  public void testWriteUserData_escaped() throws Exception {
+  public void testWriteUserData_escaped() {
     storeUnderTest.writeUserData(
         SESSION_ID_1, metadataWithUserId(SESSION_ID_1, ESCAPED).getUserId());
     UserMetadata userData = UserMetadata.loadFromExistingSession(SESSION_ID_1, fileStore, worker);
-    worker.await();
     assertEquals(ESCAPED.trim(), userData.getUserId());
   }
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsControllerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsControllerTest.java
@@ -25,14 +25,16 @@ import static org.mockito.Mockito.when;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
+import com.google.firebase.crashlytics.internal.CrashlyticsWorker;
 import com.google.firebase.crashlytics.internal.common.CurrentTimeProvider;
 import com.google.firebase.crashlytics.internal.common.DataCollectionArbiter;
 import com.google.firebase.crashlytics.internal.common.DeliveryMechanism;
-import com.google.firebase.crashlytics.internal.common.ExecutorUtils;
 import com.google.firebase.crashlytics.internal.common.InstallIdProvider;
 import com.google.firebase.crashlytics.internal.common.InstallIdProvider.InstallIds;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONObject;
 
@@ -57,7 +59,9 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
   private SettingsSpiCall mockSettingsSpiCall;
   private DataCollectionArbiter mockDataCollectionArbiter;
 
-  private Executor networkExecutor = ExecutorUtils.buildSingleThreadExecutorService("network");
+  private final CrashlyticsWorker commonWorker =
+      new CrashlyticsWorker(TestOnlyExecutors.background());
+  private final ExecutorService networkExecutor = TestOnlyExecutors.blocking();
 
   public DefaultSettingsControllerTest() {}
 
@@ -121,7 +125,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
             mockDataCollectionArbiter,
             false);
 
-    await(controller.loadSettingsData(networkExecutor));
+    await(controller.loadSettingsData(commonWorker, networkExecutor));
     assertEquals(cachedSettings, controller.getSettingsSync());
 
     verifyNoMoreInteractions(mockSettingsSpiCall);
@@ -153,7 +157,8 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
             mockDataCollectionArbiter,
             true);
 
-    controller.loadSettingsData(SettingsCacheBehavior.SKIP_CACHE_LOOKUP, networkExecutor);
+    controller.loadSettingsData(
+        SettingsCacheBehavior.SKIP_CACHE_LOOKUP, commonWorker, networkExecutor);
     assertNotNull(controller.getSettingsSync());
 
     dataCollectionPermission.trySetResult(null);
@@ -177,8 +182,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
     JSONObject cachedJson = new JSONObject();
     when(mockCachedSettingsIo.readCachedSettings()).thenReturn(cachedJson);
 
-    when(mockCurrentTimeProvider.getCurrentTimeMillis())
-        .thenReturn(Long.valueOf(EXPIRED_CURRENT_TIME_MILLIS));
+    when(mockCurrentTimeProvider.getCurrentTimeMillis()).thenReturn(EXPIRED_CURRENT_TIME_MILLIS);
 
     when(mockSettingsJsonParser.parseSettingsJson(cachedJson)).thenReturn(cachedSettings);
     when(mockSettingsJsonParser.parseSettingsJson(fetchedJson)).thenReturn(fetchedSettings);
@@ -198,7 +202,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
             mockDataCollectionArbiter,
             false);
 
-    Task<Void> loadFinished = controller.loadSettingsData(networkExecutor);
+    Task<Void> loadFinished = controller.loadSettingsData(commonWorker, networkExecutor);
 
     assertEquals(cachedSettings, controller.getSettingsSync());
     assertEquals(cachedSettings, await(controller.getSettingsAsync()));
@@ -220,8 +224,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
     JSONObject cachedJson = new JSONObject();
     when(mockCachedSettingsIo.readCachedSettings()).thenReturn(cachedJson);
 
-    when(mockCurrentTimeProvider.getCurrentTimeMillis())
-        .thenReturn(Long.valueOf(EXPIRED_CURRENT_TIME_MILLIS));
+    when(mockCurrentTimeProvider.getCurrentTimeMillis()).thenReturn(EXPIRED_CURRENT_TIME_MILLIS);
 
     Settings cachedSettings = new TestSettings();
     when(mockSettingsJsonParser.parseSettingsJson(cachedJson)).thenReturn(cachedSettings);
@@ -236,7 +239,8 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
             mockSettingsSpiCall,
             mockDataCollectionArbiter,
             false);
-    controller.loadSettingsData(SettingsCacheBehavior.IGNORE_CACHE_EXPIRATION, networkExecutor);
+    controller.loadSettingsData(
+        SettingsCacheBehavior.IGNORE_CACHE_EXPIRATION, commonWorker, networkExecutor);
     assertEquals(cachedSettings, controller.getSettingsSync());
 
     verifyNoMoreInteractions(mockSettingsSpiCall);
@@ -256,8 +260,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
     JSONObject expiredCachedSettingsJson = new JSONObject();
     when(mockCachedSettingsIo.readCachedSettings()).thenReturn(expiredCachedSettingsJson);
 
-    when(mockCurrentTimeProvider.getCurrentTimeMillis())
-        .thenReturn(Long.valueOf(EXPIRED_CURRENT_TIME_MILLIS));
+    when(mockCurrentTimeProvider.getCurrentTimeMillis()).thenReturn(EXPIRED_CURRENT_TIME_MILLIS);
 
     Settings expiredCachedSettings = new TestSettings();
     when(mockSettingsJsonParser.parseSettingsJson(expiredCachedSettingsJson))
@@ -279,7 +282,8 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
             false);
 
     Task<Void> loadFinished =
-        controller.loadSettingsData(SettingsCacheBehavior.SKIP_CACHE_LOOKUP, networkExecutor);
+        controller.loadSettingsData(
+            SettingsCacheBehavior.SKIP_CACHE_LOOKUP, commonWorker, networkExecutor);
     assertEquals(expiredCachedSettings, controller.getSettingsSync());
 
     dataCollectionPermission.trySetResult(null);
@@ -330,7 +334,8 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
             false);
 
     Task<Void> loadFinished =
-        controller.loadSettingsData(SettingsCacheBehavior.SKIP_CACHE_LOOKUP, networkExecutor);
+        controller.loadSettingsData(
+            SettingsCacheBehavior.SKIP_CACHE_LOOKUP, commonWorker, networkExecutor);
     assertEquals(expiredCachedSettings, controller.getSettingsSync());
 
     dataCollectionPermission.trySetResult(null);
@@ -364,7 +369,7 @@ public class DefaultSettingsControllerTest extends CrashlyticsTestCase {
             mockDataCollectionArbiter,
             false);
 
-    Task<Void> loadFinished = controller.loadSettingsData(networkExecutor);
+    Task<Void> loadFinished = controller.loadSettingsData(commonWorker, networkExecutor);
     assertNotNull(controller.getSettingsSync());
     assertFalse(controller.getSettingsAsync().isComplete());
 

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsSpiCallTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsSpiCallTest.java
@@ -16,6 +16,7 @@ package com.google.firebase.crashlytics.internal.settings;
 
 import static org.mockito.Mockito.*;
 
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.internal.CrashlyticsTestCase;
 import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 public class DefaultSettingsSpiCallTest extends CrashlyticsTestCase {
 
@@ -83,7 +85,8 @@ public class DefaultSettingsSpiCallTest extends CrashlyticsTestCase {
               }
             });
 
-    assertNotNull(call.invoke(requestData, true));
+    Future<?> future = TestOnlyExecutors.blocking().submit(() -> call.invoke(requestData, true));
+    assertNotNull(future.get());
 
     assertEquals(url, request.getUrl());
 
@@ -128,7 +131,8 @@ public class DefaultSettingsSpiCallTest extends CrashlyticsTestCase {
               }
             });
 
-    assertNotNull(call.invoke(requestData, true));
+    Future<?> future = TestOnlyExecutors.blocking().submit(() -> call.invoke(requestData, true));
+    assertNotNull(future.get());
 
     assertEquals(url, request.getUrl());
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsPreconditions.kt
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsPreconditions.kt
@@ -60,10 +60,7 @@ internal object CrashlyticsPreconditions {
 
   private fun isBlockingThread() = threadName.contains("Firebase Blocking Thread #")
 
-  // TODO(mrober): Remove the Crashlytics thread when fully migrated to Firebase common threads.
-  private fun isBackgroundThread() =
-    threadName.contains("Firebase Background Thread #") ||
-      threadName.contains("Crashlytics Exception Handler")
+  private fun isBackgroundThread() = threadName.contains("Firebase Background Thread #")
 
   private fun checkThread(isCorrectThread: () -> Boolean, failureMessage: () -> String) {
     if (strictLevel.level >= WARN.level && !isCorrectThread()) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsWorker.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsWorker.java
@@ -22,6 +22,8 @@ import com.google.android.gms.tasks.Tasks;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Helper for executing tasks sequentially on the given executor service.
@@ -116,13 +118,13 @@ public class CrashlyticsWorker {
   }
 
   /**
-   * Blocks until all current pending tasks have completed.
+   * Blocks until all current pending tasks have completed, up to 30 seconds. Useful for testing.
    *
    * <p>This is not a shutdown, this does not stop new tasks from being submitted to the queue.
    */
   @VisibleForTesting
-  public void await() throws ExecutionException, InterruptedException {
-    // Submit an empty runnable, and await on it.
-    Tasks.await(submit(() -> {}));
+  public void await() throws ExecutionException, InterruptedException, TimeoutException {
+    // Submit an empty runnable, and await on it for 30 sec so deadlocked tests fail faster.
+    Tasks.await(submit(() -> {}), 30, TimeUnit.SECONDS);
   }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CommonUtils.java
@@ -114,7 +114,9 @@ public class CommonUtils {
       matcher.put("x86", X86_32);
     }
 
-    /** @Return {@link CommonUtils.Architecture} enum based on @param String */
+    /**
+     * @Return {@link CommonUtils.Architecture} enum based on @param String
+     */
     static Architecture getValue() {
       String arch = Build.CPU_ABI;
 
@@ -248,7 +250,9 @@ public class CommonUtils {
     }
   }
 
-  /** @deprecated This method will now always return false. It should not be used. */
+  /**
+   * @deprecated This method will now always return false. It should not be used.
+   */
   @Deprecated
   public static boolean isLoggingEnabled(Context context) {
     return false;
@@ -532,7 +536,9 @@ public class CommonUtils {
     }
   }
 
-  /** @return if the given permission is granted */
+  /**
+   * @return if the given permission is granted
+   */
   public static boolean checkPermission(Context context, String permission) {
     final int res = context.checkCallingOrSelfPermission(permission);
     return (res == PackageManager.PERMISSION_GRANTED);
@@ -556,7 +562,9 @@ public class CommonUtils {
     }
   }
 
-  /** @return true if s1.equals(s2), or if both are null. */
+  /**
+   * @return true if s1.equals(s2), or if both are null.
+   */
   public static boolean nullSafeEquals(@Nullable String s1, @Nullable String s2) {
     // :TODO: replace calls to this method with Objects.equals(...) when minSdkVersion is 19+
     if (s1 == null) {

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/Utils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/Utils.java
@@ -20,7 +20,6 @@ import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/Utils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/Utils.java
@@ -77,31 +77,6 @@ public final class Utils {
     return result.getTask();
   }
 
-  /** Similar to Tasks.call, but takes a Callable that returns a Task. */
-  public static <T> Task<T> callTask(Executor executor, Callable<Task<T>> callable) {
-    final TaskCompletionSource<T> result = new TaskCompletionSource<>();
-    executor.execute(
-        () -> {
-          try {
-            callable
-                .call()
-                .continueWith(
-                    executor,
-                    task -> {
-                      if (task.isSuccessful()) {
-                        result.setResult(task.getResult());
-                      } else if (task.getException() != null) {
-                        result.setException(task.getException());
-                      }
-                      return null;
-                    });
-          } catch (Exception e) {
-            result.setException(e);
-          }
-        });
-    return result.getTask();
-  }
-
   /**
    * Blocks until the given Task completes, and then returns the value the Task was resolved with,
    * if successful. If the Task fails, an exception will be thrown, wrapping the Exception of the

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/metadata/UserMetadata.java
@@ -17,8 +17,8 @@ package com.google.firebase.crashlytics.internal.metadata;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.firebase.crashlytics.internal.CrashlyticsWorker;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
-import com.google.firebase.crashlytics.internal.common.CrashlyticsBackgroundWorker;
 import com.google.firebase.crashlytics.internal.model.CrashlyticsReport;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
 import java.util.List;
@@ -47,7 +47,7 @@ public class UserMetadata {
   @VisibleForTesting public static final int MAX_ROLLOUT_ASSIGNMENTS = 128;
 
   private final MetaDataStore metaDataStore;
-  private final CrashlyticsBackgroundWorker backgroundWorker;
+  private final CrashlyticsWorker backgroundWorker;
   private String sessionIdentifier;
 
   // The following references contain a marker bit, which is true if the data maintained in the
@@ -69,9 +69,9 @@ public class UserMetadata {
   }
 
   public static UserMetadata loadFromExistingSession(
-      String sessionId, FileStore fileStore, CrashlyticsBackgroundWorker backgroundWorker) {
+      String sessionId, FileStore fileStore, CrashlyticsWorker commonWorker) {
     MetaDataStore store = new MetaDataStore(fileStore);
-    UserMetadata metadata = new UserMetadata(sessionId, fileStore, backgroundWorker);
+    UserMetadata metadata = new UserMetadata(sessionId, fileStore, commonWorker);
     // We don't use the set methods in this class, because they will attempt to re-serialize the
     // data, which is unnecessary because we just read them from disk.
     metadata.customKeys.map.getReference().setKeys(store.readKeyData(sessionId, false));
@@ -82,10 +82,10 @@ public class UserMetadata {
   }
 
   public UserMetadata(
-      String sessionIdentifier, FileStore fileStore, CrashlyticsBackgroundWorker backgroundWorker) {
+      String sessionIdentifier, FileStore fileStore, CrashlyticsWorker commonWorker) {
     this.sessionIdentifier = sessionIdentifier;
     this.metaDataStore = new MetaDataStore(fileStore);
-    this.backgroundWorker = backgroundWorker;
+    this.backgroundWorker = commonWorker;
   }
 
   /**

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/network/HttpGetRequest.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/network/HttpGetRequest.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.crashlytics.internal.network;
 
+import com.google.firebase.crashlytics.internal.CrashlyticsPreconditions;
 import com.google.firebase.crashlytics.internal.Logger;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -56,6 +57,7 @@ public class HttpGetRequest {
   }
 
   public HttpResponse execute() throws IOException {
+    CrashlyticsPreconditions.checkBlockingThread(); // Network calls must be on a blocking thread.
     InputStream stream = null;
     HttpsURLConnection connection = null;
     String body = null;

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsSpiCall.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/DefaultSettingsSpiCall.java
@@ -15,6 +15,7 @@
 package com.google.firebase.crashlytics.internal.settings;
 
 import android.text.TextUtils;
+import com.google.firebase.crashlytics.internal.CrashlyticsPreconditions;
 import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.common.CrashlyticsCore;
 import com.google.firebase.crashlytics.internal.network.HttpGetRequest;
@@ -96,6 +97,7 @@ class DefaultSettingsSpiCall implements SettingsSpiCall {
 
   @Override
   public JSONObject invoke(SettingsRequest requestData, boolean dataCollectionToken) {
+    CrashlyticsPreconditions.checkBlockingThread();
     if (!dataCollectionToken) {
       throw new RuntimeException("An invalid data collection token was used.");
     }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/settings/SettingsController.java
@@ -23,6 +23,7 @@ import com.google.android.gms.tasks.SuccessContinuation;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.crashlytics.internal.CrashlyticsWorker;
 import com.google.firebase.crashlytics.internal.Logger;
 import com.google.firebase.crashlytics.internal.common.CommonUtils;
 import com.google.firebase.crashlytics.internal.common.CurrentTimeProvider;
@@ -33,7 +34,8 @@ import com.google.firebase.crashlytics.internal.common.SystemCurrentTimeProvider
 import com.google.firebase.crashlytics.internal.network.HttpRequestFactory;
 import com.google.firebase.crashlytics.internal.persistence.FileStore;
 import java.util.Locale;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -149,8 +151,9 @@ public class SettingsController implements SettingsProvider {
    *
    * @return a task that is resolved when loading is completely finished.
    */
-  public Task<Void> loadSettingsData(Executor executor) {
-    return loadSettingsData(SettingsCacheBehavior.USE_CACHE, executor);
+  public Task<Void> loadSettingsData(
+      CrashlyticsWorker commonWorker, ExecutorService networkExecutor) {
+    return loadSettingsData(SettingsCacheBehavior.USE_CACHE, commonWorker, networkExecutor);
   }
 
   /**
@@ -158,7 +161,10 @@ public class SettingsController implements SettingsProvider {
    *
    * @return a task that is resolved when loading is completely finished.
    */
-  public Task<Void> loadSettingsData(SettingsCacheBehavior cacheBehavior, Executor executor) {
+  public Task<Void> loadSettingsData(
+      SettingsCacheBehavior cacheBehavior,
+      CrashlyticsWorker commonWorker,
+      ExecutorService networkExecutor) {
     // TODO: Refactor this so that it doesn't do the cache lookup twice when settings are
     // expired.
 
@@ -186,18 +192,22 @@ public class SettingsController implements SettingsProvider {
     }
 
     // Kick off fetching fresh settings.
+    // TODO(mrober): Refactor to call worker directly, not expose executor.
     return dataCollectionArbiter
-        .waitForDataCollectionPermission(executor)
+        .waitForDataCollectionPermission(commonWorker.getExecutor())
         .onSuccessTask(
-            executor,
+            commonWorker.getExecutor(),
             new SuccessContinuation<Void, Void>() {
               @NonNull
               @Override
               public Task<Void> then(@Nullable Void aVoid) throws Exception {
                 // Waited for data collection permission, so this is safe.
                 final boolean dataCollectionToken = true;
-                final JSONObject settingsJson =
-                    settingsSpiCall.invoke(settingsRequest, dataCollectionToken);
+                Future<JSONObject> settingsFuture =
+                    networkExecutor.submit(
+                        () -> settingsSpiCall.invoke(settingsRequest, dataCollectionToken));
+                // TODO(mrober): Should we add a timeout here, or let the entire init timeout?
+                JSONObject settingsJson = settingsFuture.get();
 
                 if (settingsJson != null) {
                   final Settings fetchedSettings =

--- a/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
+++ b/firebase-crashlytics/src/test/java/com/google/firebase/crashlytics/internal/common/CrashlyticsControllerRobolectricTest.java
@@ -28,8 +28,10 @@ import android.app.ApplicationExitInfo;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
+import com.google.firebase.concurrent.TestOnlyExecutors;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponent;
 import com.google.firebase.crashlytics.internal.CrashlyticsNativeComponentDeferredProxy;
+import com.google.firebase.crashlytics.internal.CrashlyticsWorker;
 import com.google.firebase.crashlytics.internal.DevelopmentPlatformProvider;
 import com.google.firebase.crashlytics.internal.analytics.AnalyticsEventLogger;
 import com.google.firebase.crashlytics.internal.metadata.LogFileManager;
@@ -164,7 +166,7 @@ public class CrashlyticsControllerRobolectricTest {
     final CrashlyticsController controller =
         new CrashlyticsController(
             testContext,
-            new CrashlyticsBackgroundWorker(Runnable::run),
+            new CrashlyticsWorker(TestOnlyExecutors.background()),
             idManager,
             mockDataCollectionArbiter,
             testFileStore,


### PR DESCRIPTION
Migrate to Firebase common executors. Use the new `CrashlyticsWorker` for common and disk write workers.