### PR TITLE
protoc-gen-firebase-encoders.gradle: use libs.versions.toml

### DIFF
--- a/encoders/protoc-gen-firebase-encoders/protoc-gen-firebase-encoders.gradle
+++ b/encoders/protoc-gen-firebase-encoders/protoc-gen-firebase-encoders.gradle
@@ -37,13 +37,13 @@ jar {
 
 
 dependencies {
-    implementation 'com.google.dagger:dagger:2.43.2'
+    implementation libs.dagger.dagger
     implementation 'com.google.guava:guava:30.0-jre'
-    implementation "com.google.protobuf:protobuf-java:3.21.9"
+    implementation libs.protobuf.java
     implementation 'com.squareup:javapoet:1.13.0'
 
-    kapt 'com.google.dagger:dagger-compiler:2.43.2'
+    kapt libs.dagger.compiler
 
-    testImplementation "com.google.truth:truth:1.0.1"
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation libs.truth
+    testImplementation libs.junit
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ kotest-runner = { module = "io.kotest:kotest-runner-junit4-jvm", version.ref = "
 kotest-assertions = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }
 kotest-property = { module = "io.kotest:kotest-property-jvm", version.ref = "kotest" }
 quickcheck = { module = "net.java:quickcheck", version.ref = "quickcheck" }
+protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "javalite" }
 
 [bundles]
 kotest = ["kotest-runner", "kotest-assertions", "kotest-property"]


### PR DESCRIPTION
This is a change that will be required once data connect is merged into main so that they share the same dependency versions.