### PR TITLE
Firestore: Improve efficiency of memory persistence when processing a large number of writes

### DIFF
--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Improve efficiency of memory persistence when processing a large number of writes. [#NNNN](//github.com/firebase/firebase-android-sdk/pull/NNNN)
 
 # 25.1.0
 * [feature] Add support for the VectorValue type. [#6154](//github.com/firebase/firebase-android-sdk/pull/6154)

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [changed] Improve efficiency of memory persistence when processing a large number of writes. [#NNNN](//github.com/firebase/firebase-android-sdk/pull/NNNN)
+* [changed] Improve efficiency of memory persistence when processing a large number of writes. [#6233](//github.com/firebase/firebase-android-sdk/pull/6233)
 
 # 25.1.0
 * [feature] Add support for the VectorValue type. [#6154](//github.com/firebase/firebase-android-sdk/pull/6154)

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/LocalStore.java
@@ -208,17 +208,17 @@ public final class LocalStore implements BundleCallback {
 
   public ImmutableSortedMap<DocumentKey, Document> handleUserChange(User user) {
     // Swap out the mutation queue, grabbing the pending mutation batches before and after.
-    List<MutationBatch> oldBatches = mutationQueue.getAllMutationBatches();
+    Collection<MutationBatch> oldBatches = mutationQueue.getAllMutationBatches();
 
     initializeUserComponents(user);
     startIndexManager();
     startMutationQueue();
 
-    List<MutationBatch> newBatches = mutationQueue.getAllMutationBatches();
+    Collection<MutationBatch> newBatches = mutationQueue.getAllMutationBatches();
 
     // Union the old/new changed keys.
     ImmutableSortedSet<DocumentKey> changedKeys = DocumentKey.emptyKeySet();
-    for (List<MutationBatch> batches : asList(oldBatches, newBatches)) {
+    for (Collection<MutationBatch> batches : asList(oldBatches, newBatches)) {
       for (MutationBatch batch : batches) {
         for (Mutation mutation : batch.getMutations()) {
           changedKeys = changedKeys.insert(mutation.getKey());

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryMutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryMutationQueue.java
@@ -107,14 +107,20 @@ final class MemoryMutationQueue implements MutationQueue {
   @Override
   public void acknowledgeBatch(MutationBatch batch, ByteString streamToken) {
     int batchId = batch.getBatchId();
-    hardAssert(queue.containsKey(batchId), "Can not acknowledge unknown batch ID: %d", batchId);
-
-    int firstKey = queue.firstKey();
     hardAssert(
-        batchId == firstKey,
-        "Can only acknowledge the first batch in the mutation queue: got batchId %d, but expected %d",
+        queue.containsKey(batchId),
+        "Can not acknowledge unknown batch ID: %d (batch=%s)",
         batchId,
-        firstKey);
+        batch);
+
+    int firstBatchId = queue.firstKey();
+    hardAssert(
+        batchId == firstBatchId,
+        "Can only acknowledge the first batch in the mutation queue:"
+            + " got batchId %d, but expected %d (batch=%s)",
+        batchId,
+        firstBatchId,
+        batch);
 
     lastStreamToken = checkNotNull(streamToken);
   }
@@ -141,7 +147,7 @@ final class MemoryMutationQueue implements MutationQueue {
       int priorKey = queue.lastKey();
       hardAssert(
           priorKey < batchId,
-          "Mutation batchIds must be monotonically increasing order:" + " priorKey=%d, batchId=%d",
+          "Mutation batchIds must be monotonically increasing order: priorKey=%d, batchId=%d",
           priorKey,
           batchId);
     }
@@ -284,15 +290,20 @@ final class MemoryMutationQueue implements MutationQueue {
   @Override
   public void removeMutationBatch(MutationBatch batch) {
     int batchId = batch.getBatchId();
-    hardAssert(queue.containsKey(batchId), "Can not remove unknown batch ID: %d", batchId);
-
-    int firstKey = queue.firstKey();
     hardAssert(
-        batchId == firstKey,
-        "Can only remove the first batch in the mutation queue:"
-            + " got batchId %d, but expected %d",
+        queue.containsKey(batchId),
+        "Can not remove unknown batch ID: %d (batch=%s)",
         batchId,
-        firstKey);
+        batch);
+
+    int firstBatchId = queue.firstKey();
+    hardAssert(
+        batchId == firstBatchId,
+        "Can only remove the first batch in the mutation queue:"
+            + " got batchId %d, but expected %d (batch=%s)",
+        batchId,
+        firstBatchId,
+        batch);
 
     queue.remove(batchId);
 

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
@@ -22,6 +22,7 @@ import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.model.mutation.MutationBatch;
 import com.google.protobuf.ByteString;
 import java.util.List;
+import java.util.SortedMap;
 
 /** A queue of mutations to apply to the remote store. */
 interface MutationQueue {
@@ -79,7 +80,7 @@ interface MutationQueue {
   /** Returns all mutation batches in the mutation queue. */
   // TODO: PERF: Current consumer only needs mutated keys; if we can provide that
   // cheaply, we should replace this.
-  List<MutationBatch> getAllMutationBatches();
+  SortedMap<Integer, MutationBatch> getAllMutationBatches();
 
   /**
    * Finds all mutation batches that could @em possibly affect the given document key. Not all

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MutationQueue.java
@@ -21,8 +21,8 @@ import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.mutation.Mutation;
 import com.google.firebase.firestore.model.mutation.MutationBatch;
 import com.google.protobuf.ByteString;
+import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
 
 /** A queue of mutations to apply to the remote store. */
 interface MutationQueue {
@@ -80,7 +80,7 @@ interface MutationQueue {
   /** Returns all mutation batches in the mutation queue. */
   // TODO: PERF: Current consumer only needs mutated keys; if we can provide that
   // cheaply, we should replace this.
-  SortedMap<Integer, MutationBatch> getAllMutationBatches();
+  Collection<MutationBatch> getAllMutationBatches();
 
   /**
    * Finds all mutation batches that could @em possibly affect the given document key. Not all

--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteOverlayMigrationManager.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/local/SQLiteOverlayMigrationManager.java
@@ -20,8 +20,8 @@ import androidx.annotation.VisibleForTesting;
 import com.google.firebase.firestore.auth.User;
 import com.google.firebase.firestore.model.DocumentKey;
 import com.google.firebase.firestore.model.mutation.MutationBatch;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /** Manages overlay migrations required to have overlay support . */
@@ -58,7 +58,7 @@ public class SQLiteOverlayMigrationManager implements OverlayMigrationManager {
 
             // Get all document keys that have local mutations
             Set<DocumentKey> allDocumentKeys = new HashSet<>();
-            List<MutationBatch> batches = mutationQueue.getAllMutationBatches();
+            Collection<MutationBatch> batches = mutationQueue.getAllMutationBatches();
             for (MutationBatch batch : batches) {
               allDocumentKeys.addAll(batch.getKeys());
             }

--- a/firebase-firestore/src/test/java/com/google/firebase/firestore/local/MutationQueueTestCase.java
+++ b/firebase-firestore/src/test/java/com/google/firebase/firestore/local/MutationQueueTestCase.java
@@ -40,6 +40,7 @@ import com.google.firebase.firestore.model.mutation.SetMutation;
 import com.google.firebase.firestore.remote.WriteStream;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -343,10 +344,10 @@ public abstract class MutationQueueTestCase {
     removeMutationBatches(batches.remove(0));
     assertEquals(9, batchCount());
 
-    List<MutationBatch> found;
+    Collection<MutationBatch> found;
 
     found = mutationQueue.getAllMutationBatches();
-    assertEquals(batches, found);
+    assertEquals(batches, new ArrayList<>(found));
     assertEquals(9, found.size());
 
     removeMutationBatches(batches.get(0), batches.get(1), batches.get(2));
@@ -356,14 +357,14 @@ public abstract class MutationQueueTestCase {
     assertEquals(6, batchCount());
 
     found = mutationQueue.getAllMutationBatches();
-    assertEquals(batches, found);
+    assertEquals(batches, new ArrayList<>(found));
     assertEquals(6, found.size());
 
     removeMutationBatches(batches.remove(0));
     assertEquals(5, batchCount());
 
     found = mutationQueue.getAllMutationBatches();
-    assertEquals(batches, found);
+    assertEquals(batches, new ArrayList<>(found));
     assertEquals(5, found.size());
 
     removeMutationBatches(batches.remove(0));
@@ -373,12 +374,12 @@ public abstract class MutationQueueTestCase {
     assertEquals(3, batchCount());
 
     found = mutationQueue.getAllMutationBatches();
-    assertEquals(batches, found);
+    assertEquals(batches, new ArrayList<>(found));
     assertEquals(3, found.size());
 
     removeMutationBatches(batches.toArray(new MutationBatch[0]));
     found = mutationQueue.getAllMutationBatches();
-    assertEquals(emptyList(), found);
+    assertEquals(emptyList(), new ArrayList<>(found));
     assertEquals(0, found.size());
     assertTrue(mutationQueue.isEmpty());
   }


### PR DESCRIPTION
Replace `ArrayList` with `ArrayDeque` so that erasing the first element does not incur O(n) cost, as when erasing the entire ArrayList this inefficiency results in O(n^2) cost. Googlers see b/364354267 and cl/671065694 for details.

Ported from https://github.com/firebase/firebase-ios-sdk/pull/13572