### PR TITLE
libs.versions.toml: add ThreeTenAbp (backport of java.time for Android)

### DIFF
--- a/firebase-dataconnect/connectors/connectors.gradle.kts
+++ b/firebase-dataconnect/connectors/connectors.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
 
   testImplementation(project(":firebase-dataconnect:testutil"))
   testImplementation(libs.androidx.test.junit)
+  testImplementation(libs.kotest.assertions)
+  testImplementation(libs.kotest.property)
   testImplementation(libs.kotlin.coroutines.test)
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
@@ -84,6 +86,7 @@ dependencies {
   androidTestImplementation(libs.kotest.assertions)
   androidTestImplementation(libs.kotest.property)
   androidTestImplementation(libs.kotlin.coroutines.test)
+  androidTestImplementation(libs.three.ten.abp)
   androidTestImplementation(libs.truth)
   androidTestImplementation(libs.truth.liteproto.extension)
   androidTestImplementation(libs.turbine)

--- a/firebase-dataconnect/connectors/connectors.gradle.kts
+++ b/firebase-dataconnect/connectors/connectors.gradle.kts
@@ -86,7 +86,7 @@ dependencies {
   androidTestImplementation(libs.kotest.assertions)
   androidTestImplementation(libs.kotest.property)
   androidTestImplementation(libs.kotlin.coroutines.test)
-  androidTestImplementation(libs.three.ten.abp)
+  androidTestImplementation(libs.testonly.three.ten.abp)
   androidTestImplementation(libs.truth)
   androidTestImplementation(libs.truth.liteproto.extension)
   androidTestImplementation(libs.turbine)

--- a/firebase-dataconnect/testutil/testutil.gradle.kts
+++ b/firebase-dataconnect/testutil/testutil.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
   implementation("com.google.firebase:firebase-auth:22.3.1")
 
   implementation(libs.androidx.test.junit)
+  implementation(libs.kotest.assertions)
   implementation(libs.kotest.property)
   implementation(libs.kotlin.coroutines.test)
   implementation(libs.kotlinx.coroutines.core)
@@ -62,6 +63,7 @@ dependencies {
   implementation(libs.mockk)
   implementation(libs.protobuf.java.lite)
   implementation(libs.robolectric)
+  implementation(libs.three.ten.abp)
   implementation(libs.truth)
 }
 

--- a/firebase-dataconnect/testutil/testutil.gradle.kts
+++ b/firebase-dataconnect/testutil/testutil.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
   implementation(libs.mockk)
   implementation(libs.protobuf.java.lite)
   implementation(libs.robolectric)
-  implementation(libs.three.ten.abp)
+  implementation(libs.testonly.three.ten.abp)
   implementation(libs.truth)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,6 +94,12 @@ quickcheck = { module = "net.java:quickcheck", version.ref = "quickcheck" }
 spotless-plugin-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 turbine = { module = "app.cash.turbine:turbine", version = "1.0.0" }
 
+# Remove three-ten-abp once minSdkVersion is changed to 26 or later, and, instead use the
+# correspondingly-named classes from the java.time package, which should be drop-in replacements.
+# Do not use three-ten-abp in production code (it's only for tests) because it has performance
+# issues.
+three-ten-abp = { module = "com.jakewharton.threetenabp:threetenabp", version = "1.4.7" }
+
 [bundles]
 kotest = ["kotest-runner", "kotest-assertions", "kotest-property", "kotest-property-arbs"]
 playservices = ["playservices-base", "playservices-basement", "playservices-tasks"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,7 +98,7 @@ turbine = { module = "app.cash.turbine:turbine", version = "1.0.0" }
 # correspondingly-named classes from the java.time package, which should be drop-in replacements.
 # Do not use three-ten-abp in production code (it's only for tests) because it has performance
 # issues.
-three-ten-abp = { module = "com.jakewharton.threetenabp:threetenabp", version = "1.4.7" }
+testonly-three-ten-abp = { module = "com.jakewharton.threetenabp:threetenabp", version = "1.4.7" }
 
 [bundles]
 kotest = ["kotest-runner", "kotest-assertions", "kotest-property", "kotest-property-arbs"]


### PR DESCRIPTION
Add "ThreeTenAbp" to `libs.versions.toml`. This library is a backport of the new JDK8 date and time classes in `java.time` to JDK7. Although we should definitely NOT use this library in production, it's quite useful in unit and integration tests to perform complicated date and time mathematics. Once the minSdkVersion is changed to 26 or later, we can drop this dependency and simply use the java.time classes from the standard library.

Although this PR does not contain any actual uses of the library, a follow-up PR will use it, and I wanted to separate the global change of modifying `libs.versions.toml` from the test code that makes use of it because changing `libs.versions.toml` has a project-wide blast radius.

For details, see https://www.threeten.org/threetenbp/ and https://github.com/JakeWharton/ThreeTenABP, the latter being the Android-specific backport added to `libs.versions.toml` by this PR.