### PR TITLE
Deprecate additional FCM upstream messaging methods.

### DIFF
--- a/firebase-messaging/CHANGELOG.md
+++ b/firebase-messaging/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* [deprecated] Deprecated additional FCM upstream messaging methods. See the
+  [FAQ](https://firebase.google.com/support/faq#fcm-23-deprecation) for more
+  details.
 
 
 # 24.0.3

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -60,8 +60,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Top level <a href="https://firebase.google.com/docs/cloud-messaging/">Firebase Cloud
- * Messaging</a> singleton that provides methods for subscribing to topics and sending upstream
- * messages.
+ * Messaging</a> singleton that provides methods for generating tokens and subscribing to topics.
  *
  * <p>In order to receive messages, declare an implementation of <br>
  * {@link FirebaseMessagingService} in the app manifest. To process messages, override base class
@@ -515,9 +514,9 @@ public class FirebaseMessaging {
    * <p>When there is an active connection the message will be sent immediately, otherwise the
    * message will be queued up to the time to live (TTL) set in the message.
    *
-   * @deprecated FCM upstream messaging is deprecated and will be decommissioned in June 2024. Learn
-   *     more in the <a href="https://firebase.google.com/support/faq#fcm-23-deprecation">FAQ about
-   *     FCM features deprecated in June 2023</a>.
+   * @deprecated FCM upstream messaging is decommissioned. Learn more in the
+   * <a href="https://firebase.google.com/support/faq#fcm-23-deprecation">FAQ about FCM features
+   * deprecated in June 2023</a>.
    */
   @Deprecated
   public void send(@NonNull RemoteMessage message) {

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java
@@ -35,8 +35,7 @@ import java.util.concurrent.ExecutorService;
  * Base class for receiving messages from Firebase Cloud Messaging.
  *
  * <p>Extending this class is required to be able to handle downstream messages. It also provides
- * functionality to automatically display notifications, and has methods that are invoked to give
- * the status of upstream messages.
+ * functionality to automatically display notifications.
  *
  * <p>Override base class methods to handle any events required by the application. All methods are
  * invoked on a background thread, and <em>may be called when the app is in the background or not
@@ -127,7 +126,12 @@ public class FirebaseMessagingService extends EnhancedIntentService {
    * Called when an upstream message has been successfully sent to the GCM connection server.
    *
    * @param msgId of the upstream message sent using {@link FirebaseMessaging#send}.
+   *
+   * @deprecated FCM upstream messaging is decommissioned. Learn more in the
+   * <a href="https://firebase.google.com/support/faq#fcm-23-deprecation">FAQ about FCM features
+   * deprecated in June 2023</a>.
    */
+  @Deprecated
   @WorkerThread
   public void onMessageSent(@NonNull String msgId) {}
 
@@ -136,7 +140,12 @@ public class FirebaseMessagingService extends EnhancedIntentService {
    *
    * @param msgId of the upstream message sent using {@link FirebaseMessaging#send}.
    * @param exception description of the error, typically a {@link SendException}.
+   *
+   * @deprecated FCM upstream messaging is decommissioned. Learn more in the
+   * <a href="https://firebase.google.com/support/faq#fcm-23-deprecation">FAQ about FCM features
+   * deprecated in June 2023</a>.
    */
+  @Deprecated
   @WorkerThread
   public void onSendError(@NonNull String msgId, @NonNull Exception exception) {}
 

--- a/firebase-messaging/src/main/java/com/google/firebase/messaging/RemoteMessage.java
+++ b/firebase-messaging/src/main/java/com/google/firebase/messaging/RemoteMessage.java
@@ -40,15 +40,10 @@ import java.util.Map;
 /**
  * A remote Firebase Message.
  *
- * <p>Messages will be received via {@link
- * FirebaseMessagingService#onMessageReceived(RemoteMessage)} and can be sent via {@link
- * FirebaseMessaging#send(RemoteMessage)}.
+ * <p>Messages will be received via {@link FirebaseMessagingService#onMessageReceived(RemoteMessage)}.
  *
  * <p>Messages may have a {@link Notification} instance if they are received while the application
  * is in the foreground, otherwise they will be automatically posted to the notification tray.
- *
- * <p>Use the {@link Builder} class for building message instances to send via {@link
- * FirebaseMessaging#send(RemoteMessage)}.
  */
 @SafeParcelable.Reserved({1 /* version field removed by bot go/versionless-safeparcelable */})
 @SafeParcelable.Class(creator = "RemoteMessageCreator")
@@ -115,11 +110,11 @@ public final class RemoteMessage extends AbstractSafeParcelable {
   /**
    * Gets the message destination.
    *
-   * <ul>
-   *   <li>For upstream messages, this will be of the form {@code SENDER_ID@fcm.googleapis.com}.
-   *   <li>For downstream messages, this will be the Firebase installations ID (FID).
-   * </ul>
+   * @deprecated FCM upstream messaging is decommissioned. Learn more in the
+   * <a href="https://firebase.google.com/support/faq#fcm-23-deprecation">FAQ about FCM features
+   * deprecated in June 2023</a>.
    */
+  @Deprecated
   @Nullable
   public String getTo() {
     return bundle.getString(MessagePayloadKeys.TO);
@@ -373,13 +368,13 @@ public final class RemoteMessage extends AbstractSafeParcelable {
     /** @hide */
     @Nullable
     public String getCollapseKey() {
-      return bundle.getString(MessagePayloadKeys.MESSAGE_TYPE);
+      return bundle.getString(MessagePayloadKeys.COLLAPSE_KEY);
     }
 
     /** @hide */
     @IntRange(from = 0, to = 86400)
     public int getTtl() {
-      return Integer.parseInt(bundle.getString(MessagePayloadKeys.MESSAGE_TYPE, "0"));
+      return Integer.parseInt(bundle.getString(MessagePayloadKeys.TTL, "0"));
     }
 
     /** @hide */


### PR DESCRIPTION
* Also removed references to upstream in documentation.