### PR TITLE
Deprecate awaitEvenIfOnMain

### DIFF
--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -248,6 +248,7 @@ class CrashlyticsController {
     try {
       // Never block on ODFs, in case they get triggered from the main thread.
       if (!isOnDemand) {
+        //noinspection deprecation drain the worker instead.
         Utils.awaitEvenIfOnMainThread(handleUncaughtExceptionTask);
       }
     } catch (TimeoutException e) {
@@ -559,7 +560,6 @@ class CrashlyticsController {
   }
 
   /**
-   *
    * Not synchronized/locked. Must be executed from the executor service runs tasks in serial order
    */
   private void doCloseSessions(

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 public class IdManager implements InstallIdProvider {
-  private static final int TIMEOUT_MILLIS = 4_000;
+  private static final int TIMEOUT_MILLIS = 10_000;
 
   public static final String DEFAULT_VERSION_NAME = "0.0";
 

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/IdManager.java
@@ -14,13 +14,15 @@
 
 package com.google.firebase.crashlytics.internal.common;
 
-import static com.google.firebase.crashlytics.internal.common.Utils.awaitEvenIfOnMainThread;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
 import androidx.annotation.NonNull;
+import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.crashlytics.internal.Logger;
+import com.google.firebase.crashlytics.internal.concurrency.CrashlyticsWorkers;
 import com.google.firebase.installations.FirebaseInstallationsApi;
 import java.util.Locale;
 import java.util.Objects;
@@ -28,6 +30,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 public class IdManager implements InstallIdProvider {
+  private static final int TIMEOUT_MILLIS = 4_000;
 
   public static final String DEFAULT_VERSION_NAME = "0.0";
 
@@ -179,19 +182,22 @@ public class IdManager implements InstallIdProvider {
    */
   @NonNull
   public FirebaseInstallationId fetchTrueFid(boolean validate) {
+    CrashlyticsWorkers.checkBackgroundThread(); // This fetch blocks, never do it on main.
     String fid = null;
     String authToken = null;
 
     if (validate) {
       // Fetch the auth token first when requested, so the fid will be validated.
       try {
-        authToken = awaitEvenIfOnMainThread(firebaseInstallations.getToken(false)).getToken();
+        authToken =
+            Tasks.await(firebaseInstallations.getToken(false), TIMEOUT_MILLIS, MILLISECONDS)
+                .getToken();
       } catch (Exception ex) {
         Logger.getLogger().w("Error getting Firebase authentication token.", ex);
       }
     }
     try {
-      fid = awaitEvenIfOnMainThread(firebaseInstallations.getId());
+      fid = Tasks.await(firebaseInstallations.getId(), TIMEOUT_MILLIS, MILLISECONDS);
     } catch (Exception ex) {
       Logger.getLogger().w("Error getting Firebase installation id.", ex);
     }
@@ -213,7 +219,9 @@ public class IdManager implements InstallIdProvider {
     return iid;
   }
 
-  /** @return the package name that identifies this App. */
+  /**
+   * @return the package name that identifies this App.
+   */
   public String getAppIdentifier() {
     return appIdentifier;
   }

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/Utils.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/Utils.java
@@ -27,10 +27,10 @@ import java.util.concurrent.TimeoutException;
 @SuppressWarnings({"ResultOfMethodCallIgnored", "UnusedReturnValue"})
 public final class Utils {
   /** Timeout in milliseconds for blocking on background threads. */
-  private static final int BACKGROUND_TIMEOUT_MILLIS = 4_000;
+  private static final int BACKGROUND_TIMEOUT_MILLIS = 5_000;
 
   /** Timeout in milliseconds for blocking on the main thread. Be careful about ANRs. */
-  private static final int MAIN_TIMEOUT_MILLIS = 2_750;
+  private static final int MAIN_TIMEOUT_MILLIS = 4_000;
 
   /**
    * Blocks until the given Task completes, and then returns the value the Task was resolved with,
@@ -44,7 +44,9 @@ public final class Utils {
    * @return the value that was returned by the task, if successful.
    * @throws InterruptedException if the method was interrupted
    * @throws TimeoutException if the method timed out while waiting for the task.
+   * @deprecated Don't use this. Drain the worker instead.
    */
+  @Deprecated
   public static <T> T awaitEvenIfOnMainThread(Task<T> task)
       throws InterruptedException, TimeoutException {
     CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
Deprecate `awaitEvenIfOnMain`. Next PR will be to drain the worker and remove this util.