### PR TITLE
dataconnect: modernize tests in ProtoStructDecoderUnitTest.kt, ProtoStructEncoderUnitTest.kt, and TimestampSerializerUnitTest.kt

### DIFF
--- a/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
+++ b/firebase-dataconnect/src/main/kotlin/com/google/firebase/dataconnect/util/ProtoUtil.kt
@@ -248,10 +248,12 @@ internal object ProtoUtil {
 
   fun Value.toAny(): Any? = valueToAnyMutualRecursion.anyValueFromValue(this)
 
-  fun List<Any?>.toValueProto(): Value {
+  fun <T> List<T>.toValueProto(): Value {
     val key = "y8czq9rh75"
     return mapOf(key to this).toStructProto().getFieldsOrThrow(key)
   }
+
+  fun <T> List<T>.toListValueProto(): ListValue = toValueProto().listValue
 
   fun Map<String, Any?>.toValueProto(): Value =
     Value.newBuilder().setStructValue(toStructProto()).build()

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/ProtoStructEncoderUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/ProtoStructEncoderUnitTest.kt
@@ -18,65 +18,55 @@
 
 package com.google.firebase.dataconnect
 
-import com.google.common.truth.Truth.assertThat
-import com.google.common.truth.extensions.proto.LiteProtoTruth.assertThat
+import com.google.firebase.dataconnect.testutil.shouldBe
+import com.google.firebase.dataconnect.testutil.shouldBeDefaultInstance
+import com.google.firebase.dataconnect.testutil.shouldContainWithNonAbuttingText
 import com.google.firebase.dataconnect.util.ProtoUtil.buildStructProto
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
 import com.google.protobuf.Struct
-import java.util.concurrent.atomic.AtomicLong
+import io.kotest.assertions.throwables.shouldThrow
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationStrategy
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.CompositeEncoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.modules.EmptySerializersModule
-import kotlinx.serialization.serializer
-import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class ProtoStructEncoderUnitTest {
 
   @Test
   fun `encodeToStruct() should throw if a NUMBER_VALUE is produced`() {
-    val exception = assertThrows(IllegalArgumentException::class.java) { encodeToStruct(42) }
-    assertThat(exception).hasMessageThat().contains("NUMBER_VALUE")
+    val exception = shouldThrow<IllegalArgumentException> { encodeToStruct(42) }
+    exception.message shouldContainWithNonAbuttingText "NUMBER_VALUE"
   }
 
   @Test
   fun `encodeToStruct() should throw if a BOOL_VALUE is produced`() {
-    val exception = assertThrows(IllegalArgumentException::class.java) { encodeToStruct(true) }
-    assertThat(exception).hasMessageThat().contains("BOOL_VALUE")
+    val exception = shouldThrow<IllegalArgumentException> { encodeToStruct(true) }
+    exception.message shouldContainWithNonAbuttingText "BOOL_VALUE"
   }
 
   @Test
   fun `encodeToStruct() should throw if a STRING_VALUE is produced`() {
     val exception =
-      assertThrows(IllegalArgumentException::class.java) {
-        encodeToStruct("arbitrary string value")
-      }
-    assertThat(exception).hasMessageThat().contains("STRING_VALUE")
+      shouldThrow<IllegalArgumentException> { encodeToStruct("arbitrary string value") }
+    exception.message shouldContainWithNonAbuttingText "STRING_VALUE"
   }
 
   @Test
   fun `encodeToStruct() should throw if a LIST_VALUE is produced`() {
     val exception =
-      assertThrows(IllegalArgumentException::class.java) {
-        encodeToStruct(listOf("element1", "element2"))
-      }
-    assertThat(exception).hasMessageThat().contains("LIST_VALUE")
+      shouldThrow<IllegalArgumentException> { encodeToStruct(listOf("element1", "element2")) }
+    exception.message shouldContainWithNonAbuttingText "LIST_VALUE"
   }
 
   @Test
   fun `encodeToStruct() should return an empty struct if an empty map is given`() {
     val encodedStruct = encodeToStruct(emptyMap<Unit, Unit>())
-    assertThat(encodedStruct).isEqualToDefaultInstance()
+    encodedStruct.shouldBeDefaultInstance()
   }
 
   @Test
   fun `encodeToStruct() should encode Unit as an empty struct`() {
     val encodedStruct = encodeToStruct(Unit)
-    assertThat(encodedStruct).isEqualToDefaultInstance()
+    encodedStruct.shouldBeDefaultInstance()
   }
 
   @Test
@@ -104,18 +94,17 @@ class ProtoStructEncoderUnitTest {
         )
       )
 
-    assertThat(encodedStruct)
-      .isEqualTo(
-        buildStructProto {
-          put("iv", 42.0)
-          put("dv", 1234.5)
-          put("bvt", true)
-          put("bvf", false)
-          put("sv", "blah blah")
-          putNull("nsvn")
-          put("nsvnn", "I'm not null")
-        }
-      )
+    encodedStruct.shouldBe(
+      buildStructProto {
+        put("iv", 42.0)
+        put("dv", 1234.5)
+        put("bvt", true)
+        put("bvf", false)
+        put("sv", "blah blah")
+        putNull("nsvn")
+        put("nsvnn", "I'm not null")
+      }
+    )
   }
 
   @Test
@@ -139,35 +128,34 @@ class ProtoStructEncoderUnitTest {
         )
       )
 
