### PR TITLE
Add spotless support for *.gradle.kts files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,10 @@ configure(subprojects) {
             target 'src/**/*.kt'
             ktfmt('0.41').googleStyle()
         }
+        kotlinGradle {
+            target('*.gradle.kts') // default target for kotlinGradle
+            ktfmt('0.41').googleStyle()
+        }
     }
 }
 

--- a/firebase-annotations/firebase-annotations.gradle.kts
+++ b/firebase-annotations/firebase-annotations.gradle.kts
@@ -12,26 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-plugins {
-  id("firebase-java-library")
-}
+plugins { id("firebase-java-library") }
 
 firebaseLibrary {
   publishSources = true
   publishJavadoc = false
-  releaseNotes { 
-    enabled.set(false)
-}
+  releaseNotes { enabled.set(false) }
 }
 
 java {
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
-tasks.withType<JavaCompile> {
-  options.compilerArgs.add("-Werror")
-}
 
-dependencies {
-  implementation(libs.javax.inject)
-}
+tasks.withType<JavaCompile> { options.compilerArgs.add("-Werror") }
+
+dependencies { implementation(libs.javax.inject) }

--- a/firebase-common/data-collection-tests/data-collection-tests.gradle.kts
+++ b/firebase-common/data-collection-tests/data-collection-tests.gradle.kts
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-plugins {
-    id("com.android.application")
-}
+plugins { id("com.android.application") }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
   compileSdk = compileSdkVersion
   namespace = "com.google.firebase.datacollectiontests"
   defaultConfig {
@@ -36,15 +34,15 @@ android {
 }
 
 dependencies {
-    implementation("com.google.firebase:firebase-common:21.0.0")
-    implementation("com.google.firebase:firebase-components:18.0.0")
+  implementation("com.google.firebase:firebase-common:21.0.0")
+  implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation(libs.androidx.core)
-    testImplementation(libs.androidx.test.junit)
-    testImplementation(libs.androidx.test.runner)
-    testImplementation(libs.autovalue.annotations)
-    testImplementation(libs.junit)
-    testImplementation(libs.mockito.core)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.truth)
+  testImplementation(libs.androidx.core)
+  testImplementation(libs.androidx.test.junit)
+  testImplementation(libs.androidx.test.runner)
+  testImplementation(libs.autovalue.annotations)
+  testImplementation(libs.junit)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.truth)
 }

--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -13,23 +13,21 @@
 // limitations under the License.
 
 plugins {
-    id("firebase-library")
-    id("kotlin-android")
+  id("firebase-library")
+  id("kotlin-android")
 }
 
 firebaseLibrary {
-    libraryGroup("common")
-    testLab.enabled = true
-    publishSources = true
-    releaseNotes {
-        enabled = false
-    }
+  libraryGroup("common")
+  testLab.enabled = true
+  publishSources = true
+  releaseNotes { enabled = false }
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   compileSdk = compileSdkVersion
   namespace = "com.google.firebase"
@@ -41,62 +39,56 @@ android {
     consumerProguardFiles("proguard.txt")
   }
   sourceSets {
-    getByName("androidTest") {
-      java.srcDirs("src/testUtil")
-    }
-    getByName("test") {
-      java.srcDirs("src/testUtil")
-    }
+    getByName("androidTest") { java.srcDirs("src/testUtil") }
+    getByName("test") { java.srcDirs("src/testUtil") }
   }
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+  kotlinOptions { jvmTarget = "1.8" }
   testOptions.unitTests.isIncludeAndroidResources = true
 }
 
 dependencies {
-    api(libs.kotlin.coroutines.tasks)
+  api(libs.kotlin.coroutines.tasks)
 
-    api("com.google.firebase:firebase-components:18.0.0")
-    api("com.google.firebase:firebase-annotations:16.2.0")
-    implementation(libs.androidx.annotation)
-    implementation(libs.androidx.futures)
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.playservices.basement)
-    implementation(libs.playservices.tasks)
+  api("com.google.firebase:firebase-components:18.0.0")
+  api("com.google.firebase:firebase-annotations:16.2.0")
+  implementation(libs.androidx.annotation)
+  implementation(libs.androidx.futures)
+  implementation(libs.kotlin.stdlib)
+  implementation(libs.playservices.basement)
+  implementation(libs.playservices.tasks)
 
-    compileOnly(libs.autovalue.annotations)
-    compileOnly(libs.findbugs.jsr305)
-    compileOnly(libs.kotlin.stdlib)
+  compileOnly(libs.autovalue.annotations)
+  compileOnly(libs.findbugs.jsr305)
+  compileOnly(libs.kotlin.stdlib)
 
-    annotationProcessor(libs.autovalue)
+  annotationProcessor(libs.autovalue)
 
-    testImplementation("com.google.guava:guava-testlib:12.0-rc2")
-    testImplementation(libs.androidx.test.core)
-    testImplementation(libs.androidx.test.junit)
-    testImplementation(libs.androidx.test.runner)
-    testImplementation(libs.junit)
-    testImplementation(libs.kotlin.coroutines.test)
-    testImplementation(libs.mockito.core)
-    testImplementation(libs.org.json)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.truth)
+  testImplementation("com.google.guava:guava-testlib:12.0-rc2")
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.androidx.test.junit)
+  testImplementation(libs.androidx.test.runner)
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlin.coroutines.test)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.org.json)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.truth)
 
