### PR TITLE
Fix encoding failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ configure(subprojects) {
     spotless {
         java {
             target 'src/**/*.java'
+            targetExclude '**/test/resources/**'
             googleJavaFormat('1.22.0').reorderImports(false).skipJavadocFormatting()
         }
         kotlin {

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedAtEmptyAnnotation.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedAtEmptyAnnotation.java
@@ -14,6 +14,10 @@
 
 package com.example;
 
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
 import java.lang.annotation.Annotation;
 
 public final class AtEmptyAnnotation {

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedAtMyAnnotation.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedAtMyAnnotation.java
@@ -14,6 +14,10 @@
 
 package com.example;
 
+import java.lang.Class;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoder.java
@@ -18,6 +18,8 @@ import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
 import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
 
 /**
  * @hide */

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoderWithUnknownType.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedGenericsEncoderWithUnknownType.java
@@ -18,6 +18,8 @@ import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
 import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
 
 /**
  * @hide */

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedMyClassEncoderWithExtraProperty.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedMyClassEncoderWithExtraProperty.java
@@ -19,6 +19,8 @@ import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
 import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
 
 /**
  * @hide */

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedRecursiveGenericEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedRecursiveGenericEncoder.java
@@ -20,6 +20,8 @@ import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
 import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
 
 /**
  * @hide */

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedSimpleClassEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedSimpleClassEncoder.java
@@ -18,6 +18,8 @@ import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
 import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
 
 /**
  * @hide */

--- a/encoders/firebase-encoders-processor/src/test/resources/ExpectedTypeWithListEncoder.java
+++ b/encoders/firebase-encoders-processor/src/test/resources/ExpectedTypeWithListEncoder.java
@@ -18,6 +18,8 @@ import com.google.firebase.encoders.ObjectEncoderContext;
 import com.google.firebase.encoders.config.Configurator;
 import com.google.firebase.encoders.config.EncoderConfig;
 import java.io.IOException;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
 
 /**
  * @hide */


### PR DESCRIPTION
Per [b/361535657](https://b.corp.google.com/issues/361535657),

This fixes the encoders unit test failures. Encoders generates imports that aren't necessarily needed, just for the sake of being safe. This also means that our resource files that we use for checking the generated encoding have the extra imports. But, our formatting/linting (spotless) removes these imports as it recognizes they're not needed.

Since we're testing the expected behavior of encoders- we expect these imports to be present regardless. It's also a reasonable assumption that spotless doesn't need to check resource files. So this PR re-adds the missing imports, and configures spotless to ignore files under `test/resources` directories.