### PR TITLE
DataConnectGrpcMetadata.kt: Omit x-firebase-gmpid if appId is empty or blank (i.e. contains only whitespace characters)

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadata.kt
@@ -72,7 +72,9 @@ internal class DataConnectGrpcMetadata(
     return Metadata().also {
       it.put(googRequestParamsHeader, googRequestParamsHeaderValue)
       it.put(googApiClientHeader, googApiClientHeaderValue(isFromGeneratedSdk))
-      it.put(gmpAppIdHeader, appId)
+      if (appId.isNotBlank()) {
+        it.put(gmpAppIdHeader, appId)
+      }
       if (authToken !== null) {
         it.put(firebaseAuthTokenHeader, authToken)
       }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadataUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/core/DataConnectGrpcMetadataUnitTest.kt
@@ -135,6 +135,32 @@ class DataConnectGrpcMetadataUnitTest {
   }
 
   @Test
+  fun `should NOT include x-firebase-gmpid if appId is the empty string`() = runTest {
+    val key = "fpm5gpgp9z"
+    val testValues = DataConnectGrpcMetadataTestValues.fromKey(key)
+    val dataConnectGrpcMetadata = testValues.newDataConnectGrpcMetadata(appId = "")
+    val requestId = Arb.requestId(key).next()
+    val isFromGeneratedSdk = Arb.boolean().next()
+
+    val metadata = dataConnectGrpcMetadata.get(requestId, isFromGeneratedSdk)
+
+    metadata.asClue { it.keys() shouldNotContain "x-firebase-gmpid" }
+  }
+
+  @Test
+  fun `should NOT include x-firebase-gmpid if appId is blank`() = runTest {
+    val key = "srvvn597dg"
+    val testValues = DataConnectGrpcMetadataTestValues.fromKey(key)
+    val dataConnectGrpcMetadata = testValues.newDataConnectGrpcMetadata(appId = " \r\n\t ")
+    val requestId = Arb.requestId(key).next()
+    val isFromGeneratedSdk = Arb.boolean().next()
+
+    val metadata = dataConnectGrpcMetadata.get(requestId, isFromGeneratedSdk)
+
+    metadata.asClue { it.keys() shouldNotContain "x-firebase-gmpid" }
+  }
+
+  @Test
   fun `should omit x-firebase-auth-token when the auth token is null`() = runTest {
     val key = "d85j28zpw9"
     val testValues = DataConnectGrpcMetadataTestValues.fromKey(key)


### PR DESCRIPTION
See for rationale: https://github.com/firebase/firebase-js-sdk/pull/4810