### PR TITLE
Move Kotlin serialization gradle plugin into libs.versions.toml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ buildscript {
         classpath 'com.google.firebase:firebase-appdistribution-gradle:5.0.0'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.5'
         classpath "com.diffplug.spotless:spotless-plugin-gradle:7.0.0.BETA1"
-        classpath "org.jetbrains.kotlin:kotlin-serialization:1.8.22"
     }
 }
 

--- a/firebase-vertexai/firebase-vertexai.gradle.kts
+++ b/firebase-vertexai/firebase-vertexai.gradle.kts
@@ -19,7 +19,7 @@
 plugins {
   id("firebase-library")
   id("kotlin-android")
-  kotlin("plugin.serialization")
+  alias(libs.plugins.kotlinx.serialization)
 }
 
 firebaseLibrary {
@@ -71,7 +71,7 @@ dependencies {
   implementation("com.google.firebase:firebase-annotations:16.2.0")
   implementation("com.google.firebase:firebase-appcheck-interop:17.1.0")
   implementation(libs.androidx.annotation)
-  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
+  implementation(libs.kotlinx.serialization.json)
   implementation("androidx.core:core-ktx:1.12.0")
   implementation("org.slf4j:slf4j-nop:2.0.9")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ dagger = "2.43.2"
 grpc = "1.62.2"
 javalite = "3.21.11"
 kotlin = "1.8.22"
+serialization-plugin = "1.8.22"
 protoc = "3.21.11"
 truth = "1.4.2"
 robolectric = "4.12"
@@ -36,7 +37,7 @@ findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version = "3.0.2
 javax-inject = { module = "javax.inject:javax.inject", version = "1" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-coroutines-tasks = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutines" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.5.0" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.5.1" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "3.12.13" }
 org-json = { module = "org.json:json", version = "20210307" }
@@ -65,3 +66,6 @@ quickcheck = { module = "net.java:quickcheck", version.ref = "quickcheck" }
 [bundles]
 kotest = ["kotest-runner", "kotest-assertions", "kotest-property"]
 playservices = ["playservices-base", "playservices-basement", "playservices-tasks"]
+
+[plugins]
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "serialization-plugin" }


### PR DESCRIPTION
A previous change, https://github.com/firebase/firebase-android-sdk/pull/6186, added the Kotlin serialization plugin to every single Gradle module; however, only one module actually used it. Moreover, it is becoming more conventional to define dependency versions in `gradle/libs.versions.toml`. This PR removes the global dependency on the Kotlin serialization plugin and, instead, moves the version into `gradle/libs.versions.toml`, and also modifies the dependency on the Kotlin JSON serialization library to use `gradle/libs.versions.toml`. This will make sure that every module uses the same version, which will become important once Data Connect, which also uses these libraries, is merged into main.