### PR TITLE
Fix `putBytes()`API to use `maxUploadRetryTimeMillis` parameter 

### DIFF
--- a/firebase-storage/CHANGELOG.md
+++ b/firebase-storage/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [fixed] Fixed an issue where `maxUploadRetryTimeMillis` parameter is ignored when uploading using
+  `putBytes()`
 
 # 21.0.0
 * [changed] Bump internal dependencies

--- a/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
+++ b/firebase-storage/src/main/java/com/google/firebase/storage/UploadTask.java
@@ -108,7 +108,7 @@ public class UploadTask extends StorageTask<UploadTask.TaskSnapshot> {
             storage.getApp().getApplicationContext(),
             mAuthProvider,
             mAppCheckProvider,
-            storage.getMaxDownloadRetryTimeMillis());
+            storage.getMaxUploadRetryTimeMillis());
   }
 
   UploadTask(


### PR DESCRIPTION
Fix issue https://github.com/firebase/firebase-android-sdk/issues/6214