### PR TITLE
Create a util for Crashlytics tasks, and move race into it

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/concurrency/ConcurrencyTesting.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/concurrency/ConcurrencyTesting.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.crashlytics.internal.concurrency;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/** Convenience methods for use in Crashlytics concurrency tests. */
+class ConcurrencyTesting {
+
+  /** Returns the current thread's name. */
+  static String getThreadName() {
+    return Thread.currentThread().getName();
+  }
+
+  /** Creates a simple executor that runs on a single named thread. */
+  static ExecutorService newNamedSingleThreadExecutor(String name) {
+    return Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, name));
+  }
+
+  /** Convenient sleep method that propagates the interruption, but does not throw. */
+  static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /** Helps to de-flake a test. */
+  static void deflake() {
+    // An easy, but ugly, way to fix a flaky test.
+    sleep(1);
+  }
+
+  private ConcurrencyTesting() {}
+}

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/concurrency/CrashlyticsTasksTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/concurrency/CrashlyticsTasksTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.crashlytics.internal.concurrency;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.crashlytics.internal.concurrency.ConcurrencyTesting.sleep;
+import static org.junit.Assert.assertThrows;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.concurrent.TestOnlyExecutors;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+public class CrashlyticsTasksTest {
+
+  @Test
+  public void raceReturnsFirstResult() throws Exception {
+    // Create 2 tasks on different workers to race.
+    Task<String> task1 =
+        new CrashlyticsWorker(TestOnlyExecutors.background())
+            .submit(
+                () -> {
+                  sleep(200);
+                  return "first";
+                });
+    Task<String> task2 =
+        new CrashlyticsWorker(TestOnlyExecutors.background())
+            .submit(
+                () -> {
+                  sleep(400);
+                  return "slow";
+                });
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2);
+    String result = Tasks.await(task);
+
+    assertThat(result).isEqualTo("first");
+  }
+
+  @Test
+  public void raceReturnsFirstException() {
+    // Create 2 tasks on different workers to race.
+    Task<String> task1 =
+        new CrashlyticsWorker(TestOnlyExecutors.background())
+            .submitTask(
+                () -> {
+                  sleep(200);
+                  return Tasks.forException(new ArithmeticException());
+                });
+    Task<String> task2 =
+        new CrashlyticsWorker(TestOnlyExecutors.background())
+            .submitTask(
+                () -> {
+                  sleep(400);
+                  return Tasks.forException(new IllegalStateException());
+                });
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2);
+    ExecutionException thrown = assertThrows(ExecutionException.class, () -> Tasks.await(task));
+
+    // The first task throws an ArithmeticException.
+    assertThat(thrown).hasCauseThat().isInstanceOf(ArithmeticException.class);
+  }
+
+  @Test
+  public void raceFirstCancelsReturnsSecondResult() throws Exception {
+    // Create 2 tasks on different workers to race.
+    Task<String> task1 =
+        new CrashlyticsWorker(TestOnlyExecutors.background())
+            .submitTask(
+                () -> {
+                  sleep(200);
+                  return Tasks.forCanceled();
+                });
+    Task<String> task2 =
+        new CrashlyticsWorker(TestOnlyExecutors.background())
+            .submitTask(
+                () -> {
+                  sleep(400);
+                  return Tasks.forResult("I am slow but didn't cancel.");
+                });
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2);
+    String result = Tasks.await(task);
+
+    assertThat(result).isEqualTo("I am slow but didn't cancel.");
+  }
+
+  @Test
+  public void raceBothCancel() {
+    // Create 2 tasks on different workers to race.
+    Task<String> task1 =
+        new CrashlyticsWorker(TestOnlyExecutors.background())
+            .submitTask(
+                () -> {
+                  sleep(200);
+                  return Tasks.forCanceled();
+                });
+    Task<String> task2 =
+        new CrashlyticsWorker(TestOnlyExecutors.background())
+            .submitTask(
+                () -> {
+                  sleep(400);
+                  return Tasks.forCanceled();
+                });
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2);
+
+    // Both cancelled, so cancel the race result.
+    assertThrows(CancellationException.class, () -> Tasks.await(task));
+  }
+
+  @Test
+  public void raceTasksOnSameWorker() throws Exception {
+    CrashlyticsWorker worker = new CrashlyticsWorker(TestOnlyExecutors.background());
+
+    // Create 2 tasks on the same worker to race.
+    Task<String> task1 =
+        worker.submit(
+            () -> {
+              sleep(20);
+              return "first";
+            });
+    Task<String> task2 =
+        worker.submit(
+            () -> {
+              sleep(30);
+              return "second";
+            });
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2);
+    String result = Tasks.await(task);
+
+    assertThat(result).isEqualTo("first");
+  }
+
+  @Test
+  public void raceTasksOnSameSingleThreadWorker() throws Exception {
+    CrashlyticsWorker worker = new CrashlyticsWorker(Executors.newSingleThreadExecutor());
+
+    // Create 2 tasks on the same worker to race.
+    Task<String> task1 = worker.submit(() -> "first");
+    Task<String> task2 = worker.submit(() -> "second");
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2);
+    String result = Tasks.await(task);
+
+    // The first task is submitted to this single thread worker first, so will always be first.
+    assertThat(result).isEqualTo("first");
+  }
+
+  @Test
+  public void raceTaskOneOnWorkerAnotherNeverCompletes() throws Exception {
+    // Create a task on a worker, and another that never completes, to race.
+    Task<String> task1 =
+        new CrashlyticsWorker(TestOnlyExecutors.background()).submit(() -> "first");
+    Task<String> task2 = new TaskCompletionSource<String>().getTask();
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2);
+    String result = Tasks.await(task);
+
+    assertThat(result).isEqualTo("first");
+  }
+
+  @Test
+  public void raceTaskOneOnWorkerAnotherOtherThatCompletesFirst() throws Exception {
+    CrashlyticsWorker worker = new CrashlyticsWorker(TestOnlyExecutors.background());
+
+    // Add a decoy task to the worker to take up some time.
+    worker.submitTask(
+        () -> {
+          sleep(200);
+          return Tasks.forResult(null);
+        });
+
+    // Create a task on this worker, and another, to race.
+    Task<String> task1 = worker.submit(() -> "worker");
+    TaskCompletionSource<String> task2 = new TaskCompletionSource<>();
+    task2.trySetResult("other");
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2.getTask());
+    String result = Tasks.await(task);
+
+    // The other tasks completes first because the first task is queued up later on the worker.
+    assertThat(result).isEqualTo("other");
+  }
+
+  @Test
+  public void raceNoExecutor() throws Exception {
+    // Create tasks with no explicit executor.
+    TaskCompletionSource<String> task1 = new TaskCompletionSource<>();
+    TaskCompletionSource<String> task2 = new TaskCompletionSource<>();
+
+    Task<String> task = CrashlyticsTasks.race(task1.getTask(), task2.getTask());
+
+    // Set a task result from another thread.
+    new Thread(
+            () -> {
+              sleep(300);
+              task1.trySetResult("yes");
+            })
+        .start();
+
+    String result = Tasks.await(task);
+
+    assertThat(result).isEqualTo("yes");
+  }
+
+  @Test
+  public void raceTasksThatNeverResolve() {
+    // Create tasks that will never resolve.
+    Task<String> task1 = new TaskCompletionSource<String>().getTask();
+    Task<String> task2 = new TaskCompletionSource<String>().getTask();
+
+    Task<String> task = CrashlyticsTasks.race(task1, task2);
+
+    // Since the tasks never resolve, the await will timeout.
+    assertThrows(TimeoutException.class, () -> Tasks.await(task, 300, TimeUnit.MILLISECONDS));
+  }
+}

