### PR TITLE
Remove `functionResponse` accessor, and mark `functionCallingConfig` nullable

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+* [changed] **Breaking Change**: Changed `functionCallingConfig` parameter type to be nullable in `ToolConfig`. (#6373)
+* [changed] **Breaking Change**: Removed `functionResponse` accessor method from `GenerateContentResponse`. (#6373)
 * [changed] **Breaking Change**: Migrated `FirebaseVertexAIException` from a sealed class to an abstract class, and marked constructors as internal. (#6368)
 * [feature] Added support for `title` and `publicationDate` in citations. (#6309)
 * [feature] Added support for `frequencyPenalty`, `presencePenalty`, and `HarmBlockMethod`. (#6309)

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/client/Types.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/common/client/Types.kt
@@ -43,7 +43,7 @@ internal data class Tool(
 
 @Serializable
 internal data class ToolConfig(
-  @SerialName("function_calling_config") val functionCallingConfig: FunctionCallingConfig
+  @SerialName("function_calling_config") val functionCallingConfig: FunctionCallingConfig?
 )
 
 @Serializable

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
@@ -151,17 +151,19 @@ internal fun HarmBlockMethod.toInternal() =
 
 internal fun ToolConfig.toInternal() =
   com.google.firebase.vertexai.common.client.ToolConfig(
-    com.google.firebase.vertexai.common.client.FunctionCallingConfig(
-      when (functionCallingConfig.mode) {
-        FunctionCallingConfig.Mode.ANY ->
-          com.google.firebase.vertexai.common.client.FunctionCallingConfig.Mode.ANY
-        FunctionCallingConfig.Mode.AUTO ->
-          com.google.firebase.vertexai.common.client.FunctionCallingConfig.Mode.AUTO
-        FunctionCallingConfig.Mode.NONE ->
-          com.google.firebase.vertexai.common.client.FunctionCallingConfig.Mode.NONE
-      },
-      functionCallingConfig.allowedFunctionNames
-    )
+    if (functionCallingConfig == null) null
+    else
+      com.google.firebase.vertexai.common.client.FunctionCallingConfig(
+        when (functionCallingConfig.mode) {
+          FunctionCallingConfig.Mode.ANY ->
+            com.google.firebase.vertexai.common.client.FunctionCallingConfig.Mode.ANY
+          FunctionCallingConfig.Mode.AUTO ->
+            com.google.firebase.vertexai.common.client.FunctionCallingConfig.Mode.AUTO
+          FunctionCallingConfig.Mode.NONE ->
+            com.google.firebase.vertexai.common.client.FunctionCallingConfig.Mode.NONE
+        },
+        functionCallingConfig.allowedFunctionNames
+      )
   )
 
 internal fun HarmBlockThreshold.toInternal() =

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
@@ -151,7 +151,6 @@ internal fun HarmBlockMethod.toInternal() =
 
 internal fun ToolConfig.toInternal() =
   com.google.firebase.vertexai.common.client.ToolConfig(
-  com.google.firebase.vertexai.common.client.ToolConfig(
     functionCallingConfig?.let {
       com.google.firebase.vertexai.common.client.FunctionCallingConfig(
         when (it.mode) {

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/internal/util/conversions.kt
@@ -151,10 +151,10 @@ internal fun HarmBlockMethod.toInternal() =
 
 internal fun ToolConfig.toInternal() =
   com.google.firebase.vertexai.common.client.ToolConfig(
-    if (functionCallingConfig == null) null
-    else
+  com.google.firebase.vertexai.common.client.ToolConfig(
+    functionCallingConfig?.let {
       com.google.firebase.vertexai.common.client.FunctionCallingConfig(
-        when (functionCallingConfig.mode) {
+        when (it.mode) {
           FunctionCallingConfig.Mode.ANY ->
             com.google.firebase.vertexai.common.client.FunctionCallingConfig.Mode.ANY
           FunctionCallingConfig.Mode.AUTO ->
@@ -162,8 +162,9 @@ internal fun ToolConfig.toInternal() =
           FunctionCallingConfig.Mode.NONE ->
             com.google.firebase.vertexai.common.client.FunctionCallingConfig.Mode.NONE
         },
-        functionCallingConfig.allowedFunctionNames
+        it.allowedFunctionNames
       )
+    }
   )
 
 internal fun HarmBlockThreshold.toInternal() =

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerateContentResponse.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/GenerateContentResponse.kt
@@ -16,8 +16,6 @@
 
 package com.google.firebase.vertexai.type
 
-import android.util.Log
-
 /**
  * Represents a response from the model.
  *
@@ -38,42 +36,5 @@ public class GenerateContentResponse(
   /** Convenience field to get all the function call parts in the request, if they exist */
   public val functionCalls: List<FunctionCallPart> by lazy {
     candidates.first().content.parts.filterIsInstance<FunctionCallPart>()
-  }
-
-  /**
-   * Convenience field representing the first function response part in the response, if it exists.
-   */
-  public val functionResponse: FunctionResponsePart? by lazy { firstPartAs() }
-
-  private inline fun <reified T : Part> firstPartAs(): T? {
-    if (candidates.isEmpty()) {
-      warn("No candidates were found, but was asked to get a candidate.")
-      return null
-    }
-
-    val (parts, otherParts) = candidates.first().content.parts.partition { it is T }
-    val type = T::class.simpleName ?: "of the part type you asked for"
-
-    if (parts.isEmpty()) {
-      if (otherParts.isNotEmpty()) {
-        warn(
-          "We didn't find any $type, but we did find other part types. Did you ask for the right type?"
-        )
-      }
-
-      return null
-    }
-
-    if (parts.size > 1) {
-      warn("Multiple $type were found, returning the first one.")
-    } else if (otherParts.isNotEmpty()) {
-      warn("Returning the only $type found, but other part types were present as well.")
-    }
-
-    return parts.first() as T
-  }
-
-  private fun warn(message: String) {
-    Log.w("GenerateContentResponse", message)
   }
 }

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/ToolConfig.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/ToolConfig.kt
@@ -22,4 +22,4 @@ package com.google.firebase.vertexai.type
  *
  * @param functionCallingConfig The config for function calling
  */
-public class ToolConfig(internal val functionCallingConfig: FunctionCallingConfig)
+public class ToolConfig(internal val functionCallingConfig: FunctionCallingConfig?)


### PR DESCRIPTION

There's no need for the response accessor, as under normal circunstances there's no need to have easy access to the [FunctionResponsePart] the app adds to a prompt.

Additionally, to make evolving the API easier and backward compatible, made `functionCallingConfig` parameter nullable in `ToolConfig`.