### PR TITLE
Add entry in the changelog for next release

### DIFF
--- a/firebase-appdistribution-api/CHANGELOG.md
+++ b/firebase-appdistribution-api/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+* [unchanged] Updated to accommodate the release of the updated
+  [appdistro] library.
 
 # 16.0.0-beta13
 * [changed] Bump internal dependencies

--- a/firebase-appdistribution/CHANGELOG.md
+++ b/firebase-appdistribution/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Internal improvements to testing on Android 14
 
 # 16.0.0-beta13
 * [changed] Bump internal dependencies

--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [changed] Updated `firebase-crashlytics` dependency to v19.0.4
 
 # 19.0.3
 * [changed] Updated `firebase-crashlytics` dependency to v19.0.3
@@ -232,4 +232,3 @@ change. The following release notes describe changes in the new SDK.
  uploading symbol files to [crashlytics] servers. See the
  [[crashlytics] Gradle plugin documentation](/docs/crashlytics/ndk-reports-new-sdk)
  for more information.
-


### PR DESCRIPTION
The next release of the NDK doesn't contain any new features, it only bumps the value to maintain parity with the crashlytics SDK.

Additional entries are for appdistribution and appdistribution-api.