### PR TITLE
dataconnect: fix gradle plugin to gracefully handle schemaExtensionsOutputEnabled not being explicitly specified

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectRunEmulatorTask.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectRunEmulatorTask.kt
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
 abstract class DataConnectRunEmulatorTask : DefaultTask() {
@@ -34,7 +35,7 @@ abstract class DataConnectRunEmulatorTask : DefaultTask() {
 
   @get:Input abstract val postgresConnectionUrl: Property<String>
 
-  @get:Input abstract val schemaExtensionsOutputEnabled: Property<Boolean>
+  @get:Optional @get:Input abstract val schemaExtensionsOutputEnabled: Property<Boolean>
 
   @get:Internal abstract val buildDirectory: DirectoryProperty
 
@@ -43,7 +44,7 @@ abstract class DataConnectRunEmulatorTask : DefaultTask() {
     val dataConnectExecutable: File = dataConnectExecutable.get().asFile
     val configDirectory: File = configDirectory.get().asFile
     val postgresConnectionUrl: String = postgresConnectionUrl.get()
-    val schemaExtensionsOutputEnabled: Boolean = schemaExtensionsOutputEnabled.get()
+    val schemaExtensionsOutputEnabled: Boolean = schemaExtensionsOutputEnabled.orNull ?: false
     val buildDirectory: File = buildDirectory.get().asFile
 
     logger.info("dataConnectExecutable={}", dataConnectExecutable.absolutePath)


### PR DESCRIPTION
The `schemaExtensionsOutputEnabled` knob of the Data Connect gradle plugin was always meant to be optional; however, it was accidentally made to be required, resulting in the following unnecessary error if it was not explicitly specified:

```
A problem was found with the configuration of task ':firebase-dataconnect:connectors:runDebugDataConnectEmulator' (type 'DataConnectRunEmulatorTask').
  - In plugin 'com.google.firebase.dataconnect.gradle.plugin.DataConnectGradlePlugin$Inject' type 'com.google.firebase.dataconnect.gradle.plugin.DataConnectRunEmulatorTask' property 'schemaExtensionsOutputEnabled' doesn't have a configured value.
    
    Reason: This property isn't marked as optional and no value has been configured.
    
    Possible solutions:
      1. Assign a value to 'schemaExtensionsOutputEnabled'.
      2. Mark property 'schemaExtensionsOutputEnabled' as optional.
```

This PR correctly makes it optional, defaulting to false.