### PR TITLE
dataconnect: gradleplugin now gets kotlin version from the main libs.versions.toml

### DIFF
--- a/firebase-dataconnect/gradleplugin/gradle/libs.versions.toml
+++ b/firebase-dataconnect/gradleplugin/gradle/libs.versions.toml
@@ -1,10 +1,8 @@
 [versions]
 androidGradlePlugin = "8.2.1"
-kotlin = "1.8.22"
 
 [libraries]
 android-gradlePlugin-api = { group = "com.android.tools.build", name = "gradle-api", version.ref = "androidGradlePlugin" }
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version = "7.0.0.BETA1" }

--- a/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
+++ b/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
@@ -16,7 +16,7 @@
 
 plugins {
   `java-gradle-plugin`
-  alias(libs.plugins.kotlin.jvm)
+  alias(firebaseLibs.plugins.kotlin.jvm)
   alias(libs.plugins.spotless)
 }
 

--- a/firebase-dataconnect/gradleplugin/settings.gradle.kts
+++ b/firebase-dataconnect/gradleplugin/settings.gradle.kts
@@ -30,6 +30,13 @@ dependencyResolutionManagement {
     google()
     mavenCentral()
   }
+
+  // Reuse libs.version.toml from the main Gradle project.
+  versionCatalogs {
+    create("firebaseLibs") {
+      from(files("../../gradle/libs.versions.toml"))
+    }
+  }
 }
 
 include(":plugin")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,4 +91,5 @@ kotest = ["kotest-runner", "kotest-assertions", "kotest-property", "kotest-prope
 playservices = ["playservices-base", "playservices-basement", "playservices-tasks"]
 
 [plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "serialization-plugin" }


### PR DESCRIPTION
The gradle plugin for Data Connect (located in `firebase-dataconnect/gradleplugin`) had its own, isolated `libs.verisons.toml` which duplicated the Kotlin version. This PR changes it to instead use the Kotlin version from the _main_ `libs.verisons.toml`, in `gradle/libs.verisons.toml`.

Future PRs will eventually move _all_ of the dependencies defined in `firebase-dataconnect/gradleplugin/gradle/libs.versions.toml` into `gradle/libs.verisons.toml`.