### PR TITLE
Use abstract class instead of sealed classes for StringFormat

### DIFF
--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Schema.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Schema.kt
@@ -16,8 +16,8 @@
 
 package com.google.firebase.vertexai.type
 
-public sealed class StringFormat(public val value: String) {
-  public class Custom(format: String) : StringFormat(format)
+public abstract class StringFormat private constructor(internal val value: String) {
+  public class Custom(value: String) : StringFormat(value)
 }
 
 /** Represents a schema */


### PR DESCRIPTION
`sealed` classes have nice properties but they don't play well with API backward compatibility. Adding a new class to a `sealed` class set is a breaking change since they require exhaustive switching.