### PR TITLE
Fix vertexAI authorization header

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+* [fixed] Fixed issue where authorization headers weren't correctly formatted and where ignored by the backend. (#6400)
 
 # 16.0.0
 * [feature] {{firebase_vertexai}} is now Generally Available (GA) and can be
@@ -52,4 +52,3 @@
 * [feature] Added support for `responseMimeType` in `GenerationConfig`.
 * [changed] Renamed `GoogleGenerativeAIException` to `FirebaseVertexAIException`.
 * [changed] Updated the KDocs for various classes and functions.
-

--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [fixed] Fixed issue where authorization headers weren't correctly formatted and where ignored by the backend. (#6400)
+* [fixed] Fixed issue where authorization headers weren't correctly formatted and were ignored by the backend. (#6400)
 
 # 16.0.0
 * [feature] {{firebase_vertexai}} is now Generally Available (GA) and can be

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -110,7 +110,7 @@ internal constructor(
             try {
               val token = internalAuthProvider.getAccessToken(false).await()
 
-              headers["Authorization"] = token.token!!
+              headers["Authorization"] = "Firebase ${token.token!!}"
             } catch (e: Exception) {
               Log.w(TAG, "Error getting Auth token ", e)
             }


### PR DESCRIPTION
The header for authenticated request from vertex was using an invalid authorization value