### PR TITLE
Introduce `FunctionCall` and `FunctionResponse` types

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Part.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Part.kt
@@ -17,7 +17,8 @@
 package com.google.firebase.vertexai.type
 
 import android.graphics.Bitmap
-import org.json.JSONObject
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 
 /** Interface representing data sent to and received from requests. */
 interface Part
@@ -49,7 +50,7 @@ class InlineDataPart(val mimeType: String, val inlineData: ByteArray) : Part
  * @param name the name of the function to call
  * @param args the function parameters and values as a [Map]
  */
-class FunctionCallPart(val name: String, val args: Map<String, String?>) : Part
+class FunctionCallPart(val functionCall: FunctionCall) : Part
 
 /**
  * Represents function call output to be returned to the model when it requests a function call.
@@ -57,7 +58,23 @@ class FunctionCallPart(val name: String, val args: Map<String, String?>) : Part
  * @param name the name of the called function
  * @param response the response produced by the function as a [JSONObject]
  */
-class FunctionResponsePart(val name: String, val response: JSONObject) : Part
+class FunctionResponsePart(val functionResponse: FunctionResponse) : Part
+
+/**
+ * Represents function call name and params received from requests.
+ *
+ * @param name the name of the function to call
+ * @param args the function parameters and values as a [Map]
+ */
+class FunctionCall(val name: String, val args: Map<String, JsonElement>)
+
+/**
+ * Represents function call output to be returned to the model when it requests a function call.
+ *
+ * @param name the name of the called function
+ * @param response the response produced by the function as a [JsonObject]
+ */
+class FunctionResponse(val name: String, val response: JsonObject)
 
 /**
  * Represents file data stored in Cloud Storage for Firebase, referenced by URI.

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Part.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Part.kt
@@ -45,23 +45,22 @@ class ImagePart(val image: Bitmap) : Part
 class InlineDataPart(val mimeType: String, val inlineData: ByteArray) : Part
 
 /**
- * Represents function call name and params received from requests.
+ * Represents a function call request from the model
  *
- * @param name the name of the function to call
- * @param args the function parameters and values as a [Map]
+ * @param functionCall The information provided by the model to call a function.
  */
 class FunctionCallPart(val functionCall: FunctionCall) : Part
 
 /**
- * Represents function call output to be returned to the model when it requests a function call.
+ * The result of calling a function as requested by the model.
  *
- * @param name the name of the called function
- * @param response the response produced by the function as a [JSONObject]
+ * @param functionResponse The information to send back to the model as the result of a functions
+ * call.
  */
 class FunctionResponsePart(val functionResponse: FunctionResponse) : Part
 
 /**
- * Represents function call name and params received from requests.
+ * The data necessary to invoke function [name] using the arguments [args].
  *
  * @param name the name of the function to call
  * @param args the function parameters and values as a [Map]
@@ -69,7 +68,7 @@ class FunctionResponsePart(val functionResponse: FunctionResponse) : Part
 class FunctionCall(val name: String, val args: Map<String, JsonElement>)
 
 /**
- * Represents function call output to be returned to the model when it requests a function call.
+ * The [response] generated after calling function [name].
  *
  * @param name the name of the called function
  * @param response the response produced by the function as a [JsonObject]

--- a/firebase-vertexai/src/test/java/com/google/firebase/vertexai/UnarySnapshotTests.kt
+++ b/firebase-vertexai/src/test/java/com/google/firebase/vertexai/UnarySnapshotTests.kt
@@ -44,6 +44,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.HttpStatusCode
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.JsonPrimitive
 import org.json.JSONArray
 import org.junit.Test
 
@@ -350,7 +351,7 @@ internal class UnarySnapshotTests {
         val response = model.generateContent("prompt")
         val callPart = (response.candidates.first().content.parts.first() as FunctionCallPart)
 
-        callPart.args["season"] shouldBe null
+        callPart.functionCall.args["season"] shouldBe JsonPrimitive(null)
       }
     }
 
@@ -367,7 +368,7 @@ internal class UnarySnapshotTests {
             it.parts.first().shouldBeInstanceOf<FunctionCallPart>()
           }
 
-        callPart.args["current"] shouldBe "true"
+        callPart.functionCall.args["current"] shouldBe JsonPrimitive(true)
       }
     }
 
@@ -378,8 +379,8 @@ internal class UnarySnapshotTests {
         val response = model.generateContent("prompt")
         val callPart = response.functionCalls.shouldNotBeEmpty().first()
 
-        callPart.name shouldBe "current_time"
-        callPart.args.isEmpty() shouldBe true
+        callPart.functionCall.name shouldBe "current_time"
+        callPart.functionCall.args.isEmpty() shouldBe true
       }
     }
 
@@ -390,9 +391,9 @@ internal class UnarySnapshotTests {
         val response = model.generateContent("prompt")
         val callPart = response.functionCalls.shouldNotBeEmpty().first()
 
-        callPart.name shouldBe "sum"
-        callPart.args["x"] shouldBe "4"
-        callPart.args["y"] shouldBe "5"
+        callPart.functionCall.name shouldBe "sum"
+        callPart.functionCall.args["x"] shouldBe JsonPrimitive(4)
+        callPart.functionCall.args["y"] shouldBe JsonPrimitive(5)
       }
     }
 
@@ -405,8 +406,8 @@ internal class UnarySnapshotTests {
 
         callList.size shouldBe 3
         callList.forEach {
-          it.name shouldBe "sum"
-          it.args.size shouldBe 2
+          it.functionCall.name shouldBe "sum"
+          it.functionCall.args.size shouldBe 2
         }
       }
     }
@@ -420,7 +421,7 @@ internal class UnarySnapshotTests {
 
         response.text shouldBe "The sum of [1, 2, 3] is"
         callList.size shouldBe 2
-        callList.forEach { it.args.size shouldBe 2 }
+        callList.forEach { it.functionCall.args.size shouldBe 2 }
       }
     }
 


### PR DESCRIPTION
Their *part counter parts will now wrap them, instead of exposing the underlying structure directly.