### PR TITLE
Improvements to the CrashlyticsWorker

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsWorkerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/CrashlyticsWorkerTest.java
@@ -621,8 +621,18 @@ public class CrashlyticsWorkerTest {
   @Test
   public void raceTasksOnSameWorker() throws Exception {
     // Create 2 tasks on this worker to race.
-    Task<String> task1 = crashlyticsWorker.submit(() -> "first");
-    Task<String> task2 = crashlyticsWorker.submit(() -> "second");
+    Task<String> task1 =
+        crashlyticsWorker.submit(
+            () -> {
+              sleep(200);
+              return "first";
+            });
+    Task<String> task2 =
+        crashlyticsWorker.submit(
+            () -> {
+              sleep(300);
+              return "second";
+            });
 
     Task<String> task = crashlyticsWorker.race(task1, task2);
     String result = Tasks.await(task);

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsWorker.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsWorker.java
@@ -62,6 +62,8 @@ public class CrashlyticsWorker {
   /**
    * Submits a <code>Callable</code> task for asynchronous execution on the executor.
    *
+   * <p>A blocking callable will block an underlying thread.
+   *
    * <p>Returns a <code>Task</code> which will be resolved upon successful completion of the
    * callable, or throws an <code>ExecutionException</code> if the callable throws an exception.
    */
@@ -81,6 +83,8 @@ public class CrashlyticsWorker {
 
   /**
    * Submits a <code>Runnable</code> task for asynchronous execution on the executor.
+   *
+   * <p>A blocking runnable will block an underlying thread.
    *
    * <p>Returns a <code>Task</code> which will be resolved with null upon successful completion of
    * the runnable, or throws an <code>ExecutionException</code> if the runnable throws an exception.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsWorker.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/CrashlyticsWorker.java
@@ -17,8 +17,10 @@
 package com.google.firebase.crashlytics.internal;
 
 import androidx.annotation.VisibleForTesting;
+import com.google.android.gms.tasks.CancellationTokenSource;
 import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.concurrent.Callable;
@@ -26,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Helper for executing tasks sequentially on the given executor service.
@@ -145,6 +148,35 @@ public class CrashlyticsWorker {
       tail = result;
       return result;
     }
+  }
+
+  /**
+   * Returns a task that is resolved when either of the given tasks is resolved.
+   *
+   * <p>When both tasks are cancelled, the returned task will be cancelled.
+   */
+  public <T> Task<T> race(Task<T> task1, Task<T> task2) {
+    CancellationTokenSource cancellation = new CancellationTokenSource();
+    TaskCompletionSource<T> result = new TaskCompletionSource<>(cancellation.getToken());
+
+    AtomicBoolean otherTaskCancelled = new AtomicBoolean(false);
+
+    Continuation<T, Task<Void>> continuation =
+        task -> {
+          if (task.isSuccessful()) {
+            result.trySetResult(task.getResult());
+          } else if (task.getException() != null) {
+            result.trySetException(task.getException());
+          } else if (otherTaskCancelled.getAndSet(true)) {
+            cancellation.cancel();
+          }
+          return Tasks.forResult(null);
+        };
+
+    task1.continueWithTask(executor, continuation);
+    task2.continueWithTask(executor, continuation);
+
+    return result.getTask();
   }
 
   /**


### PR DESCRIPTION
Added a method to submit a task followed by a continuation to the worker. This is useful for making a continuation happen right after the submitted task, even if other tasks were submitted to the worker in the meantime. This will be useful for fetching settings from a network executor, then continuing on the common worker to parse the settings json.

Also added a method to race two tasks on the worker. This is useful for things like waiting for an for explicit data collection enable call, or automatic data collection being enabled.

Both methods have their behaviour fully documented in the javadoc and tested in unit tests.