### PR TITLE
VertexAI: use updated set of mock responses

### DIFF
--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/StreamingSnapshotTests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/StreamingSnapshotTests.kt
@@ -72,8 +72,8 @@ internal class StreamingSnapshotTests {
     }
 
   @Test
-  fun `unknown enum`() =
-    goldenStreamingFile("streaming-success-unknown-enum.txt") {
+  fun `unknown enum in safety ratings`() =
+    goldenStreamingFile("streaming-success-unknown-safety-enum.txt") {
       val responses = model.generateContentStream("prompt")
 
       withTimeout(testTimeout) {

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/UnarySnapshotTests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/UnarySnapshotTests.kt
@@ -77,8 +77,8 @@ internal class UnarySnapshotTests {
     }
 
   @Test
-  fun `unknown enum`() =
-    goldenUnaryFile("unary-success-unknown-enum.json") {
+  fun `unknown enum in safety ratings`() =
+    goldenUnaryFile("unary-success-unknown-enum-safety-ratings.json") {
       withTimeout(testTimeout) {
         val response = model.generateContent("prompt")
 
@@ -322,7 +322,7 @@ internal class UnarySnapshotTests {
 
   @Test
   fun `service disabled`() =
-    goldenUnaryFile("unary-failure-service-disabled.json", HttpStatusCode.Forbidden) {
+    goldenUnaryFile("unary-failure-firebaseml-api-not-enabled.json", HttpStatusCode.Forbidden) {
       withTimeout(testTimeout) {
         shouldThrow<ServiceDisabledException> { model.generateContent("prompt") }
       }

--- a/firebase-vertexai/update_responses.sh
+++ b/firebase-vertexai/update_responses.sh
@@ -17,7 +17,7 @@
 # This script replaces mock response files for Vertex AI unit tests with a fresh
 # clone of the shared repository of Vertex AI test data.
 
-RESPONSES_VERSION='v1.*' # The major version of mock responses to use
+RESPONSES_VERSION='v2.*' # The major version of mock responses to use
 REPO_NAME="vertexai-sdk-test-data"
 REPO_LINK="https://github.com/FirebaseExtended/$REPO_NAME.git"
 


### PR DESCRIPTION
The set of mock responses were updated to reduce some more duplication: https://github.com/FirebaseExtended/vertexai-sdk-test-data/pull/12

This updates the test code to use the updated version.