### PR TITLE
Ignore removed entries in CHANGED_FROM_STATIC

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/semver/DeltaType.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/semver/DeltaType.kt
@@ -594,6 +594,10 @@ enum class DeltaType {
   },
   CHANGED_FROM_STATIC {
     override fun getViolations(before: ClassInfo?, after: ClassInfo?): List<Delta> {
+      // Safe to ignore: if `after` is null, then it has been removed and another check will
+      // report this.
+      if (after == null) return emptyList()
+
       val allBeforeMethods = getAllMethods(before)
       val allAfterMethods = getAllMethods(after)
       val afterStaticMethods =


### PR DESCRIPTION
The check fails if the `after` state is null. This cases only happens when the entry has been removed entirely, instead of only changed from static to non-static.

There are other tests that look for those changes, so it's safe to ignore it from the CHANGED_FROM_STATIC check.