### PR TITLE
Fix release notes + dataconnect config

### DIFF
--- a/encoders/firebase-encoders-proto/CHANGELOG.md
+++ b/encoders/firebase-encoders-proto/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 

--- a/firebase-config/CHANGELOG.md
+++ b/firebase-config/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 # 22.0.0
 * [changed] Bump internal dependencies

--- a/firebase-crashlytics/CHANGELOG.md
+++ b/firebase-crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 
 # 19.2.0

--- a/firebase-dataconnect/CHANGELOG.md
+++ b/firebase-dataconnect/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 # 16.0.0-beta01
 * [feature] Initial release of the Data Connect SDK (public preview). Learn how to

--- a/firebase-dataconnect/firebase-dataconnect.gradle.kts
+++ b/firebase-dataconnect/firebase-dataconnect.gradle.kts
@@ -31,8 +31,8 @@ firebaseLibrary {
   publishJavadoc = false
   previewMode = "beta"
   releaseNotes {
-    name.set("{{firebase_data_connect}}")
-    versionName.set("dataconnect")
+    name.set("{{data_connect_short}}")
+    versionName.set("data-connect")
     hasKTX.set(false)
   }
 

--- a/firebase-firestore/CHANGELOG.md
+++ b/firebase-firestore/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 * [changed] Update Firestore proto definitions. [#6369](//github.com/firebase/firebase-android-sdk/pull/6369)
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 # 25.1.0
 * [feature] Add support for the VectorValue type. [#6154](//github.com/firebase/firebase-android-sdk/pull/6154)

--- a/firebase-inappmessaging-display/CHANGELOG.md
+++ b/firebase-inappmessaging-display/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 # 21.0.0
 * [fixed] Fixed bad token exception while showing FIAM

--- a/firebase-inappmessaging/CHANGELOG.md
+++ b/firebase-inappmessaging/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 # 21.0.0
 * [fixed] Fixed bad token exception while showing FIAM

--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 
 # 24.0.2

--- a/firebase-ml-modeldownloader/CHANGELOG.md
+++ b/firebase-ml-modeldownloader/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 
 # 25.0.0

--- a/firebase-perf/CHANGELOG.md
+++ b/firebase-perf/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
-* [fixed] Fix IllegalStateException when starting a trace before Firebase initializes.
+* [fixed] Fixed `IllegalStateException` that happened when starting a trace
+  before Firebase initializes.
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 # 21.0.1
 * [fixed] Fixed an `ExceptionInInitializerError` where the `url.openStream()` causes a crash if

--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Unreleased
+* [feature] {{firebase_vertexai}} is now Generally Available (GA) and can be
+  used in production apps.
+
+  Use the {{firebase_vertexai_sdk}} to call the {{gemini_api_vertexai_long}}
+  directly from your app. This client SDK is built specifically for use with
+  Android apps, offering security options against unauthorized clients
+  as well as integrations with other Firebase services.
+
+    * If you're new to this library, visit the
+      [getting started guide](/docs/vertex-ai/get-started?platform=android).
+
+    * If you used the preview version of the library, visit the
+      [migration guide](/docs/vertex-ai/migrate-to-ga?platform=android) to learn
+      about some important updates.
 * [changed] **Breaking Change**: Changed `functionCallingConfig` parameter type to be nullable in `ToolConfig`. (#6373)
 * [changed] **Breaking Change**: Removed `functionResponse` accessor method from `GenerateContentResponse`. (#6373)
 * [changed] **Breaking Change**: Migrated `FirebaseVertexAIException` from a sealed class to an abstract class, and marked constructors as internal. (#6368)

--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -10,7 +10,7 @@
     * If you're new to this library, visit the
       [getting started guide](/docs/vertex-ai/get-started?platform=android).
 
-    * If you used the preview version of the library, visit the
+    * If you were using the preview version of the library, visit the
       [migration guide](/docs/vertex-ai/migrate-to-ga?platform=android) to learn
       about some important updates.
 * [changed] **Breaking Change**: Changed `functionCallingConfig` parameter type to be nullable in `ToolConfig`. (#6373)

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAI.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/FirebaseVertexAI.kt
@@ -42,7 +42,7 @@ internal constructor(
   /**
    * Instantiates a new [GenerativeModel] given the provided parameters.
    *
-   * @param modelName The name of the model to use, for example "gemini-1.5-pro".
+   * @param modelName The name of the model to use, for example `"gemini-1.5-pro"`.
    * @param generationConfig The configuration parameters to use for content generation.
    * @param safetySettings The safety bounds the model will abide to during content generation.
    * @param tools A list of [Tool]s the model may use to generate content.

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/java/ChatFutures.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/java/ChatFutures.kt
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.google.firebase.vertexai.Chat
 import com.google.firebase.vertexai.type.Content
 import com.google.firebase.vertexai.type.GenerateContentResponse
+import com.google.firebase.vertexai.type.InvalidStateException
 import kotlinx.coroutines.reactive.asPublisher
 import org.reactivestreams.Publisher
 

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/java/GenerativeModelFutures.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/java/GenerativeModelFutures.kt
@@ -22,6 +22,7 @@ import com.google.firebase.vertexai.GenerativeModel
 import com.google.firebase.vertexai.java.ChatFutures.Companion.from
 import com.google.firebase.vertexai.type.Content
 import com.google.firebase.vertexai.type.CountTokensResponse
+import com.google.firebase.vertexai.type.FirebaseVertexAIException
 import com.google.firebase.vertexai.type.GenerateContentResponse
 import kotlinx.coroutines.reactive.asPublisher
 import org.reactivestreams.Publisher
@@ -65,13 +66,13 @@ public abstract class GenerativeModelFutures internal constructor() {
   public abstract fun countTokens(vararg prompt: Content): ListenableFuture<CountTokensResponse>
 
   /**
-   * Creates a [ChatFuture] instance which internally tracks the ongoing conversation with the
+   * Creates a [ChatFutures] instance which internally tracks the ongoing conversation with the
    * model.
    */
   public abstract fun startChat(): ChatFutures
 
   /**
-   * Creates a [ChatFuture] instance, initialized using the optionally provided [history].
+   * Creates a [ChatFutures] instance, initialized using the optionally provided [history].
    *
    * @param history A list of previous interactions with the model to use as a starting point
    */

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Content.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/type/Content.kt
@@ -24,8 +24,8 @@ import android.graphics.Bitmap
  * `Content` is composed of a one or more heterogeneous parts that can be represent data in
  * different formats, like text or images.
  *
- * @param role The producer of the content. Must be either 'user' or 'model'. By default, it's
- * "user".
+ * @param role The producer of the content. Must be either `"user"` or `"model"`. By default, it's
+ * `"user"`.
  * @param parts An ordered list of [Part] that constitute this content.
  */
 public class Content

--- a/transport/transport-backend-cct/CHANGELOG.md
+++ b/transport/transport-backend-cct/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 
 # 3.3.0

--- a/transport/transport-runtime/CHANGELOG.md
+++ b/transport/transport-runtime/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 * [changed] Updated protobuf dependency to `3.25.5` to fix
-  [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8).
+  [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254).
 
 
 # 3.3.0


### PR DESCRIPTION
Per [b/373637986](https://b.corp.google.com/issues/373637986),

This fixes the release notes configuration for the `data-connect` SDK, as they seemed to be incorrect.

This PR also fixes the following:

- [b/373639079](https://b.corp.google.com/issues/373639079) -> Refactor github vuln links to `nist.gov`
- [b/374115995](https://b.corp.google.com/issues/374115995) -> Fix VertexAI Javadocs