### PR TITLE
Update crashlytics NDK CHANGELOG.md and version

### DIFF
--- a/firebase-crashlytics-ndk/CHANGELOG.md
+++ b/firebase-crashlytics-ndk/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [changed] Updated `firebase-crashlytics` dependency to v19.0.4
+* [changed] Updated `firebase-crashlytics` dependency to v19.1.0
 
 # 19.0.3
 * [changed] Updated `firebase-crashlytics` dependency to v19.0.3

--- a/firebase-crashlytics-ndk/gradle.properties
+++ b/firebase-crashlytics-ndk/gradle.properties
@@ -1,2 +1,2 @@
-version=19.0.4
+version=19.1.0
 latestReleasedVersion=19.0.3


### PR DESCRIPTION
The correct version to match is 19.1.0, not 19.0.4