### PR TITLE
Replace auto-value dependency declaration with kapt

### DIFF
--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -112,7 +112,7 @@ dependencies {
   implementation(libs.playservices.basement)
   api(libs.playservices.tasks)
 
- kapt(libs.autovalue)
+  kapt(libs.autovalue)
   annotationProcessor(libs.dagger.compiler)
 
   testImplementation(libs.androidx.test.core)

--- a/firebase-functions/firebase-functions.gradle.kts
+++ b/firebase-functions/firebase-functions.gradle.kts
@@ -112,7 +112,7 @@ dependencies {
   implementation(libs.playservices.basement)
   api(libs.playservices.tasks)
 
-  annotationProcessor(libs.autovalue)
+ kapt(libs.autovalue)
   annotationProcessor(libs.dagger.compiler)
 
   testImplementation(libs.androidx.test.core)


### PR DESCRIPTION
Old declaration is deprecated. The generated error message is

xx-xx: 'annotationProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.google.auto.value:auto-value:1.10.1'.