-    assertThat(encodedStruct)
-      .isEqualTo(
-        buildStructProto {
-          putList("iv") {
-            add(42.0)
-            add(43.0)
-          }
-          putList("dv") {
-            add(1234.5)
-            add(5678.9)
-          }
-          putList("bv") {
-            add(true)
-            add(false)
-            add(false)
-            add(true)
-          }
-          putList("sv") {
-            add("abcde")
-            add("fghij")
-          }
-          putList("nsv") {
-            add("klmno")
-            addNull()
-            add("pqrst")
-            addNull()
-          }
+    encodedStruct.shouldBe(
+      buildStructProto {
+        putList("iv") {
+          add(42.0)
+          add(43.0)
         }
-      )
+        putList("dv") {
+          add(1234.5)
+          add(5678.9)
+        }
+        putList("bv") {
+          add(true)
+          add(false)
+          add(false)
+          add(true)
+        }
+        putList("sv") {
+          add("abcde")
+          add("fghij")
+        }
+        putList("nsv") {
+          add("klmno")
+          addNull()
+          add("pqrst")
+          addNull()
+        }
+      }
+    )
   }
 
   @Test
@@ -177,15 +165,14 @@ class ProtoStructEncoderUnitTest {
     @Serializable data class TestData1(val data2: TestData2)
     val encodedStruct = encodeToStruct(TestData1(TestData2(TestData3("zzzz"), null)))
 
-    assertThat(encodedStruct)
-      .isEqualTo(
-        buildStructProto {
-          putStruct("data2") {
-            putNull("data3N")
-            putStruct("data3") { put("s", "zzzz") }
-          }
+    encodedStruct.shouldBe(
+      buildStructProto {
+        putStruct("data2") {
+          putNull("data3N")
+          putStruct("data3") { put("s", "zzzz") }
         }
-      )
+      }
+    )
   }
 
   @Test
@@ -194,7 +181,7 @@ class ProtoStructEncoderUnitTest {
 
     val encodedStruct = encodeToStruct(TestData(OptionalVariable.Undefined))
 
-    assertThat(encodedStruct).isEqualTo(Struct.getDefaultInstance())
+    encodedStruct shouldBe Struct.getDefaultInstance()
   }
 
   @Test
@@ -203,7 +190,7 @@ class ProtoStructEncoderUnitTest {
 
     val encodedStruct = encodeToStruct(TestData(OptionalVariable.Undefined))
 
-    assertThat(encodedStruct).isEqualTo(Struct.getDefaultInstance())
+    encodedStruct shouldBe Struct.getDefaultInstance()
   }
 
   @Test
@@ -212,7 +199,7 @@ class ProtoStructEncoderUnitTest {
 
     val encodedStruct = encodeToStruct(TestData(OptionalVariable.Value("Hello")))
 
-    assertThat(encodedStruct).isEqualTo(buildStructProto { put("s", "Hello") })
+    encodedStruct shouldBe buildStructProto { put("s", "Hello") }
   }
 
   @Test
@@ -221,7 +208,7 @@ class ProtoStructEncoderUnitTest {
 
     val encodedStruct = encodeToStruct(TestData(OptionalVariable.Value("World")))
 
-    assertThat(encodedStruct).isEqualTo(buildStructProto { put("s", "World") })
+    encodedStruct shouldBe buildStructProto { put("s", "World") }
   }
 
   @Test
@@ -230,169 +217,6 @@ class ProtoStructEncoderUnitTest {
 
     val encodedStruct = encodeToStruct(TestData(OptionalVariable.Value(null)))
 
-    assertThat(encodedStruct).isEqualTo(buildStructProto { putNull("s") })
-  }
-}
-
-/**
- * An encoder that can be useful during testing to simply print the method invocations in order to
- * discover how an encoder should be implemented.
- */
-@Suppress("unused")
-private class LoggingEncoder(
-  private val idBySerialDescriptor: MutableMap<SerialDescriptor, Long> = mutableMapOf()
-) : Encoder, CompositeEncoder {
-  val id = nextEncoderId.incrementAndGet()
-
-  override val serializersModule = EmptySerializersModule()
-
-  private fun log(message: String) {
-    println("zzyzx LoggingEncoder[$id] $message")
-  }
-
-  private fun idFor(descriptor: SerialDescriptor) =
-    idBySerialDescriptor[descriptor]
-      ?: nextSerialDescriptorId.incrementAndGet().also { idBySerialDescriptor[descriptor] = it }
-
-  override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
-    log(
-      "beginStructure() descriptorId=${idFor(descriptor)} kind=${descriptor.kind} " +
-        "elementsCount=${descriptor.elementsCount}"
-    )
-    return LoggingEncoder(idBySerialDescriptor)
-  }
-
-  override fun endStructure(descriptor: SerialDescriptor) {
-    log("endStructure() descriptorId=${idFor(descriptor)} kind=${descriptor.kind}")
-  }
-
-  override fun encodeBoolean(value: Boolean) {
-    log("encodeBoolean($value)")
-  }
-
-  override fun encodeByte(value: Byte) {
-    log("encodeByte($value)")
-  }
-
-  override fun encodeChar(value: Char) {
-    log("encodeChar($value)")
-  }
-
-  override fun encodeDouble(value: Double) {
-    log("encodeDouble($value)")
-  }
-
-  override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
-    log("encodeEnum($index)")
-  }
-
-  override fun encodeFloat(value: Float) {
-    log("encodeFloat($value)")
-  }
-
-  override fun encodeInline(descriptor: SerialDescriptor): Encoder {
-    log("encodeInline() kind=${descriptor.kind} serialName=${descriptor.serialName}")
-    return LoggingEncoder(idBySerialDescriptor)
-  }
-
-  override fun encodeInt(value: Int) {
-    log("encodeInt($value)")
-  }
-
-  override fun encodeLong(value: Long) {
-    log("encodeLong($value)")
-  }
-
-  @ExperimentalSerializationApi
-  override fun encodeNull() {
-    log("encodeNull()")
-  }
-
-  override fun encodeShort(value: Short) {
-    log("encodeShort($value)")
-  }
-
-  override fun encodeString(value: String) {
-    log("encodeString($value)")
-  }
-
-  override fun encodeBooleanElement(descriptor: SerialDescriptor, index: Int, value: Boolean) {
-    log("encodeBooleanElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  override fun encodeByteElement(descriptor: SerialDescriptor, index: Int, value: Byte) {
-    log("encodeByteElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  override fun encodeCharElement(descriptor: SerialDescriptor, index: Int, value: Char) {
-    log("encodeCharElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  override fun encodeDoubleElement(descriptor: SerialDescriptor, index: Int, value: Double) {
-    log("encodeDoubleElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  override fun encodeFloatElement(descriptor: SerialDescriptor, index: Int, value: Float) {
-    log("encodeFloatElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  override fun encodeInlineElement(descriptor: SerialDescriptor, index: Int): Encoder {
-    log("encodeInlineElement() index=$index elementName=${descriptor.getElementName(index)}")
-    return LoggingEncoder(idBySerialDescriptor)
-  }
-
-  override fun encodeIntElement(descriptor: SerialDescriptor, index: Int, value: Int) {
-    log("encodeIntElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  override fun encodeLongElement(descriptor: SerialDescriptor, index: Int, value: Long) {
-    log("encodeLongElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  override fun encodeShortElement(descriptor: SerialDescriptor, index: Int, value: Short) {
-    log("encodeShortElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  override fun encodeStringElement(descriptor: SerialDescriptor, index: Int, value: String) {
-    log("encodeStringElement($value) index=$index elementName=${descriptor.getElementName(index)}")
-  }
-
-  @ExperimentalSerializationApi
-  override fun <T : Any> encodeNullableSerializableElement(
-    descriptor: SerialDescriptor,
-    index: Int,
-    serializer: SerializationStrategy<T>,
-    value: T?
-  ) {
-    log(
-      "encodeNullableSerializableElement($value) index=$index elementName=${descriptor.getElementName(index)}"
-    )
-    if (value != null) {
-      encodeSerializableValue(serializer, value)
-    }
-  }
-
-  override fun <T> encodeSerializableElement(
-    descriptor: SerialDescriptor,
-    index: Int,
-    serializer: SerializationStrategy<T>,
-    value: T
-  ) {
-    log(
-      "encodeSerializableElement($value) index=$index elementName=${descriptor.getElementName(index)}"
-    )
-    encodeSerializableValue(serializer, value)
-  }
-
-  companion object {
-
-    fun <T : Any> encode(serializer: SerializationStrategy<T>, value: T) {
-      LoggingEncoder().encodeSerializableValue(serializer, value)
-    }
-
-    inline fun <reified T : Any> encode(value: T) = encode(serializer(), value)
-
-    private val nextEncoderId = AtomicLong(0)
-    private val nextSerialDescriptorId = AtomicLong(998800000L)
+    encodedStruct shouldBe buildStructProto { putNull("s") }
   }
 }

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/TimestampSerializerUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/TimestampSerializerUnitTest.kt
@@ -16,12 +16,14 @@
 
 package com.google.firebase.dataconnect.serializers
 
-import com.google.common.truth.Truth.assertThat
 import com.google.firebase.Timestamp
-import com.google.firebase.dataconnect.testutil.assertThrows
 import com.google.firebase.dataconnect.util.ProtoUtil.buildStructProto
 import com.google.firebase.dataconnect.util.ProtoUtil.decodeFromStruct
 import com.google.firebase.dataconnect.util.ProtoUtil.encodeToStruct
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import org.junit.Test
 
@@ -54,150 +56,150 @@ class TimestampSerializerUnitTest {
 
   @Test
   fun `decoding should succeed when 'time-secfrac' is omitted`() {
-    assertThat(decodeTimestamp("2006-01-02T15:04:05Z")).isEqualTo(Timestamp(1136214245, 0))
+    decodeTimestamp("2006-01-02T15:04:05Z") shouldBe Timestamp(1136214245, 0)
   }
 
   @Test
   fun `decoding should succeed when 'time-secfrac' has millisecond precision`() {
-    assertThat(decodeTimestamp("2006-01-02T15:04:05.123Z"))
-      .isEqualTo(Timestamp(1136214245, 123_000_000))
+    decodeTimestamp("2006-01-02T15:04:05.123Z") shouldBe Timestamp(1136214245, 123_000_000)
   }
 
   @Test
   fun `decoding should succeed when 'time-secfrac' has microsecond precision`() {
-    assertThat(decodeTimestamp("2006-01-02T15:04:05.123456Z"))
-      .isEqualTo(Timestamp(1136214245, 123_456_000))
+    decodeTimestamp("2006-01-02T15:04:05.123456Z") shouldBe Timestamp(1136214245, 123_456_000)
   }
 
   @Test
   fun `decoding should succeed when 'time-secfrac' has nanosecond precision`() {
-    assertThat(decodeTimestamp("2006-01-02T15:04:05.123456789Z"))
-      .isEqualTo(Timestamp(1136214245, 123_456_789))
+    decodeTimestamp("2006-01-02T15:04:05.123456789Z") shouldBe Timestamp(1136214245, 123_456_789)
   }
 
   @Test
   fun `decoding should succeed when time offset is 0`() {
-    assertThat(decodeTimestamp("2006-01-02T15:04:05-00:00"))
-      .isEqualTo(decodeTimestamp("2006-01-02T15:04:05Z"))
-
-    assertThat(decodeTimestamp("2006-01-02T15:04:05+00:00"))
-      .isEqualTo(decodeTimestamp("2006-01-02T15:04:05Z"))
+    assertSoftly {
+      decodeTimestamp("2006-01-02T15:04:05-00:00") shouldBe decodeTimestamp("2006-01-02T15:04:05Z")
+      decodeTimestamp("2006-01-02T15:04:05+00:00") shouldBe decodeTimestamp("2006-01-02T15:04:05Z")
+    }
   }
 
   @Test
   fun `decoding should succeed when time offset is positive`() {
-    assertThat(decodeTimestamp("2006-01-02T15:04:05+11:01"))
-      .isEqualTo(decodeTimestamp("2006-01-02T04:03:05Z"))
+    decodeTimestamp("2006-01-02T15:04:05+11:01") shouldBe decodeTimestamp("2006-01-02T04:03:05Z")
   }
 
   @Test
   fun `decoding should succeed when time offset is negative`() {
-    assertThat(decodeTimestamp("2006-01-02T15:04:05-05:10"))
-      .isEqualTo(decodeTimestamp("2006-01-02T20:14:05Z"))
+    decodeTimestamp("2006-01-02T15:04:05-05:10") shouldBe decodeTimestamp("2006-01-02T20:14:05Z")
   }
 
   @Test
   fun `decoding should succeed when there are both time-secfrac and - time offset`() {
-    assertThat(decodeTimestamp("2023-05-21T11:04:05.462-11:07"))
-      .isEqualTo(decodeTimestamp("2023-05-21T22:11:05.462Z"))
+    assertSoftly {
+      decodeTimestamp("2023-05-21T11:04:05.462-11:07") shouldBe decodeTimestamp("2023-05-21T22:11:05.462Z")
 
-    assertThat(decodeTimestamp("2053-11-02T15:04:05.743393-05:10"))
-      .isEqualTo(decodeTimestamp("2053-11-02T20:14:05.743393Z"))
+      decodeTimestamp("2053-11-02T15:04:05.743393-05:10") shouldBe decodeTimestamp("2053-11-02T20:14:05.743393Z")
 
-    assertThat(decodeTimestamp("1538-03-05T15:04:05.653498752-03:01"))
-      .isEqualTo(decodeTimestamp("1538-03-05T18:05:05.653498752Z"))
+      decodeTimestamp("1538-03-05T15:04:05.653498752-03:01") shouldBe decodeTimestamp("1538-03-05T18:05:05.653498752Z")
+    }
   }
 
   @Test
   fun `decoding should succeed when there are both time-secfrac and + time offset`() {
-    assertThat(decodeTimestamp("2023-05-21T11:04:05.662+11:01"))
-      .isEqualTo(decodeTimestamp("2023-05-21T00:03:05.662Z"))
+    assertSoftly {
+      decodeTimestamp("2023-05-21T11:04:05.662+11:01") shouldBe decodeTimestamp("2023-05-21T00:03:05.662Z")
 
-    assertThat(decodeTimestamp("2144-01-02T15:04:05.753493+01:00"))
-      .isEqualTo(decodeTimestamp("2144-01-02T14:04:05.753493Z"))
+      decodeTimestamp("2144-01-02T15:04:05.753493+01:00") shouldBe decodeTimestamp("2144-01-02T14:04:05.753493Z")
 
-    assertThat(decodeTimestamp("1358-03-05T15:04:05.527094582+11:03"))
-      .isEqualTo(decodeTimestamp("1358-03-05T04:01:05.527094582Z"))
+      decodeTimestamp("1358-03-05T15:04:05.527094582+11:03") shouldBe decodeTimestamp("1358-03-05T04:01:05.527094582Z")
+    }
   }
 
   @Test
   fun `decoding should be case-insensitive`() {
     // According to https://www.rfc-editor.org/rfc/rfc3339#section-5.6 the "t" and "z" are
     // case-insensitive.
-    assertThat(decodeTimestamp("2006-01-02t15:04:05.123456789z"))
-      .isEqualTo(decodeTimestamp("2006-01-02T15:04:05.123456789Z"))
+    decodeTimestamp("2006-01-02t15:04:05.123456789z") shouldBe decodeTimestamp("2006-01-02T15:04:05.123456789Z")
   }
 
   @Test
   fun `decoding should parse the minimum value officially supported by Data Connect`() {
-    assertThat(decodeTimestamp("1583-01-01T00:00:00.000000Z")).isEqualTo(Timestamp(-12212553600, 0))
+    decodeTimestamp("1583-01-01T00:00:00.000000Z") shouldBe Timestamp(-12212553600, 0)
   }
 
   @Test
   fun `decoding should parse the maximum value officially supported by Data Connect`() {
-    assertThat(decodeTimestamp("9999-12-31T23:59:59.999999999Z"))
-      .isEqualTo(Timestamp(253402300799, 999999999))
+    decodeTimestamp("9999-12-31T23:59:59.999999999Z") shouldBe Timestamp(253402300799, 999999999)
   }
 
   @Test
   fun `decoding should fail for an empty string`() {
-    assertThrows(IllegalArgumentException::class) { decodeTimestamp("") }
+    shouldThrow<IllegalArgumentException> {
+      decodeTimestamp("")
+    }
   }
 
   @Test
   fun `decoding should fail if 'time-offset' is omitted`() {
-    assertThrows(IllegalArgumentException::class) {
+    shouldThrow<IllegalArgumentException> {
       decodeTimestamp("2006-01-02T15:04:05.123456789")
     }
   }
 
   @Test
   fun `decoding should fail if 'time-offset' when 'time-secfrac' and time offset are both omitted`() {
-    assertThrows(IllegalArgumentException::class) { decodeTimestamp("2006-01-02T15:04:05") }
+    shouldThrow<IllegalArgumentException> {
+      decodeTimestamp("2006-01-02T15:04:05")
+    }
   }
 
   @Test
   fun `decoding should fail if the date portion cannot be parsed`() {
-    assertThrows(IllegalArgumentException::class) {
+    shouldThrow<IllegalArgumentException> {
       decodeTimestamp("200X-01-02T15:04:05.123456789Z")
     }
   }
 
   @Test
   fun `decoding should fail if some character other than period delimits the 'time-secfrac'`() {
-    assertThrows(IllegalArgumentException::class) {
+    shouldThrow<IllegalArgumentException> {
       decodeTimestamp("2006-01-02T15:04:05 123456789Z")
     }
   }
 
   @Test
   fun `decoding should fail if 'time-secfrac' contains an invalid character`() {
-    assertThrows(IllegalArgumentException::class) {
+    shouldThrow<IllegalArgumentException> {
       decodeTimestamp("2006-01-02T15:04:05.123456X89Z")
     }
   }
 
   @Test
   fun `decoding should fail if time offset has no + or - sign`() {
-    assertThrows(IllegalArgumentException::class) { decodeTimestamp("1985-04-12T23:20:5007:00") }
+    shouldThrow<IllegalArgumentException> {
+      decodeTimestamp("1985-04-12T23:20:5007:00")
+    }
   }
 
   @Test
   fun `decoding should fail if time string has mix format`() {
-    assertThrows(IllegalArgumentException::class) {
+    shouldThrow<IllegalArgumentException> {
       decodeTimestamp("2006-01-02T15:04:05-07:00.123456X89Z")
     }
   }
 
   @Test
   fun `decoding should fail if time offset is not in the correct format`() {
-    assertThrows(IllegalArgumentException::class) { decodeTimestamp("1985-04-12T23:20:50+7:00") }
+    shouldThrow<IllegalArgumentException> { decodeTimestamp("1985-04-12T23:20:50+7:00") }
   }
 
   @Test
   fun `decoding should throw an exception if the timestamp is invalid`() {
-    invalidTimestampStrs.forEach {
-      assertThrows(IllegalArgumentException::class) { decodeTimestamp(it) }
+    assertSoftly {
+      for (invalidTimestampStr in invalidTimestampStrs) {
+        withClue(invalidTimestampStr) {
+          shouldThrow<IllegalArgumentException> { decodeTimestamp(invalidTimestampStr) }
+        }
+      }
     }
   }
 
@@ -211,7 +213,7 @@ class TimestampSerializerUnitTest {
     fun verifyEncodeDecodeRoundTrip(timestamp: Timestamp) {
       val encoded = encodeToStruct(TimestampWrapper(timestamp))
       val decoded = decodeFromStruct<TimestampWrapper>(encoded)
-      assertThat(decoded.timestamp).isEqualTo(timestamp)
+      decoded.timestamp shouldBe timestamp
     }
 
     fun decodeTimestamp(text: String): Timestamp {

--- a/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/TimestampSerializerUnitTest.kt
+++ b/firebase-dataconnect/src/test/kotlin/com/google/firebase/dataconnect/serializers/TimestampSerializerUnitTest.kt
@@ -95,22 +95,28 @@ class TimestampSerializerUnitTest {
   @Test
   fun `decoding should succeed when there are both time-secfrac and - time offset`() {
     assertSoftly {
-      decodeTimestamp("2023-05-21T11:04:05.462-11:07") shouldBe decodeTimestamp("2023-05-21T22:11:05.462Z")
+      decodeTimestamp("2023-05-21T11:04:05.462-11:07") shouldBe
+        decodeTimestamp("2023-05-21T22:11:05.462Z")
 
-      decodeTimestamp("2053-11-02T15:04:05.743393-05:10") shouldBe decodeTimestamp("2053-11-02T20:14:05.743393Z")
+      decodeTimestamp("2053-11-02T15:04:05.743393-05:10") shouldBe
+        decodeTimestamp("2053-11-02T20:14:05.743393Z")
 
-      decodeTimestamp("1538-03-05T15:04:05.653498752-03:01") shouldBe decodeTimestamp("1538-03-05T18:05:05.653498752Z")
+      decodeTimestamp("1538-03-05T15:04:05.653498752-03:01") shouldBe
+        decodeTimestamp("1538-03-05T18:05:05.653498752Z")
     }
   }
 
   @Test
   fun `decoding should succeed when there are both time-secfrac and + time offset`() {
     assertSoftly {
-      decodeTimestamp("2023-05-21T11:04:05.662+11:01") shouldBe decodeTimestamp("2023-05-21T00:03:05.662Z")
+      decodeTimestamp("2023-05-21T11:04:05.662+11:01") shouldBe
+        decodeTimestamp("2023-05-21T00:03:05.662Z")
 
-      decodeTimestamp("2144-01-02T15:04:05.753493+01:00") shouldBe decodeTimestamp("2144-01-02T14:04:05.753493Z")
+      decodeTimestamp("2144-01-02T15:04:05.753493+01:00") shouldBe
+        decodeTimestamp("2144-01-02T14:04:05.753493Z")
 
-      decodeTimestamp("1358-03-05T15:04:05.527094582+11:03") shouldBe decodeTimestamp("1358-03-05T04:01:05.527094582Z")
+      decodeTimestamp("1358-03-05T15:04:05.527094582+11:03") shouldBe
+        decodeTimestamp("1358-03-05T04:01:05.527094582Z")
     }
   }
 
@@ -118,7 +124,8 @@ class TimestampSerializerUnitTest {
   fun `decoding should be case-insensitive`() {
     // According to https://www.rfc-editor.org/rfc/rfc3339#section-5.6 the "t" and "z" are
     // case-insensitive.
-    decodeTimestamp("2006-01-02t15:04:05.123456789z") shouldBe decodeTimestamp("2006-01-02T15:04:05.123456789Z")
+    decodeTimestamp("2006-01-02t15:04:05.123456789z") shouldBe
+      decodeTimestamp("2006-01-02T15:04:05.123456789Z")
   }
 
   @Test
@@ -133,51 +140,37 @@ class TimestampSerializerUnitTest {
 
   @Test
   fun `decoding should fail for an empty string`() {
-    shouldThrow<IllegalArgumentException> {
-      decodeTimestamp("")
-    }
+    shouldThrow<IllegalArgumentException> { decodeTimestamp("") }
   }
 
   @Test
   fun `decoding should fail if 'time-offset' is omitted`() {
-    shouldThrow<IllegalArgumentException> {
-      decodeTimestamp("2006-01-02T15:04:05.123456789")
-    }
+    shouldThrow<IllegalArgumentException> { decodeTimestamp("2006-01-02T15:04:05.123456789") }
   }
 
   @Test
   fun `decoding should fail if 'time-offset' when 'time-secfrac' and time offset are both omitted`() {
-    shouldThrow<IllegalArgumentException> {
-      decodeTimestamp("2006-01-02T15:04:05")
-    }
+    shouldThrow<IllegalArgumentException> { decodeTimestamp("2006-01-02T15:04:05") }
   }
 
   @Test
   fun `decoding should fail if the date portion cannot be parsed`() {
-    shouldThrow<IllegalArgumentException> {
-      decodeTimestamp("200X-01-02T15:04:05.123456789Z")
-    }
+    shouldThrow<IllegalArgumentException> { decodeTimestamp("200X-01-02T15:04:05.123456789Z") }
   }
 
   @Test
   fun `decoding should fail if some character other than period delimits the 'time-secfrac'`() {
-    shouldThrow<IllegalArgumentException> {
-      decodeTimestamp("2006-01-02T15:04:05 123456789Z")
-    }
+    shouldThrow<IllegalArgumentException> { decodeTimestamp("2006-01-02T15:04:05 123456789Z") }
   }
 
   @Test
   fun `decoding should fail if 'time-secfrac' contains an invalid character`() {
-    shouldThrow<IllegalArgumentException> {
-      decodeTimestamp("2006-01-02T15:04:05.123456X89Z")
-    }
+    shouldThrow<IllegalArgumentException> { decodeTimestamp("2006-01-02T15:04:05.123456X89Z") }
   }
 
   @Test
   fun `decoding should fail if time offset has no + or - sign`() {
-    shouldThrow<IllegalArgumentException> {
-      decodeTimestamp("1985-04-12T23:20:5007:00")
-    }
+    shouldThrow<IllegalArgumentException> { decodeTimestamp("1985-04-12T23:20:5007:00") }
   }
 
   @Test

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/ProtoTestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/ProtoTestUtils.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.dataconnect.testutil
+
+import com.google.protobuf.MessageLite
+import com.google.protobuf.Struct
+import com.google.protobuf.Value
+import io.kotest.assertions.print.print
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.neverNullMatcher
+import io.kotest.matchers.should
+import java.util.regex.Pattern
+
+/** Asserts that a proto message is equal to the given proto message. */
+infix fun MessageLite?.shouldBe(other: MessageLite?): MessageLite? {
+  this should beEqualTo(other)
+  return this
+}
+
+/** Asserts that a proto Struct is equal to the given proto Struct. */
+infix fun Struct?.shouldBe(other: Struct?): Struct? {
+  this should beEqualTo(other)
+  return this
+}
+
+/** Asserts that a proto Struct is equal to the given proto Struct. */
+infix fun Value?.shouldBe(other: Value?): Value? {
+  this should beEqualTo(other)
+  return this
+}
+
+/** Asserts that a proto message is equal to the default instance of its type. */
+fun MessageLite?.shouldBeDefaultInstance(): MessageLite? {
+  this should beEqualToDefaultInstance()
+  return this
+}
+
+/**
+ * Creates and returns a [Matcher] that can be used with kotest assertions for verifying that a
+ * proto message is equal to the default instance of that type.
+ */
+fun beEqualToDefaultInstance(): Matcher<MessageLite?> = neverNullMatcher { value ->
+  val valueStr = value.toTrimmedStringForTesting()
+  val defaultInstance = value.defaultInstanceForType
+  val defaultStr = defaultInstance.toTrimmedStringForTesting()
+  MatcherResult(
+    valueStr == defaultStr,
+    {
+      "${value::class.qualifiedName} ${value.print().value} should be equal to " +
+        "the default instance: ${defaultInstance.print().value}"
+    },
+    {
+      "${value::class.qualifiedName} ${value.print().value} should not be equal to : " +
+        "the default instance: ${defaultInstance.print().value}"
+    }
+  )
+}
+
+/**
+ * Creates and returns a [Matcher] that can be used with kotest assertions for verifying that a
+ * proto message is equal to the given proto message.
+ */
+fun beEqualTo(other: MessageLite?): Matcher<MessageLite?> = neverNullMatcher { value ->
+  if (other === null) {
+    MatcherResult(
+      false,
+      { "${value::class.qualifiedName} ${value.print().value} should be null" },
+      { TODO("should not get here (error code: r2kap3te33)") }
+    )
+  } else {
+    val valueClass = value::class
+    val otherClass = other::class
+    val valueStr = value.toTrimmedStringForTesting()
+    val otherStr = other.toTrimmedStringForTesting()
+    MatcherResult(
+      valueClass == otherClass && valueStr == otherStr,
+      {
+        "${valueClass.qualifiedName} ${value.print().value} should be equal to " +
+          "${otherClass.qualifiedName}: ${other.print().value}"
+      },
+      {
+        "${valueClass.qualifiedName} ${value.print().value} should not be equal to " +
+          "${otherClass.qualifiedName}: ${other.print().value}"
+      }
+    )
+  }
+}
+
+/**
+ * Creates and returns a [Matcher] that can be used with kotest assertions for verifying that a
+ * proto Struct is equal to the given proto Struct.
+ */
+fun beEqualTo(other: Struct?): Matcher<Struct?> = neverNullMatcher { value ->
+  if (other === null) {
+    MatcherResult(
+      false,
+      { "${value.print().value} should be null" },
+      { TODO("should not get here (error code: r2kap3te33)") }
+    )
+  } else {
+    MatcherResult(
+      value == other,
+      { "${value.print().value} should be equal to ${other.print().value}" },
+      { "${value.print().value} should not be equal to ${other.print().value}" }
+    )
+  }
+}
+
+/**
+ * Creates and returns a [Matcher] that can be used with kotest assertions for verifying that a
+ * proto Value is equal to the given proto Value.
+ */
+fun beEqualTo(other: Value?): Matcher<Value?> = neverNullMatcher { value ->
+  if (other === null) {
+    MatcherResult(
+      false,
+      { "${value.print().value} should be null" },
+      { TODO("should not get here (error code: r2kap3te33)") }
+    )
+  } else {
+    MatcherResult(
+      value == other,
+      { "${value.print().value} should be equal to ${other.print().value}" },
+      { "${value.print().value} should not be equal to ${other.print().value}" }
+    )
+  }
+}
+
+// It is wrong to compare protos using their string representations. The MessageLite runtime
+// deliberately prefixes debug strings with their Object.toString() to discourage string
+// comparison. However, this reads poorly in tests, and makes it harder to identify differences
+// from the strings alone. So, we manually strip this prefix.
+// This code was adapted from
+// https://github.com/google/truth/blob/f1f4d1450d/extensions/liteproto/src/main/java/com/google/common/truth/extensions/proto/LiteProtoSubject.java#L73-L93
+private fun MessageLite?.toTrimmedStringForTesting(): String {
+  if (this === null) {
+    return "<null>"
+  }
+
+  val subjectString =
+    toString().let { subjectString ->
+      subjectString.trim().let { trimmedSubjectString ->
+        if (!trimmedSubjectString.startsWith("# ")) {
+          subjectString
+        } else {
+          val objectToString = "# ${this::class.qualifiedName}@${Integer.toHexString(hashCode())}"
+          if (trimmedSubjectString.startsWith(objectToString)) {
+            trimmedSubjectString.replaceFirst(Pattern.quote(objectToString), "").trim()
+          } else {
+            subjectString
+          }
+        }
+      }
+    }
+
+  return subjectString.ifEmpty { "[empty proto]" }
+}

--- a/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestUtils.kt
+++ b/firebase-dataconnect/testutil/src/main/kotlin/com/google/firebase/dataconnect/testutil/TestUtils.kt
@@ -50,19 +50,26 @@ import org.junit.Assert
  * string contains the given string with non-abutting text. See [shouldContainWithNonAbuttingText]
  * for full details.
  */
-fun containWithNonAbuttingText(s: String): Matcher<String?> = neverNullMatcher { value ->
-  val fullPattern = "(^|\\W)${Pattern.quote(s)}($|\\W)"
-  val expr = Pattern.compile(fullPattern)
-  MatcherResult(
-    expr.matcher(value).find(),
-    {
-      "${value.print().value} should contain the substring ${s.print().value} with non-abutting text"
-    },
-    {
-      "${value.print().value} should not contain the substring ${s.print().value} with non-abutting text"
-    }
-  )
-}
+fun containWithNonAbuttingText(s: String, ignoreCase: Boolean = false): Matcher<String?> =
+  neverNullMatcher { value ->
+    val fullPattern = "(^|\\W)${Pattern.quote(s)}($|\\W)"
+    val expr =
+      if (ignoreCase) {
+        Pattern.compile(fullPattern)
+      } else {
+        Pattern.compile(fullPattern, Pattern.CASE_INSENSITIVE)
+      }
+
+    MatcherResult(
+      expr.matcher(value).find(),
+      {
+        "${value.print().value} should contain the substring ${s.print().value} with non-abutting text"
+      },
+      {
+        "${value.print().value} should not contain the substring ${s.print().value} with non-abutting text"
+      }
+    )
+  }
 
 /**
  * Asserts that a string contains another string, verifying that the character immediately preceding
@@ -72,7 +79,13 @@ fun containWithNonAbuttingText(s: String): Matcher<String?> = neverNullMatcher {
  * messages and forgetting to leave a space between words.
  */
 infix fun String?.shouldContainWithNonAbuttingText(s: String): String? {
-  this should containWithNonAbuttingText(s)
+  this should containWithNonAbuttingText(s, ignoreCase = false)
+  return this
+}
+
+/** Same as [shouldContainWithNonAbuttingText] but ignoring case. */
+infix fun String?.shouldContainWithNonAbuttingTextIgnoringCase(s: String): String? {
+  this should containWithNonAbuttingText(s, ignoreCase = false)
   return this
 }
 

--- a/firebase-dataconnect/testutil/testutil.gradle.kts
+++ b/firebase-dataconnect/testutil/testutil.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.core)
   implementation(libs.mockk)
+  implementation(libs.protobuf.java.lite)
   implementation(libs.robolectric)
   implementation(libs.truth)
 }


### PR DESCRIPTION
The main changes are replacing Truth and assertThrows with kotest assertions (https://kotest.io/docs/assertions/assertions.html) and using kotest property testing (https://kotest.io/docs/proptest/property-based-testing.html) instead of hand-picking example values. Future PRs will modernize other tests.