### PR TITLE
Fix typo in class made final check in semver

### DIFF
--- a/buildSrc/src/main/java/com/google/firebase/gradle/plugins/semver/DeltaType.kt
+++ b/buildSrc/src/main/java/com/google/firebase/gradle/plugins/semver/DeltaType.kt
@@ -394,7 +394,7 @@ enum class DeltaType {
           Delta(
             after.name,
             "",
-            String.format("Class %s made abstract.", after.name),
+            String.format("Class %s made final.", after.name),
             CLASS_MADE_FINAL,
             VersionDelta.MAJOR
           )


### PR DESCRIPTION
The error message for classes made final has "abstract" instead of "final" on them.