### PR TITLE
Fixed exception propagation on null default uncaught exception handler

### DIFF
--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * [fixed] Improved data consistency for rapid user actions.
+* [fixed] Fixed exception propagation in the case of no default uncaught exception handler.
 * [changed] Internal changes to improve startup time.
 * [changed] Internal changes to the way background tasks are scheduled.
 * [changed] Migrated SDK to use standard Firebase executors.

--- a/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsUncaughtExceptionHandler.java
+++ b/firebase-crashlytics/src/main/java/com/google/firebase/crashlytics/internal/common/CrashlyticsUncaughtExceptionHandler.java
@@ -58,8 +58,13 @@ class CrashlyticsUncaughtExceptionHandler implements Thread.UncaughtExceptionHan
     } catch (Exception e) {
       Logger.getLogger().e("An error occurred in the uncaught exception handler", e);
     } finally {
-      Logger.getLogger().d("Completed exception processing. Invoking default exception handler.");
-      defaultHandler.uncaughtException(thread, ex);
+      if (defaultHandler != null) {
+        Logger.getLogger().d("Completed exception processing. Invoking default exception handler.");
+        defaultHandler.uncaughtException(thread, ex);
+      } else {
+        Logger.getLogger().d("Completed exception processing, but no default exception handler.");
+        System.exit(1);
+      }
       isHandlingException.set(false);
     }
   }


### PR DESCRIPTION
Fixed exception propagation in the case of no default uncaught exception handler. Exit code 1 is what the default java uncaught exception handler exits with.

