### PR TITLE
RemoteConfigComponentTest.java: fix flaky test

### DIFF
--- a/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
+++ b/firebase-config/src/test/java/com/google/firebase/remoteconfig/RemoteConfigComponentTest.java
@@ -185,7 +185,7 @@ public class RemoteConfigComponentTest {
     when(mockMetadataClient.getRealtimeBackoffMetadata())
         .thenReturn(new ConfigMetadataClient.RealtimeBackoffMetadata(0, new Date()));
 
-    RemoteConfigComponent frcComponent = getNewFrcComponent();
+    RemoteConfigComponent frcComponent = getNewFrcComponentWithoutLoadingDefault();
     FirebaseRemoteConfig instance = getFrcInstanceFromComponent(frcComponent, DEFAULT_NAMESPACE);
 
     frcComponent.registerRolloutsStateSubscriber(DEFAULT_NAMESPACE, mockRolloutsStateSubscriber);


### PR DESCRIPTION
The flaky test is: registerRolloutsStateSubscriber_firebaseNamespace_callsSubscriptionHandler

The flaky failure is due to a race condition, and the error looks like this:

```
Argument passed to verify() is of type RolloutsStateSubscriptionsHandler and is not a mock!
Make sure you place the parenthesis correctly!
See the examples of correct verifications:
    verify(mock).someMethod();
    verify(mock, times(10)).someMethod();
    verify(mock, atLeastOnce()).someMethod();
org.mockito.exceptions.misusing.NotAMockException: 
Argument passed to verify() is of type RolloutsStateSubscriptionsHandler and is not a mock!

at com.google.firebase.remoteconfig.RemoteConfigComponentTest.registerRolloutsStateSubscriber_firebaseNamespace_callsSubscriptionHandler(RemoteConfigComponentTest.java:194)
```