-    androidTestImplementation(project(":integ-testing")) {
-        exclude("com.google.firebase","firebase-common")
-        exclude("com.google.firebase","firebase-common-ktx")
-    }
+  androidTestImplementation(project(":integ-testing")) {
+    exclude("com.google.firebase", "firebase-common")
+    exclude("com.google.firebase", "firebase-common-ktx")
+  }
 
-    // TODO(Remove when FirbaseAppTest has been modernized to use LiveData)
-    androidTestImplementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
-    androidTestImplementation(libs.androidx.test.junit)
-    androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation(libs.junit)
-    androidTestImplementation(libs.mockito.core)
-    androidTestImplementation(libs.mockito.dexmaker)
-    androidTestImplementation(libs.truth)
+  // TODO(Remove when FirbaseAppTest has been modernized to use LiveData)
+  androidTestImplementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
+  androidTestImplementation(libs.androidx.test.junit)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.mockito.core)
+  androidTestImplementation(libs.mockito.dexmaker)
+  androidTestImplementation(libs.truth)
 }

--- a/firebase-common/ktx/ktx.gradle.kts
+++ b/firebase-common/ktx/ktx.gradle.kts
@@ -13,49 +13,41 @@
 // limitations under the License.
 
 plugins {
-    id("firebase-library")
-    id("kotlin-android")
+  id("firebase-library")
+  id("kotlin-android")
 }
 
 firebaseLibrary {
-    libraryGroup("common")
-    publishJavadoc = false
-    releaseNotes { 
-        enabled.set(false)
-    }
+  libraryGroup("common")
+  publishJavadoc = false
+  releaseNotes { enabled.set(false) }
 }
 
 android {
-    val compileSdkVersion : Int by rootProject
-    val targetSdkVersion : Int by rootProject
-    val minSdkVersion : Int by rootProject
-    compileSdk = compileSdkVersion
-    namespace = "com.google.firebase.ktx"
-    defaultConfig {
-        minSdk = minSdkVersion
-        targetSdk = targetSdkVersion
-    }
-    sourceSets {
-        getByName("main") {
-            java.srcDirs("src/main/kotlin")
-        }
-        getByName("test") {
-            java.srcDirs("src/test/kotlin")
-        }
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    testOptions.unitTests.isIncludeAndroidResources = true
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
+  compileSdk = compileSdkVersion
+  namespace = "com.google.firebase.ktx"
+  defaultConfig {
+    minSdk = minSdkVersion
+    targetSdk = targetSdkVersion
+  }
+  sourceSets {
+    getByName("main") { java.srcDirs("src/main/kotlin") }
+    getByName("test") { java.srcDirs("src/test/kotlin") }
+  }
+  kotlinOptions { jvmTarget = "1.8" }
+  testOptions.unitTests.isIncludeAndroidResources = true
 }
 
 dependencies {
-    api(project(":firebase-common"))
-    implementation("com.google.firebase:firebase-components:18.0.0")
-    implementation("com.google.firebase:firebase-annotations:16.2.0")
-    testImplementation(libs.androidx.test.core)
-    testImplementation(libs.junit)
-    testImplementation(libs.kotlin.coroutines.test)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.truth)
+  api(project(":firebase-common"))
+  implementation("com.google.firebase:firebase-components:18.0.0")
+  implementation("com.google.firebase:firebase-annotations:16.2.0")
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlin.coroutines.test)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.truth)
 }