--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/concurrency/CrashlyticsWorkerTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/concurrency/CrashlyticsWorkerTest.java
@@ -17,10 +17,13 @@
 package com.google.firebase.crashlytics.internal.concurrency;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.firebase.crashlytics.internal.concurrency.ConcurrencyTesting.deflake;
+import static com.google.firebase.crashlytics.internal.concurrency.ConcurrencyTesting.getThreadName;
+import static com.google.firebase.crashlytics.internal.concurrency.ConcurrencyTesting.newNamedSingleThreadExecutor;
+import static com.google.firebase.crashlytics.internal.concurrency.ConcurrencyTesting.sleep;
 import static org.junit.Assert.assertThrows;
 
 import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.concurrent.TestOnlyExecutors;
 import java.io.IOException;
@@ -30,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -59,7 +63,7 @@ public class CrashlyticsWorkerTest {
 
     // Find thread names by adding the names we touch to the set.
     for (int i = 0; i < 100; i++) {
-      crashlyticsWorker.submit(() -> threads.add(Thread.currentThread().getName()));
+      crashlyticsWorker.submit(() -> threads.add(getThreadName()));
     }
 
     crashlyticsWorker.await();
@@ -396,16 +400,16 @@ public class CrashlyticsWorkerTest {
     // 1 active thread when doing a local task.
     assertThat(Tasks.await(localWorker.submit(localExecutor::getActiveCount))).isEqualTo(1);
 
-    sleep(1); // The test is a bit flaky without this.
-
     // 0 active local threads when waiting for other task.
     // Waiting for a task from another worker does not block a local thread.
+    deflake();
     assertThat(Tasks.await(localWorker.submitTask(() -> otherTask))).isEqualTo(0);
 
     // 1 active thread when doing a task.
     assertThat(Tasks.await(localWorker.submit(localExecutor::getActiveCount))).isEqualTo(1);
 
     // No active threads after.
+    deflake();
     assertThat(localExecutor.getActiveCount()).isEqualTo(0);
   }
 
@@ -522,163 +526,59 @@ public class CrashlyticsWorkerTest {
   }
 
   @Test
-  public void raceReturnsFirstResult() throws Exception {
-    // Create 2 tasks on different workers to race.
-    Task<String> task1 =
-        new CrashlyticsWorker(TestOnlyExecutors.background())
-            .submit(
-                () -> {
-                  sleep(200);
-                  return "first";
-                });
-    Task<String> task2 =
-        new CrashlyticsWorker(TestOnlyExecutors.background())
-            .submit(
-                () -> {
-                  sleep(400);
-                  return "slow";
-                });
+  public void tasksRunOnCorrectThreads() throws Exception {
+    ExecutorService executor = newNamedSingleThreadExecutor("workerThread");
+    CrashlyticsWorker worker = new CrashlyticsWorker(executor);
 
-    Task<String> task = crashlyticsWorker.race(task1, task2);
-    String result = Tasks.await(task);
+    ExecutorService otherExecutor = newNamedSingleThreadExecutor("otherThread");
+    CrashlyticsWorker otherWorker = new CrashlyticsWorker(otherExecutor);
 
-    assertThat(result).isEqualTo("first");
-  }
-
-  @Test
-  public void raceReturnsFirstException() {
-    // Create 2 tasks on different workers to race.
-    Task<String> task1 =
-        new CrashlyticsWorker(TestOnlyExecutors.background())
-            .submitTask(
-                () -> {
-                  sleep(200);
-                  return Tasks.forException(new ArithmeticException());
-                });
-    Task<String> task2 =
-        new CrashlyticsWorker(TestOnlyExecutors.background())
-            .submitTask(
-                () -> {
-                  sleep(400);
-                  return Tasks.forException(new IllegalStateException());
-                });
-
-    Task<String> task = crashlyticsWorker.race(task1, task2);
-    ExecutionException thrown = assertThrows(ExecutionException.class, () -> Tasks.await(task));
-
-    // The first task throws an ArithmeticException.
-    assertThat(thrown).hasCauseThat().isInstanceOf(ArithmeticException.class);
-  }
-
-  @Test
-  public void raceFirstCancelsReturnsSecondResult() throws Exception {
-    // Create 2 tasks on different workers to race.
-    Task<String> task1 =
-        new CrashlyticsWorker(TestOnlyExecutors.background())
-            .submitTask(
-                () -> {
-                  sleep(200);
-                  return Tasks.forCanceled();
-                });
-    Task<String> task2 =
-        new CrashlyticsWorker(TestOnlyExecutors.background())
-            .submitTask(
-                () -> {
-                  sleep(400);
-                  return Tasks.forResult("I am slow but didn't cancel.");
-                });
-
-    Task<String> task = crashlyticsWorker.race(task1, task2);
-    String result = Tasks.await(task);
-
-    assertThat(result).isEqualTo("I am slow but didn't cancel.");
-  }
-
-  @Test
-  public void raceBothCancel() {
-    // Create 2 tasks on different workers to race.
-    Task<String> task1 =
-        new CrashlyticsWorker(TestOnlyExecutors.background())
-            .submitTask(
-                () -> {
-                  sleep(200);
-                  return Tasks.forCanceled();
-                });
-    Task<String> task2 =
-        new CrashlyticsWorker(TestOnlyExecutors.background())
-            .submitTask(
-                () -> {
-                  sleep(400);
-                  return Tasks.forCanceled();
-                });
-
-    Task<String> task = crashlyticsWorker.race(task1, task2);
-
-    // Both cancelled, so cancel the race result.
-    assertThrows(CancellationException.class, () -> Tasks.await(task));
-  }
-
-  @Test
-  public void raceTasksOnSameWorker() throws Exception {
-    // Create 2 tasks on this worker to race.
-    Task<String> task1 =
-        crashlyticsWorker.submit(
-            () -> {
-              sleep(200);
-              return "first";
-            });
-    Task<String> task2 =
-        crashlyticsWorker.submit(
-            () -> {
-              sleep(300);
-              return "second";
-            });
-
-    Task<String> task = crashlyticsWorker.race(task1, task2);
-    String result = Tasks.await(task);
-
-    // The first task is submitted to this worker first, so will always be first.
-    assertThat(result).isEqualTo("first");
-  }
-
-  @Test
-  public void raceTaskOneOnSameWorkerAnotherNeverCompletes() throws Exception {
-    // Create a task on this worker, and another that never completes, to race.
-    Task<String> task1 = crashlyticsWorker.submit(() -> "first");
-    Task<String> task2 = new TaskCompletionSource<String>().getTask();
-
-    Task<String> task = crashlyticsWorker.race(task1, task2);
-    String result = Tasks.await(task);
-
-    assertThat(result).isEqualTo("first");
-  }
-
-  @Test
-  public void raceTaskOneOnSameWorkerAnotherOtherThatCompletesFirst() throws Exception {
-    // Add a decoy task to the worker to take up some time.
-    crashlyticsWorker.submitTask(
+    // Submit a Runnable.
+    worker.submit(
         () -> {
-          sleep(200);
+          // The runnable blocks an underlying thread.
+          assertThat(getThreadName()).isEqualTo("workerThread");
+        });
+
+    // Submit a Callable.
+    worker.submit(
+        () -> {
+          // The callable blocks an underlying thread.
+          assertThat(getThreadName()).isEqualTo("workerThread");
+          return null;
+        });
+
+    // Submit a Callable<Task>.
+    worker.submitTask(
+        () -> {
+          // The callable itself blocks an underlying thread.
+          assertThat(getThreadName()).isEqualTo("workerThread");
+          return otherWorker.submit(
+              () -> {
+                // The called task blocks an underlying thread in its own executor.
+                assertThat(getThreadName()).isEqualTo("otherThread");
+              });
+        });
+
+    // Submit a Callable<Task> with a Continuation.
+    worker.submitTask(
+        () -> {
+          // The callable itself blocks an underlying thread.
+          assertThat(getThreadName()).isEqualTo("workerThread");
+          return otherWorker.submitTask(
+              () -> {
+                // The called task blocks an underlying thread in its own executor.
+                assertThat(getThreadName()).isEqualTo("otherThread");
+                return Tasks.forResult(null);
+              });
+        },
+        task -> {
+          // The continuation blocks an underlying thread of the original worker.
+          assertThat(getThreadName()).isEqualTo("workerThread");
           return Tasks.forResult(null);
         });
 
-    // Create a task on this worker, and another, to race.
-    Task<String> task1 = crashlyticsWorker.submit(() -> "same worker");
-    TaskCompletionSource<String> task2 = new TaskCompletionSource<>();
-    task2.trySetResult("other");
-
-    Task<String> task = crashlyticsWorker.race(task1, task2.getTask());
-    String result = Tasks.await(task);
-
-    // The other tasks completes first because the first task is queued up later on the worker.
-    assertThat(result).isEqualTo("other");
-  }
-
-  private static void sleep(long millis) {
-    try {
-      Thread.sleep(millis);
-    } catch (InterruptedException ex) {
-      Thread.currentThread().interrupt();
-    }
+    // Await on the worker to force all the tasks to run their assertions.
+    worker.await();
   }
 }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/concurrency/CrashlyticsTasks.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/concurrency/CrashlyticsTasks.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.crashlytics.internal.concurrency;
+
+import com.google.android.gms.tasks.CancellationTokenSource;
+import com.google.android.gms.tasks.Continuation;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.android.gms.tasks.Tasks;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Crashlytics specific utilities for dealing with Tasks.
+ *
+ * @hide
+ */
+public final class CrashlyticsTasks {
+  /** An Executor that runs on the calling thread. */
+  private static final Executor DIRECT = Runnable::run;
+
+  /**
+   * Returns a task that is resolved when either of the given tasks is resolved.
+   *
+   * <p>If both tasks are cancelled, the returned task will be cancelled.
+   */
+  public static <T> Task<T> race(Task<T> task1, Task<T> task2) {
+    CancellationTokenSource cancellation = new CancellationTokenSource();
+    TaskCompletionSource<T> result = new TaskCompletionSource<>(cancellation.getToken());
+
+    AtomicBoolean otherTaskCancelled = new AtomicBoolean(false);
+
+    Continuation<T, Task<Void>> continuation =
+        task -> {
+          if (task.isSuccessful()) {
+            // Task is complete and successful.
+            result.trySetResult(task.getResult());
+          } else if (task.getException() != null) {
+            // Task is complete but unsuccessful.
+            result.trySetException(task.getException());
+          } else if (otherTaskCancelled.getAndSet(true)) {
+            // Both tasks are cancelled.
+            cancellation.cancel();
+          }
+          return Tasks.forResult(null);
+        };
+
+    task1.continueWithTask(DIRECT, continuation);
+    task2.continueWithTask(DIRECT, continuation);
+
+    return result.getTask();
+  }
+
+  private CrashlyticsTasks() {}
+}

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/concurrency/CrashlyticsWorker.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/concurrency/CrashlyticsWorker.java
@@ -17,10 +17,8 @@
 package com.google.firebase.crashlytics.internal.concurrency;
 
 import androidx.annotation.VisibleForTesting;
-import com.google.android.gms.tasks.CancellationTokenSource;
 import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.concurrent.Callable;
@@ -28,10 +26,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Helper for executing tasks sequentially on the given executor service.
+ * Worker for executing tasks sequentially on the given executor service.
  *
  * <p>Work on the queue may block, or it may return a Task, such that the underlying thread may be
  * re-used while the worker queue is still blocked.
@@ -152,35 +149,6 @@ public class CrashlyticsWorker {
       tail = result;
       return result;
     }
-  }
-
-  /**
-   * Returns a task that is resolved when either of the given tasks is resolved.
-   *
-   * <p>When both tasks are cancelled, the returned task will be cancelled.
-   */
-  public <T> Task<T> race(Task<T> task1, Task<T> task2) {
-    CancellationTokenSource cancellation = new CancellationTokenSource();
-    TaskCompletionSource<T> result = new TaskCompletionSource<>(cancellation.getToken());
-
-    AtomicBoolean otherTaskCancelled = new AtomicBoolean(false);
-
-    Continuation<T, Task<Void>> continuation =
-        task -> {
-          if (task.isSuccessful()) {
-            result.trySetResult(task.getResult());
-          } else if (task.getException() != null) {
-            result.trySetException(task.getException());
-          } else if (otherTaskCancelled.getAndSet(true)) {
-            cancellation.cancel();
-          }
-          return Tasks.forResult(null);
-        };
-
-    task1.continueWithTask(executor, continuation);
-    task2.continueWithTask(executor, continuation);
-
-    return result.getTask();
   }
 
   /**


### PR DESCRIPTION
Create a util for Crashlytics-specific Tasks, and move `race` into it. This util class will hold other things later, so they don't make the worker class a mess. We will need something like `submitWaiting` next to block until a task is complete, this is how data collection is implemented. 