### PR TITLE
dataconnect: gradle plugin modified to load executable versions from a json file

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
+++ b/firebase-dataconnect/gradleplugin/plugin/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
   `java-gradle-plugin`
   alias(firebaseLibs.plugins.kotlin.jvm)
+  alias(firebaseLibs.plugins.kotlinx.serialization)
   alias(firebaseLibs.plugins.spotless)
 }
 
@@ -25,6 +26,8 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 dependencies {
   compileOnly(firebaseLibs.android.gradlePlugin.gradle.api)
   implementation(gradleKotlinDsl())
+  implementation(firebaseLibs.kotlinx.serialization.core)
+  implementation(firebaseLibs.kotlinx.serialization.json)
 }
 
 gradlePlugin {

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutable.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutable.kt
@@ -15,7 +15,11 @@
  */
 package com.google.firebase.dataconnect.gradle.plugin
 
+import java.io.InputStream
 import java.io.Serializable
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
 
 // The following command was used to generate the `serialVersionUID` constants for each class.
 // serialver -classpath \
@@ -29,84 +33,16 @@ sealed interface DataConnectExecutable {
     Serializable {
 
     companion object {
-      fun forVersion(version: String): VerificationInfo =
-        when (version) {
-          "1.3.4" ->
-            VerificationInfo(
-              fileSizeInBytes = 24_125_592L,
-              sha512DigestHex =
-                "3ec9317db593ebeacfea9756cdd08a02849296fbab67f32f3d811a766be6ce2506f" +
-                  "c7a0cf5f5ea880926f0c4defa5ded965268f5dfe5d07eb80cef926f216c7e"
-            )
-          "1.3.5" ->
-            VerificationInfo(
-              fileSizeInBytes = 24_146_072L,
-              sha512DigestHex =
-                "630391e3c50568cca36e562e51b300e673fa7190c0cae0475a03e4af4003babe711" +
-                  "98c5b0309ecd261b3a3362e8c4d49bdb6cbc6f2b2d3297444112a018a0c10"
-            )
-          "1.3.6" ->
-            VerificationInfo(
-              fileSizeInBytes = 24_785_048L,
-              sha512DigestHex =
-                "77b2fd79a8a70e47defb1592a092c63642fda6c33715f1977d7a44daed3d7e181c3" +
-                  "870aad0fee7b035aabea7778a244135ab3e633247ccd5f937105f6d495a26"
-            )
-          "1.3.7" ->
-            VerificationInfo(
-              fileSizeInBytes = 24_928_408L,
-              sha512DigestHex =
-                "99d9774f3b29a6845f0e096893d1205e69b6f8654797a3fc7d54d22e8f7059d1b65" +
-                  "49ae23b8e8f18c952c1c7d25a07b0b8b29a957abd97e1a79c703448497cef"
-            )
-          "1.3.8" ->
-            VerificationInfo(
-              fileSizeInBytes = 24_940_696L,
-              sha512DigestHex =
-                "aea3583ebe1a36938eec5164de79405951ddf05b70a857ddb4f346f1424666f1d96" +
-                  "989a5f81326c7e2aef4a195d31ff356fdf2331ed98fa1048c4bd469cbfd97"
-            )
-          "1.3.9" ->
-            VerificationInfo(
-              fileSizeInBytes = 24_977_560L,
-              sha512DigestHex =
-                "4558928c2a84b54113e0d6918907eb75bdeb9bd059dcc4b6f22cb4a7c9c7421a357" +
-                  "7f3b0d2eeb246b1df739b38f1eb91e5a6166b0e559707746d79e6ccdf9ed4"
-            )
-          "1.4.0" ->
-            VerificationInfo(
-              fileSizeInBytes = 25_018_520L,
-              sha512DigestHex =
-                "c06ccade89cb46459452f71c6d49a01b4b30c9f96cc4cb770ed168e7420ef0cb368" +
-                  "cd602ff596137e6586270046cf0ffd9f8d294e44b036e5c5b373a074b7e5a"
-            )
-          "1.4.1" ->
-            VerificationInfo(
-              fileSizeInBytes = 25_034_904L,
-              sha512DigestHex =
-                "f4a16aca3a68c431407fc88a900940c73612a0046d9603ca80195c8c9641ee38fd8" +
-                  "1b67cc158af600e173de1abc3cb0df9377b1a6012c808ab0871bb1bdbc0b1"
-            )
-          "1.4.2" ->
-            VerificationInfo(
-              fileSizeInBytes = 25_034_904L,
-              sha512DigestHex =
-                "24ee2db55a034dcb95000715919e1dc35c91403000dbd3b912e6b5b55587b862eca" +
-                  "886bb1ca86e19cdaa25c77c29492e5d3b0c740c8649a90297cf84e9c9123b"
-            )
-          "1.4.3" ->
-            VerificationInfo(
-              fileSizeInBytes = 25_034_904L,
-              sha512DigestHex =
-                "c25fd2cb9ef4896cadc05fab79f767f8fc8212e3b967f2ae535855befd63339539a" +
-                  "4f6cd648743c024f40139b668cc69fb9c6691490259664af5821d116896cf"
-            )
-          else ->
-            throw DataConnectGradleException(
+      fun forVersion(version: String): VerificationInfo {
+        val versions = VersionsJson.load().versions
+        val versionInfo =
+          versions[version]
+            ?: throw DataConnectGradleException(
               "3svd27ch8y",
               "File size and SHA512 digest is not known for version: $version"
             )
-        }
+        return VerificationInfo(versionInfo.size, versionInfo.sha512DigestHex)
+      }
     }
   }
 
@@ -122,7 +58,8 @@ sealed interface DataConnectExecutable {
     DataConnectExecutable {
     companion object {
 
-      private const val DEFAULT_VERSION = "1.4.3"
+      private val defaultVersion: String
+        get() = VersionsJson.load().default
 
       fun forVersionWithDefaultVerificationInfo(version: String): Version {
         val verificationInfo = DataConnectExecutable.VerificationInfo.forVersion(version)
@@ -130,7 +67,29 @@ sealed interface DataConnectExecutable {
       }
 
       fun forDefaultVersionWithDefaultVerificationInfo(): Version =
-        forVersionWithDefaultVerificationInfo(DEFAULT_VERSION)
+        forVersionWithDefaultVerificationInfo(defaultVersion)
     }
+  }
+
+  @OptIn(ExperimentalSerializationApi::class)
+  object VersionsJson {
+
+    private const val RESOURCE_PATH =
+      "com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json"
+
+    fun load(): Root = openFile().use { Json.decodeFromStream<Root>(it) }
+
+    private fun openFile(): InputStream =
+      this::class.java.classLoader.getResourceAsStream(RESOURCE_PATH)
+        ?: throw DataConnectGradleException("antkaw2gjp", "resource not found: $RESOURCE_PATH")
+
+    @kotlinx.serialization.Serializable
+    data class Root(
+      val default: String,
+      val versions: Map<String, VerificationInfo>,
+    )
+
+    @kotlinx.serialization.Serializable
+    data class VerificationInfo(val size: Long, val sha512DigestHex: String)
   }
 }

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/plugin/DataConnectExecutableVersions.json
@@ -1,0 +1,45 @@
+{
+  "default": "1.4.3",
+  "versions": {
+    "1.3.4": {
+      "size": 24125592,
+      "sha512DigestHex": "3ec9317db593ebeacfea9756cdd08a02849296fbab67f32f3d811a766be6ce2506fc7a0cf5f5ea880926f0c4defa5ded965268f5dfe5d07eb80cef926f216c7e"
+    },
+    "1.3.5": {
+      "size": 24146072,
+      "sha512DigestHex": "630391e3c50568cca36e562e51b300e673fa7190c0cae0475a03e4af4003babe71198c5b0309ecd261b3a3362e8c4d49bdb6cbc6f2b2d3297444112a018a0c10"
+    },
+    "1.3.6": {
+      "size": 24785048,
+      "sha512DigestHex": "77b2fd79a8a70e47defb1592a092c63642fda6c33715f1977d7a44daed3d7e181c3870aad0fee7b035aabea7778a244135ab3e633247ccd5f937105f6d495a26"
+    },
+    "1.3.7": {
+      "size": 24928408,
+      "sha512DigestHex": "99d9774f3b29a6845f0e096893d1205e69b6f8654797a3fc7d54d22e8f7059d1b6549ae23b8e8f18c952c1c7d25a07b0b8b29a957abd97e1a79c703448497cef"
+    },
+    "1.3.8": {
+      "size": 24940696,
+      "sha512DigestHex": "aea3583ebe1a36938eec5164de79405951ddf05b70a857ddb4f346f1424666f1d96989a5f81326c7e2aef4a195d31ff356fdf2331ed98fa1048c4bd469cbfd97"
+    },
+    "1.3.9": {
+      "size": 24977560,
+      "sha512DigestHex": "4558928c2a84b54113e0d6918907eb75bdeb9bd059dcc4b6f22cb4a7c9c7421a3577f3b0d2eeb246b1df739b38f1eb91e5a6166b0e559707746d79e6ccdf9ed4"
+    },
+    "1.4.0": {
+      "size": 25018520,
+      "sha512DigestHex": "c06ccade89cb46459452f71c6d49a01b4b30c9f96cc4cb770ed168e7420ef0cb368cd602ff596137e6586270046cf0ffd9f8d294e44b036e5c5b373a074b7e5a"
+    },
+    "1.4.1": {
+      "size": 25034904,
+      "sha512DigestHex": "f4a16aca3a68c431407fc88a900940c73612a0046d9603ca80195c8c9641ee38fd81b67cc158af600e173de1abc3cb0df9377b1a6012c808ab0871bb1bdbc0b1"
+    },
+    "1.4.2": {
+      "size": 25034904,
+      "sha512DigestHex": "24ee2db55a034dcb95000715919e1dc35c91403000dbd3b912e6b5b55587b862eca886bb1ca86e19cdaa25c77c29492e5d3b0c740c8649a90297cf84e9c9123b"
+    },
+    "1.4.3": {
+      "size": 25034904,
+      "sha512DigestHex": "c25fd2cb9ef4896cadc05fab79f767f8fc8212e3b967f2ae535855befd63339539a4f6cd648743c024f40139b668cc69fb9c6691490259664af5821d116896cf"
+    }
+  }
+}


### PR DESCRIPTION
Previously, the version information about data connect toolkit executables was hardcoded in Kotlin.