### PR TITLE
[vertexai] Include appcheck token unconditionally

### DIFF
--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* [fixed] Fixed issue where error AppCheck tokens were missing from the requests unintentionally. (#6409)
 * [fixed] Fixed issue where authorization headers weren't correctly formatted and were ignored by the backend. (#6400)
 
 # 16.0.0

--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [fixed] Fixed issue where error AppCheck tokens were missing from the requests unintentionally. (#6409)
+* [fixed] Fixed issue where error Firebase App Check tokens were missing from the requests unintentionally. (#6409)
 
 
 # 16.0.1

--- a/firebase-vertexai/CHANGELOG.md
+++ b/firebase-vertexai/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* [fixed] Fixed issue where error Firebase App Check tokens were missing from the requests unintentionally. (#6409)
+* [fixed] Fixed issue where Firebase App Check error tokens were unintentionally missing from the requests. (#6409)
 
 
 # 16.0.1

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -100,8 +100,8 @@ internal constructor(
             if (token.error != null) {
               Log.w(TAG, "Error obtaining AppCheck token", token.error)
             }
-            // The Firebase App Check backend can differentiate between apps without App Check, and wrongly
-            // configured apps by verifying the value of the token, so it always needs to be
+            // The Firebase App Check backend can differentiate between apps without App Check, and
+            // wrongly configured apps by verifying the value of the token, so it always needs to be
             // included.
             headers["X-Firebase-AppCheck"] = token.token
           }

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -101,7 +101,8 @@ internal constructor(
               Log.w(TAG, "Error obtaining AppCheck token", token.error)
             }
             // The appcheck backend can differentiate between apps without appcheck, and wrongly
-            // configured apps by verifying the value of the token, so it always needs to be included.
+            // configured apps by verifying the value of the token, so it always needs to be
+            // included.
             headers["X-Firebase-AppCheck"] = token.token
           }
 

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -99,9 +99,10 @@ internal constructor(
 
             if (token.error != null) {
               Log.w(TAG, "Error obtaining AppCheck token", token.error)
-            } else {
-              headers["X-Firebase-AppCheck"] = token.token
             }
+            // The appcheck backend can differentiate between apps without appcheck, and wrongly
+            // configured apps by verifying the value of the token, so it always needs to be included.
+            headers["X-Firebase-AppCheck"] = token.token
           }
 
           if (internalAuthProvider == null) {

--- a/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
+++ b/firebase-vertexai/src/main/kotlin/com/google/firebase/vertexai/GenerativeModel.kt
@@ -100,7 +100,7 @@ internal constructor(
             if (token.error != null) {
               Log.w(TAG, "Error obtaining AppCheck token", token.error)
             }
-            // The appcheck backend can differentiate between apps without appcheck, and wrongly
+            // The Firebase App Check backend can differentiate between apps without App Check, and wrongly
             // configured apps by verifying the value of the token, so it always needs to be
             // included.
             headers["X-Firebase-AppCheck"] = token.token


### PR DESCRIPTION
The app check backend can differentiate between apps that do not use appcheck at all, and those sending invalid data, by using a special placeholder token when errors happen. We were previously not including the token value in error cases, but we should.