### PR TITLE
Use gradle/libs.versions.toml to specify the Spotless version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.15'
         classpath 'com.google.firebase:firebase-appdistribution-gradle:5.0.0'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.5'
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:7.0.0.BETA1"
+        classpath libs.spotless.plugin.gradle
     }
 }
 

--- a/firebase-dataconnect/gradleplugin/gradle/libs.versions.toml
+++ b/firebase-dataconnect/gradleplugin/gradle/libs.versions.toml
@@ -1,2 +1,0 @@
-[plugins]
-spotless = { id = "com.diffplug.spotless", version = "7.0.0.BETA1" }

--- a/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
+++ b/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
   `java-gradle-plugin`
   alias(firebaseLibs.plugins.kotlin.jvm)
-  alias(libs.plugins.spotless)
+  alias(firebaseLibs.plugins.spotless)
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ protobufjavautil = "3.21.11"
 kotest = "5.9.1"
 quickcheck = "0.6"
 serialization = "1.5.1"
+spotless = "7.0.0.BETA1"
 androidx-test-core="1.5.0"
 androidx-test-junit="1.1.5"
 androidx-test-truth = "1.5.0"
@@ -88,6 +89,7 @@ kotest-assertions = { module = "io.kotest:kotest-assertions-core-jvm", version.r
 kotest-property = { module = "io.kotest:kotest-property-jvm", version.ref = "kotest" }
 kotest-property-arbs = { module = "io.kotest.extensions:kotest-property-arbs", version = "2.1.2" }
 quickcheck = { module = "net.java:quickcheck", version.ref = "quickcheck" }
+spotless-plugin-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 turbine = { module = "app.cash.turbine:turbine", version = "1.0.0" }
 
 [bundles]
@@ -97,3 +99,4 @@ playservices = ["playservices-base", "playservices-basement", "playservices-task
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "serialization-plugin" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
Specifying the spotless version centrally in gradle/libs.versions.toml avoids duplicating the version number in multiple places.