### PR TITLE
Fix flaky test

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsWorkerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsWorkerTest.java
@@ -385,7 +385,7 @@ public class CrashlyticsWorkerTest {
     Task<Integer> otherTask =
         crashlyticsWorker.submit(
             () -> {
-              sleep(30);
+              sleep(300);
               return localExecutor.getActiveCount();
             });
 
@@ -394,6 +394,8 @@ public class CrashlyticsWorkerTest {
 
     // 1 active thread when doing a local task.
     assertThat(Tasks.await(localWorker.submit(localExecutor::getActiveCount))).isEqualTo(1);
+
+    sleep(1); // The test is a bit flaky without this.
 
     // 0 active local threads when waiting for other task.
     // Waiting for a task from another worker does not block a local thread.


### PR DESCRIPTION
Fix flaky `submitTaskFromAnotherWorkerDoesNotUseLocalThreads` test. This test would fail about 2% of the time on my machine due to dealing with threads. With this change, it fails less than 0.5% of the time. Tested by running the test in a loop 1,000 times.