--- a/firebase-components/firebase-components.gradle.kts
+++ b/firebase-components/firebase-components.gradle.kts
@@ -12,22 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-plugins {
-    id("firebase-library")
-}
+plugins { id("firebase-library") }
 
 firebaseLibrary {
-    publishSources = true
-    publishJavadoc = false
-    releaseNotes { 
-        enabled.set(false)
-    }
+  publishSources = true
+  publishJavadoc = false
+  releaseNotes { enabled.set(false) }
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
   compileSdk = compileSdkVersion
   namespace = "com.google.firebase.components"
   defaultConfig {

--- a/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
+++ b/firebase-components/firebase-dynamic-module-support/firebase-dynamic-module-support.gradle.kts
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-plugins {
-  id("firebase-library")
-}
+plugins { id("firebase-library") }
 
 group = "com.google.firebase"
 
@@ -30,9 +28,9 @@ firebaseLibrary {
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
   compileSdk = compileSdkVersion
   namespace = "com.google.firebase.dynamicloading"
   defaultConfig {

--- a/firebase-config-interop/firebase-config-interop.gradle.kts
+++ b/firebase-config-interop/firebase-config-interop.gradle.kts
@@ -14,51 +14,47 @@
  * limitations under the License.
  */
 
-plugins {
-    id("firebase-library")
-}
+plugins { id("firebase-library") }
 
 firebaseLibrary {
-    publishSources = true
-    publishJavadoc = false
-    releaseNotes {
-        enabled.set(false)
-    }
+  publishSources = true
+  publishJavadoc = false
+  releaseNotes { enabled.set(false) }
 }
 
 android {
-    val compileSdkVersion : Int by rootProject
-    val targetSdkVersion: Int by rootProject
-    val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
-    namespace = "com.google.firebase.remoteconfiginterop"
-    compileSdk = compileSdkVersion
+  namespace = "com.google.firebase.remoteconfiginterop"
+  compileSdk = compileSdkVersion
 
-    defaultConfig {
-        minSdk = minSdkVersion
-        targetSdk = targetSdkVersion
+  defaultConfig {
+    minSdk = minSdkVersion
+    targetSdk = targetSdkVersion
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
 }
 
 dependencies {
-    api("com.google.firebase:firebase-encoders-json:18.0.1")
-    api("com.google.firebase:firebase-encoders:17.0.0")
+  api("com.google.firebase:firebase-encoders-json:18.0.1")
+  api("com.google.firebase:firebase-encoders:17.0.0")
 
-    compileOnly("com.google.auto.value:auto-value-annotations:1.10.1")
+  compileOnly("com.google.auto.value:auto-value-annotations:1.10.1")
 
-    annotationProcessor("com.google.auto.value:auto-value:1.10.1")
-    annotationProcessor(project(":encoders:firebase-encoders-processor"))
+  annotationProcessor("com.google.auto.value:auto-value:1.10.1")
+  annotationProcessor(project(":encoders:firebase-encoders-processor"))
 
-    testImplementation(libs.junit)
-    testImplementation(libs.truth)
-    testImplementation(libs.robolectric)
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+  testImplementation(libs.robolectric)
 
-    androidTestImplementation(libs.androidx.test.junit)
+  androidTestImplementation(libs.androidx.test.junit)
 }

--- a/firebase-config/firebase-config.gradle.kts
+++ b/firebase-config/firebase-config.gradle.kts
@@ -15,93 +15,89 @@
  */
 
 plugins {
-    id("firebase-library")
-    id("kotlin-android")
+  id("firebase-library")
+  id("kotlin-android")
 }
 
 firebaseLibrary {
-    libraryGroup("config")
-    testLab.enabled = true
-    publishSources = true
-    releaseNotes {
-        name.set("{{remote_config}}")
-        versionName.set("remote-config")
-    }
+  libraryGroup("config")
+  testLab.enabled = true
+  publishSources = true
+  releaseNotes {
+    name.set("{{remote_config}}")
+    versionName.set("remote-config")
+  }
 }
 
 android {
-    val compileSdkVersion : Int by rootProject
-    val targetSdkVersion: Int by rootProject
-    val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
-    namespace = "com.google.firebase.remoteconfig"
-    compileSdk = targetSdkVersion
+  namespace = "com.google.firebase.remoteconfig"
+  compileSdk = targetSdkVersion
 
-    defaultConfig {
-      minSdk = 21
-      targetSdk = targetSdkVersion
-      multiDexEnabled = true
-      testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
+  defaultConfig {
+    minSdk = 21
+    targetSdk = targetSdkVersion
+    multiDexEnabled = true
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
 
-    sourceSets {
-        getByName("androidTest").java.srcDir("src/androidTest/res")
-    }
+  sourceSets { getByName("androidTest").java.srcDir("src/androidTest/res") }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    testOptions.unitTests.isIncludeAndroidResources = true
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+  kotlinOptions { jvmTarget = "1.8" }
+  testOptions.unitTests.isIncludeAndroidResources = true
 }
 
 dependencies {
-    // Firebase
-    api("com.google.firebase:firebase-config-interop:16.0.1")
-    api("com.google.firebase:firebase-annotations:16.2.0")
-    api("com.google.firebase:firebase-installations-interop:17.1.0")
-    api("com.google.firebase:firebase-abt:21.1.1") {
-         exclude(group = "com.google.firebase", module = "firebase-common")
-         exclude(group = "com.google.firebase", module = "firebase-components")
-     }
-    api("com.google.firebase:firebase-measurement-connector:18.0.0") {
-         exclude(group = "com.google.firebase", module = "firebase-common")
-         exclude(group = "com.google.firebase", module = "firebase-components")
-     }
-    api("com.google.firebase:firebase-common:21.0.0")
-    api("com.google.firebase:firebase-common-ktx:21.0.0")
-    api("com.google.firebase:firebase-components:18.0.0")
-    api("com.google.firebase:firebase-installations:17.2.0")
+  // Firebase
+  api("com.google.firebase:firebase-config-interop:16.0.1")
+  api("com.google.firebase:firebase-annotations:16.2.0")
+  api("com.google.firebase:firebase-installations-interop:17.1.0")
+  api("com.google.firebase:firebase-abt:21.1.1") {
+    exclude(group = "com.google.firebase", module = "firebase-common")
+    exclude(group = "com.google.firebase", module = "firebase-components")
+  }
+  api("com.google.firebase:firebase-measurement-connector:18.0.0") {
+    exclude(group = "com.google.firebase", module = "firebase-common")
+    exclude(group = "com.google.firebase", module = "firebase-components")
+  }
+  api("com.google.firebase:firebase-common:21.0.0")
+  api("com.google.firebase:firebase-common-ktx:21.0.0")
+  api("com.google.firebase:firebase-components:18.0.0")
+  api("com.google.firebase:firebase-installations:17.2.0")
 
-    // Kotlin & Android
-    implementation(libs.kotlin.stdlib)
-    implementation("androidx.annotation:annotation:1.1.0")
-    api("com.google.android.gms:play-services-tasks:18.0.1")
+  // Kotlin & Android
+  implementation(libs.kotlin.stdlib)
+  implementation("androidx.annotation:annotation:1.1.0")
+  api("com.google.android.gms:play-services-tasks:18.0.1")
 
-    // Annotations and static analysis
-    annotationProcessor("com.google.auto.value:auto-value:1.6.6")
-    javadocClasspath("com.google.auto.value:auto-value-annotations:1.6.6")
-    compileOnly("com.google.auto.value:auto-value-annotations:1.6.6")
-    compileOnly("com.google.code.findbugs:jsr305:3.0.2")
+  // Annotations and static analysis
+  annotationProcessor("com.google.auto.value:auto-value:1.6.6")
+  javadocClasspath("com.google.auto.value:auto-value-annotations:1.6.6")
+  compileOnly("com.google.auto.value:auto-value-annotations:1.6.6")
+  compileOnly("com.google.code.findbugs:jsr305:3.0.2")
 
-    // Testing
-    testImplementation(libs.junit)
-    testImplementation(libs.androidx.test.core)
-    testImplementation(libs.androidx.test.runner)
-    testImplementation(libs.androidx.test.truth)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.mockito.core)
-    testImplementation(libs.truth)
-    testImplementation("org.skyscreamer:jsonassert:1.5.0")
+  // Testing
+  testImplementation(libs.junit)
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.androidx.test.runner)
+  testImplementation(libs.androidx.test.truth)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.truth)
+  testImplementation("org.skyscreamer:jsonassert:1.5.0")
 
-    androidTestImplementation(libs.truth)
-    androidTestImplementation(libs.junit)
-    androidTestImplementation(libs.mockito.core)
-    androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation("org.skyscreamer:jsonassert:1.5.0")
-    androidTestImplementation("com.linkedin.dexmaker:dexmaker-mockito:2.28.1")
-    androidTestImplementation("com.linkedin.dexmaker:dexmaker:2.28.1")
+  androidTestImplementation(libs.truth)
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.mockito.core)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation("org.skyscreamer:jsonassert:1.5.0")
+  androidTestImplementation("com.linkedin.dexmaker:dexmaker-mockito:2.28.1")
+  androidTestImplementation("com.linkedin.dexmaker:dexmaker:2.28.1")
 }

--- a/firebase-config/test-app/test-app.gradle.kts
+++ b/firebase-config/test-app/test-app.gradle.kts
@@ -28,9 +28,9 @@ plugins {
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
   val targetSdkVersion: Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.testing.config"
   compileSdk = compileSdkVersion
@@ -47,9 +47,7 @@ android {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
+  kotlinOptions { jvmTarget = "1.8" }
 }
 
 dependencies {
@@ -62,7 +60,8 @@ dependencies {
   implementation(project(":firebase-config:ktx"))
 
   // This is required since a `project` dependency on frc does not expose the APIs of its
-  // "implementation" dependencies. The alternative would be to make common an "api" dep of remote-config.
+  // "implementation" dependencies. The alternative would be to make common an "api" dep of
+  // remote-config.
   // Released artifacts don't need these dependencies since they don't use `project` to refer
   // to Remote Config.
   implementation("com.google.firebase:firebase-common:21.0.0")

--- a/firebase-database-collection/firebase-database-collection.gradle.kts
+++ b/firebase-database-collection/firebase-database-collection.gradle.kts
@@ -17,13 +17,11 @@ plugins { id("firebase-library") }
 firebaseLibrary {
   publishSources = true
   publishJavadoc = false
-  releaseNotes {
-    enabled.set(false)
-  }
+  releaseNotes { enabled.set(false) }
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
   val targetSdkVersion: Int by rootProject
   val minSdkVersion: Int by rootProject
 

--- a/firebase-database/firebase-database.gradle.kts
+++ b/firebase-database/firebase-database.gradle.kts
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 plugins {
-    id("firebase-library")
-    id("kotlin-android")
-    id("copy-google-services")
+  id("firebase-library")
+  id("kotlin-android")
+  id("copy-google-services")
 }
 
 firebaseLibrary {
@@ -29,7 +29,7 @@ firebaseLibrary {
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
   val targetSdkVersion: Int by rootProject
   val minSdkVersion: Int by rootProject
 
@@ -62,39 +62,39 @@ android {
 }
 
 dependencies {
-    api("com.google.firebase:firebase-appcheck-interop:17.1.0")
-    api("com.google.firebase:firebase-common:21.0.0")
-    api("com.google.firebase:firebase-common-ktx:21.0.0")
-    api("com.google.firebase:firebase-components:18.0.0")
-    api("com.google.firebase:firebase-auth-interop:20.0.0") {
-     exclude(group = "com.google.firebase", module = "firebase-common")
-     exclude(group = "com.google.firebase", module = "firebase-components")
-   }
-    api("com.google.firebase:firebase-database-collection:18.0.1")
-    implementation(libs.androidx.annotation)
-    implementation(libs.bundles.playservices)
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.kotlinx.coroutines.core)
-    api(libs.playservices.tasks)
+  api("com.google.firebase:firebase-appcheck-interop:17.1.0")
+  api("com.google.firebase:firebase-common:21.0.0")
+  api("com.google.firebase:firebase-common-ktx:21.0.0")
+  api("com.google.firebase:firebase-components:18.0.0")
+  api("com.google.firebase:firebase-auth-interop:20.0.0") {
+    exclude(group = "com.google.firebase", module = "firebase-common")
+    exclude(group = "com.google.firebase", module = "firebase-components")
+  }
+  api("com.google.firebase:firebase-database-collection:18.0.1")
+  implementation(libs.androidx.annotation)
+  implementation(libs.bundles.playservices)
+  implementation(libs.kotlin.stdlib)
+  implementation(libs.kotlinx.coroutines.core)
+  api(libs.playservices.tasks)
 
-    testImplementation("com.fasterxml.jackson.core:jackson-core:2.13.1")
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
-    testImplementation("com.firebase:firebase-token-generator:2.0.0")
-    testImplementation(libs.androidx.test.core)
-    testImplementation(libs.androidx.test.rules)
-    testImplementation(libs.junit)
-    testImplementation(libs.mockito.core)
-    testImplementation(libs.quickcheck)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.truth)
+  testImplementation("com.fasterxml.jackson.core:jackson-core:2.13.1")
+  testImplementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
+  testImplementation("com.firebase:firebase-token-generator:2.0.0")
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.androidx.test.rules)
+  testImplementation(libs.junit)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.quickcheck)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.truth)
 
-    androidTestImplementation("com.fasterxml.jackson.core:jackson-core:2.13.1")
-    androidTestImplementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
-    androidTestImplementation("org.hamcrest:hamcrest:2.2")
-    androidTestImplementation("org.hamcrest:hamcrest-library:2.2")
-    androidTestImplementation(libs.androidx.test.junit)
-    androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation(libs.junit)
-    androidTestImplementation(libs.quickcheck)
-    androidTestImplementation(libs.truth)
+  androidTestImplementation("com.fasterxml.jackson.core:jackson-core:2.13.1")
+  androidTestImplementation("com.fasterxml.jackson.core:jackson-databind:2.13.1")
+  androidTestImplementation("org.hamcrest:hamcrest:2.2")
+  androidTestImplementation("org.hamcrest:hamcrest-library:2.2")
+  androidTestImplementation(libs.androidx.test.junit)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.quickcheck)
+  androidTestImplementation(libs.truth)
 }

--- a/firebase-database/ktx/ktx.gradle.kts
+++ b/firebase-database/ktx/ktx.gradle.kts
@@ -23,9 +23,7 @@ group = "com.google.firebase"
 firebaseLibrary {
   libraryGroup("database")
   publishJavadoc = false
-  releaseNotes { 
-    enabled.set(false)
-}
+  releaseNotes { enabled.set(false) }
   publishSources = true
 }
 
@@ -52,14 +50,14 @@ android {
 }
 
 dependencies {
-    api("com.google.firebase:firebase-common:21.0.0")
-    api("com.google.firebase:firebase-common-ktx:21.0.0")
-    api(project(":firebase-database"))
+  api("com.google.firebase:firebase-common:21.0.0")
+  api("com.google.firebase:firebase-common-ktx:21.0.0")
+  api(project(":firebase-database"))
 
-    implementation("com.google.firebase:firebase-components:18.0.0")
+  implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation(libs.androidx.test.core)
-    testImplementation(libs.junit)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.truth)
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.junit)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.truth)
 }

--- a/firebase-dataconnect/androidTestutil/androidTestutil.gradle.kts
+++ b/firebase-dataconnect/androidTestutil/androidTestutil.gradle.kts
@@ -23,9 +23,9 @@ plugins {
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.dataconnect.androidTestutil"
   compileSdk = compileSdkVersion
@@ -68,7 +68,5 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>().all {
-  kotlinOptions {
-    freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
-  }
+  kotlinOptions { freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn") }
 }

--- a/firebase-dataconnect/connectors/connectors.gradle.kts
+++ b/firebase-dataconnect/connectors/connectors.gradle.kts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.google.firebase.dataconnect.gradle.plugin.UpdateDataConnectExecutableVersionsTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("com.android.library")
@@ -25,9 +25,9 @@ plugins {
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.dataconnect.connectors"
   compileSdk = compileSdkVersion
@@ -59,9 +59,7 @@ android {
 
   dataconnect {
     configDir = file("../emulator/dataconnect")
-    codegen {
-      connectors = listOf("demo", "keywords")
-    }
+    codegen { connectors = listOf("demo", "keywords") }
   }
 }
 
@@ -92,9 +90,7 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>().all {
-  kotlinOptions {
-    freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
-  }
+  kotlinOptions { freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn") }
 }
 
 // Enable Kotlin "Explicit API Mode". This causes the Kotlin compiler to fail if any
@@ -123,28 +119,37 @@ tasks.withType<KotlinCompile>().all {
 // The `--info` argument can be omitted; it merely controls the level of log output.
 tasks.register<UpdateDataConnectExecutableVersionsTask>("updateJson") {
   outputs.upToDateWhen { false }
-  jsonFile.set(project.layout.projectDirectory.file(
-    "../gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/" +
-        "plugin/DataConnectExecutableVersions.json"))
+  jsonFile.set(
+    project.layout.projectDirectory.file(
+      "../gradleplugin/plugin/src/main/resources/com/google/firebase/dataconnect/gradle/" +
+        "plugin/DataConnectExecutableVersions.json"
+    )
+  )
   workDirectory.set(project.layout.buildDirectory.dir("updateJson"))
 
   val singleVersion: String? = project.providers.gradleProperty("version").orNull
-  val multipleVersions: List<String>? = project.providers.gradleProperty("versions").orNull?.split(',')
-  versions.set(buildList {
-    singleVersion?.let{add(it)}
-    multipleVersions?.let{addAll(it)}
-    if (isEmpty()) {
-      throw Exception("bm6d5ezxzd 'version' or 'versions' property must be specified")
+  val multipleVersions: List<String>? =
+    project.providers.gradleProperty("versions").orNull?.split(',')
+  versions.set(
+    buildList {
+      singleVersion?.let { add(it) }
+      multipleVersions?.let { addAll(it) }
+      if (isEmpty()) {
+        throw Exception("bm6d5ezxzd 'version' or 'versions' property must be specified")
+      }
     }
-  })
+  )
 
-  updateMode.set(project.providers.gradleProperty("updateMode").map {
-    when (it) {
-      "overwrite" -> UpdateDataConnectExecutableVersionsTask.UpdateMode.Overwrite
-      "update" -> UpdateDataConnectExecutableVersionsTask.UpdateMode.Update
-      else -> throw Exception("ahe4zadcjs 'updateMode' must be 'overwrite' or 'update', but got: $it")
+  updateMode.set(
+    project.providers.gradleProperty("updateMode").map {
+      when (it) {
+        "overwrite" -> UpdateDataConnectExecutableVersionsTask.UpdateMode.Overwrite
+        "update" -> UpdateDataConnectExecutableVersionsTask.UpdateMode.Update
+        else ->
+          throw Exception("ahe4zadcjs 'updateMode' must be 'overwrite' or 'update', but got: $it")
+      }
     }
-  })
+  )
 
   defaultVersion.set(project.providers.gradleProperty("defaultVersion"))
 }

--- a/firebase-dataconnect/firebase-dataconnect.gradle.kts
+++ b/firebase-dataconnect/firebase-dataconnect.gradle.kts
@@ -35,13 +35,12 @@ firebaseLibrary {
     versionName.set("data-connect")
     hasKTX.set(false)
   }
-
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.dataconnect"
   compileSdk = compileSdkVersion
@@ -74,37 +73,19 @@ android {
 }
 
 protobuf {
-  protoc {
-    artifact = "${libs.protoc.get()}"
-  }
+  protoc { artifact = "${libs.protoc.get()}" }
   plugins {
-    create("java") {
-      artifact = "${libs.grpc.protoc.gen.java.get()}"
-    }
-    create("grpc") {
-      artifact = "${libs.grpc.protoc.gen.java.get()}"
-    }
-    create("grpckt") {
-      artifact = "${libs.grpc.protoc.gen.kotlin.get()}:jdk8@jar"
-    }
+    create("java") { artifact = "${libs.grpc.protoc.gen.java.get()}" }
+    create("grpc") { artifact = "${libs.grpc.protoc.gen.java.get()}" }
+    create("grpckt") { artifact = "${libs.grpc.protoc.gen.kotlin.get()}:jdk8@jar" }
   }
   generateProtoTasks {
     all().forEach { task ->
-      task.builtins {
-        create("kotlin") {
-          option("lite")
-        }
-      }
+      task.builtins { create("kotlin") { option("lite") } }
       task.plugins {
-        create("java") {
-          option("lite")
-        }
-        create("grpc") {
-          option("lite")
-        }
-        create("grpckt") {
-          option("lite")
-        }
+        create("java") { option("lite") }
+        create("grpc") { option("lite") }
+        create("grpckt") { option("lite") }
       }
     }
   }
@@ -163,9 +144,7 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>().all {
-  kotlinOptions {
-    freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
-  }
+  kotlinOptions { freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn") }
 }
 
 // Enable Kotlin "Explicit API Mode". This causes the Kotlin compiler to fail if any

--- a/firebase-dataconnect/testutil/testutil.gradle.kts
+++ b/firebase-dataconnect/testutil/testutil.gradle.kts
@@ -23,9 +23,9 @@ plugins {
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.dataconnect.testutil"
   compileSdk = compileSdkVersion
@@ -66,7 +66,5 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>().all {
-  kotlinOptions {
-    freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
-  }
+  kotlinOptions { freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn") }
 }

--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -15,27 +15,27 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 // limitations under the License.
 
 plugins {
-    id("firebase-library")
-    id("kotlin-android")
-    id("firebase-vendor")
-    id("copy-google-services")
-    kotlin("kapt")
+  id("firebase-library")
+  id("kotlin-android")
+  id("firebase-vendor")
+  id("copy-google-services")
+  kotlin("kapt")
 }
 
 firebaseLibrary {
-    libraryGroup("functions")
-    testLab.enabled = true
-    publishSources = true
-    releaseNotes {
-        name.set("{{functions_client}}")
-        versionName.set("functions-client")
-    }
+  libraryGroup("functions")
+  testLab.enabled = true
+  publishSources = true
+  releaseNotes {
+    name.set("{{functions_client}}")
+    versionName.set("functions-client")
+  }
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.functions"
   compileSdk = compileSdkVersion
@@ -46,9 +46,7 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("proguard.txt")
   }
-  sourceSets {
-    getByName("androidTest").java.srcDirs("src/testUtil")
-  }
+  sourceSets { getByName("androidTest").java.srcDirs("src/testUtil") }
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -72,69 +70,67 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    javadocClasspath("org.codehaus.mojo:animal-sniffer-annotations:1.21")
-    javadocClasspath(libs.autovalue.annotations)
-    javadocClasspath(libs.findbugs.jsr305)
-    implementation("com.google.firebase:firebase-annotations:16.2.0")
-    implementation("com.google.firebase:firebase-common:20.3.1")
-    implementation("com.google.firebase:firebase-components:17.1.0")
-    implementation("com.google.firebase:firebase-appcheck-interop:17.1.0")
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.playservices.base)
-    implementation(libs.playservices.basement)
-    implementation(libs.playservices.tasks)
-    implementation("com.google.firebase:firebase-iid:21.1.0") {
-        exclude(group = "com.google.firebase", module = "firebase-common")
-        exclude(group = "com.google.firebase", module = "firebase-components")
-    }
-    implementation("com.google.firebase:firebase-auth-interop:18.0.0") {
-        exclude(group = "com.google.firebase", module = "firebase-common")
-    }
-    implementation("com.google.firebase:firebase-iid-interop:17.1.0")
-    implementation(libs.okhttp)
+  javadocClasspath("org.codehaus.mojo:animal-sniffer-annotations:1.21")
+  javadocClasspath(libs.autovalue.annotations)
+  javadocClasspath(libs.findbugs.jsr305)
+  implementation("com.google.firebase:firebase-annotations:16.2.0")
+  implementation("com.google.firebase:firebase-common:20.3.1")
+  implementation("com.google.firebase:firebase-components:17.1.0")
+  implementation("com.google.firebase:firebase-appcheck-interop:17.1.0")
+  implementation(libs.kotlin.stdlib)
+  implementation(libs.playservices.base)
+  implementation(libs.playservices.basement)
+  implementation(libs.playservices.tasks)
+  implementation("com.google.firebase:firebase-iid:21.1.0") {
+    exclude(group = "com.google.firebase", module = "firebase-common")
+    exclude(group = "com.google.firebase", module = "firebase-components")
+  }
+  implementation("com.google.firebase:firebase-auth-interop:18.0.0") {
+    exclude(group = "com.google.firebase", module = "firebase-common")
+  }
+  implementation("com.google.firebase:firebase-iid-interop:17.1.0")
+  implementation(libs.okhttp)
 
-    api("com.google.firebase:firebase-appcheck-interop:17.1.0")
-    api("com.google.firebase:firebase-common:21.0.0")
-    api("com.google.firebase:firebase-common-ktx:21.0.0")
-    api("com.google.firebase:firebase-components:18.0.0")
-    api("com.google.firebase:firebase-annotations:16.2.0")
-    api("com.google.firebase:firebase-auth-interop:18.0.0") {
-       exclude(group = "com.google.firebase", module = "firebase-common")
-   }
-    api("com.google.firebase:firebase-iid:21.1.0") {
-       exclude(group = "com.google.firebase", module = "firebase-common")
-       exclude(group = "com.google.firebase", module = "firebase-components")
-   }
-    api("com.google.firebase:firebase-iid-interop:17.1.0")
-    implementation(libs.androidx.annotation)
-    implementation(libs.javax.inject)
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.okhttp)
-    implementation(libs.playservices.base)
-    implementation(libs.playservices.basement)
-    api(libs.playservices.tasks)
+  api("com.google.firebase:firebase-appcheck-interop:17.1.0")
+  api("com.google.firebase:firebase-common:21.0.0")
+  api("com.google.firebase:firebase-common-ktx:21.0.0")
+  api("com.google.firebase:firebase-components:18.0.0")
+  api("com.google.firebase:firebase-annotations:16.2.0")
+  api("com.google.firebase:firebase-auth-interop:18.0.0") {
+    exclude(group = "com.google.firebase", module = "firebase-common")
+  }
+  api("com.google.firebase:firebase-iid:21.1.0") {
+    exclude(group = "com.google.firebase", module = "firebase-common")
+    exclude(group = "com.google.firebase", module = "firebase-components")
+  }
+  api("com.google.firebase:firebase-iid-interop:17.1.0")
+  implementation(libs.androidx.annotation)
+  implementation(libs.javax.inject)
+  implementation(libs.kotlin.stdlib)
+  implementation(libs.okhttp)
+  implementation(libs.playservices.base)
+  implementation(libs.playservices.basement)
+  api(libs.playservices.tasks)
 
-    annotationProcessor(libs.autovalue)
-    annotationProcessor(libs.dagger.compiler)
+  annotationProcessor(libs.autovalue)
+  annotationProcessor(libs.dagger.compiler)
 
-    testImplementation(libs.androidx.test.core)
-    testImplementation(libs.androidx.test.rules)
-    testImplementation(libs.junit)
-    testImplementation(libs.mockito.core)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.robolectric) {}
-    testImplementation(libs.truth)
-    vendor(libs.dagger.dagger) {
-     exclude(group = "javax.inject", module = "javax.inject")
-   }
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.androidx.test.rules)
+  testImplementation(libs.junit)
+  testImplementation(libs.mockito.core)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.robolectric) {}
+  testImplementation(libs.truth)
+  vendor(libs.dagger.dagger) { exclude(group = "javax.inject", module = "javax.inject") }
 
-    androidTestImplementation(project(":integ-testing"))
-    androidTestImplementation(libs.junit)
-    androidTestImplementation(libs.truth)
-    androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation(libs.androidx.test.junit)
-    androidTestImplementation(libs.mockito.core)
-    androidTestImplementation(libs.mockito.dexmaker)
-    kapt("com.google.dagger:dagger-android-processor:2.43.2")
-    kapt("com.google.dagger:dagger-compiler:2.43.2")
+  androidTestImplementation(project(":integ-testing"))
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.truth)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.androidx.test.junit)
+  androidTestImplementation(libs.mockito.core)
+  androidTestImplementation(libs.mockito.dexmaker)
+  kapt("com.google.dagger:dagger-android-processor:2.43.2")
+  kapt("com.google.dagger:dagger-compiler:2.43.2")
 }

--- a/firebase-functions/ktx/ktx.gradle.kts
+++ b/firebase-functions/ktx/ktx.gradle.kts
@@ -14,23 +14,21 @@
 
 plugins {
   id("firebase-library")
-    id("kotlin-android")
+  id("kotlin-android")
 }
 
 firebaseLibrary {
   libraryGroup("functions")
   publishJavadoc = false
-  releaseNotes { 
-    enabled.set(false)
-}
+  releaseNotes { enabled.set(false) }
   publishSources = true
   testLab.enabled = true
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.functions.ktx"
   compileSdk = compileSdkVersion
@@ -49,18 +47,18 @@ android {
 }
 
 dependencies {
-    api("com.google.firebase:firebase-common:21.0.0")
-    api("com.google.firebase:firebase-common-ktx:21.0.0")
-    api(project(":firebase-functions"))
+  api("com.google.firebase:firebase-common:21.0.0")
+  api("com.google.firebase:firebase-common-ktx:21.0.0")
+  api(project(":firebase-functions"))
 
-    implementation("com.google.firebase:firebase-components:18.0.0")
+  implementation("com.google.firebase:firebase-components:18.0.0")
 
-    testImplementation(libs.androidx.test.core)
-    testImplementation(libs.junit)
-    testImplementation(libs.robolectric)
-    testImplementation(libs.truth)
+  testImplementation(libs.androidx.test.core)
+  testImplementation(libs.junit)
+  testImplementation(libs.robolectric)
+  testImplementation(libs.truth)
 
-    androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation(libs.junit)
-    androidTestImplementation(libs.truth)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.truth)
 }

--- a/firebase-sessions/firebase-sessions.gradle.kts
+++ b/firebase-sessions/firebase-sessions.gradle.kts
@@ -28,15 +28,13 @@ firebaseLibrary {
   testLab.enabled = true
   publishSources = true
   publishJavadoc = false
-  releaseNotes { 
-    enabled.set(false)
-}
+  releaseNotes { enabled.set(false) }
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
-  val targetSdkVersion : Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
+  val targetSdkVersion: Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.sessions"
   compileSdk = compileSdkVersion

--- a/firebase-sessions/test-app/test-app.gradle.kts
+++ b/firebase-sessions/test-app/test-app.gradle.kts
@@ -29,9 +29,9 @@ plugins {
 }
 
 android {
-  val compileSdkVersion : Int by rootProject
+  val compileSdkVersion: Int by rootProject
   val targetSdkVersion: Int by rootProject
-  val minSdkVersion : Int by rootProject
+  val minSdkVersion: Int by rootProject
 
   namespace = "com.google.firebase.testing.sessions"
   compileSdk = compileSdkVersion

--- a/firebase-vertexai/firebase-vertexai.gradle.kts
+++ b/firebase-vertexai/firebase-vertexai.gradle.kts
@@ -18,7 +18,6 @@
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-
 plugins {
   id("firebase-library")
   id("kotlin-android")
@@ -51,10 +50,7 @@ android {
   buildTypes {
     release {
       isMinifyEnabled = false
-      proguardFiles(
-        getDefaultProguardFile("proguard-android-optimize.txt"),
-        "proguard-rules.pro"
-      )
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
     }
   }
   compileOptions {
@@ -81,7 +77,6 @@ tasks.withType<KotlinCompile>().all {
     }
   }
 }
-
 
 dependencies {
   val ktorVersion = "2.3.2"

--- a/integ-testing/integ-testing.gradle.kts
+++ b/integ-testing/integ-testing.gradle.kts
@@ -34,9 +34,7 @@ android {
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
+  kotlinOptions { jvmTarget = "1.8" }
 }
 
 dependencies {

--- a/tools/lint/lint.gradle.kts
+++ b/tools/lint/lint.gradle.kts
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-plugins {
-  id("org.jetbrains.kotlin.jvm")
-}
+plugins { id("org.jetbrains.kotlin.jvm") }
 
 dependencies {
   compileOnly(libs.android.lint.api)
@@ -28,7 +26,5 @@ dependencies {
 }
 
 tasks.jar {
-  manifest {
-    attributes("Lint-Registry-v2" to "com.google.firebase.lint.checks.CheckRegistry")
-  }
+  manifest { attributes("Lint-Registry-v2" to "com.google.firebase.lint.checks.CheckRegistry") }
 }


### PR DESCRIPTION
The more we cover by the formatter the better.

That being said, support for groovy is broken. I hit https://github.com/diffplug/spotless/issues/1922 when trying to use groovyGradle formatting.