### PR TITLE
libs.versions.toml: add kotlinx-datetime

### DIFF
--- a/firebase-dataconnect/firebase-dataconnect.gradle.kts
+++ b/firebase-dataconnect/firebase-dataconnect.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
   implementation("com.google.firebase:firebase-components:18.0.0")
 
   compileOnly(libs.javax.annotation.jsr250)
+  compileOnly(libs.kotlinx.datetime)
   implementation(libs.grpc.android)
   implementation(libs.grpc.kotlin.stub)
   implementation(libs.grpc.okhttp)
@@ -117,6 +118,7 @@ dependencies {
   testImplementation(libs.kotest.property)
   testImplementation(libs.kotest.property.arbs)
   testImplementation(libs.kotlin.coroutines.test)
+  testImplementation(libs.kotlinx.datetime)
   testImplementation(libs.kotlinx.serialization.json)
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
@@ -136,6 +138,7 @@ dependencies {
   androidTestImplementation(libs.kotest.property)
   androidTestImplementation(libs.kotest.property.arbs)
   androidTestImplementation(libs.kotlin.coroutines.test)
+  androidTestImplementation(libs.kotlinx.datetime)
   androidTestImplementation(libs.mockk)
   androidTestImplementation(libs.mockk.android)
   androidTestImplementation(libs.truth)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ javax-inject = { module = "javax.inject:javax.inject", version = "1" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-coroutines-tasks = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "coroutines" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.1" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }


### PR DESCRIPTION
Add "kotlinx.datetime" to `libs.versions.toml`. Although this PR does not contain any actual uses of the library, a follow-up PR will use it, and I wanted to separate the global change of modifying `libs.versions.toml` from the code that makes use of it because changing `libs.versions.toml` has a project-wide blast radius.

See https://github.com/Kotlin/kotlinx-datetime and https://kotlinlang.org/api/kotlinx-datetime/ for more details about the kotlinx.datetime library.