### PR TITLE
Migrate auto-value annotationProcessor dependencies to kapt

### DIFF
--- a/firebase-common/firebase-common.gradle.kts
+++ b/firebase-common/firebase-common.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
   compileOnly(libs.findbugs.jsr305)
   compileOnly(libs.kotlin.stdlib)
 
-  annotationProcessor(libs.autovalue)
+  kapt(libs.autovalue)
 
   testImplementation("com.google.guava:guava-testlib:12.0-rc2")
   testImplementation(libs.androidx.test.core)

--- a/firebase-config-interop/firebase-config-interop.gradle.kts
+++ b/firebase-config-interop/firebase-config-interop.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 
   compileOnly(libs.autovalue.annotations)
 
-  annotationProcessor(libs.autovalue)
+  kapt(libs.autovalue)
   annotationProcessor(project(":encoders:firebase-encoders-processor"))
 
   testImplementation(libs.junit)

--- a/firebase-crashlytics/firebase-crashlytics.gradle
+++ b/firebase-crashlytics/firebase-crashlytics.gradle
@@ -90,7 +90,7 @@ dependencies {
     compileOnly(libs.autovalue.annotations)
 
     annotationProcessor(project(":encoders:firebase-encoders-processor"))
-    annotationProcessor(libs.autovalue)
+    kapt(libs.autovalue)
 
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.test.runner)

--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -112,7 +112,7 @@ dependencies {
   implementation(libs.playservices.basement)
   api(libs.playservices.tasks)
 
-  annotationProcessor(libs.autovalue)
+ kapt(libs.autovalue)
   annotationProcessor(libs.dagger.compiler)
 
   testImplementation(libs.androidx.test.core)


### PR DESCRIPTION
Old declaration is deprecated. The generated error message is

xx-xx: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.google.auto.value:auto-value:1.10.1'.