### PR TITLE
Remove redundant null declaration

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerationConfig.kt
@@ -78,7 +78,7 @@ private constructor(
   val maxOutputTokens: Int?,
   val stopSequences: List<String>?,
   val responseMimeType: String?,
-  val responseSchema: Schema? = null,
+  val responseSchema: Schema?,
 ) {
 
   /**


### PR DESCRIPTION
Since the constructor is private, and the builder sets it to null if missing, this declaration is actually redundant.

b/368368914