### PR TITLE
dataconnect: improve gradle plugin errors when the version of the cli is not found

### DIFF
--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectDslExtension.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectDslExtension.kt
@@ -89,9 +89,6 @@ abstract class DataConnectDslExtension @Inject constructor(objectFactory: Object
     var version: String?
     var file: File?
     var regularFile: RegularFile?
-    var fileSizeInBytes: Long?
-    var sha512DigestHex: String?
-    var verificationEnabled: Boolean
   }
 
   private class DataConnectExecutableBuilderImpl(initialValues: DataConnectExecutable?) :
@@ -121,29 +118,16 @@ abstract class DataConnectDslExtension @Inject constructor(objectFactory: Object
         _regularFile = value
       }
 
-    override var fileSizeInBytes: Long? = null
-    override var sha512DigestHex: String? = null
-    override var verificationEnabled: Boolean = true
-
     fun updateFrom(info: DataConnectExecutable.File) {
       file = info.file
-      updateFrom(info.verificationInfo)
     }
 
     fun updateFrom(info: DataConnectExecutable.RegularFile) {
       regularFile = info.file
-      updateFrom(info.verificationInfo)
     }
 
     fun updateFrom(info: DataConnectExecutable.Version) {
       version = info.version
-      updateFrom(info.verificationInfo)
-    }
-
-    fun updateFrom(info: DataConnectExecutable.VerificationInfo?) {
-      verificationEnabled = info !== null
-      fileSizeInBytes = info?.fileSizeInBytes
-      sha512DigestHex = info?.sha512DigestHex
     }
 
     init {
@@ -159,9 +143,6 @@ abstract class DataConnectDslExtension @Inject constructor(objectFactory: Object
       val version = version
       val file = file
       val regularFile = regularFile
-      val fileSizeInBytes = fileSizeInBytes
-      val sha512DigestHex = sha512DigestHex
-      val verificationEnabled = verificationEnabled
 
       if (version === null && file === null && regularFile === null) {
         return null
@@ -195,41 +176,12 @@ abstract class DataConnectDslExtension @Inject constructor(objectFactory: Object
         )
       }
 
-      val verificationInfo: DataConnectExecutable.VerificationInfo? =
-        if (!verificationEnabled) {
-          null
-        } else if (fileSizeInBytes === null && sha512DigestHex === null) {
-          if (version !== null) {
-            DataConnectExecutable.VerificationInfo.forVersion(version)
-          } else {
-            throw DataConnectGradleException(
-              "8s9venv4ch",
-              "Both 'fileSizeInBytes' and 'sha512DigestHex' were null" +
-                " but _both_ must be set when verificationEnabled==true" +
-                " and file!=null or regularFile!=null" +
-                " (file=$file regularFile=$regularFile)"
-            )
-          }
-        } else if (fileSizeInBytes === null || sha512DigestHex === null) {
-          throw DataConnectGradleException(
-            "gjzykv9pqq",
-            "Both 'fileSizeInBytes' and 'sha512DigestHex' have to be set or both unset" +
-              " when verificationEnabled==true, but one of them was set and the other was not" +
-              " (fileSizeInBytes=$fileSizeInBytes, sha512DigestHex=$sha512DigestHex)"
-          )
-        } else {
-          DataConnectExecutable.VerificationInfo(
-            fileSizeInBytes = fileSizeInBytes,
-            sha512DigestHex = sha512DigestHex,
-          )
-        }
-
       return if (version !== null) {
-        DataConnectExecutable.Version(version = version, verificationInfo = verificationInfo)
+        DataConnectExecutable.Version(version = version)
       } else if (file !== null) {
-        DataConnectExecutable.File(file = file, verificationInfo = verificationInfo)
+        DataConnectExecutable.File(file = file)
       } else if (regularFile !== null) {
-        DataConnectExecutable.RegularFile(file = regularFile, verificationInfo = verificationInfo)
+        DataConnectExecutable.RegularFile(file = regularFile)
       } else {
         throw DataConnectGradleException(
           "yg49q5nzxt",

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectGradlePlugin.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectGradlePlugin.kt
@@ -110,17 +110,6 @@ abstract class DataConnectGradlePlugin : Plugin<Project> {
               }
             )
           )
-          verificationInfo.set(
-            dataConnectExecutable.map(
-              TransformerInterop {
-                when (it) {
-                  is DataConnectExecutable.File -> it.verificationInfo
-                  is DataConnectExecutable.RegularFile -> it.verificationInfo
-                  is DataConnectExecutable.Version -> it.verificationInfo
-                }
-              }
-            )
-          )
           outputFile.set(
             dataConnectExecutable.map {
               when (it) {

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectLocalSettings.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectLocalSettings.kt
@@ -29,9 +29,9 @@ class DataConnectLocalSettings(project: Project) {
       ) { settingName, settingValue, project ->
         if (settingName == KEY_DATA_CONNECT_EXECUTABLE_FILE) {
           val regularFile = project.layout.projectDirectory.file(settingValue)
-          DataConnectExecutable.RegularFile(regularFile, verificationInfo = null)
+          DataConnectExecutable.RegularFile(regularFile)
         } else if (settingName == KEY_DATA_CONNECT_EXECUTABLE_VERSION) {
-          DataConnectExecutable.Version.forVersionWithDefaultVerificationInfo(settingValue)
+          DataConnectExecutable.Version(settingValue)
         } else {
           throw IllegalStateException(
             "fileValue==null && versionValue==null (error code rbhmsd524t)"

--- a/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectProviders.kt
+++ b/firebase-dataconnect/gradleplugin/plugin/src/main/kotlin/com/google/firebase/dataconnect/gradle/plugin/DataConnectProviders.kt
@@ -35,11 +35,11 @@ class DataConnectProviders(
     val fileValueFromGradleProperty: Provider<DataConnectExecutable> =
       project.providers.gradleProperty(fileGradlePropertyName).map {
         val regularFile = project.layout.projectDirectory.file(it)
-        DataConnectExecutable.RegularFile(regularFile, verificationInfo = null)
+        DataConnectExecutable.RegularFile(regularFile)
       }
     val versionValueFromGradleProperty: Provider<DataConnectExecutable> =
       project.providers.gradleProperty(versionGradlePropertyName).map {
-        DataConnectExecutable.Version.forVersionWithDefaultVerificationInfo(it)
+        DataConnectExecutable.Version(it)
       }
     val valueFromVariant: Provider<DataConnectExecutable> = variantExtension.dataConnectExecutable
     val valueFromProject: Provider<DataConnectExecutable> =
@@ -50,7 +50,7 @@ class DataConnectProviders(
       .orElse(versionValueFromGradleProperty)
       .orElse(valueFromVariant)
       .orElse(valueFromProject)
-      .orElse(DataConnectExecutable.Version.forDefaultVersionWithDefaultVerificationInfo())
+      .orElse(DataConnectExecutable.Version.default)
   }
 
   val postgresConnectionUrl: Provider<String> = run {


### PR DESCRIPTION
If a version of the Data Connect CLI is not found, then the error message produced by the Data Connect gradle plugin is not very helpful. This PR changes the error message to list the versions that _are_ available, and also print JSON blob that can be copied and pasted into `DataConnectExecutableVersions.json` so that the version is no longer "unknown".