### PR TITLE
Migrate SDKs to version catalog

### DIFF
--- a/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
+++ b/appcheck/firebase-appcheck-debug-testing/firebase-appcheck-debug-testing.gradle
@@ -60,21 +60,21 @@ dependencies {
     api 'com.google.firebase:firebase-common-ktx:21.0.0'
     api 'com.google.firebase:firebase-components:18.0.0'
 
-    implementation "androidx.test:core:$androidxTestCoreVersion"
+    implementation libs.androidx.test.core
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
 
     testImplementation project(':appcheck:firebase-appcheck-playintegrity')
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation project(':firebase-storage')
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.13-beta-2'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
 }

--- a/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
+++ b/appcheck/firebase-appcheck-debug/firebase-appcheck-debug.gradle
@@ -63,10 +63,10 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/appcheck/firebase-appcheck-interop/firebase-appcheck-interop.gradle
+++ b/appcheck/firebase-appcheck-interop/firebase-appcheck-interop.gradle
@@ -49,10 +49,10 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
+++ b/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
@@ -66,7 +66,7 @@ dependencies {
     }
     testImplementation libs.androidx.test.core
     testImplementation libs.truth
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation 'org.mockito:mockito-core:3.4.6'
     testImplementation libs.robolectric
 }

--- a/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
+++ b/appcheck/firebase-appcheck-playintegrity/firebase-appcheck-playintegrity.gradle
@@ -64,9 +64,9 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.6'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -51,7 +51,7 @@ android {
 dependencies {
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
 
-    api 'com.google.android.gms:play-services-tasks:18.1.0'
+    api libs.playservices.tasks
     api 'com.google.firebase:firebase-annotations:16.2.0'
     api "com.google.firebase:firebase-appcheck-interop:17.1.0"
     api("com.google.firebase:firebase-common:21.0.0")
@@ -59,7 +59,7 @@ dependencies {
     api("com.google.firebase:firebase-components:18.0.0")
 
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-base:18.1.0'
+    implementation libs.playservices.base
     implementation libs.kotlin.stdlib
 
     testImplementation(project(":integ-testing")){
@@ -71,7 +71,7 @@ dependencies {
     testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13-beta-2'
-    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation libs.mockito.core
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation libs.robolectric
 

--- a/appcheck/firebase-appcheck/firebase-appcheck.gradle
+++ b/appcheck/firebase-appcheck/firebase-appcheck.gradle
@@ -60,20 +60,20 @@ dependencies {
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-base:18.1.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     testImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation project(':appcheck:firebase-appcheck')
     androidTestImplementation(project(":integ-testing")){
@@ -81,10 +81,10 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
     androidTestImplementation "androidx.annotation:annotation:1.0.0"
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation libs.androidx.test.core
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation 'org.mockito:mockito-inline:2.25.0'

--- a/appcheck/firebase-appcheck/ktx/ktx.gradle
+++ b/appcheck/firebase-appcheck/ktx/ktx.gradle
@@ -61,14 +61,14 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation libs.androidx.test.core
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'com.google.firebase:firebase-appcheck-interop:17.1.0'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,6 @@
 // limitations under the License.
 
 buildscript {
-    // TODO: remove once all sdks have migrated to version catalog
-    ext.kotlinVersion = libs.versions.kotlin.get()
-    ext.coroutinesVersion = libs.versions.coroutines.get()
-
     repositories {
         google()
         mavenCentral()
@@ -46,15 +42,6 @@ buildscript {
 
 apply from: 'sdkProperties.gradle'
 apply from: "gradle/errorProne.gradle"
-
-ext {
-    // TODO: remove once all sdks have migrated to version catalog
-    googleTruthVersion = libs.versions.truth.get()
-    grpcVersion = libs.versions.grpc.get()
-    robolectricVersion = libs.versions.robolectric.get()
-    androidxTestCoreVersion = libs.versions.androidx.test.core.get()
-    androidxTestJUnitVersion = libs.versions.androidx.test.junit.get()
-}
 
 apply plugin: com.google.firebase.gradle.plugins.PublishingPlugin
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
     implementation("com.google.auto.value:auto-value-annotations:1.8.1")
     annotationProcessor("com.google.auto.value:auto-value:1.6.5")
     implementation(kotlin("gradle-plugin", "1.8.22"))
-    implementation("org.json:json:20210307")
+    implementation(libs.org.json)
 
     implementation("org.eclipse.aether:aether-api:1.0.0.v20140518")
     implementation("org.eclipse.aether:aether-util:1.0.0.v20140518")
@@ -63,8 +63,8 @@ dependencies {
     implementation(libs.android.gradlePlugin.builder.test.api)
 
     testImplementation(libs.bundles.kotest)
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("com.google.truth:truth:1.4.2")
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
     testImplementation("commons-io:commons-io:2.15.1")
 }
 

--- a/encoders/firebase-decoders-json/firebase-decoders-json.gradle
+++ b/encoders/firebase-decoders-json/firebase-decoders-json.gradle
@@ -49,11 +49,11 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.junit
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13-rc-1'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }
 
 tasks.withType(JavaCompile) {

--- a/encoders/firebase-encoders-json/firebase-encoders-json.gradle
+++ b/encoders/firebase-encoders-json/firebase-encoders-json.gradle
@@ -55,11 +55,11 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'androidx.test:runner:1.3.0'
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    testImplementation libs.androidx.test.junit
     testImplementation "com.google.truth:truth:1.0.1"
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }
 
 tasks.withType(JavaCompile) {

--- a/encoders/firebase-encoders-proto/firebase-encoders-proto.gradle
+++ b/encoders/firebase-encoders-proto/firebase-encoders-proto.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     testImplementation 'com.google.guava:guava:31.0-jre'
     testImplementation libs.protobuf.java.util
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
+++ b/encoders/firebase-encoders-reflective/firebase-encoders-reflective.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     testImplementation 'androidx.test:runner:1.3.0'
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    testImplementation libs.androidx.test.junit
     testImplementation 'com.google.truth:truth:1.0.1'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/encoders/firebase-encoders/firebase-encoders.gradle
+++ b/encoders/firebase-encoders/firebase-encoders.gradle
@@ -33,7 +33,7 @@ java {
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13'
 }
 

--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -61,7 +61,7 @@ dependencies {
         exclude group: "com.google.firebase", module: "firebase-common"
     }
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22")
+    implementation(libs.kotlin.stdlib.jdk8)
 
     testImplementation 'androidx.test:runner:1.2.0'
     testImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/firebase-abt/firebase-abt.gradle
+++ b/firebase-abt/firebase-abt.gradle
@@ -69,5 +69,5 @@ dependencies {
     testImplementation 'io.grpc:grpc-testing:1.12.0'
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -67,8 +67,7 @@ dependencies {
     testImplementation project(':firebase-appdistribution-api')
     testImplementation libs.androidx.test.core
     testImplementation libs.truth
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-inline:3.4.0'
     testImplementation libs.robolectric

--- a/firebase-appdistribution-api/firebase-appdistribution-api.gradle
+++ b/firebase-appdistribution-api/firebase-appdistribution-api.gradle
@@ -58,24 +58,24 @@ dependencies {
     api("com.google.firebase:firebase-components:18.0.0")
 
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
 
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 
     testImplementation project(':firebase-appdistribution-api')
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-inline:3.4.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation libs.androidx.test.core
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "org.mockito:mockito-android:3.4.0"
 }

--- a/firebase-appdistribution-api/ktx/ktx.gradle
+++ b/firebase-appdistribution-api/ktx/ktx.gradle
@@ -62,13 +62,13 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation libs.androidx.test.core
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.12'
 }

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -95,11 +95,11 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
@@ -107,8 +107,8 @@ dependencies {
     }
     androidTestImplementation "androidx.annotation:annotation:1.0.0"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation 'org.mockito:mockito-inline:2.25.0'

--- a/firebase-appdistribution/firebase-appdistribution.gradle
+++ b/firebase-appdistribution/firebase-appdistribution.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation libs.javax.inject
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22")
+    implementation libs.kotlin.stdlib.jdk8
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.5'
 
@@ -97,7 +97,7 @@ dependencies {
     }
     testImplementation libs.androidx.test.core
     testImplementation libs.truth
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation libs.robolectric
 

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -95,7 +95,7 @@ dependencies {
     // Shake detection
     implementation 'com.squareup:seismic:1.0.3'
     // Other dependencies
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     // Beta flavor uses the full implementation
     betaImplementation project(':firebase-appdistribution')

--- a/firebase-appdistribution/test-app/test-app.gradle
+++ b/firebase-appdistribution/test-app/test-app.gradle
@@ -100,5 +100,5 @@ dependencies {
     // Beta flavor uses the full implementation
     betaImplementation project(':firebase-appdistribution')
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
 }

--- a/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
+++ b/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
@@ -50,7 +50,7 @@ android {
 
 dependencies {
   implementation("com.google.android.play:feature-delivery:2.0.0")
-  implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22")
+  implementation(libs.kotlin.stdlib.jdk8)
   api("com.google.firebase:firebase-common:21.0.0")
   api("com.google.firebase:firebase-components:18.0.0")
 }

--- a/firebase-config-interop/firebase-config-interop.gradle.kts
+++ b/firebase-config-interop/firebase-config-interop.gradle.kts
@@ -51,9 +51,9 @@ dependencies {
     api("com.google.firebase:firebase-encoders-json:18.0.1")
     api("com.google.firebase:firebase-encoders:17.0.0")
 
-    compileOnly("com.google.auto.value:auto-value-annotations:1.10.1")
+    compileOnly(libs.autovalue.annotations)
 
-    annotationProcessor("com.google.auto.value:auto-value:1.10.1")
+    annotationProcessor(libs.autovalue)
     annotationProcessor(project(":encoders:firebase-encoders-processor"))
 
     testImplementation(libs.junit)

--- a/firebase-config/firebase-config.gradle.kts
+++ b/firebase-config/firebase-config.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     annotationProcessor("com.google.auto.value:auto-value:1.6.6")
     javadocClasspath("com.google.auto.value:auto-value-annotations:1.6.6")
     compileOnly("com.google.auto.value:auto-value-annotations:1.6.6")
-    compileOnly("com.google.code.findbugs:jsr305:3.0.2")
+    compileOnly(libs.findbugs.jsr305)
 
     // Testing
     testImplementation(libs.junit)

--- a/firebase-config/ktx/ktx.gradle
+++ b/firebase-config/ktx/ktx.gradle
@@ -61,9 +61,9 @@ dependencies {
     implementation("com.google.firebase:firebase-components:18.0.0")
     implementation 'com.google.firebase:firebase-installations-interop:17.1.0'
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -120,9 +120,9 @@ dependencies {
     testImplementation 'androidx.test:runner:1.4.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.4.3'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation libs.androidx.test.core
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation libs.protobuf.java.lite
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'

--- a/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
+++ b/firebase-crashlytics-ndk/firebase-crashlytics-ndk.gradle
@@ -115,10 +115,10 @@ dependencies {
     api "com.google.firebase:firebase-common-ktx:21.0.0"
     api "com.google.firebase:firebase-components:18.0.0"
 
-    implementation 'com.google.android.gms:play-services-basement:18.1.0'
+    implementation libs.playservices.basement
 
     testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation 'org.mockito:mockito-core:3.4.3'
     testImplementation libs.robolectric
 

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -59,9 +59,9 @@ dependencies {
     implementation 'com.google.android.datatransport:transport-runtime:3.2.0'
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22")
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-datatransport/firebase-datatransport.gradle
+++ b/firebase-datatransport/firebase-datatransport.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'com.google.android.datatransport:transport-api:3.1.0'
     implementation 'com.google.android.datatransport:transport-backend-cct:3.2.0'
     implementation 'com.google.android.datatransport:transport-runtime:3.2.0'
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22")
+    implementation(libs.kotlin.stdlib.jdk8)
 
     testImplementation libs.androidx.test.core
     testImplementation 'androidx.test:runner:1.2.0'

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -61,7 +61,7 @@ android {
 
 dependencies {
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    javadocClasspath libs.findbugs.jsr305
     javadocClasspath 'org.checkerframework:checker-qual:2.5.2'
 
     api 'com.google.android.gms:play-services-tasks:18.0.1'
@@ -76,8 +76,8 @@ dependencies {
      }
 
     implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'com.google.android.gms:play-services-base:18.0.1'
-    implementation 'com.google.android.gms:play-services-basement:18.1.0'
+    implementation libs.playservices.base
+    implementation libs.playservices.basement
     implementation libs.kotlin.stdlib
 
     testAnnotationProcessor "com.google.auto.value:auto-value:1.6.3"
@@ -92,7 +92,7 @@ dependencies {
     testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
     testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation libs.robolectric

--- a/firebase-dynamic-links/firebase-dynamic-links.gradle
+++ b/firebase-dynamic-links/firebase-dynamic-links.gradle
@@ -78,11 +78,11 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     testAnnotationProcessor "com.google.auto.value:auto-value:1.6.3"
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'com.android.support.test:runner:1.0.2'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
     testImplementation('com.google.android.gms:play-services-appinvite:18.0.0') {
@@ -90,12 +90,12 @@ dependencies {
          exclude group: 'com.google.firebase', module: 'firebase-dynamic-links'
      }
     testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'
 }

--- a/firebase-dynamic-links/ktx/ktx.gradle
+++ b/firebase-dynamic-links/ktx/ktx.gradle
@@ -52,9 +52,9 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -135,8 +135,8 @@ dependencies {
     api('com.google.firebase:firebase-database-collection:18.0.1')
 
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.google.android.gms:play-services-base:18.0.1'
-    implementation 'com.google.android.gms:play-services-basement:18.1.0'
+    implementation libs.playservices.base
+    implementation libs.playservices.basement
     implementation libs.grpc.android
     implementation libs.grpc.okhttp
     implementation libs.grpc.protobuf.lite
@@ -145,7 +145,7 @@ dependencies {
     implementation libs.kotlinx.coroutines.core
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
-    compileOnly 'javax.annotation:jsr250-api:1.0'
+    compileOnly libs.javax.annotation.jsr250
 
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
 
@@ -159,7 +159,7 @@ dependencies {
     testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
     testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation libs.robolectric
@@ -167,14 +167,14 @@ dependencies {
     testCompileOnly libs.protobuf.java
 
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
-    androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation libs.androidx.test.rules
+    androidTestImplementation libs.androidx.test.runner
     androidTestImplementation libs.androidx.test.junit
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     androidTestImplementation(libs.truth) {
         exclude group: "org.codehaus.mojo", module: "animal-sniffer-annotations"
     }
-    androidTestImplementation 'junit:junit:4.13.2'
+    androidTestImplementation libs.junit
     androidTestImplementation 'org.mockito:mockito-android:2.25.0'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
 }

--- a/firebase-firestore/firebase-firestore.gradle
+++ b/firebase-firestore/firebase-firestore.gradle
@@ -40,7 +40,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
+            artifact = libs.grpc.protoc.gen.java.get().toString()
         }
     }
     generateProtoTasks {
@@ -137,12 +137,12 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-basement:18.1.0'
-    implementation "io.grpc:grpc-android:$grpcVersion"
-    implementation "io.grpc:grpc-okhttp:$grpcVersion"
-    implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"
-    implementation "io.grpc:grpc-stub:$grpcVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+    implementation libs.grpc.android
+    implementation libs.grpc.okhttp
+    implementation libs.grpc.protobuf.lite
+    implementation libs.grpc.stub
+    implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.core
 
     compileOnly 'com.google.auto.value:auto-value-annotations:1.6.6'
     compileOnly 'javax.annotation:jsr250-api:1.0'
@@ -153,25 +153,25 @@ dependencies {
 
     testImplementation project(':firebase-database-collection')
     testImplementation project(':firebase-firestore')
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     testImplementation 'com.google.android.gms:play-services-tasks:18.0.1'
     testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.hamcrest:hamcrest-junit:2.0.0.0"
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     testCompileOnly libs.protobuf.java
 
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'androidx.test:runner:1.5.2'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation libs.androidx.test.junit
     androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-    androidTestImplementation("com.google.truth:truth:$googleTruthVersion") {
+    androidTestImplementation(libs.truth) {
         exclude group: "org.codehaus.mojo", module: "animal-sniffer-annotations"
     }
     androidTestImplementation 'junit:junit:4.13.2'

--- a/firebase-firestore/ktx/ktx.gradle
+++ b/firebase-firestore/ktx/ktx.gradle
@@ -63,13 +63,13 @@ dependencies {
     implementation("com.google.firebase:firebase-components:18.0.0")
 
     testImplementation project(':firebase-database-collection')
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
     testImplementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     testCompileOnly libs.protobuf.java
 }

--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -136,5 +136,5 @@ dependencies {
     androidTestImplementation(libs.mockito.core)
     androidTestImplementation(libs.mockito.dexmaker)
     kapt("com.google.dagger:dagger-android-processor:2.43.2")
-    kapt("com.google.dagger:dagger-compiler:2.43.2")
+    kapt(libs.dagger.compiler)
 }

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
-    implementation 'javax.inject:javax.inject:1'
+    implementation libs.javax.inject
     implementation libs.kotlin.stdlib
 
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'

--- a/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
+++ b/firebase-inappmessaging-display/firebase-inappmessaging-display.gradle
@@ -102,24 +102,24 @@ dependencies {
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
     implementation 'com.google.auto.value:auto-value-annotations:1.6.6'
     implementation 'javax.inject:javax.inject:1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
     annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
     annotationProcessor libs.dagger.compiler
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation ("com.google.firebase:firebase-analytics:17.0.0") {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
     testImplementation 'com.google.guava:guava:30.1-android'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation "com.google.truth:truth:1.0"
     testImplementation "junit:junit:4.12"
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:2.25.0"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
@@ -129,7 +129,7 @@ dependencies {
     androidTestImplementation 'androidx.annotation:annotation:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    androidTestImplementation libs.androidx.test.junit
     androidTestImplementation "com.google.dexmaker:dexmaker:1.2"
     androidTestImplementation ("com.google.firebase:firebase-analytics:17.4.0") {
          exclude group: "com.google.firebase", module: "firebase-common"

--- a/firebase-inappmessaging-display/ktx/ktx.gradle
+++ b/firebase-inappmessaging-display/ktx/ktx.gradle
@@ -56,11 +56,11 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation ("com.google.firebase:firebase-analytics:17.0.0") {
          exclude group: "com.google.firebase", module: "firebase-common"
      }
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -36,7 +36,7 @@ protobuf {
     }
     plugins {
         grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
+            artifact = libs.grpc.protoc.gen.java.get().toString()
         }
     }
     generateProtoTasks {
@@ -133,13 +133,13 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.auto.value:auto-value-annotations:1.8.1'
-    implementation "io.grpc:grpc-okhttp:$grpcVersion"
-    implementation "io.grpc:grpc-protobuf-lite:$grpcVersion"
-    implementation "io.grpc:grpc-stub:$grpcVersion"
+    implementation libs.grpc.okhttp
+    implementation libs.grpc.protobuf.lite
+    implementation libs.grpc.stub
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.14'
     implementation 'javax.inject:javax.inject:1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     compileOnly 'javax.annotation:jsr250-api:1.0'
 
@@ -153,16 +153,16 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'androidx.test:runner:1.3.0'
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    testImplementation libs.androidx.test.junit
     testImplementation 'com.google.guava:guava:30.1-android'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "io.grpc:grpc-testing:$grpcVersion"
+    testImplementation libs.truth
+    testImplementation libs.grpc.testing
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.mockito:mockito-core:5.2.0'
-    testImplementation ("org.robolectric:robolectric:$robolectricVersion") {
+    testImplementation (libs.robolectric) {
          exclude group: 'com.google.protobuf', module: 'protobuf-java'
      }
 
@@ -172,11 +172,11 @@ dependencies {
     }
     androidTestImplementation "androidx.annotation:annotation:1.0.0"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.truth
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.28.1'
-    androidTestImplementation "io.grpc:grpc-testing:$grpcVersion"
+    androidTestImplementation libs.grpc.testing
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.awaitility:awaitility:3.1.0'
 }

--- a/firebase-inappmessaging/firebase-inappmessaging.gradle
+++ b/firebase-inappmessaging/firebase-inappmessaging.gradle
@@ -138,10 +138,10 @@ dependencies {
     implementation libs.grpc.stub
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.14'
-    implementation 'javax.inject:javax.inject:1'
+    implementation libs.javax.inject
     implementation libs.kotlin.stdlib
 
-    compileOnly 'javax.annotation:jsr250-api:1.0'
+    compileOnly libs.javax.annotation.jsr250
 
     annotationProcessor 'com.google.auto.value:auto-value:1.6.5'
     annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.6'
@@ -161,7 +161,7 @@ dependencies {
     testImplementation libs.grpc.testing
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13.1'
-    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation libs.mockito.core
     testImplementation (libs.robolectric) {
          exclude group: 'com.google.protobuf', module: 'protobuf-java'
      }

--- a/firebase-inappmessaging/ktx/ktx.gradle
+++ b/firebase-inappmessaging/ktx/ktx.gradle
@@ -55,8 +55,8 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -59,7 +59,7 @@ dependencies {
     api 'com.google.firebase:firebase-installations-interop:17.1.0'
     api("com.google.firebase:firebase-installations-interop:17.1.1")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.5"
 
@@ -69,13 +69,13 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation(project(":integ-testing")){
         exclude group: 'com.google.firebase', module: 'firebase-common'
@@ -83,8 +83,8 @@ dependencies {
     }
     androidTestImplementation "androidx.annotation:annotation:1.0.0"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'
     androidTestImplementation 'org.mockito:mockito-inline:2.25.0'

--- a/firebase-installations/firebase-installations.gradle
+++ b/firebase-installations/firebase-installations.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    javadocClasspath libs.findbugs.jsr305
 
     api 'com.google.android.gms:play-services-tasks:18.0.1'
     api 'com.google.firebase:firebase-annotations:16.2.0'
@@ -73,7 +73,7 @@ dependencies {
     testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'junit:junit:4.13'
-    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation libs.mockito.core
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation libs.robolectric
 

--- a/firebase-installations/ktx/ktx.gradle
+++ b/firebase-installations/ktx/ktx.gradle
@@ -55,8 +55,8 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -114,14 +114,14 @@ dependencies {
         implementation 'com.google.android.gms:play-services-stats:17.0.2'
         implementation "com.google.android.gms:play-services-tasks:18.0.1"
         implementation "com.google.errorprone:error_prone_annotations:2.9.0"
-        implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+        implementation libs.kotlin.stdlib
 
         annotationProcessor project(":encoders:firebase-encoders-processor")
 
         testAnnotationProcessor "com.google.auto.value:auto-value:1.6.3"
 
         testImplementation 'androidx.core:core:1.6.0'
-        testImplementation "androidx.test:core:$androidxTestCoreVersion"
+        testImplementation libs.androidx.test.core
         testImplementation 'androidx.test:rules:1.2.0'
         testImplementation 'androidx.test:runner:1.2.0'
         testImplementation 'androidx.test.espresso:espresso-intents:3.2.0'
@@ -141,11 +141,11 @@ dependencies {
          exclude group: "com.google.firebase", module: "firebase-installations"
      }
         testImplementation 'com.google.guava:guava-testlib:12.0-rc2'
-        testImplementation "com.google.truth:truth:$googleTruthVersion"
+        testImplementation libs.truth
         testImplementation 'junit:junit:4.12'
         testImplementation 'junit:junit:4.13-beta-2'
         testImplementation 'org.mockito:mockito-core:5.2.0'
-        testImplementation "org.robolectric:robolectric:$robolectricVersion"
+        testImplementation libs.robolectric
 
         testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'
 
@@ -154,8 +154,8 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-components' }
         androidTestImplementation "androidx.annotation:annotation:1.0.0"
         androidTestImplementation 'androidx.test:runner:1.2.0'
-        androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-        androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+        androidTestImplementation libs.androidx.test.junit
+        androidTestImplementation libs.truth
         androidTestImplementation 'junit:junit:4.12'
         androidTestImplementation 'org.mockito:mockito-core:5.2.0'
         androidTestImplementation 'org.mockito:mockito-inline:5.2.0'

--- a/firebase-messaging/firebase-messaging.gradle
+++ b/firebase-messaging/firebase-messaging.gradle
@@ -144,7 +144,7 @@ dependencies {
         testImplementation libs.truth
         testImplementation 'junit:junit:4.12'
         testImplementation 'junit:junit:4.13-beta-2'
-        testImplementation 'org.mockito:mockito-core:5.2.0'
+        testImplementation libs.mockito.core
         testImplementation libs.robolectric
 
         testCompileOnly 'com.google.auto.value:auto-value-annotations:1.6.3'
@@ -157,6 +157,6 @@ dependencies {
         androidTestImplementation libs.androidx.test.junit
         androidTestImplementation libs.truth
         androidTestImplementation 'junit:junit:4.12'
-        androidTestImplementation 'org.mockito:mockito-core:5.2.0'
+        androidTestImplementation libs.mockito.core
         androidTestImplementation 'org.mockito:mockito-inline:5.2.0'
 }

--- a/firebase-messaging/ktx/ktx.gradle
+++ b/firebase-messaging/ktx/ktx.gradle
@@ -54,8 +54,8 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
+++ b/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
     implementation 'com.google.auto.service:auto-service-annotations:1.0.1'
     implementation 'javax.inject:javax.inject:1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"
 
@@ -117,22 +117,22 @@ dependencies {
         exclude group: 'com.google.firebase', module: 'firebase-common'
         exclude group: 'com.google.firebase', module: 'firebase-components'
     }
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'androidx.test:runner:1.5.1'
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
+    testImplementation libs.androidx.test.junit
     testImplementation 'com.github.tomakehurst:wiremock-standalone:2.26.3'
     testImplementation libs.protobuf.java.util
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.apache.httpcomponents:httpclient-android:4.3.5.1'
     testImplementation 'org.mockito:mockito-core:5.2.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.13.1'
 }

--- a/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
+++ b/firebase-ml-modeldownloader/firebase-ml-modeldownloader.gradle
@@ -80,7 +80,7 @@ thirdPartyLicenses {
 }
 
 dependencies {
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    javadocClasspath libs.findbugs.jsr305
 
     vendor (libs.dagger.dagger) {
          exclude group: "javax.inject", module: "javax.inject"
@@ -104,7 +104,7 @@ dependencies {
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
     implementation 'com.google.android.datatransport:transport-runtime:3.1.8'
     implementation 'com.google.auto.service:auto-service-annotations:1.0.1'
-    implementation 'javax.inject:javax.inject:1'
+    implementation libs.javax.inject
     implementation libs.kotlin.stdlib
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"
@@ -125,9 +125,9 @@ dependencies {
     testImplementation libs.truth
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
     testImplementation 'junit:junit:4.13-beta-2'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation 'org.apache.httpcomponents:httpclient-android:4.3.5.1'
-    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation libs.mockito.core
     testImplementation libs.robolectric
 
     androidTestImplementation "androidx.annotation:annotation:1.1.0"

--- a/firebase-ml-modeldownloader/ktx/ktx.gradle
+++ b/firebase-ml-modeldownloader/ktx/ktx.gradle
@@ -52,9 +52,9 @@ dependencies {
     implementation("com.google.firebase:firebase-components:18.0.0")
 
     testImplementation 'androidx.test:runner:1.5.1'
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.junit
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.6.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-ml-modeldownloader/ktx/ktx.gradle
+++ b/firebase-ml-modeldownloader/ktx/ktx.gradle
@@ -54,7 +54,7 @@ dependencies {
     testImplementation 'androidx.test:runner:1.5.1'
     testImplementation libs.androidx.test.junit
     testImplementation libs.truth
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation 'org.mockito:mockito-core:3.6.0'
     testImplementation libs.robolectric
 }

--- a/firebase-ml-modeldownloader/ml-data-collection-tests/ml-data-collection-tests.gradle
+++ b/firebase-ml-modeldownloader/ml-data-collection-tests/ml-data-collection-tests.gradle
@@ -43,7 +43,7 @@ android {
 
 dependencies {
     implementation project(':firebase-ml-modeldownloader')
-    implementation 'androidx.core:core:1.2.0'
+    implementation libs.androidx.core
     implementation 'com.google.firebase:firebase-common:21.0.0'
     implementation 'com.google.firebase:firebase-common-ktx:21.0.0'
 

--- a/firebase-ml-modeldownloader/ml-data-collection-tests/ml-data-collection-tests.gradle
+++ b/firebase-ml-modeldownloader/ml-data-collection-tests/ml-data-collection-tests.gradle
@@ -48,8 +48,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-common-ktx:21.0.0'
 
     testImplementation 'androidx.test:runner:1.2.0'
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.junit
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 }

--- a/firebase-perf/dev-app/dev-app.gradle
+++ b/firebase-perf/dev-app/dev-app.gradle
@@ -114,7 +114,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
     // Integration Test Deps
-    androidTestImplementation 'junit:junit:4.13.2'
+    androidTestImplementation libs.junit
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/firebase-perf/e2e-app/e2e-app.gradle
+++ b/firebase-perf/e2e-app/e2e-app.gradle
@@ -104,12 +104,12 @@ dependencies {
 
     // Integration Test Deps
     androidTestImplementation 'junit:junit:4.13.1'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "androidx.test:core:$androidxTestCoreVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.androidx.test.core
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation "androidx.test.espresso:espresso-contrib:3.3.0"
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.truth
 }

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -125,7 +125,7 @@ dependencies {
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    javadocClasspath libs.findbugs.jsr305
     runtimeOnly("com.google.firebase:firebase-datatransport:18.1.8") {
          exclude group: 'com.google.firebase', module: 'firebase-common'
          exclude group: 'com.google.firebase', module: 'firebase-components'
@@ -136,7 +136,7 @@ dependencies {
     testImplementation libs.robolectric
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation libs.mockito.core
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
 }

--- a/firebase-perf/firebase-perf.gradle
+++ b/firebase-perf/firebase-perf.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-process:2.3.1"
     implementation "com.google.android.gms:play-services-tasks:18.0.1"
     implementation libs.protobuf.java.lite
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.kotlin.stdlib
     implementation 'androidx.annotation:annotation:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.datatransport:transport-api:3.0.0'
@@ -131,9 +131,9 @@ dependencies {
          exclude group: 'com.google.firebase', module: 'firebase-components'
      }
     testCompileOnly libs.protobuf.java
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
+    testImplementation libs.robolectric
     testImplementation 'androidx.test:rules:1.2.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:5.2.0'

--- a/firebase-perf/ktx/ktx.gradle
+++ b/firebase-perf/ktx/ktx.gradle
@@ -53,11 +53,11 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     testCompileOnly libs.protobuf.java
 }

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -85,7 +85,7 @@ android {
 
 dependencies {
     javadocClasspath 'com.google.auto.value:auto-value-annotations:1.6.6'
-    javadocClasspath 'com.google.code.findbugs:jsr305:3.0.2'
+    javadocClasspath libs.findbugs.jsr305
 
     api("com.google.firebase:firebase-annotations:16.2.0")
     api("com.google.firebase:firebase-appcheck:17.1.0") {

--- a/firebase-storage/firebase-storage.gradle
+++ b/firebase-storage/firebase-storage.gradle
@@ -106,20 +106,20 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-tasks:18.0.1'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+    implementation libs.kotlin.stdlib
+    implementation libs.kotlinx.coroutines.core
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'androidx.test:rules:1.2.0'
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation "androidx.annotation:annotation:1.1.0"
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.12'
 }

--- a/firebase-storage/ktx/ktx.gradle
+++ b/firebase-storage/ktx/ktx.gradle
@@ -65,13 +65,13 @@ dependencies {
 
     implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.12'
 }

--- a/firebase-vertexai/firebase-vertexai.gradle.kts
+++ b/firebase-vertexai/firebase-vertexai.gradle.kts
@@ -122,7 +122,6 @@ dependencies {
   testImplementation(libs.robolectric)
   testImplementation(libs.truth)
 
-  androidTestImplementation("androidx.test.ext:junit:1.1.5")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
   androidTestImplementation(libs.androidx.test.junit)
   androidTestImplementation(libs.androidx.test.runner)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ grpc-android = { module = "io.grpc:grpc-android", version.ref = "grpc" }
 grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpcKotlin" }
 grpc-okhttp = { module = "io.grpc:grpc-okhttp", version.ref = "grpc" }
 grpc-protobuf-lite = { module = "io.grpc:grpc-protobuf-lite", version.ref = "grpc" }
+grpc-testing = { module= "io.grpc:grpc-testing", version.ref="grpc" }
 grpc-protoc-gen-java = { module = "io.grpc:protoc-gen-grpc-java", version.ref = "grpc" }
 grpc-protoc-gen-kotlin = { module = "io.grpc:protoc-gen-grpc-kotlin", version.ref = "grpcKotlin" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,16 +76,13 @@ androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "andro
 androidx-test-truth = { module = "androidx.test.ext:truth", version.ref = "androidx-test-truth" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-core" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.5.2" }
-
 junit = { module = "junit:junit", version = "4.13.2" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-
 mockito-core = { module = "org.mockito:mockito-core", version = "5.2.0" }
 mockito-dexmaker = { module = "com.linkedin.dexmaker:dexmaker-mockito", version = "2.28.3" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 truth-liteproto-extension = { module = "com.google.truth.extensions:truth-liteproto-extension", version.ref = "truth" }
 protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobufjavautil" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,21 +29,27 @@ androidx-test-truth = "1.5.0"
 android-gradlePlugin-gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 android-gradlePlugin-gradle-api = { group = "com.android.tools.build", name = "gradle-api", version.ref = "androidGradlePlugin" }
 android-gradlePlugin-builder-test-api = { group = "com.android.tools.build", name = "builder-test-api", version.ref = "androidGradlePlugin" }
+
 android-lint = { module = "com.android.tools.lint:lint", version.ref = "android-lint" }
 android-lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "android-lint" }
 android-lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "android-lint" }
 android-lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "android-lint" }
 android-lint-testutils = { module = "com.android.tools:testutils", version.ref = "android-lint" }
+
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.5.0" }
 androidx-core = { module = "androidx.core:core", version = "1.2.0" }
 androidx-futures = { module = "androidx.concurrent:concurrent-futures", version = "1.1.0" }
+
 auth0-jwt = { module = "com.auth0:java-jwt", version = "4.4.0" }
 autovalue = { module = "com.google.auto.value:auto-value", version.ref = "autovalue" }
 autovalue-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "autovalue" }
+
 dagger-dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
+
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version = "2.26.0" }
 findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }
+
 grpc-android = { module = "io.grpc:grpc-android", version.ref = "grpc" }
 grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpcKotlin" }
 grpc-okhttp = { module = "io.grpc:grpc-okhttp", version.ref = "grpc" }
@@ -52,18 +58,22 @@ grpc-testing = { module= "io.grpc:grpc-testing", version.ref="grpc" }
 grpc-protoc-gen-java = { module = "io.grpc:protoc-gen-grpc-java", version.ref = "grpc" }
 grpc-protoc-gen-kotlin = { module = "io.grpc:protoc-gen-grpc-kotlin", version.ref = "grpcKotlin" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
+
 javax-annotation-jsr250 = { module = "javax.annotation:jsr250-api", version = "1.0" }
 javax-inject = { module = "javax.inject:javax.inject", version = "1" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-coroutines-tasks = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutines" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "3.12.13" }
 org-json = { module = "org.json:json", version = "20210307" }
+
 playservices-base = { module = "com.google.android.gms:play-services-base", version = "18.1.0" }
 playservices-basement = { module = "com.google.android.gms:play-services-basement", version = "18.3.0" }
 playservices-tasks = { module = "com.google.android.gms:play-services-tasks", version = "18.1.0" }
+
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "javalite" }
 protobuf-java-lite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "javalite" }
@@ -75,13 +85,16 @@ androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "andro
 androidx-test-truth = { module = "androidx.test.ext:truth", version.ref = "androidx-test-truth" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-core" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.5.2" }
+
 junit = { module = "junit:junit", version = "4.13.2" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
 mockito-core = { module = "org.mockito:mockito-core", version = "5.2.0" }
 mockito-dexmaker = { module = "com.linkedin.dexmaker:dexmaker-mockito", version = "2.28.3" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 truth-liteproto-extension = { module = "com.google.truth.extensions:truth-liteproto-extension", version.ref = "truth" }
 protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobufjavautil" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,27 +29,21 @@ androidx-test-truth = "1.5.0"
 android-gradlePlugin-gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 android-gradlePlugin-gradle-api = { group = "com.android.tools.build", name = "gradle-api", version.ref = "androidGradlePlugin" }
 android-gradlePlugin-builder-test-api = { group = "com.android.tools.build", name = "builder-test-api", version.ref = "androidGradlePlugin" }
-
 android-lint = { module = "com.android.tools.lint:lint", version.ref = "android-lint" }
 android-lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "android-lint" }
 android-lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "android-lint" }
 android-lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "android-lint" }
 android-lint-testutils = { module = "com.android.tools:testutils", version.ref = "android-lint" }
-
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.5.0" }
 androidx-core = { module = "androidx.core:core", version = "1.2.0" }
 androidx-futures = { module = "androidx.concurrent:concurrent-futures", version = "1.1.0" }
-
 auth0-jwt = { module = "com.auth0:java-jwt", version = "4.4.0" }
 autovalue = { module = "com.google.auto.value:auto-value", version.ref = "autovalue" }
 autovalue-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "autovalue" }
-
 dagger-dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
-
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version = "2.26.0" }
 findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }
-
 grpc-android = { module = "io.grpc:grpc-android", version.ref = "grpc" }
 grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpcKotlin" }
 grpc-okhttp = { module = "io.grpc:grpc-okhttp", version.ref = "grpc" }
@@ -58,7 +52,6 @@ grpc-testing = { module= "io.grpc:grpc-testing", version.ref="grpc" }
 grpc-protoc-gen-java = { module = "io.grpc:protoc-gen-grpc-java", version.ref = "grpc" }
 grpc-protoc-gen-kotlin = { module = "io.grpc:protoc-gen-grpc-kotlin", version.ref = "grpcKotlin" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
-
 javax-annotation-jsr250 = { module = "javax.annotation:jsr250-api", version = "1.0" }
 javax-inject = { module = "javax.inject:javax.inject", version = "1" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
@@ -69,11 +62,9 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version = "3.12.13" }
 org-json = { module = "org.json:json", version = "20210307" }
-
 playservices-base = { module = "com.google.android.gms:play-services-base", version = "18.1.0" }
 playservices-basement = { module = "com.google.android.gms:play-services-basement", version = "18.3.0" }
 playservices-tasks = { module = "com.google.android.gms:play-services-tasks", version = "18.1.0" }
-
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protoc" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "javalite" }
 protobuf-java-lite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "javalite" }

--- a/health-metrics/benchmark/template/app/build.gradle.mustache
+++ b/health-metrics/benchmark/template/app/build.gradle.mustache
@@ -70,7 +70,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     androidTestImplementation "androidx.test.ext:junit:1.1.5"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/health-metrics/benchmark/template/macrobenchmark/build.gradle
+++ b/health-metrics/benchmark/template/macrobenchmark/build.gradle
@@ -51,7 +51,7 @@ android {
 dependencies {
     implementation 'androidx.benchmark:benchmark-macro-junit4:1.1.0'
     implementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation "androidx.test.ext:junit:1.1.5"
+    implementation libs.androidx.test.junit
     implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }
 

--- a/smoke-tests/build.gradle
+++ b/smoke-tests/build.gradle
@@ -64,7 +64,7 @@ android {
 apply from: "configure.gradle"
 
 dependencies {
-  implementation "androidx.test:core:1.5.0"
+  implementation libs.androidx.test.core
   // Common utilities (application side)
   implementation "androidx.test:rules:1.4.0"
   implementation "androidx.test:runner:1.4.0"
@@ -90,11 +90,11 @@ dependencies {
   implementation "com.google.firebase:firebase-perf"
   implementation "com.google.firebase:firebase-storage"
   implementation "com.google.truth:truth:1.0.1"
-  implementation "junit:junit:4.13.2"
+  implementation libs.junit
 
   // Common utilities (instrumentation side)
   androidTestImplementation "androidx.test:runner:1.4.0"
-  androidTestImplementation "junit:junit:4.13.2"
+  androidTestImplementation libs.junit
 }
 
 clean.doLast {

--- a/smoke-tests/settings.gradle
+++ b/smoke-tests/settings.gradle
@@ -11,3 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/transport/transport-api/transport-api.gradle
+++ b/transport/transport-api/transport-api.gradle
@@ -46,6 +46,6 @@ dependencies {
 
     annotationProcessor "com.google.auto.value:auto-value:1.6.5"
 
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13-beta-3'
 }

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -69,10 +69,10 @@ dependencies {
     annotationProcessor project(':encoders:firebase-encoders-processor')
     annotationProcessor "com.google.auto.value:auto-value:1.6.5"
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
+    testImplementation libs.androidx.test.core
     testImplementation 'com.github.tomakehurst:wiremock:3.0.1'
     testImplementation libs.protobuf.java.util
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.truth
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
     testImplementation 'junit:junit:4.13.1'
     testImplementation "org.robolectric:robolectric:4.12"

--- a/transport/transport-backend-cct/transport-backend-cct.gradle
+++ b/transport/transport-backend-cct/transport-backend-cct.gradle
@@ -75,7 +75,7 @@ dependencies {
     testImplementation libs.truth
     testImplementation 'com.google.truth.extensions:truth-proto-extension:1.0'
     testImplementation 'junit:junit:4.13.1'
-    testImplementation "org.robolectric:robolectric:4.12"
+    testImplementation libs.robolectric
 
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/transport/transport-runtime-testing/transport-runtime-testing.gradle
+++ b/transport/transport-runtime-testing/transport-runtime-testing.gradle
@@ -44,5 +44,5 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation libs.androidx.test.junit
     androidTestImplementation libs.truth
-    androidTestImplementation 'junit:junit:4.13.2'
+    androidTestImplementation libs.junit
 }

--- a/transport/transport-runtime-testing/transport-runtime-testing.gradle
+++ b/transport/transport-runtime-testing/transport-runtime-testing.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.13.2'
 }

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -121,17 +121,17 @@ dependencies {
 
     androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.27'
 
-    testImplementation "androidx.test:core:$androidxTestCoreVersion"
-    testImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    testImplementation "com.google.truth:truth:$googleTruthVersion"
+    testImplementation libs.androidx.test.core
+    testImplementation libs.androidx.test.junit
+    testImplementation libs.truth
     testImplementation 'junit:junit:4.13-beta-2'
     testImplementation 'org.mockito:mockito-core:2.25.0'
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation libs.robolectric
 
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation "androidx.test.ext:junit:$androidxTestJUnitVersion"
-    androidTestImplementation "com.google.truth:truth:$googleTruthVersion"
+    androidTestImplementation libs.androidx.test.junit
+    androidTestImplementation libs.truth
     androidTestImplementation 'junit:junit:4.13-beta-3'
     androidTestImplementation 'org.mockito:mockito-android:2.25.0'
     androidTestImplementation 'org.mockito:mockito-core:2.25.0'

--- a/transport/transport-runtime/transport-runtime.gradle
+++ b/transport/transport-runtime/transport-runtime.gradle
@@ -110,7 +110,7 @@ dependencies {
     api "com.google.firebase:firebase-encoders-proto:16.0.0"
 
     implementation 'androidx.annotation:annotation:1.3.0'
-    implementation 'javax.inject:javax.inject:1'
+    implementation libs.javax.inject
 
     compileOnly "com.google.auto.value:auto-value-annotations:1.6.6"
     compileOnly "com.google.errorprone:error_prone_annotations:2.9.0"


### PR DESCRIPTION
Per [b/374135906](https://b.corp.google.com/issues/374135906),

This migrates all our SDKs to use the version catalog where appropriate.

This is **_ONLY_** done when the version we use in the version catalog is the same version the SDK was using, so this should be a NOP change. There may also be other dependencies that could be moved to the version catalog, but research needs to be performed for that- which is out of scope of this PR.

NO_RELEASE_CHANGE