### PR TITLE
feat: `Instant` support

### DIFF
--- a/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
+++ b/firebase-firestore/src/main/java/com/google/firebase/firestore/util/CustomClassMapper.java
@@ -18,6 +18,8 @@ import static com.google.firebase.firestore.util.ApiUtil.invoke;
 import static com.google.firebase.firestore.util.ApiUtil.newInstance;
 
 import android.net.Uri;
+import android.os.Build;
+import androidx.annotation.RequiresApi;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.Blob;
 import com.google.firebase.firestore.DocumentId;
@@ -41,6 +43,7 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.net.URI;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -175,6 +178,9 @@ public class CustomClassMapper {
         || o instanceof DocumentReference
         || o instanceof FieldValue) {
       return o;
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && o instanceof Instant) {
+      Instant instant = (Instant) o;
+      return new Timestamp(instant.getEpochSecond(), instant.getNano());
     } else if (o instanceof Uri || o instanceof URI || o instanceof URL) {
       return o.toString();
     } else {
@@ -235,6 +241,8 @@ public class CustomClassMapper {
       return (T) convertDate(o, context);
     } else if (Timestamp.class.isAssignableFrom(clazz)) {
       return (T) convertTimestamp(o, context);
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Instant.class.isAssignableFrom(clazz)) {
+      return (T) convertInstant(o, context);
     } else if (Blob.class.isAssignableFrom(clazz)) {
       return (T) convertBlob(o, context);
     } else if (GeoPoint.class.isAssignableFrom(clazz)) {
@@ -505,6 +513,20 @@ public class CustomClassMapper {
       throw deserializeError(
           context.errorPath,
           "Failed to convert value of type " + o.getClass().getName() + " to Timestamp");
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.O)
+  private static Instant convertInstant(Object o, DeserializeContext context) {
+    if (o instanceof Timestamp) {
+      Timestamp timestamp = (Timestamp) o;
+      return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanoseconds());
+    } else if (o instanceof Date) {
+      return Instant.ofEpochMilli(((Date) o).getTime());
+    } else {
+      throw deserializeError(
+          context.errorPath,
+          "Failed to convert value of type " + o.getClass().getName() + " to Instant");
     }
   }
 
@@ -919,13 +941,14 @@ public class CustomClassMapper {
     private void applyFieldAnnotations(Field field) {
       if (field.isAnnotationPresent(ServerTimestamp.class)) {
         Class<?> fieldType = field.getType();
-        if (fieldType != Date.class && fieldType != Timestamp.class) {
+        if (fieldType != Date.class && fieldType != Timestamp.class
+                        && ! (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && fieldType == Instant.class)) {
           throw new IllegalArgumentException(
               "Field "
                   + field.getName()
                   + " is annotated with @ServerTimestamp but is "
                   + fieldType
-                  + " instead of Date or Timestamp.");
+                  + " instead of Date, Timestamp, or Instant.");
         }
         serverTimestamps.add(propertyName(field));
       }
@@ -940,13 +963,14 @@ public class CustomClassMapper {
     private void applyGetterAnnotations(Method method) {
       if (method.isAnnotationPresent(ServerTimestamp.class)) {
         Class<?> returnType = method.getReturnType();
-        if (returnType != Date.class && returnType != Timestamp.class) {
+        if (returnType != Date.class && returnType != Timestamp.class
+                        && ! (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && returnType == Instant.class)) {
           throw new IllegalArgumentException(
               "Method "
                   + method.getName()
                   + " is annotated with @ServerTimestamp but returns "
                   + returnType
-                  + " instead of Date or Timestamp.");
+                  + " instead of Date, Timestamp, or Instant.");
         }
         serverTimestamps.add(propertyName(method));
       }


### PR DESCRIPTION
Add support for `java.time.Instant` as a timestamp type.
This is a port of https://github.com/googleapis/java-firestore/pull/1586.