### PR TITLE
Change platform logging tag to "fire-data-connect", was "fire-dataconnect"

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectRegistrar.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/FirebaseDataConnectRegistrar.kt
@@ -67,7 +67,7 @@ internal class FirebaseDataConnectRegistrar : ComponentRegistrar {
     )
 
   companion object {
-    private const val LIBRARY_NAME = "fire-dataconnect"
+    private const val LIBRARY_NAME = "fire-data-connect"
 
     private val firebaseApp = Qualified.unqualified(FirebaseApp::class.java)
     private val context = Qualified.unqualified(Context::class.java)


### PR DESCRIPTION
Change platform logging tag to `fire-data-connect` (was `fire-dataconnect`)
    
Googlers see https://docs.google.com/spreadsheets/d/16kRJGsann0Kt2ohTGiei0Aa_c7mWBGD0w9EQ9AgoMVI/edit?gid=0#gid=0