### PR TITLE
Add missing `FirstOrdinalSerializer` to enum

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/server/Types.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/server/Types.kt
@@ -31,6 +31,9 @@ internal object BlockReasonSerializer :
 internal object HarmProbabilitySerializer :
   KSerializer<HarmProbability> by FirstOrdinalSerializer(HarmProbability::class)
 
+internal object HarmSeveritySerializer :
+  KSerializer<HarmSeverity> by FirstOrdinalSerializer(HarmSeverity::class)
+
 internal object FinishReasonSerializer :
   KSerializer<FinishReason> by FirstOrdinalSerializer(FinishReason::class)
 
@@ -117,7 +120,7 @@ internal enum class HarmProbability {
   HIGH
 }
 
-@Serializable
+@Serializable(HarmSeveritySerializer::class)
 internal enum class HarmSeverity {
   UNKNOWN,
   @SerialName("HARM_SEVERITY_UNSPECIFIED") UNSPECIFIED,

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/shared/Types.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/shared/Types.kt
@@ -32,6 +32,9 @@ import kotlinx.serialization.json.jsonObject
 internal object HarmCategorySerializer :
   KSerializer<HarmCategory> by FirstOrdinalSerializer(HarmCategory::class)
 
+internal object OutcomeSerializer :
+  KSerializer<Outcome> by FirstOrdinalSerializer(Outcome::class)
+
 @Serializable(HarmCategorySerializer::class)
 internal enum class HarmCategory {
   UNKNOWN,
@@ -84,7 +87,7 @@ internal data class Blob(@SerialName("mime_type") val mimeType: String, val data
 
 @Serializable internal data class CodeExecutionResult(val outcome: Outcome, val output: String)
 
-@Serializable
+@Serializable(OutcomeSerializer::class)
 internal enum class Outcome {
   @SerialName("OUTCOME_UNSPECIFIED") UNSPECIFIED,
   OUTCOME_OK,

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/shared/Types.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/shared/Types.kt
@@ -32,8 +32,6 @@ import kotlinx.serialization.json.jsonObject
 internal object HarmCategorySerializer :
   KSerializer<HarmCategory> by FirstOrdinalSerializer(HarmCategory::class)
 
-internal object OutcomeSerializer : KSerializer<Outcome> by FirstOrdinalSerializer(Outcome::class)
-
 @Serializable(HarmCategorySerializer::class)
 internal enum class HarmCategory {
   UNKNOWN,
@@ -60,11 +58,6 @@ internal data class Content(@EncodeDefault val role: String? = "user", val parts
 @Serializable
 internal data class FunctionResponsePart(val functionResponse: FunctionResponse) : Part
 
-@Serializable internal data class ExecutableCodePart(val executableCode: ExecutableCode) : Part
-
-@Serializable
-internal data class CodeExecutionResultPart(val codeExecutionResult: CodeExecutionResult) : Part
-
 @Serializable internal data class FunctionResponse(val name: String, val response: JsonObject)
 
 @Serializable
@@ -81,18 +74,6 @@ internal data class FileData(
 
 @Serializable
 internal data class Blob(@SerialName("mime_type") val mimeType: String, val data: Base64)
-
-@Serializable internal data class ExecutableCode(val language: String, val code: String)
-
-@Serializable internal data class CodeExecutionResult(val outcome: Outcome, val output: String)
-
-@Serializable(OutcomeSerializer::class)
-internal enum class Outcome {
-  @SerialName("OUTCOME_UNSPECIFIED") UNSPECIFIED,
-  OUTCOME_OK,
-  OUTCOME_FAILED,
-  OUTCOME_DEADLINE_EXCEEDED,
-}
 
 @Serializable
 internal data class SafetySetting(
@@ -126,8 +107,6 @@ internal object PartSerializer : JsonContentPolymorphicSerializer<Part>(Part::cl
       "functionResponse" in jsonObject -> FunctionResponsePart.serializer()
       "inlineData" in jsonObject -> BlobPart.serializer()
       "fileData" in jsonObject -> FileDataPart.serializer()
-      "executableCode" in jsonObject -> ExecutableCodePart.serializer()
-      "codeExecutionResult" in jsonObject -> CodeExecutionResultPart.serializer()
       else -> throw SerializationException("Unknown Part type")
     }
   }

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/shared/Types.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/shared/Types.kt
@@ -32,8 +32,7 @@ import kotlinx.serialization.json.jsonObject
 internal object HarmCategorySerializer :
   KSerializer<HarmCategory> by FirstOrdinalSerializer(HarmCategory::class)
 
-internal object OutcomeSerializer :
-  KSerializer<Outcome> by FirstOrdinalSerializer(Outcome::class)
+internal object OutcomeSerializer : KSerializer<Outcome> by FirstOrdinalSerializer(Outcome::class)
 
 @Serializable(HarmCategorySerializer::class)
 internal enum class HarmCategory {

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/common/UnarySnapshotTests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/common/UnarySnapshotTests.kt
@@ -20,13 +20,8 @@ import com.google.firebase.vertexai.common.server.BlockReason
 import com.google.firebase.vertexai.common.server.FinishReason
 import com.google.firebase.vertexai.common.server.HarmProbability
 import com.google.firebase.vertexai.common.server.HarmSeverity
-import com.google.firebase.vertexai.common.shared.CodeExecutionResult
-import com.google.firebase.vertexai.common.shared.CodeExecutionResultPart
-import com.google.firebase.vertexai.common.shared.ExecutableCode
-import com.google.firebase.vertexai.common.shared.ExecutableCodePart
 import com.google.firebase.vertexai.common.shared.FunctionCallPart
 import com.google.firebase.vertexai.common.shared.HarmCategory
-import com.google.firebase.vertexai.common.shared.Outcome
 import com.google.firebase.vertexai.common.shared.TextPart
 import com.google.firebase.vertexai.common.util.goldenUnaryFile
 import com.google.firebase.vertexai.common.util.shouldNotBeNullOrEmpty
@@ -350,25 +345,6 @@ internal class UnarySnapshotTests {
 
         callPart.functionCall.name shouldBe "current_time"
         callPart.functionCall.args shouldBe null
-      }
-    }
-
-  @Test
-  fun `code execution parses correctly`() =
-    goldenUnaryFile("success-code-execution.json") {
-      withTimeout(testTimeout) {
-        val response = apiController.generateContent(textGenerateContentRequest("prompt"))
-        val content = response.candidates.shouldNotBeNullOrEmpty().first().content
-        content.shouldNotBeNull()
-        val executableCodePart = content.parts[0]
-        val codeExecutionResult = content.parts[1]
-
-        executableCodePart.shouldBe(
-          ExecutableCodePart(ExecutableCode("PYTHON", "print(\"Hello World\")"))
-        )
-        codeExecutionResult.shouldBe(
-          CodeExecutionResultPart(CodeExecutionResult(Outcome.OUTCOME_OK, "Hello World"))
-        )
       }
     }
 }


### PR DESCRIPTION
It's only necessary on enums we receive from the backend, not from the ones we send.