### PR TITLE
Create the function declaration schema at construction time

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
@@ -153,7 +153,7 @@ internal fun Tool.toInternal() =
   com.google.firebase.vertexai.common.client.Tool(functionDeclarations.map { it.toInternal() })
 
 internal fun FunctionDeclaration.toInternal() =
-  com.google.firebase.vertexai.common.client.FunctionDeclaration(name, "", parameters.toInternal())
+  com.google.firebase.vertexai.common.client.FunctionDeclaration(name, "", schema.toInternal())
 
 internal fun com.google.firebase.vertexai.type.Schema.toInternal(): Schema =
   Schema(

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
@@ -153,16 +153,7 @@ internal fun Tool.toInternal() =
   com.google.firebase.vertexai.common.client.Tool(functionDeclarations.map { it.toInternal() })
 
 internal fun FunctionDeclaration.toInternal() =
-  com.google.firebase.vertexai.common.client.FunctionDeclaration(
-    name,
-    description,
-    Schema(
-      properties = parameters.mapValues { it.value.toInternal() },
-      required = parameters.keys.minus(optionalParameters.toSet()).toList(),
-      type = "OBJECT",
-      nullable = false,
-    ),
-  )
+  com.google.firebase.vertexai.common.client.FunctionDeclaration(name, "", parameters.toInternal())
 
 internal fun com.google.firebase.vertexai.type.Schema.toInternal(): Schema =
   Schema(

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/FunctionDeclaration.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/FunctionDeclaration.kt
@@ -42,6 +42,6 @@ class FunctionDeclaration(
   val parameters: Map<String, Schema>,
   val optionalParameters: List<String> = emptyList(),
 ) {
-  private val schema: Schema =
+  internal val schema: Schema =
     Schema.obj(properties = parameters, optionalProperties = optionalParameters, nullable = false)
 }

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/FunctionDeclaration.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/FunctionDeclaration.kt
@@ -41,4 +41,7 @@ class FunctionDeclaration(
   val description: String,
   val parameters: Map<String, Schema>,
   val optionalParameters: List<String> = emptyList(),
-)
+) {
+  private val schema: Schema =
+    Schema.obj(properties = parameters, optionalProperties = optionalParameters, nullable = false)
+}

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Schema.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Schema.kt
@@ -130,14 +130,20 @@ internal constructor(
       optionalProperties: List<String> = emptyList(),
       description: String? = null,
       nullable: Boolean = false,
-    ) =
-      Schema(
+    ): Schema {
+      if (!properties.keys.containsAll(optionalProperties)) {
+        throw IllegalArgumentException(
+          "All optional properties must be present in properties. Missing: ${optionalProperties.minus(properties.keys)}"
+        )
+      }
+      return Schema(
         description = description,
         nullable = nullable,
         properties = properties,
         required = properties.keys.minus(optionalProperties.toSet()).toList(),
         type = "OBJECT",
       )
+    }
 
     /**
      * Returns a schema for an array.


### PR DESCRIPTION
By creating the schema earlier, any errors when declaring the schema will be caught at the declaration site, which makes debugging much easier.