### PR TITLE
Bump python-setup version to v5.2

### DIFF
--- a/.github/workflows/api-information.yml
+++ b/.github/workflows/api-information.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.10'
       - name: Set up fireci

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.9'
       - run: |

--- a/.github/workflows/fireci.yml
+++ b/.github/workflows/fireci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.8'
       - run: |
@@ -24,4 +24,4 @@ jobs:
       - run: |
           pytest ci/fireci
       - run: |
-          mypy --config-file ci/fireci/setup.cfg ci/fireci/ 
+          mypy --config-file ci/fireci/setup.cfg ci/fireci/

--- a/.github/workflows/fireperf-e2e.yml
+++ b/.github/workflows/fireperf-e2e.yml
@@ -34,7 +34,7 @@ jobs:
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.10'
       - name: Set up fireci

--- a/.github/workflows/health-metrics.yml
+++ b/.github/workflows/health-metrics.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.10'
       - uses: google-github-actions/auth@v2
@@ -70,7 +70,7 @@ jobs:
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.10'
       - uses: google-github-actions/auth@v2
@@ -106,7 +106,7 @@ jobs:
           distribution: temurin
           cache: gradle
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.10'
       - uses: google-github-actions/auth@v2

--- a/.github/workflows/make-bom.yml
+++ b/.github/workflows/make-bom.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.10'
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/release-note-changes.yml
+++ b/.github/workflows/release-note-changes.yml
@@ -33,7 +33,7 @@ jobs:
         cache: gradle
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
       if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
       with:
         python-version: '3.10'

--- a/.github/workflows/update-cpp-sdk-on-release.yml
+++ b/.github/workflows/update-cpp-sdk-on-release.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: 3.7
 


### PR DESCRIPTION
Instead of using the tagged version, the change moves to the actual commit has instead.