### PR TITLE
Bump latest released version of vertexai

### DIFF
--- a/firebase-vertexai/gradle.properties
+++ b/firebase-vertexai/gradle.properties
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=16.0.0-beta04
-latestReleasedVersion=16.0.0-beta03
+version=16.0.0-beta05
+latestReleasedVersion=16.0.0-beta04


### PR DESCRIPTION
This was missed on the last mergeback that included vertexAI. Version beta04 is already out

NO_RELEASE_CHANGE