### PR TITLE
Make init suspend on settings only

### DIFF
--- a/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
+++ b/firebase-crashlytics/src/androidTest/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCoreTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.when;
 import android.content.Context;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import com.google.android.gms.tasks.SuccessContinuation;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
@@ -379,14 +377,7 @@ public class CrashlyticsCoreTest extends CrashlyticsTestCase {
 
     return crashlyticsCore
         .doBackgroundInitializationAsync(mockSettingsController)
-        .onSuccessTask(
-            new SuccessContinuation<Void, CrashlyticsCore>() {
-              @NonNull
-              @Override
-              public Task<CrashlyticsCore> then(@Nullable Void aVoid) throws Exception {
-                return Tasks.forResult(crashlyticsCore);
-              }
-            });
+        .onSuccessTask(unused -> Tasks.forResult(crashlyticsCore));
   }
 
   /** Helper class for building CrashlyticsCore instances. */

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsController.java
@@ -339,8 +339,6 @@ class CrashlyticsController {
     return unsentReportsHandled.getTask();
   }
 
-  // TODO(b/261014167): Use an explicit executor in continuations.
-  @SuppressLint("TaskMainThread")
   Task<Void> submitAllReports(Task<Settings> settingsDataTask) {
     if (!reportingCoordinator.hasReportsToSend()) {
       // Just notify the user that there are no reports and stop.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsCore.java
@@ -224,13 +224,13 @@ public class CrashlyticsCore {
 
   /** Performs background initialization asynchronously on the common worker. */
   @CanIgnoreReturnValue
-  public Task<Void> doBackgroundInitializationAsync(SettingsProvider settingsProvider) {
+  public Task<Settings> doBackgroundInitializationAsync(SettingsProvider settingsProvider) {
     return crashlyticsWorkers.common.submitTask(() -> doBackgroundInitialization(settingsProvider));
   }
 
   /** Performs background initialization synchronously on the calling thread. */
   @CanIgnoreReturnValue
-  private Task<Void> doBackgroundInitialization(SettingsProvider settingsProvider) {
+  private Task<Settings> doBackgroundInitialization(SettingsProvider settingsProvider) {
     CrashlyticsWorkers.checkBackgroundThread();
     // create the marker for this run
     markInitializationStarted();
@@ -254,10 +254,9 @@ public class CrashlyticsCore {
         Logger.getLogger().w("Previous sessions could not be finalized.");
       }
 
-      // TODO: Move this call out of this method, so that the return value merely indicates
-      // initialization is complete. Callers that want to know when report sending is complete can
-      // handle that as a separate call.
-      return controller.submitAllReports(settingsProvider.getSettingsAsync());
+      Task<Settings> settings = settingsProvider.getSettingsAsync();
+      controller.submitAllReports(settings);
+      return settings;
     } catch (Exception e) {
       Logger.getLogger()
           .e("Crashlytics encountered a problem during asynchronous initialization.", e);


### PR DESCRIPTION
Make init suspend on settings only, not on race. This allows us to avoid having a separate queue just for init and settings.

If the app has unsent reports, but data collection and send unsent reports both have not been triggered, still let user actions queue up.