### PR TITLE
Fix release notes export name

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Upload release notes
         uses: actions/upload-artifact@v4.3.3
         with:
-          name: release_artifacts
+          name: release_notes
           path: build/release-notes.zip
           retention-days: 15
 

--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -29,19 +29,19 @@ jobs:
         uses: actions/upload-artifact@v4.3.3
         with:
           name: m2repository
-          path: build/m2repository.zip
+          path: build/m2repository/
           retention-days: 15
 
       - name: Upload release notes
         uses: actions/upload-artifact@v4.3.3
         with:
           name: release_notes
-          path: build/release-notes.zip
+          path: build/release-notes/
           retention-days: 15
 
       - name: Upload kotlindocs
         uses: actions/upload-artifact@v4.3.3
         with:
           name: kotlindocs
-          path: build/kotlindoc.zip
+          path: build/firebase-kotlindoc/
           retention-days: 15


### PR DESCRIPTION
Per [b/361778952](https://b.corp.google.com/issues/361778952),

This renames the exported release notes in the build artifact workflow to be `release_notes` instead of `release_artifacts`. It seems my previous commit to do this didn't make it in before the branch was merged.

This PR also fixes the following:
- [b/361781459](https://b.corp.google.com/issues/361781459) -> Fix build artifact double zipping